### PR TITLE
Fix Code Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const { pr, hash } = await wallet.requestMint(200);
 console.log({ pr }, { hash });
 
 async function invoiceHasBeenPaid() {
-	const proofs = await wallet.requestTokens(200, hash);
+	const { proofs } = await wallet.requestTokens(200, hash);
 	//Encoded proofs can be spent at the mint
 	const encoded = getEncodedToken({
 		token: [{ mint: '{MINT_URL}', proofs }]


### PR DESCRIPTION
I tried to run the example provided in `README.md` only to run into a Type Error.

`proofs` in the `invoiceHasBeenPaid` function should be destructured instead of being directly referenced.

The call signature of `wallet.requestTokens` is as follows:

```ts
CashuWallet.requestTokens(amount: number, hash: string, AmountPreference?: Cashu.AmountPreference[] | undefined): Promise<{
    proofs: Cashu.Proof[];
    newKeys?: Cashu.MintKeys | undefined;
}>
```