### PR TITLE
Deterministic secrets and restore from seed phrase :fire: 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
 			"dependencies": {
 				"@gandlaf21/bolt11-decode": "^3.0.6",
 				"@noble/curves": "^1.0.0",
+				"@scure/bip32": "^1.3.2",
+				"@scure/bip39": "^1.2.1",
+				"bip32": "^4.0.0",
+				"bip39": "github:ProtonMail/bip39#semver:1.0.2",
 				"buffer": "^6.0.3"
 			},
 			"devDependencies": {
@@ -1136,29 +1140,26 @@
 			}
 		},
 		"node_modules/@noble/curves": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-			"integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			],
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+			"integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
 			"dependencies": {
-				"@noble/hashes": "1.3.0"
+				"@noble/hashes": "1.3.2"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@noble/hashes": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-			"integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			]
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+			"integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -1193,6 +1194,39 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@scure/base": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
+			"integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@scure/bip32": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+			"integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+			"dependencies": {
+				"@noble/curves": "~1.2.0",
+				"@noble/hashes": "~1.3.2",
+				"@scure/base": "~1.1.2"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@scure/bip39": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+			"integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+			"dependencies": {
+				"@noble/hashes": "~1.3.0",
+				"@scure/base": "~1.1.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@sinclair/typebox": {
@@ -1961,6 +1995,14 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/base-x": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+			"integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1984,6 +2026,25 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+		},
+		"node_modules/bip32": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
+			"integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+			"dependencies": {
+				"@noble/hashes": "^1.2.0",
+				"@scure/base": "^1.1.1",
+				"typeforce": "^1.11.5",
+				"wif": "^2.0.6"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/bip39": {
+			"version": "1.0.1",
+			"resolved": "git+ssh://git@github.com/ProtonMail/bip39.git#4f54228f4fcd824740f033a3a693ac6dcfef168c",
+			"license": "ISC"
 		},
 		"node_modules/bn.js": {
 			"version": "4.12.0",
@@ -2050,6 +2111,24 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+			"dependencies": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"node_modules/bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"dependencies": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"node_modules/bser": {
@@ -2213,6 +2292,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
@@ -2290,6 +2378,18 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
+		},
+		"node_modules/create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dependencies": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
@@ -3579,6 +3679,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3688,8 +3801,7 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.4",
@@ -4814,6 +4926,16 @@
 				"node": ">= 12"
 			}
 		},
+		"node_modules/md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5358,6 +5480,19 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -5468,6 +5603,15 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5491,6 +5635,25 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -5512,6 +5675,18 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"bin": {
+				"sha.js": "bin.js"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -5617,6 +5792,14 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-length": {
@@ -6053,6 +6236,11 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/typeforce": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+		},
 		"node_modules/typescript": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -6115,6 +6303,11 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -6208,6 +6401,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/wif": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+			"integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+			"dependencies": {
+				"bs58check": "<3.0.0"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -7165,17 +7366,17 @@
 			}
 		},
 		"@noble/curves": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-			"integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+			"integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
 			"requires": {
-				"@noble/hashes": "1.3.0"
+				"@noble/hashes": "1.3.2"
 			}
 		},
 		"@noble/hashes": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-			"integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+			"integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -7201,6 +7402,30 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@scure/base": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
+			"integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
+		},
+		"@scure/bip32": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+			"integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+			"requires": {
+				"@noble/curves": "~1.2.0",
+				"@noble/hashes": "~1.3.2",
+				"@scure/base": "~1.1.2"
+			}
+		},
+		"@scure/bip39": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+			"integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+			"requires": {
+				"@noble/hashes": "~1.3.0",
+				"@scure/base": "~1.1.0"
 			}
 		},
 		"@sinclair/typebox": {
@@ -7784,6 +8009,14 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"base-x": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+			"integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7793,6 +8026,21 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+		},
+		"bip32": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
+			"integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+			"requires": {
+				"@noble/hashes": "^1.2.0",
+				"@scure/base": "^1.1.1",
+				"typeforce": "^1.11.5",
+				"wif": "^2.0.6"
+			}
+		},
+		"bip39": {
+			"version": "git+ssh://git@github.com/ProtonMail/bip39.git#4f54228f4fcd824740f033a3a693ac6dcfef168c",
+			"from": "git+ssh://git@github.com/ProtonMail/bip39.git#4f54228f4fcd824740f033a3a693ac6dcfef168c"
 		},
 		"bn.js": {
 			"version": "4.12.0",
@@ -7837,6 +8085,24 @@
 			"dev": true,
 			"requires": {
 				"fast-json-stable-stringify": "2.x"
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"bser": {
@@ -7948,6 +8214,15 @@
 			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
 			"dev": true
 		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"cjs-module-lexer": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
@@ -8012,6 +8287,18 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -8947,6 +9234,16 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
+		"hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"requires": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			}
+		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9017,8 +9314,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"internal-slot": {
 			"version": "1.0.4",
@@ -9862,6 +10158,16 @@
 			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
 			"dev": true
 		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -10237,6 +10543,16 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
+		"readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
 		"regexp.prototype.flags": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -10307,6 +10623,15 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10315,6 +10640,11 @@
 			"requires": {
 				"queue-microtask": "^1.2.2"
 			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"safe-regex-test": {
 			"version": "1.0.0",
@@ -10332,6 +10662,15 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -10418,6 +10757,14 @@
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"string-length": {
@@ -10718,6 +11065,11 @@
 				}
 			}
 		},
+		"typeforce": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+		},
 		"typescript": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -10754,6 +11106,11 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -10837,6 +11194,14 @@
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
+			}
+		},
+		"wif": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+			"integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+			"requires": {
+				"bs58check": "<3.0.0"
 			}
 		},
 		"word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
 				"@noble/curves": "^1.0.0",
 				"@scure/bip32": "^1.3.2",
 				"@scure/bip39": "^1.2.1",
-				"bip32": "^4.0.0",
-				"bip39": "github:ProtonMail/bip39#semver:1.0.2",
 				"buffer": "^6.0.3"
 			},
 			"devDependencies": {
@@ -1995,14 +1993,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"node_modules/base-x": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-			"integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2026,25 +2016,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-		},
-		"node_modules/bip32": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
-			"integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
-			"dependencies": {
-				"@noble/hashes": "^1.2.0",
-				"@scure/base": "^1.1.1",
-				"typeforce": "^1.11.5",
-				"wif": "^2.0.6"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/bip39": {
-			"version": "1.0.1",
-			"resolved": "git+ssh://git@github.com/ProtonMail/bip39.git#4f54228f4fcd824740f033a3a693ac6dcfef168c",
-			"license": "ISC"
 		},
 		"node_modules/bn.js": {
 			"version": "4.12.0",
@@ -2111,24 +2082,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-			"dependencies": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"node_modules/bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"dependencies": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
 			}
 		},
 		"node_modules/bser": {
@@ -2292,15 +2245,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
@@ -2378,18 +2322,6 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
-		},
-		"node_modules/create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dependencies": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
@@ -3679,19 +3611,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3801,7 +3720,8 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.4",
@@ -4926,16 +4846,6 @@
 				"node": ">= 12"
 			}
 		},
