### PR TITLE
Refactored `request` error handling

### DIFF
--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -1,0 +1,7 @@
+export class HttpResponseError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -1,7 +1,7 @@
 export class HttpResponseError extends Error {
-    status: number;
-    constructor(message: string, status: number) {
-        super(message);
-        this.status = status;
-    }
+	status: number;
+	constructor(message: string, status: number) {
+		super(message);
+		this.status = status;
+	}
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -36,7 +36,7 @@ async function _request({
 	if (!response.ok) {
 		// expecting: { error: '', code: 0 }
 		// or: { detail: '' } (cashuBtc via pythonApi)
-		const { error, detail } = await response.json().catch(() => ({ error: 'bad response' }))
+		const { error, detail } = await response.json().catch(() => ({ error: 'bad response' }));
 		throw new HttpResponseError(error || detail || 'bad response', response.status);
 	}
 
@@ -44,7 +44,7 @@ async function _request({
 		return await response.json();
 	} catch (err) {
 		console.error('Failed to parse HTTP response', err);
-		throw new HttpResponseError('bad response', response.status)
+		throw new HttpResponseError('bad response', response.status);
 	}
 }
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -135,7 +135,7 @@ describe('receive', () => {
 	});
 	test('test receive tokens already spent', async () => {
 		const msg = 'tokens already spent. Secret: oEpEuViVHUV2vQH81INUbq++Yv2w3u5H0LhaqXJKeR0=';
-		nock(mintUrl).post('/split').reply(200, { detail: msg });
+		nock(mintUrl).post('/split').reply(500, { detail: msg });
 		const wallet = new CashuWallet(mint);
 
 		const { tokensWithErrors } = await wallet.receive(tokenInput);
@@ -152,7 +152,7 @@ describe('receive', () => {
 		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
 	});
 	test('test receive could not verify proofs', async () => {
-		nock(mintUrl).post('/split').reply(200, { code: 0, error: 'could not verify proofs.' });
+		nock(mintUrl).post('/split').reply(500, { code: 0, error: 'could not verify proofs.' });
 		const wallet = new CashuWallet(mint);
 
 		const { tokensWithErrors } = await wallet.receive(tokenInput);


### PR DESCRIPTION
Exception is now identifiable as HttpResponseError providing a status code. 
**Breaking?** We no longer look for error messages on `ok` responses. (HTTP2XX)

# Fixes: Not yet.

## Description
This is a small PR as part of an ongoing effort to address https://github.com/cashubtc/cashu-ts/issues/86
...

## Changes

- Exception is now identifiable as HttpResponseError providing a status code. 
- **Breaking?** We no longer look for error messages on `ok` responses. (HTTP2XX)


## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`