### PR TITLE
Axios: `/melt` without timeout

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -49,7 +49,8 @@ class CashuMint {
 	 */
 	public static async requestMint(mintUrl: string, amount: number): Promise<RequestMintResponse> {
 		const { data } = await axios.get<RequestMintResponse>(`${mintUrl}/mint`, {
-			params: { amount }
+			params: { amount },
+			timeout: 0
 		});
 		return data;
 	}
@@ -153,7 +154,9 @@ class CashuMint {
 	 */
 	public static async split(mintUrl: string, splitPayload: SplitPayload): Promise<SplitResponse> {
 		try {
-			const { data } = await axios.post<SplitResponse>(`${mintUrl}/split`, splitPayload);
+			const { data } = await axios.post<SplitResponse>(`${mintUrl}/split`, splitPayload, {
+				timeout: 0
+			});
 			checkResponse(data);
 			if (!isObj(data) || !Array.isArray(data?.fst) || !Array.isArray(data?.snd)) {
 				throw new Error('bad response');

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -49,8 +49,7 @@ class CashuMint {
 	 */
 	public static async requestMint(mintUrl: string, amount: number): Promise<RequestMintResponse> {
 		const { data } = await axios.get<RequestMintResponse>(`${mintUrl}/mint`, {
-			params: { amount },
-			timeout: 0
+			params: { amount }
 		});
 		return data;
 	}
@@ -84,7 +83,8 @@ class CashuMint {
 						// payment_hash is deprecated
 						payment_hash: hash,
 						hash
-					}
+					},
+					timeout: 0
 				}
 			);
 			checkResponse(data);

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -180,7 +180,9 @@ class CashuMint {
 	 */
 	public static async melt(mintUrl: string, meltPayload: MeltPayload): Promise<MeltResponse> {
 		try {
-			const { data } = await axios.post<MeltResponse>(`${mintUrl}/melt`, meltPayload, { timeout: 0 });
+			const { data } = await axios.post<MeltResponse>(`${mintUrl}/melt`, meltPayload, {
+				timeout: 0
+			});
 			checkResponse(data);
 			if (
 				!isObj(data) ||

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -180,7 +180,7 @@ class CashuMint {
 	 */
 	public static async melt(mintUrl: string, meltPayload: MeltPayload): Promise<MeltResponse> {
 		try {
-			const { data } = await axios.post<MeltResponse>(`${mintUrl}/melt`, meltPayload);
+			const { data } = await axios.post<MeltResponse>(`${mintUrl}/melt`, meltPayload, { timeout: 0 });
 			checkResponse(data);
 			if (
 				!isObj(data) ||


### PR DESCRIPTION
Removes `/melt` timeout. LN payments can take a long time and its best to keep the connection to the mint as long as possible so we can receive change after the payment is done. SoonTM we would have a "pending" state that could make this unnecessary.

closes #78 