### PR TITLE
update Buffer imports

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -278,19 +278,14 @@ class CashuWallet {
 		if (this.keysetId === keysetId) {
 			return this.keys;
 		}
-		// let newKeys = this.keysMap.get(keysetId);
-		// if (newKeys) {
-		// 	return newKeys;
-		// }
+
 		const keys =
 			!mint || mint === this.mint.mintUrl
 				? await this.mint.getKeys(arr[0].id)
 				: await CashuMint.getKeys(mint, arr[0].id);
-		// this.keysMap.set(keysetId, keys);
 		return keys;
 	}
 
-	//keep amount 1 send amount 2
 	private createSplitPayload(
 		amount1: number,
 		amount2: number,

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 
 function encodeUint8toBase64(uint8array: Uint8Array): string {
 	return Buffer.from(uint8array).toString('base64');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import { MintKeys, Proof, Token, TokenEntry, TokenV2 } from './model/types/index
 import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants.js';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
+import { Buffer } from 'buffer/';
 
 function splitAmount(value: number): Array<number> {
 	const chunks: Array<number> = [];


### PR DESCRIPTION
update Buffer imports from
```
import { Buffer } from 'buffer';
```
to
```
import { Buffer } from 'buffer/';
```
to use the Buffer npm pkg and not nodes Buffer

from https://www.npmjs.com/package/buffer

```
To depend on this module explicitly (without browserify), require it like this:

var Buffer = require('buffer/').Buffer  // note: the trailing slash is important!

To require this module explicitly, use require('buffer/') which tells the node.js module lookup algorithm (also used by browserify) to use the npm module named buffer instead of the node.js core module named buffer!
```