-		"node_modules/md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dependencies": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5480,19 +5390,6 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -5603,15 +5500,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dependencies": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5635,25 +5523,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -5675,18 +5544,6 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			},
-			"bin": {
-				"sha.js": "bin.js"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -5792,14 +5649,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-length": {
@@ -6236,11 +6085,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/typeforce": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
-		},
 		"node_modules/typescript": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -6303,11 +6147,6 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -6401,14 +6240,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/wif": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-			"integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
-			"dependencies": {
-				"bs58check": "<3.0.0"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -8009,14 +7840,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"base-x": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-			"integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -8026,21 +7849,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-		},
-		"bip32": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
-			"integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
-			"requires": {
-				"@noble/hashes": "^1.2.0",
-				"@scure/base": "^1.1.1",
-				"typeforce": "^1.11.5",
-				"wif": "^2.0.6"
-			}
-		},
-		"bip39": {
-			"version": "git+ssh://git@github.com/ProtonMail/bip39.git#4f54228f4fcd824740f033a3a693ac6dcfef168c",
-			"from": "git+ssh://git@github.com/ProtonMail/bip39.git#4f54228f4fcd824740f033a3a693ac6dcfef168c"
 		},
 		"bn.js": {
 			"version": "4.12.0",
@@ -8085,24 +7893,6 @@
 			"dev": true,
 			"requires": {
 				"fast-json-stable-stringify": "2.x"
-			}
-		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
 			}
 		},
 		"bser": {
@@ -8214,15 +8004,6 @@
 			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
 			"dev": true
 		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"cjs-module-lexer": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
@@ -8287,18 +8068,6 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -9234,16 +9003,6 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
-		"hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			}
-		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9314,7 +9073,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"internal-slot": {
 			"version": "1.0.4",
@@ -10158,16 +9918,6 @@
 			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
 			"dev": true
 		},
-		"md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -10543,16 +10293,6 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
-		"readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			}
-		},
 		"regexp.prototype.flags": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -10623,15 +10363,6 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10640,11 +10371,6 @@
 			"requires": {
 				"queue-microtask": "^1.2.2"
 			}
-		},
-		"safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"safe-regex-test": {
 			"version": "1.0.0",
@@ -10662,15 +10388,6 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -10757,14 +10474,6 @@
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
-			}
-		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
 			}
 		},
 		"string-length": {
@@ -11065,11 +10774,6 @@
 				}
 			}
 		},
-		"typeforce": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
-		},
 		"typescript": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -11106,11 +10810,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -11194,14 +10893,6 @@
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
-			}
-		},
-		"wif": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-			"integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
-			"requires": {
-				"bs58check": "<3.0.0"
 			}
 		},
 		"word-wrap": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
 	"dependencies": {
 		"@gandlaf21/bolt11-decode": "^3.0.6",
 		"@noble/curves": "^1.0.0",
+		"@scure/bip32": "^1.3.2",
+		"@scure/bip39": "^1.2.1",
+		"bip32": "^4.0.0",
+		"bip39": "github:ProtonMail/bip39#semver:1.0.2",
 		"buffer": "^6.0.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
 		"@noble/curves": "^1.0.0",
 		"@scure/bip32": "^1.3.2",
 		"@scure/bip39": "^1.2.1",
-		"bip32": "^4.0.0",
-		"bip39": "github:ProtonMail/bip39#semver:1.0.2",
 		"buffer": "^6.0.3"
 	}
 }

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -263,18 +263,18 @@ class CashuMint {
 			requestBody: restorePayload
 		});
 
-		if (!isObj(data) || !Array.isArray(data?.outputs) || !Array.isArray(data?.promises) ) {
+		if (!isObj(data) || !Array.isArray(data?.outputs) || !Array.isArray(data?.promises)) {
 			throw new Error('bad response');
 		}
 
 		return data;
 	}
 
