### PR TITLE
allow custom axios instance

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+
+import { axios } from './axios.js';
 import {
 	CheckSpendablePayload,
 	CheckSpendableResponse,

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -1,4 +1,3 @@
-
 import { axios } from './axios.js';
 import {
 	CheckSpendablePayload,

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,8 +1,8 @@
 import * as _axios from 'axios';
 import { CreateAxiosDefaults } from 'axios';
 
-export let axios = _axios.default.create()
+export let axios = _axios.default.create();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function setupAxios(config?: CreateAxiosDefaults<any> | undefined) {
-	axios = _axios.default.create(config)
+	axios = _axios.default.create(config);
 }

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,0 +1,8 @@
+import * as _axios from 'axios';
+import { CreateAxiosDefaults } from 'axios';
+
+export let axios = _axios.default.create()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function setupAxios(config?: CreateAxiosDefaults<any> | undefined) {
+	axios = _axios.default.create(config)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,15 +35,15 @@ function bigIntStringify<T>(_key: unknown, value: T) {
  * @returns
  */
 function getEncodedProofs(proofs: Array<Proof>, mint: string, memo?: string): string {
-	const token: Token= {
+	const token: Token = {
 		token: [{ mint, proofs }]
 	};
-	
+
 	//add memo if exist
 	if (memo) {
-		token.memo = memo
+		token.memo = memo;
 	}
-	
+
 	return TOKEN_PREFIX + TOKEN_VERSION + encodeJsonToBase64(token);
 }
 


### PR DESCRIPTION
This would allow users to do things like 

```typescript
import { setupAxios } from './axios';

setupAxios({ timeout: 1000 })
```
or

```typescript
setupAxios({
	'httpAgent': new SocksProxyAgent(`socks5h://${torConfig.ip}:${torConfig.port}`),
	'httpsAgent': new SocksProxyAgent(`socks5h://${torConfig.ip}:${torConfig.port}`),
})
```