### PR TITLE
make token entry public

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -209,7 +209,7 @@ class CashuWallet {
 		};
 	}
 
-	private async receiveTokenEntry(tokenEntry: TokenEntry): Promise<ReceiveTokenEntryResponse> {
+	async receiveTokenEntry(tokenEntry: TokenEntry): Promise<ReceiveTokenEntryResponse> {
 		const proofsWithError: Array<Proof> = [];
 		const proofs: Array<Proof> = [];
 		let newKeys: MintKeys | undefined;


### PR DESCRIPTION
I think we can make this function public. It gives some more flexibility to wallets, on how they would like to receive tokens. 