-	async restore(restorePayload: { outputs: Array<SerializedBlindedMessage> }): Promise<PostRestoreResponse> {
+	async restore(restorePayload: {
+		outputs: Array<SerializedBlindedMessage>;
+	}): Promise<PostRestoreResponse> {
 		return CashuMint.restore(this._mintUrl, restorePayload);
 	}
-
-	
 }
 
 export { CashuMint };

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -5,6 +5,7 @@ import {
 	MeltPayload,
 	MeltResponse,
 	MintKeys,
+	PostRestoreResponse,
 	RequestMintResponse,
 	SerializedBlindedMessage,
 	SerializedBlindedSignature,
@@ -251,6 +252,29 @@ class CashuMint {
 	async check(checkPayload: CheckSpendablePayload): Promise<CheckSpendableResponse> {
 		return CashuMint.check(this._mintUrl, checkPayload);
 	}
+
+	public static async restore(
+		mintUrl: string,
+		restorePayload: { outputs: Array<SerializedBlindedMessage> }
+	): Promise<PostRestoreResponse> {
+		const data = await request<PostRestoreResponse>({
+			endpoint: joinUrls(mintUrl, 'restore'),
+			method: 'POST',
+			requestBody: restorePayload
+		});
+
+		if (!isObj(data) || !Array.isArray(data?.outputs) || !Array.isArray(data?.promises) ) {
+			throw new Error('bad response');
+		}
+
+		return data;
+	}
+
+	async restore(restorePayload: { outputs: Array<SerializedBlindedMessage> }): Promise<PostRestoreResponse> {
+		return CashuMint.restore(this._mintUrl, restorePayload);
+	}
+
+	
 }
 
 export { CashuMint };

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -511,8 +511,10 @@ class CashuWallet {
 		keysetId?: string
 	): BlindedMessageData & { amounts: Array<number> } {
 		// if we atempt to create deterministic messages without a _seed, abort.
-		if (count!=undefined && !this._seed) {
-			throw new Error('Cannot create deterministic messages without seed. Instantiate CashuWallet with a mnemonic, or omit count param.')
+		if (count != undefined && !this._seed) {
+			throw new Error(
+				'Cannot create deterministic messages without seed. Instantiate CashuWallet with a mnemonic, or omit count param.'
+			);
 		}
 		const blindedMessages: Array<SerializedBlindedMessage> = [];
 		const secrets: Array<Uint8Array> = [];
@@ -521,8 +523,10 @@ class CashuWallet {
 			let deterministicR = undefined;
 			let secret = undefined;
 			if (this._seed && count != undefined) {
-				secret = deriveSecret(this._seed, keysetId??this.keysetId, count + i);
-				deterministicR = bytesToNumber(deriveBlindingFactor(this._seed, keysetId??this.keysetId, count + i));
+				secret = deriveSecret(this._seed, keysetId ?? this.keysetId, count + i);
+				deterministicR = bytesToNumber(
+					deriveBlindingFactor(this._seed, keysetId ?? this.keysetId, count + i)
+				);
 			} else {
 				secret = randomBytes(32);
 			}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -553,6 +553,7 @@ class CashuWallet {
 	 */
 	private createBlankOutputs(feeReserve: number, count?: number): BlindedMessageData {
 		let counter = Math.ceil(Math.log2(feeReserve)) || 1;
+		//Prevent counter from being -Infinity
 		if (counter < 0) {
 			counter = 0;
 		}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -43,20 +43,26 @@ class CashuWallet {
 	/**
 	 * @param keys public keys from the mint
 	 * @param mint Cashu mint instance is used to make api calls
-	 * @param mnemonic mnemonic seed phrase to initial derivation key for this wallets deterministic secrets
+	 * @param mnemonicOrSeed mnemonic phrase or Seed to initial derivation key for this wallets deterministic secrets. When the mnemonic is provided, the seed will be derived from it. 
+	 * This can lead to poor performance, in which case the seed should be directly provided
 	 */
-	constructor(mint: CashuMint, keys?: MintKeys, mnemonic?: string) {
+	constructor(mint: CashuMint, keys?: MintKeys, mnemonicOrSeed?: string | Uint8Array) {
 		this._keys = keys || {};
 		this.mint = mint;
 		if (keys) {
 			this._keysetId = deriveKeysetId(this._keys);
 		}
-		if (mnemonic) {
-			if (!validateMnemonic(mnemonic, wordlist)) {
-				throw new Error('Tried to instantiate with mnemonic, but mnemonic was invalid');
-			}
-			this._seed = deriveSeedFromMnemonic(mnemonic);
+		if (!mnemonicOrSeed) {
+			return
 		}
+		if (mnemonicOrSeed instanceof Uint8Array) {
+			this._seed = mnemonicOrSeed
+			return
+		}
+		if (!validateMnemonic(mnemonicOrSeed, wordlist)) {
+			throw new Error('Tried to instantiate with mnemonic, but mnemonic was invalid');
+		}
+		this._seed = deriveSeedFromMnemonic(mnemonicOrSeed);
 	}
 
 	get keys(): MintKeys {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -352,13 +352,14 @@ class CashuWallet {
 	 */
 	async restore(
 		count: number,
-		startIndex = 0
+		startIndex = 0,
+		keysetId?: string
 	): Promise<{ proofs: Array<Proof>; newKeys?: MintKeys }> {
 		if (!this._seed) {
 			throw new Error('CashuWallet must be initialized with mnemonic to use restore');
 		}
 		const amounts = Array(count).fill(0);
-		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, startIndex);
+		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, startIndex, keysetId);
 
 		const { outputs, promises } = await this.mint.restore({ outputs: blindedMessages });
 
@@ -504,7 +505,8 @@ class CashuWallet {
 	 */
 	private createBlindedMessages(
 		amounts: Array<number>,
-		count?: number
+		count?: number,
+		keysetId?: string
 	): BlindedMessageData & { amounts: Array<number> } {
 		const blindedMessages: Array<SerializedBlindedMessage> = [];
 		const secrets: Array<Uint8Array> = [];
@@ -513,8 +515,8 @@ class CashuWallet {
 			let deterministicR = undefined;
 			let secret = undefined;
 			if (this._seed && count != undefined) {
-				secret = deriveSecret(this._seed, this.keysetId, count + i);
-				deterministicR = bytesToNumber(deriveBlindingFactor(this._seed, this.keysetId, count + i));
+				secret = deriveSecret(this._seed, keysetId??this.keysetId, count + i);
+				deterministicR = bytesToNumber(deriveBlindingFactor(this._seed, keysetId??this.keysetId, count + i));
 			} else {
 				secret = randomBytes(32);
 			}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -43,7 +43,7 @@ class CashuWallet {
 	/**
 	 * @param keys public keys from the mint
 	 * @param mint Cashu mint instance is used to make api calls
-	 * @param mnemonicOrSeed mnemonic phrase or Seed to initial derivation key for this wallets deterministic secrets. When the mnemonic is provided, the seed will be derived from it. 
+	 * @param mnemonicOrSeed mnemonic phrase or Seed to initial derivation key for this wallets deterministic secrets. When the mnemonic is provided, the seed will be derived from it.
 	 * This can lead to poor performance, in which case the seed should be directly provided
 	 */
 	constructor(mint: CashuMint, keys?: MintKeys, mnemonicOrSeed?: string | Uint8Array) {
@@ -53,11 +53,11 @@ class CashuWallet {
 			this._keysetId = deriveKeysetId(this._keys);
 		}
 		if (!mnemonicOrSeed) {
-			return
+			return;
 		}
 		if (mnemonicOrSeed instanceof Uint8Array) {
-			this._seed = mnemonicOrSeed
-			return
+			this._seed = mnemonicOrSeed;
+			return;
 		}
 		if (!validateMnemonic(mnemonicOrSeed, wordlist)) {
 			throw new Error('Tried to instantiate with mnemonic, but mnemonic was invalid');
@@ -375,7 +375,7 @@ class CashuWallet {
 
 		const { outputs, promises } = await this.mint.restore({ outputs: blindedMessages });
 
-		// Collect and map the secrets and blinding factors with the blinded messages that were returned from the mint 
+		// Collect and map the secrets and blinding factors with the blinded messages that were returned from the mint
 		const validRs = rs.filter((r, i) => outputs.map((o) => o.B_).includes(blindedMessages[i].B_));
 		const validSecrets = secrets.filter((s, i) =>
 			outputs.map((o) => o.B_).includes(blindedMessages[i].B_)

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -357,8 +357,7 @@ class CashuWallet {
 		if (!this._seed) {
 			throw new Error('CashuWallet must be initialized with mnemonic to use restore');
 		}
-		const numberOfMessages = count - startIndex;
-		const amounts = Array(numberOfMessages).fill(0);
+		const amounts = Array(count).fill(0);
 		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, startIndex);
 
 		const { outputs, promises } = await this.mint.restore({ outputs: blindedMessages });
@@ -540,7 +539,7 @@ class CashuWallet {
 		if (counter < 0) {
 			counter = 0;
 		}
-		const amounts = counter ? Array(counter).fill(0) : [];
+		const amounts = counter ? Array(counter).fill(1) : [];
 		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, count);
 		return { blindedMessages, secrets, rs };
 	}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -510,6 +510,10 @@ class CashuWallet {
 		count?: number,
 		keysetId?: string
 	): BlindedMessageData & { amounts: Array<number> } {
+		// if we atempt to create deterministic messages without a _seed, abort.
+		if (count!=undefined && !this._seed) {
+			throw new Error('Cannot create deterministic messages without seed. Instantiate CashuWallet with a mnemonic, or omit count param.')
+		}
 		const blindedMessages: Array<SerializedBlindedMessage> = [];
 		const secrets: Array<Uint8Array> = [];
 		const rs: Array<bigint> = [];

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -346,9 +346,9 @@ class CashuWallet {
 
 	/**
 	 * Regenerates
-	 * @param count? set number of blinded messages that should be generated
+	 * @param count set number of blinded messages that should be generated
 	 * @param startIndex optionally set starting point for count (default is 0)
-	 * @returns proofs and newKeys if they have changed
+	 * @returns proofs (and newKeys, if they have changed)
 	 */
 	async restore(
 		count: number,
@@ -358,6 +358,7 @@ class CashuWallet {
 		if (!this._seed) {
 			throw new Error('CashuWallet must be initialized with mnemonic to use restore');
 		}
+		// create blank amounts for unknown restore amounts
 		const amounts = Array(count).fill(0);
 		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, startIndex, keysetId);
 
@@ -484,7 +485,7 @@ class CashuWallet {
 	/**
 	 * Creates blinded messages for a given amount
 	 * @param amount amount to create blinded messages for
-	 * @param preference optional preference for splitting proofs into specific amounts. overrides amount param
+	 * @param amountPreference optional preference for splitting proofs into specific amounts. overrides amount param
 	 * @param count? optionally set count to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
 	 * @returns blinded messages, secrets, rs, and amounts
 	 */
@@ -501,6 +502,7 @@ class CashuWallet {
 	 * Creates blinded messages for a according to @param amounts
 	 * @param amount array of amounts to create blinded messages for
 	 * @param count? optionally set count to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
+	 * @param keyksetId? override the keysetId derived from the current mintKeys with a custom one. This should be a keyset that was fetched from the `/keysets` endpoint
 	 * @returns blinded messages, secrets, rs, and amounts
 	 */
 	private createBlindedMessages(
@@ -526,7 +528,7 @@ class CashuWallet {
 			const blindedMessage = new BlindedMessage(amounts[i], B_);
 			blindedMessages.push(blindedMessage.getSerializedBlindedMessage());
 		}
-		return { amounts, blindedMessages, rs, secrets };
+		return { blindedMessages, secrets, rs, amounts };
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -346,13 +346,13 @@ class CashuWallet {
 
 	/**
 	 * Regenerates
+	 * @param start set starting point for count (first cycle for each keyset should usually be 0)
 	 * @param count set number of blinded messages that should be generated
-	 * @param startIndex optionally set starting point for count (default is 0)
 	 * @returns proofs (and newKeys, if they have changed)
 	 */
 	async restore(
+		start: number,
 		count: number,
-		startIndex = 0,
 		keysetId?: string
 	): Promise<{ proofs: Array<Proof>; newKeys?: MintKeys }> {
 		if (!this._seed) {
@@ -360,7 +360,7 @@ class CashuWallet {
 		}
 		// create blank amounts for unknown restore amounts
 		const amounts = Array(count).fill(0);
-		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, startIndex, keysetId);
+		const { blindedMessages, rs, secrets } = this.createBlindedMessages(amounts, start, keysetId);
 
 		const { outputs, promises } = await this.mint.restore({ outputs: blindedMessages });
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -325,14 +325,14 @@ class CashuWallet {
 	/**
 	 * Request tokens from the mint
 	 * @param amount amount to request
-	 * @param hash hash to use to identify the request*
+	 * @param id id to identify the mint request*
 	 * @param preference optional preference for splitting proofs into specific amounts. overrides amount param
 	 * @param count? optionally set count to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
 	 * @returns proofs and newKeys if they have changed
 	 */
 	async requestTokens(
 		amount: number,
-		hash: string,
+		id: string,
 		AmountPreference?: Array<AmountPreference>,
 		count?: number
 	): Promise<{ proofs: Array<Proof>; newKeys?: MintKeys }> {
@@ -342,7 +342,7 @@ class CashuWallet {
 			count
 		);
 		const payloads = { outputs: blindedMessages };
-		const { promises } = await this.mint.mint(payloads, hash);
+		const { promises } = await this.mint.mint(payloads, id);
 		return {
 			proofs: dhke.constructProofs(promises, rs, secrets, await this.getKeys(promises)),
 			newKeys: await this.changedKeys(promises)

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -369,6 +369,7 @@ class CashuWallet {
 
 		const { outputs, promises } = await this.mint.restore({ outputs: blindedMessages });
 
+		// Collect and map the secrets and blinding factors with the blinded messages that were returned from the mint 
 		const validRs = rs.filter((r, i) => outputs.map((o) => o.B_).includes(blindedMessages[i].B_));
 		const validSecrets = secrets.filter((s, i) =>
 			outputs.map((o) => o.B_).includes(blindedMessages[i].B_)

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -27,6 +27,8 @@ import {
 	splitAmount
 } from './utils.js';
 import { deriveBlindingFactor, deriveSecret, deriveSeedFromMnemonic } from './secrets.js';
+import { validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 
 /**
  * Class that represents a Cashu wallet.
@@ -50,6 +52,9 @@ class CashuWallet {
 			this._keysetId = deriveKeysetId(this._keys);
 		}
 		if (mnemonic) {
+			if (!validateMnemonic(mnemonic, wordlist)) {
+				throw new Error('Tried to instantiate with mnemonic, but mnemonic was invalid');
+			}
 			this._seed = deriveSeedFromMnemonic(mnemonic);
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { CashuWallet } from './CashuWallet.js';
 import { setGlobalRequestOptions } from './request.js';
 import { getEncodedToken, getDecodedToken, deriveKeysetId } from './utils.js';
 import { decode as getDecodedLnInvoice } from '@gandlaf21/bolt11-decode';
-
+import { generateNewMnemonic } from './secrets.js';
 export * from './model/types/index.js';
 
 export {
@@ -13,5 +13,6 @@ export {
 	getEncodedToken,
 	deriveKeysetId,
 	getDecodedLnInvoice,
-	setGlobalRequestOptions
+	setGlobalRequestOptions,
+	generateNewMnemonic
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { CashuWallet } from './CashuWallet.js';
 import { setGlobalRequestOptions } from './request.js';
 import { getEncodedToken, getDecodedToken, deriveKeysetId } from './utils.js';
 import { decode as getDecodedLnInvoice } from '@gandlaf21/bolt11-decode';
-import { generateNewMnemonic } from './secrets.js';
+import { generateNewMnemonic, deriveSeedFromMnemonic } from './secrets.js';
 export * from './model/types/index.js';
 
 export {
@@ -14,5 +14,6 @@ export {
 	deriveKeysetId,
 	getDecodedLnInvoice,
 	setGlobalRequestOptions,
-	generateNewMnemonic
+	generateNewMnemonic,
+	deriveSeedFromMnemonic
 };

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -337,7 +337,7 @@ export type GetInfoResponse = {
 	parameter: { peg_out_only: boolean };
 };
 /**
- * Response from mint at /info endpoint
+ * Response from mint at /restore endpoint
  */
 export type PostRestoreResponse = {
 	outputs: Array<SerializedBlindedMessage>;

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -336,6 +336,13 @@ export type GetInfoResponse = {
 	motd?: string;
 	parameter: { peg_out_only: boolean };
 };
+/**
+ * Response from mint at /info endpoint
+ */
+export type PostRestoreResponse = {
+	outputs: Array<SerializedBlindedMessage>
+    promises: Array<SerializedBlindedSignature>
+};
 
 export type AmountPreference = {
 	amount: number;

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -340,8 +340,8 @@ export type GetInfoResponse = {
  * Response from mint at /info endpoint
  */
 export type PostRestoreResponse = {
-	outputs: Array<SerializedBlindedMessage>
-    promises: Array<SerializedBlindedSignature>
+	outputs: Array<SerializedBlindedMessage>;
+	promises: Array<SerializedBlindedSignature>;
 };
 
 export type AmountPreference = {

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -40,7 +40,12 @@ const derive = (
 ): Uint8Array => {
 	const hdkey = HDKey.fromMasterSeed(seed);
 	const keysetIdInt = bytesToNumber(encodeBase64toUint8(keysetId)) % BigInt(2 ** 31 - 1);
-	const derived = hdkey.derive(`m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`);
+	const derivationPath = `m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`
+
+	//todo: remove this after tests are fixed
+	console.log(derivationPath)
+	
+	const derived = hdkey.derive(derivationPath);
 	if (derived.privateKey === null) {
 		throw new Error('Could not derive private key');
 	}

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -5,11 +5,11 @@ import { encodeBase64toUint8 } from './base64';
 import { bytesToNumber } from './utils';
 import { hexToNumber } from '@noble/curves/abstract/utils';
 
-const STANDARD_DERIVATION_PATH = `m/129372'/0'`
+const STANDARD_DERIVATION_PATH = `m/129372'/0'`;
 
-enum DerivationType{
-	SECRET=0,
-	BLINDING_FACTOR=1
+enum DerivationType {
+	SECRET = 0,
+	BLINDING_FACTOR = 1
 }
 
 export const generateNewMnemonic = (): string => {
@@ -41,7 +41,7 @@ const derive = (
 	secretOrBlinding: DerivationType
 ): Uint8Array => {
 	const hdkey = HDKey.fromMasterSeed(seed);
-	const keysetIdInt = getKeysetIdInt(keysetId)
+	const keysetIdInt = getKeysetIdInt(keysetId);
 	const derivationPath = `${STANDARD_DERIVATION_PATH}/${keysetIdInt}'/${counter}'/${secretOrBlinding}`;
 	const derived = hdkey.derive(derivationPath);
 	if (derived.privateKey === null) {
@@ -50,14 +50,13 @@ const derive = (
 	return derived.privateKey;
 };
 
-const getKeysetIdInt = (keysetId:string): bigint =>{
-	let keysetIdInt: bigint
+const getKeysetIdInt = (keysetId: string): bigint => {
+	let keysetIdInt: bigint;
 	if (/^[a-fA-F0-9]+$/.test(keysetId)) {
-		keysetIdInt = (hexToNumber(keysetId)) % BigInt(2 ** 31 - 1);
-	}
-	else {
+		keysetIdInt = hexToNumber(keysetId) % BigInt(2 ** 31 - 1);
+	} else {
 		//legacy keyset compatibility
 		keysetIdInt = bytesToNumber(encodeBase64toUint8(keysetId)) % BigInt(2 ** 31 - 1);
 	}
-	return keysetIdInt
-}
+	return keysetIdInt;
+};

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,0 +1,48 @@
+import { HDKey } from '@scure/bip32';
+import {
+	generateMnemonic,
+	validateMnemonic,
+	mnemonicToSeedSync
+} from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+import { encodeBase64toUint8 } from './base64';
+import { bytesToNumber } from './utils';
+export const generateNewMnemonic = (): string => {
+	const mnemonic = generateMnemonic(wordlist, 128);
+	if (!validateMnemonic(mnemonic, wordlist)) {
+		return generateNewMnemonic();
+	}
+	return mnemonic;
+};
+
+export const deriveSeedFromMnemonic = (mnemonic: string): Uint8Array => {
+	const seed = mnemonicToSeedSync(mnemonic);
+	return seed;
+};
+
+export const deriveSecret = (seed: Uint8Array, keysetId: string, counter: number): Uint8Array => {
+	return derive(seed, keysetId, counter, 0);
+};
+
+export const deriveBlindingFactor = (
+	seed: Uint8Array,
+	keysetId: string,
+	counter: number
+): Uint8Array => {
+	return derive(seed, keysetId, counter, 1);
+};
+
+const derive = (
+	seed: Uint8Array,
+	keysetId: string,
+	counter: number,
+	secretOrBlinding: 0 | 1
+): Uint8Array => {
+	const hdkey = HDKey.fromMasterSeed(seed);
+	const keysetIdInt = bytesToNumber(encodeBase64toUint8(keysetId)) % BigInt(2 ** 31 - 1);
+	const derived = hdkey.derive(`m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`);
+	if (derived.privateKey === null) {
+		throw new Error('Could not derive private key');
+	}
+	return derived.privateKey;
+};

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,9 +1,5 @@
 import { HDKey } from '@scure/bip32';
-import {
-	generateMnemonic,
-	validateMnemonic,
-	mnemonicToSeedSync
-} from '@scure/bip39';
+import { generateMnemonic, validateMnemonic, mnemonicToSeedSync } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 import { encodeBase64toUint8 } from './base64';
 import { bytesToNumber } from './utils';
@@ -40,11 +36,11 @@ const derive = (
 ): Uint8Array => {
 	const hdkey = HDKey.fromMasterSeed(seed);
 	const keysetIdInt = bytesToNumber(encodeBase64toUint8(keysetId)) % BigInt(2 ** 31 - 1);
-	const derivationPath = `m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`
+	const derivationPath = `m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`;
 
 	//todo: remove this after tests are fixed
-	console.log(derivationPath)
-	
+	console.log(derivationPath);
+
 	const derived = hdkey.derive(derivationPath);
 	if (derived.privateKey === null) {
 		throw new Error('Could not derive private key');

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -6,9 +6,6 @@ import { bytesToNumber } from './utils';
 import { hexToNumber } from '@noble/curves/abstract/utils';
 export const generateNewMnemonic = (): string => {
 	const mnemonic = generateMnemonic(wordlist, 128);
-	if (!validateMnemonic(mnemonic, wordlist)) {
-		return generateNewMnemonic();
-	}
 	return mnemonic;
 };
 

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -4,6 +4,14 @@ import { wordlist } from '@scure/bip39/wordlists/english';
 import { encodeBase64toUint8 } from './base64';
 import { bytesToNumber } from './utils';
 import { hexToNumber } from '@noble/curves/abstract/utils';
+
+const STANDARD_DERIVATION_PATH = `m/129372'/0'`
+
+enum DerivationType{
+	SECRET=0,
+	BLINDING_FACTOR=1
+}
+
 export const generateNewMnemonic = (): string => {
 	const mnemonic = generateMnemonic(wordlist, 128);
 	return mnemonic;
@@ -15,7 +23,7 @@ export const deriveSeedFromMnemonic = (mnemonic: string): Uint8Array => {
 };
 
 export const deriveSecret = (seed: Uint8Array, keysetId: string, counter: number): Uint8Array => {
-	return derive(seed, keysetId, counter, 0);
+	return derive(seed, keysetId, counter, DerivationType.SECRET);
 };
 
 export const deriveBlindingFactor = (
@@ -23,18 +31,18 @@ export const deriveBlindingFactor = (
 	keysetId: string,
 	counter: number
 ): Uint8Array => {
-	return derive(seed, keysetId, counter, 1);
+	return derive(seed, keysetId, counter, DerivationType.BLINDING_FACTOR);
 };
 
 const derive = (
 	seed: Uint8Array,
 	keysetId: string,
 	counter: number,
-	secretOrBlinding: 0 | 1
+	secretOrBlinding: DerivationType
 ): Uint8Array => {
 	const hdkey = HDKey.fromMasterSeed(seed);
 	const keysetIdInt = getKeysetIdInt(keysetId)
-	const derivationPath = `m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`;
+	const derivationPath = `${STANDARD_DERIVATION_PATH}/${keysetIdInt}'/${counter}'/${secretOrBlinding}`;
 	const derived = hdkey.derive(derivationPath);
 	if (derived.privateKey === null) {
 		throw new Error('Could not derive private key');

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -37,10 +37,6 @@ const derive = (
 	const hdkey = HDKey.fromMasterSeed(seed);
 	const keysetIdInt = bytesToNumber(encodeBase64toUint8(keysetId)) % BigInt(2 ** 31 - 1);
 	const derivationPath = `m/129372'/0'/${keysetIdInt}'/${counter}'/${secretOrBlinding}`;
-
-	//todo: remove this after tests are fixed
-	console.log(derivationPath);
-
 	const derived = hdkey.derive(derivationPath);
 	if (derived.privateKey === null) {
 		throw new Error('Could not derive private key');

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -1,42 +1,32 @@
-import {
-	deriveSecret,
-	generateNewMnemonic,
-	deriveSeedFromMnemonic,
-	deriveBlindingFactor
-} from '../src/secrets';
+import { bytesToHex } from "@noble/curves/abstract/utils";
+import { deriveSeedFromMnemonic } from "../src/secrets";
+import { deriveBlindingFactor, deriveSecret } from "../src/secrets";
+import { HDKey } from "@scure/bip32";
 
 const mnemonic =
-	'vehicle liberty balcony ensure label shiver garage fish shrimp various slam audit';
-const seed = new Uint8Array([
-	145, 161, 210, 31, 40, 240, 127, 134, 145, 5, 205, 11, 105, 44, 150, 208, 149, 141, 80, 33, 36,
-	57, 83, 205, 173, 128, 123, 107, 64, 199, 63, 176, 167, 239, 255, 243, 189, 64, 189, 51, 56, 24,
-	33, 162, 20, 119, 154, 207, 143, 74, 191, 58, 135, 167, 204, 46, 141, 115, 107, 182, 236, 248, 58,
-	150
-]);
-describe('testing deterministic secrets', () => {
-	test('generate new mnemonic', async () => {
-		const mnem = generateNewMnemonic();
-		console.log(mnem);
-		expect(mnem.split(' ').length).toBe(12);
-	});
+  "half depart obvious quality work element tank gorilla view sugar picture humble";
+const seed = deriveSeedFromMnemonic(mnemonic);
 
-	test('derive seed', async () => {
-		const seed = deriveSeedFromMnemonic(mnemonic);
-		console.log(seed);
-		expect(seed.toString()).toBe(
-			[
-				145, 161, 210, 31, 40, 240, 127, 134, 145, 5, 205, 11, 105, 44, 150, 208, 149, 141, 80, 33,
-				36, 57, 83, 205, 173, 128, 123, 107, 64, 199, 63, 176, 167, 239, 255, 243, 189, 64, 189, 51,
-				56, 24, 33, 162, 20, 119, 154, 207, 143, 74, 191, 58, 135, 167, 204, 46, 141, 115, 107, 182,
-				236, 248, 58, 150
-			].toString()
-		);
-	});
+describe("testing deterministic secrets", () => {
+  const secrets = [
+    "9bfb12704297fe90983907d122838940755fcce370ce51e9e00a4275a347c3fe",
+    "dbc5e05f2b1f24ec0e2ab6e8312d5e13f57ada52594d4caf429a697d9c742490",
+    "06a29fa8081b3a620b50b473fc80cde9a575c3b94358f3513c03007f8b66321e",
+    "652d08c804bd2c5f2c1f3e3d8895860397df394b30473753227d766affd15e89",
+    "654e5997f8a20402f7487296b6f7e463315dd52fc6f6cc5a4e35c7f6ccac77e0",
+  ];
+  test("derive Secret", async () => {
 
-	test('derive Secret', async () => {
-		const secret = deriveSecret(seed, 'z32vUtKgNCm1', 0);
-	});
-	test('derive BF', async () => {
-		const secret = deriveBlindingFactor(seed, 'z32vUtKgNCm1', 0);
-	});
+    const secret1 = deriveSecret(seed, "1cCNIAZ2X/w1", 0);
+    const secret2 = deriveSecret(seed, "1cCNIAZ2X/w1", 1);
+    const secret3 = deriveSecret(seed, "1cCNIAZ2X/w1", 2);
+    const secret4 = deriveSecret(seed, "1cCNIAZ2X/w1", 3);
+    const secret5 = deriveSecret(seed, "1cCNIAZ2X/w1", 4);
+
+    expect(bytesToHex(secret1)).toBe(secrets[0]);
+    expect(bytesToHex(secret2)).toBe(secrets[1]);
+    expect(bytesToHex(secret3)).toBe(secrets[2]);
+    expect(bytesToHex(secret4)).toBe(secrets[3]);
+    expect(bytesToHex(secret5)).toBe(secrets[4]);
+  })
 });

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -1,32 +1,64 @@
-import { bytesToHex } from "@noble/curves/abstract/utils";
-import { deriveSeedFromMnemonic } from "../src/secrets";
-import { deriveBlindingFactor, deriveSecret } from "../src/secrets";
-import { HDKey } from "@scure/bip32";
+import { bytesToHex } from '@noble/curves/abstract/utils';
+import { deriveSeedFromMnemonic } from '../src/secrets';
+import { deriveBlindingFactor, deriveSecret } from '../src/secrets';
+import { HDKey } from '@scure/bip32';
 
-const mnemonic =
-  "half depart obvious quality work element tank gorilla view sugar picture humble";
+const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
 const seed = deriveSeedFromMnemonic(mnemonic);
 
-describe("testing deterministic secrets", () => {
-  const secrets = [
-    "9bfb12704297fe90983907d122838940755fcce370ce51e9e00a4275a347c3fe",
-    "dbc5e05f2b1f24ec0e2ab6e8312d5e13f57ada52594d4caf429a697d9c742490",
-    "06a29fa8081b3a620b50b473fc80cde9a575c3b94358f3513c03007f8b66321e",
-    "652d08c804bd2c5f2c1f3e3d8895860397df394b30473753227d766affd15e89",
-    "654e5997f8a20402f7487296b6f7e463315dd52fc6f6cc5a4e35c7f6ccac77e0",
-  ];
-  test("derive Secret", async () => {
 
-    const secret1 = deriveSecret(seed, "1cCNIAZ2X/w1", 0);
-    const secret2 = deriveSecret(seed, "1cCNIAZ2X/w1", 1);
-    const secret3 = deriveSecret(seed, "1cCNIAZ2X/w1", 2);
-    const secret4 = deriveSecret(seed, "1cCNIAZ2X/w1", 3);
-    const secret5 = deriveSecret(seed, "1cCNIAZ2X/w1", 4);
+describe('testing hdkey from seed', () => {
+	test('hdkey from seed', async () => {
+		const hdkey = HDKey.fromMasterSeed(seed);
+		expect(hdkey).not.toBeNull();
+	});
 
-    expect(bytesToHex(secret1)).toBe(secrets[0]);
-    expect(bytesToHex(secret2)).toBe(secrets[1]);
-    expect(bytesToHex(secret3)).toBe(secrets[2]);
-    expect(bytesToHex(secret4)).toBe(secrets[3]);
-    expect(bytesToHex(secret5)).toBe(secrets[4]);
-  })
+	test('hdkey to uint8array', async () => {
+		const hdkey = HDKey.fromMasterSeed(seed);
+		const privateKey = hdkey.privateKey;
+		expect(privateKey).not.toBeNull();
+
+		const seed_expected =
+			'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8';
+		const seed_uint8_array_expected = Uint8Array.from(Buffer.from(seed_expected, 'hex'));
+		expect(seed).toEqual(seed_uint8_array_expected);
+	});
+});
+
+describe('testing deterministic secrets', () => {
+	const secrets = [
+		'9d32fc57e6fa2942d05ee475d28ba6a56839b8cb8a3f174b05ed0ed9d3a420f6',
+		'1c0f2c32e7438e7cc992612049e9dfcdbffd454ea460901f24cc429921437802',
+		'327c606b761af03cbe26fa13c4b34a6183b868c52cda059fe57fdddcb4e1e1e7',
+		'53476919560398b56c0fdc5dd92cf8628b1e06de6f2652b0f7d6e8ac319de3b7',
+		'b2f5d632229378a716be6752fc79ac8c2b43323b820859a7956f2dfe5432b7b4'
+	];
+	test('derive Secret', async () => {
+		const secret1 = deriveSecret(seed, '1cCNIAZ2X/w1', 0);
+		const secret2 = deriveSecret(seed, '1cCNIAZ2X/w1', 1);
+		const secret3 = deriveSecret(seed, '1cCNIAZ2X/w1', 2);
+		const secret4 = deriveSecret(seed, '1cCNIAZ2X/w1', 3);
+		const secret5 = deriveSecret(seed, '1cCNIAZ2X/w1', 4);
+
+		expect(bytesToHex(secret1)).toBe(secrets[0]);
+		expect(bytesToHex(secret2)).toBe(secrets[1]);
+		expect(bytesToHex(secret3)).toBe(secrets[2]);
+		expect(bytesToHex(secret4)).toBe(secrets[3]);
+		expect(bytesToHex(secret5)).toBe(secrets[4]);
+	});
+});
+
+describe('test private key derivation from derivation path', () => {
+	const seed =
+		'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8';
+	const seed_uint8_array = Uint8Array.from(Buffer.from(seed, 'hex'));
+	const hdkey = HDKey.fromMasterSeed(seed_uint8_array);
+	const expected_privatekey = '9d32fc57e6fa2942d05ee475d28ba6a56839b8cb8a3f174b05ed0ed9d3a420f6';
+	const derivation_path = "m/129372'/0'/2004500376'/0'/0";
+	const derived = hdkey.derive(derivation_path);
+	test('derive Secret', async () => {
+		expect(derived.privateKey).not.toBeNull();
+		const privateKey = derived.privateKey || new Uint8Array();
+		expect(bytesToHex(privateKey)).toBe(expected_privatekey);
+	});
 });

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -6,7 +6,6 @@ import { HDKey } from '@scure/bip32';
 const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
 const seed = deriveSeedFromMnemonic(mnemonic);
 
-
 describe('testing hdkey from seed', () => {
 	test('hdkey from seed', async () => {
 		const hdkey = HDKey.fromMasterSeed(seed);

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -1,0 +1,42 @@
+import {
+	deriveSecret,
+	generateNewMnemonic,
+	deriveSeedFromMnemonic,
+	deriveBlindingFactor
+} from '../src/secrets';
+
+const mnemonic =
+	'vehicle liberty balcony ensure label shiver garage fish shrimp various slam audit';
+const seed = new Uint8Array([
+	145, 161, 210, 31, 40, 240, 127, 134, 145, 5, 205, 11, 105, 44, 150, 208, 149, 141, 80, 33, 36,
+	57, 83, 205, 173, 128, 123, 107, 64, 199, 63, 176, 167, 239, 255, 243, 189, 64, 189, 51, 56, 24,
+	33, 162, 20, 119, 154, 207, 143, 74, 191, 58, 135, 167, 204, 46, 141, 115, 107, 182, 236, 248, 58,
+	150
+]);
+describe('testing deterministic secrets', () => {
+	test('generate new mnemonic', async () => {
+		const mnem = generateNewMnemonic();
+		console.log(mnem);
+		expect(mnem.split(' ').length).toBe(12);
+	});
+
+	test('derive seed', async () => {
+		const seed = deriveSeedFromMnemonic(mnemonic);
+		console.log(seed);
+		expect(seed.toString()).toBe(
+			[
+				145, 161, 210, 31, 40, 240, 127, 134, 145, 5, 205, 11, 105, 44, 150, 208, 149, 141, 80, 33,
+				36, 57, 83, 205, 173, 128, 123, 107, 64, 199, 63, 176, 167, 239, 255, 243, 189, 64, 189, 51,
+				56, 24, 33, 162, 20, 119, 154, 207, 143, 74, 191, 58, 135, 167, 204, 46, 141, 115, 107, 182,
+				236, 248, 58, 150
+			].toString()
+		);
+	});
+
+	test('derive Secret', async () => {
+		const secret = deriveSecret(seed, 'z32vUtKgNCm1', 0);
+	});
+	test('derive BF', async () => {
+		const secret = deriveBlindingFactor(seed, 'z32vUtKgNCm1', 0);
+	});
+});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -33,67 +33,74 @@ describe('test fees', () => {
 describe('receive', () => {
 	const tokenInput =
 		'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19';
-		test('test receive', async () => {
-			nock(mintUrl)
-				.post('/split')
-				.reply(200, {
-					promises: [
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						}
-					]
-				});
-			const wallet = new CashuWallet(mint);
-	
-			const { token: t, tokensWithErrors } = await wallet.receive(tokenInput);
-	
-			expect(t.token).toHaveLength(1);
-			expect(t.token[0].proofs).toHaveLength(1);
-			expect(t.token[0]).toMatchObject({
-				proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
-				mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
+	test('test receive', async () => {
+		nock(mintUrl)
+			.post('/split')
+			.reply(200, {
+				promises: [
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					}
+				]
 			});
-			expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-			expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-			expect(tokensWithErrors).toBe(undefined);
+		const wallet = new CashuWallet(mint);
+
+		const { token: t, tokensWithErrors } = await wallet.receive(tokenInput);
+
+		expect(t.token).toHaveLength(1);
+		expect(t.token[0].proofs).toHaveLength(1);
+		expect(t.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
+			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 		});
-		test('test receive custom split', async () => {
-			nock(mintUrl)
-				.post('/split')
-				.reply(200, {
-					promises: [
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						},
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						},
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						}
-					]
-				});
-			const wallet = new CashuWallet(mint);
-			const token3sat = 'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19'
-			const { token: t, tokensWithErrors } = await wallet.receive(token3sat, [{amount:1, count:3}]);
-	
-			expect(t.token).toHaveLength(1);
-			expect(t.token[0].proofs).toHaveLength(3);
-			expect(t.token[0]).toMatchObject({
-				proofs: [{ amount: 1, id: 'z32vUtKgNCm1' },{ amount: 1, id: 'z32vUtKgNCm1' },{ amount: 1, id: 'z32vUtKgNCm1' }],
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(tokensWithErrors).toBe(undefined);
+	});
+	test('test receive custom split', async () => {
+		nock(mintUrl)
+			.post('/split')
+			.reply(200, {
+				promises: [
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					},
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					},
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					}
+				]
 			});
-			expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-			expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-			expect(tokensWithErrors).toBe(undefined);
+		const wallet = new CashuWallet(mint);
+		const token3sat =
+			'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19';
+		const { token: t, tokensWithErrors } = await wallet.receive(token3sat, [
+			{ amount: 1, count: 3 }
+		]);
+
+		expect(t.token).toHaveLength(1);
+		expect(t.token[0].proofs).toHaveLength(3);
+		expect(t.token[0]).toMatchObject({
+			proofs: [
+				{ amount: 1, id: 'z32vUtKgNCm1' },
+				{ amount: 1, id: 'z32vUtKgNCm1' },
+				{ amount: 1, id: 'z32vUtKgNCm1' }
+			]
 		});
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(tokensWithErrors).toBe(undefined);
+	});
 	test('test receive tokens already spent', async () => {
 		const msg = 'tokens already spent. Secret: oEpEuViVHUV2vQH81INUbq++Yv2w3u5H0LhaqXJKeR0=';
 		nock(mintUrl).post('/split').reply(200, { detail: msg });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -9,6 +9,8 @@ const mint = new CashuMint(mintUrl);
 const invoice =
 	'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
 
+	const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
+
 beforeAll(() => {
 	nock.disableNetConnect();
 });
@@ -565,5 +567,22 @@ describe('send', () => {
 			.catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));
+	});
+});
+
+describe('deterministic', () => {
+	test('no seed', async () => {
+		const wallet = new CashuWallet(mint);
+		const result = await wallet
+		.send(1, [
+			{
+				id: 'z32vUtKgNCm1',
+				amount: 2,
+				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
+			}
+		], undefined, 1)
+		.catch((e) => e);
+		expect(result).toEqual(new Error('Cannot create deterministic messages without seed. Instantiate CashuWallet with a mnemonic, or omit count param.'));
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -9,7 +9,7 @@ const mint = new CashuMint(mintUrl);
 const invoice =
 	'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
 
-	const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
+const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
 
 beforeAll(() => {
 	nock.disableNetConnect();
@@ -574,15 +574,24 @@ describe('deterministic', () => {
 	test('no seed', async () => {
 		const wallet = new CashuWallet(mint);
 		const result = await wallet
-		.send(1, [
-			{
-				id: 'z32vUtKgNCm1',
-				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
-				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
-			}
-		], undefined, 1)
-		.catch((e) => e);
-		expect(result).toEqual(new Error('Cannot create deterministic messages without seed. Instantiate CashuWallet with a mnemonic, or omit count param.'));
+			.send(
+				1,
+				[
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 2,
+						secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+						C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
+					}
+				],
+				undefined,
+				1
+			)
+			.catch((e) => e);
+		expect(result).toEqual(
+			new Error(
+				'Cannot create deterministic messages without seed. Instantiate CashuWallet with a mnemonic, or omit count param.'
+			)
+		);
 	});
 });


### PR DESCRIPTION
# new feature: Deterministic secrets and restore from seed phrase :fire: 

## Description

This PR introduces the functionality for creating ecash derived from a seed. This allows for a backup and restore scheme where the wallet owner only needs to store the 12 words seed phrase to restore his ecash.

## Changes

**External changes**
- Add and expose function `generateNewMnemonic()` for creating new mnemonics
- Add optional `mnemonic` param to pass mnemonic to `CashuWallet` constructor
- Add optional `count` param to all functions that create tokens, to pass the current state of the derivation path
- Add restore() function that recreates ecash that has previously been signed by the mint (doesn't check for validity!)

**Internal changes**
- Add paths for deterministic secret and blinding factor if `mnemonic` and `count` are present
- Implementation secret and blinding factor derivation from seed 
- refactored `createblankOutputs` to reduce duplicate code 

There are no breaking changes, deterministic secrets is opt in. By ommiting  `count` or `mnemonic` params, ecash will be generated randomly.

## how it works

presentation slides --> https://det-sec.gandlaf.com/

## Usage

```typescript
import { CashuMint, CashuWallet, generateNewMnemonic } from '@cashu/cashu-ts';

//generate seed phrase
const seed = generateNewMnemonic();

const cashuMint = new CashuMint('https://.........');

// initialize wallet with seed phrase
const wallet = new CashuWallet(cashuMint, mint.keys, seed);

// as the implementer we have to keep track of the current counter of a keyset as an example, 
// we asume we store the counter in keysetID.counter. (The counter needs to be persistent)
// pass counter into function that creates proofs. 
const {proofs, newKeys} = await wallet.receive({{ some token }}, undefined, keysetID.counter) 

// You need to update your wallet internal counter,
// for the keysetID by the number of proofs that were created
keysetID.counter += proofs.length

// restore. can be called multiple times as long as we find new signatures. 
//In this case it would recreate the blinded messages from 100 to 200
const { proofs, newKeys } = await wallet.restore(100, 100);

// check for valid ecash after creating proofs
const {proofs: validProofs} = await wallet.checkProofsSpent(proofs)

```

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
