### PR TITLE
Update NUT-06: deprecate `amount` in `PostSplitRequest`

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -21,7 +21,7 @@ class CashuMint {
 	/**
 	 * @param _mintUrl requires mint URL to create this object
 	 */
-	constructor(private _mintUrl: string) { }
+	constructor(private _mintUrl: string) {}
 
 	get mintUrl() {
 		return this._mintUrl;

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -21,7 +21,7 @@ class CashuMint {
 	/**
 	 * @param _mintUrl requires mint URL to create this object
 	 */
-	constructor(private _mintUrl: string) {}
+	constructor(private _mintUrl: string) { }
 
 	get mintUrl() {
 		return this._mintUrl;
@@ -143,7 +143,7 @@ class CashuMint {
 			requestBody: splitPayload
 		});
 
-		if (!isObj(data) || !Array.isArray(data?.fst) || !Array.isArray(data?.snd)) {
+		if (!isObj(data) || !Array.isArray(data?.promises)) {
 			throw new Error('bad response');
 		}
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -179,17 +179,16 @@ class CashuWallet {
 		let newKeys: MintKeys | undefined;
 		try {
 			const amount = tokenEntry.proofs.reduce((total, curr) => total + curr.amount, 0);
-			const { payload, blindedMessages } = this.createSplitPayload(
-				amount,
-				tokenEntry.proofs
-			);
+			const { payload, blindedMessages } = this.createSplitPayload(amount, tokenEntry.proofs);
 			const { promises } = await CashuMint.split(tokenEntry.mint, payload);
-			proofs.push(...dhke.constructProofs(
-				promises,
-				blindedMessages.rs,
-				blindedMessages.secrets,
-				await this.getKeys(promises, tokenEntry.mint)
-			));
+			proofs.push(
+				...dhke.constructProofs(
+					promises,
+					blindedMessages.rs,
+					blindedMessages.secrets,
+					await this.getKeys(promises, tokenEntry.mint)
+				)
+			);
 			newKeys =
 				tokenEntry.mint === this.mint.mintUrl
 					? await this.changedKeys([...(promises || [])])
@@ -228,10 +227,7 @@ class CashuWallet {
 		}
 		if (amount < amountAvailable) {
 			const { amount1, amount2 } = this.splitReceive(amount, amountAvailable);
-			const { payload, blindedMessages } = this.createSplitPayload(
-				amount1,
-				proofsToSend
-			);
+			const { payload, blindedMessages } = this.createSplitPayload(amount1, proofsToSend);
 			const { promises } = await this.mint.split(payload);
 			const proofs = dhke.constructProofs(
 				promises,

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -159,10 +159,6 @@ export type SplitPayload = {
 	 */
 	proofs: Array<Proof>;
 	/**
-	 * Amount that needs to be split from the total amount provided (in proofs)
-	 */
-	amount: number;
-	/**
 	 * Fresh blinded messages to be signed by the mint to create the split proofs
 	 */
 	outputs: Array<SerializedBlindedMessage>;
@@ -172,13 +168,9 @@ export type SplitPayload = {
  */
 export type SplitResponse = {
 	/**
-	 * represents the left-over amount after the split
+	 * represents the outputs after the split
 	 */
-	fst: Array<SerializedBlindedSignature>;
-	/**
-	 * represents the specified amount when splitting
-	 */
-	snd: Array<SerializedBlindedSignature>;
+	promises: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 /**

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -37,8 +37,7 @@ describe('receive', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				fst: [],
-				snd: [
+				promises: [
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 1,
@@ -99,8 +98,7 @@ describe('receive', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				fst: [],
-				snd: [
+				promises: [
 					{
 						id: 'test',
 						amount: 1,
@@ -287,8 +285,7 @@ describe('send', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				fst: [],
-				snd: [
+				promises: [
 					{
 						id: '0NI3TUAs1Sfy',
 						amount: 1,
@@ -310,14 +307,12 @@ describe('send', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				fst: [
+				promises: [
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-					}
-				],
-				snd: [
+					},
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 1,
@@ -350,14 +345,12 @@ describe('send', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				fst: [
+				promises: [
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-					}
-				],
-				snd: [
+					},
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 1,
@@ -391,8 +384,7 @@ describe('send', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				fst: [],
-				snd: [
+				promises: [
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 1,


### PR DESCRIPTION
implements [update](https://github.com/cashubtc/nuts/pull/34) in [nut-06](https://github.com/cashubtc/nuts/blob/main/06.md) deprecating the `amount` field in `PostSplitRequest` and only returning `promises` in `PostSplitResponse`.

Partly overlaps with #77