### PR TITLE
Cashu V1 API

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,10 +4,9 @@
 name: Node.js CI
 
 on: 
-  pull_request:
-    types:
-      - ready_for_review
-      - opened
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -15,9 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 16.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -28,3 +25,9 @@ jobs:
       - run: npm ci
       - run: npm run compile
       - run: npm test
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          destination_dir: coverage
+          publish_dir: ./coverage/lcov-report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,10 +8,10 @@ on:
   push:
     branches:
       - '*'
-  pull_request:
-    types:
-      - ready_for_review
-      - opened
+  # pull_request:
+  #   types:
+  #     - ready_for_review
+  #     - opened
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,14 @@
 
 name: Node.js CI
 
-on: [pull_request]
+on: 
+  pull_request:
+    types:
+      - ready_for_review
+      - opened
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,7 +6,7 @@ name: Node.js CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,3 +24,9 @@ jobs:
       - run: npm ci
       - run: npm run compile
       - run: npm test
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          destination_dir: coverage
+          publish_dir: ./coverage/lcov-report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,15 +3,7 @@
 
 name: Node.js CI
 
-on:
-  # push for all branches
-  push:
-    branches:
-      - '*'
-  # pull_request:
-  #   types:
-  #     - ready_for_review
-  #     - opened
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,11 @@
 
 name: Node.js CI
 
-on: 
+on:
+  # push for all branches
+  push:
+    branches:
+      - '*'
   pull_request:
     types:
       - ready_for_review

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -14,9 +14,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Compose
-        run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
+        uses: docker/compose-action@v1
+        with:
+          compose-yaml: docker-compose.yml
+          compose-version: '1.27.4'
 
       - name: Build and start services
         run: |
@@ -26,10 +27,10 @@ jobs:
       - name: Run ifconfig
         run: ifconfig
       - name: Curl on localhost:4448/keys
-        run: curl http://127.0.0.1:4448/
+        run: curl http://localhost:4448/
 
       - name: Curl on localhost:3338/keys
-        run: curl http://127.0.0.1:3338/keys
+        run: curl http://localhost:3338/keys
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -7,12 +7,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Set up Docker Compose
-        uses: adambirds/docker-compose-action@v1.3.0
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
       - name: Checkout Nutshell repository
         uses: actions/checkout@v2
         with:
           repository: 'cashubtc/nutshell'
-          ref: 'docker-network-mode-host'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and start mint

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -24,6 +24,10 @@ jobs:
         run: |
           docker-compose up -d
 
+      - name: Navigate to the parent directory
+        run: cd ..
+      - uses: actions/checkout@v3
+
       - name: Run Tests
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Set up Docker Compose
         uses: adambirds/docker-compose-action@v1.3.0
@@ -13,6 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'cashubtc/nutshell'
+          ref: 'docker/network_mode_host'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and start mint
         run: |

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -1,0 +1,42 @@
+name: CI Test Workflow
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:19.03.12
+        ports:
+          - 3338:3338
+        options: --privileged
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          repository: 'cashubtc/nutshell'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and Run Docker Container
+        run: |
+          docker build -t nutshell-app .
+          docker run -d -e MINT_LIGHTNING_BACKEND=FakeWallet -p 3338:3338 nutshell-app
+
+      - name: Execute Command Inside the Container
+        run: |
+          docker exec $(docker ps -q) poetry run mint --port 3338 --host 0.0.0.0
+
+      - name: Run Tests
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20x
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run compile
+      - run: npm test

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -14,10 +14,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Compose
-        uses: docker/compose-action@v1
+        uses: adambirds/docker-compose-action@v1.3.0
         with:
-          compose-yaml: docker-compose.yml
-          compose-version: '1.27.4'
+          compose-file: docker-compose.yml
 
       - name: Build and start services
         run: |

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -1,7 +1,7 @@
 name: CI Test Workflow
 
-# on: [push, pull_request]
-on: []
+on: [push, pull_request]
+# on: []
 
 jobs:
   build-and-test:

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -14,6 +14,7 @@ jobs:
           repository: 'cashubtc/nutshell'
           ref: 'docker-network-mode-host'
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and start mint
         run: |
           docker-compose up -d

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Build and start mint
         run: |
           docker-compose up -d
-      - name: Run ifconfig
-        run: ifconfig
+      - name: Run netstat
+        run: netstat -lp
       - name: Curl on localhost:3338/keys
         run: curl http://localhost:3338/keys
       - name: Navigate to the parent directory

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -1,16 +1,15 @@
 name: CI Test Workflow
 
 on: [push, pull_request]
-# on: []
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Compose
+      - name: Set up Docker
         run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
+          sudo apt-get update
+          sudo apt-get install -y docker.io
 
       - name: Checkout Nutshell repository
         uses: actions/checkout@v2
@@ -18,22 +17,27 @@ jobs:
           repository: 'cashubtc/nutshell'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and start mint
+      - name: Pull and start mint
         run: |
-          docker-compose up -d
-      - name: Run netstat
-        run: netstat -lp
+          sudo docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.15.0 poetry run mint
+
+      - name: Check running containers
+        run: sudo docker ps
+
       - name: Curl on localhost:3338/keys
         run: curl http://localhost:3338/keys
+
       - name: Navigate to the parent directory
         run: cd ..
+
       - name: Checkout cashu-ts repository
         uses: actions/checkout@v3
 
-      - name: Run Tests
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           cache: 'npm'
+
       - run: npm ci
       - run: npm run compile
       - run: npm run test-integration

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           docker-compose up -d
       - name: Check if services are running
-        run: docker-compose ps
+        run: netstat -lp
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -19,11 +19,6 @@ jobs:
           sudo chmod +x /usr/local/bin/docker-compose
 
       - name: Build and start services
-        env:
-          MINT_LIGHTNING_BACKEND: FakeWallet
-          MINT_LISTEN_HOST: 0.0.0.0
-          MINT_LISTEN_PORT: 3338
-          MINT_PRIVATE_KEY: TEST_PRIVATE_KEY
         run: |
           docker-compose up
       - name: Check if services are running

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'cashubtc/nutshell'
-          ref: 'docker/network_mode_host'
+          ref: 'docker-network-mode-host'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and start mint
         run: |

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Build and start mint
         run: |
           docker-compose up -d
+      - name: Run ifconfig
+        run: ifconfig
       - name: Curl on localhost:3338/keys
         run: curl http://localhost:3338/keys
       - name: Navigate to the parent directory

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -1,4 +1,4 @@
-name: CI Test Workflow
+name: Nutshell end-to-end tests
 
 on: [push, pull_request]
 
@@ -13,10 +13,10 @@ jobs:
       - name: Check running containers
         run: docker ps
 
-      - name: Sleep 5 seconds and curl on localhost:3338/v1/keys
-        run: |
-          sleep 5
-          curl localhost:3338/v1/keys
+      # - name: Sleep 5 seconds and curl on localhost:3338/v1/info
+      #   run: |
+      #     sleep 5
+      #     curl localhost:3338/v1/info
 
       - name: Checkout cashu-ts repository
         uses: actions/checkout@v3

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           MINT_LIGHTNING_BACKEND: FakeWallet
         run: |
-          docker-compose up -d
+          docker-compose up --build -d
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Set up Docker Compose
         uses: adambirds/docker-compose-action@v1.3.0
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build and start mint
         run: |
-          docker-compose up
+          docker-compose up -d
       - name: Run netstat
         run: netstat -lp
       - name: Curl on localhost:3338/keys

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Docker Compose
         uses: adambirds/docker-compose-action@v1.3.0
         with:
-          compose-file: nutshell/docker-compose.yml
+          compose-file: ../nutshell/docker-compose.yml
 
       - name: Build and start services
         run: |

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -13,8 +13,10 @@ jobs:
       - name: Check running containers
         run: docker ps
 
-      - name: Curl on localhost:3338/v1/keys
-        run: curl http://localhost:3338/v1/keys
+      - name: Sleep 5 seconds and curl on localhost:3338/v1/keys
+        run: |
+          sleep 5
+          curl localhost:3338/v1/keys
 
       - name: Checkout cashu-ts repository
         uses: actions/checkout@v3

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -25,7 +25,7 @@ jobs:
           MINT_LISTEN_PORT: 3338
           MINT_PRIVATE_KEY: TEST_PRIVATE_KEY
         run: |
-          docker-compose up --build -d
+          docker-compose up -d
       - name: Check if services are running
         run: docker-compose ps
 
@@ -39,4 +39,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run compile
-      - run: npm test-integration
+      - run: npm run test-integration

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build and start mint
         run: |
-          docker-compose up -d
+          docker-compose up -d && netstat -lp
       - name: Run netstat
         run: netstat -lp
       - name: Curl on localhost:3338/keys

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Docker Compose
         uses: adambirds/docker-compose-action@v1.3.0
         with:
-          compose-file: docker-compose.yml
+          compose-file: nutshell/docker-compose.yml
 
       - name: Build and start services
         run: |

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run ifconfig
         run: ifconfig
       - name: Curl on localhost:3338/keys
-        run: curl http://mint:3338/keys
+        run: curl http://127.0.0.1:3338/keys
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -23,6 +23,8 @@ jobs:
           MINT_LIGHTNING_BACKEND: FakeWallet
         run: |
           docker-compose up --build -d
+      - name: Check if services are running
+        run: docker-compose ps
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -1,15 +1,17 @@
 name: CI Test Workflow
 
-on: [push, pull_request]
+# on: [push, pull_request]
+on: []
 
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
+
       - name: Checkout Nutshell repository
         uses: actions/checkout@v2
         with:
@@ -25,7 +27,8 @@ jobs:
         run: curl http://localhost:3338/keys
       - name: Navigate to the parent directory
         run: cd ..
-      - uses: actions/checkout@v3
+      - name: Checkout cashu-ts repository
+        uses: actions/checkout@v3
 
       - name: Run Tests
         uses: actions/setup-node@v3

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -25,6 +25,9 @@ jobs:
         run: netstat -lp
       - name: Run ifconfig
         run: ifconfig
+      - name: Curl on localhost:4448/keys
+        run: curl http://127.0.0.1:4448/
+
       - name: Curl on localhost:3338/keys
         run: curl http://127.0.0.1:3338/keys
 

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -23,6 +23,8 @@ jobs:
           docker-compose up -d
       - name: Check if services are running
         run: netstat -lp
+      - name: Run ifconfig
+        run: ifconfig
       - name: Curl on localhost:3338/keys
         run: curl http://mint:3338/keys
 

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -28,6 +28,8 @@ jobs:
           docker-compose up -d
       - name: Check if services are running
         run: netstat -lp
+      - name: Curl on localhost:3338/keys
+        run: curl http://localhost:3338/keys
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check if services are running
         run: netstat -lp
       - name: Curl on localhost:3338/keys
-        run: curl http://localhost:3338/keys
+        run: curl http://mint:3338/keys
 
       - name: Navigate to the parent directory
         run: cd ..

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Build and start services
         env:
           MINT_LIGHTNING_BACKEND: FakeWallet
+          MINT_LISTEN_HOST: 0.0.0.0
+          MINT_LISTEN_PORT: 3338
+          MINT_PRIVATE_KEY: TEST_PRIVATE_KEY
         run: |
           docker-compose up --build -d
       - name: Check if services are running
@@ -36,4 +39,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run compile
-      - run: npm test
+      - run: npm test-integration

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -6,29 +6,15 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-
-      - name: Checkout Nutshell repository
-        uses: actions/checkout@v2
-        with:
-          repository: 'cashubtc/nutshell'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Pull and start mint
         run: |
-          sudo docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.15.0 poetry run mint
+          docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.15.0 poetry run mint
 
       - name: Check running containers
-        run: sudo docker ps
+        run: docker ps
 
-      - name: Curl on localhost:3338/keys
-        run: curl http://localhost:3338/keys
-
-      - name: Navigate to the parent directory
-        run: cd ..
+      - name: Curl on localhost:3338/v1/keys
+        run: curl http://localhost:3338/v1/keys
 
       - name: Checkout cashu-ts repository
         uses: actions/checkout@v3

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -7,30 +7,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Set up Docker Compose
+        uses: adambirds/docker-compose-action@v1.3.0
+      - name: Checkout Nutshell repository
         uses: actions/checkout@v2
         with:
           repository: 'cashubtc/nutshell'
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Compose
-        uses: adambirds/docker-compose-action@v1.3.0
-        with:
-          compose-file: ../nutshell/docker-compose.yml
-
-      - name: Build and start services
+      - name: Build and start mint
         run: |
           docker-compose up -d
-      - name: Check if services are running
-        run: netstat -lp
-      - name: Run ifconfig
-        run: ifconfig
-      - name: Curl on localhost:4448/keys
-        run: curl http://localhost:4448/
-
       - name: Curl on localhost:3338/keys
         run: curl http://localhost:3338/keys
-
       - name: Navigate to the parent directory
         run: cd ..
       - uses: actions/checkout@v3

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Run Tests
         uses: actions/setup-node@v3
         with:
-          node-version: 20x
           cache: 'npm'
       - run: npm ci
       - run: npm run compile

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -25,7 +25,7 @@ jobs:
           MINT_LISTEN_PORT: 3338
           MINT_PRIVATE_KEY: TEST_PRIVATE_KEY
         run: |
-          docker-compose up -d
+          docker-compose up
       - name: Check if services are running
         run: netstat -lp
       - name: Curl on localhost:3338/keys

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build and start mint
         run: |
-          docker-compose up -d && netstat -lp
+          docker-compose up
       - name: Run netstat
         run: netstat -lp
       - name: Curl on localhost:3338/keys

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -6,13 +6,6 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    services:
-      docker:
-        image: docker:19.03.12
-        ports:
-          - 3338:3338
-        options: --privileged
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -20,17 +13,16 @@ jobs:
           repository: 'cashubtc/nutshell'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build and Run Docker Container
+      - name: Set up Docker Compose
         run: |
-          docker build -t nutshell-app .
-          docker run -d -e MINT_LIGHTNING_BACKEND=FakeWallet -p 3338:3338 nutshell-app
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: Execute Command Inside the Container
+      - name: Build and start services
+        env:
+          MINT_LIGHTNING_BACKEND: FakeWallet
         run: |
-          docker exec $(docker ps -q) poetry run mint --port 3338 --host 0.0.0.0
+          docker-compose up -d
 
       - name: Run Tests
         uses: actions/setup-node@v3

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build and start services
         run: |
-          docker-compose up
+          docker-compose up -d
       - name: Check if services are running
         run: netstat -lp
       - name: Curl on localhost:3338/keys

--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -3,7 +3,7 @@ name: Nutshell end-to-end tests
 on: [push, pull_request]
 
 jobs:
-  build-and-test:
+  integration:
     runs-on: ubuntu-latest
     steps:
       - name: Pull and start mint

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -28,4 +28,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          destination_dir: docs
           publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![npm](https://img.shields.io/npm/v/@cashu/cashu-ts)
 ![npm type definitions](https://img.shields.io/npm/types/@cashu/cashu-ts)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/@cashu/cashu-ts)
-[code coverage](https://cashubtc.github.io/docs/cashu-ts/)
+[code coverage](https://cashubtc.github.io/cashu-ts/coverage)
 
 ⚠️ **Don't be reckless:** This project is in early development, it does however work with real sats! Always use amounts you don't mind losing.
 
@@ -44,7 +44,7 @@ Supported token formats:
 
 ## Usage
 
-Go to the [docs](https://cashubtc.github.io/docs/cashu-ts/) for detailed usage.
+Go to the [docs](https://cashubtc.github.io/cashu-ts/docs) for detailed usage.
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![npm](https://img.shields.io/npm/v/@cashu/cashu-ts)
 ![npm type definitions](https://img.shields.io/npm/types/@cashu/cashu-ts)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/@cashu/cashu-ts)
+[code coverage](https://cashubtc.github.io/docs/cashu-ts/)
 
 ⚠️ **Don't be reckless:** This project is in early development, it does however work with real sats! Always use amounts you don't mind losing.
 
@@ -43,7 +44,7 @@ Supported token formats:
 
 ## Usage
 
-Go to the [docs](https://cashubtc.github.io/cashu-ts/) for detailed usage.
+Go to the [docs](https://cashubtc.github.io/docs/cashu-ts/) for detailed usage.
 
 ### Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "0.8.2-rc.4",
+	"version": "0.8.2-rc.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cashu/cashu-ts",
-			"version": "0.8.2-rc.4",
+			"version": "0.8.2-rc.5",
 			"license": "MIT",
 			"dependencies": {
 				"@gandlaf21/bolt11-decode": "^3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "0.8.2-rc.5",
+	"version": "0.8.2-rc.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cashu/cashu-ts",
-			"version": "0.8.2-rc.5",
+			"version": "0.8.2-rc.6",
 			"license": "MIT",
 			"dependencies": {
 				"@gandlaf21/bolt11-decode": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "0.8.2-rc.5",
+	"version": "0.8.2-rc.6",
 	"description": "cashu library for communicating with a cashu mint",
 	"main": "dist/lib/es5/index.js",
 	"module": "dist/lib/es6/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "0.8.2-rc.4",
+	"version": "0.8.2-rc.5",
 	"description": "cashu library for communicating with a cashu mint",
 	"main": "dist/lib/es5/index.js",
 	"module": "dist/lib/es6/index.js",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 	},
 	"scripts": {
 		"compile": "rm -rf dist/lib && tsc && tsc --build tsconfig.es5.json",
-		"test": "jest --coverage --testPathIgnorePatterns ./test/integration.test.ts",
-		"test-integration": "jest --coverage --testPathPattern ./test/integration.test.ts",
+        "test": "jest --coverage --testPathIgnorePatterns ./test/integration.test.ts",  
+        "test-integration": "jest --coverage --testPathPattern ./test/integration.test.ts",  
 		"dev": "tsc --watch",
 		"lint": "eslint --ext .js,.ts . --fix",
 		"format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 	},
 	"scripts": {
 		"compile": "rm -rf dist/lib && tsc && tsc --build tsconfig.es5.json",
-		"test": "jest --coverage",
+		"test": "jest --coverage --testPathIgnorePatterns ./test/integration.test.ts",
+		"test-integration": "jest --coverage --testPathPattern ./test/integration.test.ts",
 		"dev": "tsc --watch",
 		"lint": "eslint --ext .js,.ts . --fix",
 		"format": "prettier --write .",

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -1,6 +1,6 @@
 import {
-	CheckSpendablePayload,
-	CheckSpendableResponse,
+	CheckStatePayload,
+	CheckStateResponse,
 	GetInfoResponse,
 	MeltPayload,
 	MeltResponse,
@@ -180,7 +180,7 @@ class CashuMint {
 	public static async split(mintUrl: string, splitPayload: SplitPayload, customRequest?: typeof request): Promise<SplitResponse> {
 		const requestInstance = customRequest || request;
 		const data = await requestInstance<SplitResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/split'),
+			endpoint: joinUrls(mintUrl, '/v1/swap'),
 			method: 'POST',
 			requestBody: splitPayload
 		});
@@ -244,7 +244,7 @@ class CashuMint {
 		if (
 			!isObj(data) ||
 			typeof data?.paid !== 'boolean' ||
-			(data?.proof !== null && typeof data?.proof !== 'string')
+			(data?.payment_preimage !== null && typeof data?.payment_preimage !== 'string')
 		) {
 			throw new Error('bad response');
 		}
@@ -268,17 +268,17 @@ class CashuMint {
 	 */
 	public static async check(
 		mintUrl: string,
-		checkPayload: CheckSpendablePayload,
+		checkPayload: CheckStatePayload,
 		customRequest?: typeof request
-	): Promise<CheckSpendableResponse> {
+	): Promise<CheckStateResponse> {
 		const requestInstance = customRequest || request;
-		const data = await requestInstance<CheckSpendableResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/check'),
+		const data = await requestInstance<CheckStateResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/checkstate'),
 			method: 'POST',
 			requestBody: checkPayload
 		});
 
-		if (!isObj(data) || !Array.isArray(data?.spendable)) {
+		if (!isObj(data) || !Array.isArray(data?.states)) {
 			throw new Error('bad response');
 		}
 
@@ -289,7 +289,7 @@ class CashuMint {
 	 * @param checkPayload
 	 * @returns redeemed and unredeemed ordered list of booleans
 	 */
-	async check(checkPayload: CheckSpendablePayload): Promise<CheckSpendableResponse> {
+	async check(checkPayload: CheckStatePayload): Promise<CheckStateResponse> {
 		return CashuMint.check(this._mintUrl, checkPayload, this._customRequest);
 	}
 

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -8,8 +8,6 @@ import {
 	MintActiveKeys,
 	MintAllKeysets,
 	RequestMintResponse,
-	SerializedBlindedMessage,
-	SerializedBlindedSignature,
 	SplitPayload,
 	SplitResponse,
 	RequestMintPayload,
@@ -239,37 +237,6 @@ class CashuMint {
 	async melt(meltPayload: MeltPayload): Promise<MeltResponse> {
 		return CashuMint.melt(this._mintUrl, meltPayload);
 	}
-	// /**
-	//  * Estimate fees for a given LN invoice
-	//  * @param mintUrl
-	//  * @param checkfeesPayload Payload containing LN invoice that needs to get a fee estimate
-	//  * @returns estimated Fee
-	//  */
-	// public static async checkFees(
-	// 	mintUrl: string,
-	// 	checkfeesPayload: { pr: string }
-	// ): Promise<{ fee: number }> {
-	// 	const data = await request<{ fee: number }>({
-	// 		endpoint: joinUrls(mintUrl, 'checkfees'),
-	// 		method: 'POST',
-	// 		requestBody: checkfeesPayload
-	// 	});
-
-	// 	if (!isObj(data) || typeof data?.fee !== 'number') {
-	// 		throw new Error('bad response');
-	// 	}
-
-	// 	return data;
-	// }
-	// /**
-	//  * Estimate fees for a given LN invoice
-	//  * @param mintUrl
-	//  * @param checkfeesPayload Payload containing LN invoice that needs to get a fee estimate
-	//  * @returns estimated Fee
-	//  */
-	// async checkFees(checkfeesPayload: { pr: string }): Promise<{ fee: number }> {
-	// 	return CashuMint.checkFees(this._mintUrl, checkfeesPayload);
-	// }
 	/**
 	 * Checks if specific proofs have already been redeemed
 	 * @param mintUrl
@@ -281,7 +248,7 @@ class CashuMint {
 		checkPayload: CheckSpendablePayload
 	): Promise<CheckSpendableResponse> {
 		const data = await request<CheckSpendableResponse>({
-			endpoint: joinUrls(mintUrl, 'check'),
+			endpoint: joinUrls(mintUrl, '/v1/check'),
 			method: 'POST',
 			requestBody: checkPayload
 		});

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -162,12 +162,12 @@ class CashuMint {
 	 */
 	public static async split(mintUrl: string, splitPayload: SplitPayload): Promise<SplitResponse> {
 		const data = await request<SplitResponse>({
-			endpoint: joinUrls(mintUrl, 'split'),
+			endpoint: joinUrls(mintUrl, '/v1/split'),
 			method: 'POST',
 			requestBody: splitPayload
 		});
 
-		if (!isObj(data) || !Array.isArray(data?.promises)) {
+		if (!isObj(data) || !Array.isArray(data?.signatures)) {
 			throw new Error('bad response');
 		}
 
@@ -239,37 +239,37 @@ class CashuMint {
 	async melt(meltPayload: MeltPayload): Promise<MeltResponse> {
 		return CashuMint.melt(this._mintUrl, meltPayload);
 	}
-	/**
-	 * Estimate fees for a given LN invoice
-	 * @param mintUrl
-	 * @param checkfeesPayload Payload containing LN invoice that needs to get a fee estimate
-	 * @returns estimated Fee
-	 */
-	public static async checkFees(
-		mintUrl: string,
-		checkfeesPayload: { pr: string }
-	): Promise<{ fee: number }> {
-		const data = await request<{ fee: number }>({
-			endpoint: joinUrls(mintUrl, 'checkfees'),
-			method: 'POST',
-			requestBody: checkfeesPayload
-		});
+	// /**
+	//  * Estimate fees for a given LN invoice
+	//  * @param mintUrl
+	//  * @param checkfeesPayload Payload containing LN invoice that needs to get a fee estimate
+	//  * @returns estimated Fee
+	//  */
+	// public static async checkFees(
+	// 	mintUrl: string,
+	// 	checkfeesPayload: { pr: string }
+	// ): Promise<{ fee: number }> {
+	// 	const data = await request<{ fee: number }>({
+	// 		endpoint: joinUrls(mintUrl, 'checkfees'),
+	// 		method: 'POST',
+	// 		requestBody: checkfeesPayload
+	// 	});
 
-		if (!isObj(data) || typeof data?.fee !== 'number') {
-			throw new Error('bad response');
-		}
+	// 	if (!isObj(data) || typeof data?.fee !== 'number') {
+	// 		throw new Error('bad response');
+	// 	}
 
-		return data;
-	}
-	/**
-	 * Estimate fees for a given LN invoice
-	 * @param mintUrl
-	 * @param checkfeesPayload Payload containing LN invoice that needs to get a fee estimate
-	 * @returns estimated Fee
-	 */
-	async checkFees(checkfeesPayload: { pr: string }): Promise<{ fee: number }> {
-		return CashuMint.checkFees(this._mintUrl, checkfeesPayload);
-	}
+	// 	return data;
+	// }
+	// /**
+	//  * Estimate fees for a given LN invoice
+	//  * @param mintUrl
+	//  * @param checkfeesPayload Payload containing LN invoice that needs to get a fee estimate
+	//  * @returns estimated Fee
+	//  */
+	// async checkFees(checkfeesPayload: { pr: string }): Promise<{ fee: number }> {
+	// 	return CashuMint.checkFees(this._mintUrl, checkfeesPayload);
+	// }
 	/**
 	 * Checks if specific proofs have already been redeemed
 	 * @param mintUrl

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -129,9 +129,9 @@ class CashuMint {
 	 * @returns the mints public keys
 	 */
 	async getKeys(keysetId?: string, mintUrl?: string, unit?: string): Promise<MintKeys> {
-		const allKeys = CashuMint.getKeys(mintUrl || this._mintUrl, keysetId);
+		const allKeys = await CashuMint.getKeys(mintUrl || this._mintUrl, keysetId);
 		// find keyset with unit 'sat'
-		const satKeys = ((await allKeys).keysets).find((keys) => keys.unit === unit ? unit : 'sat');
+		const satKeys = (allKeys.keysets).find((keys) => keys.unit === unit ? unit : 'sat');
 		if (!satKeys) {
 			throw new Error('No keyset with unit "sat" found');
 		}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from '@noble/hashes/utils';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
 import { CashuMint } from './CashuMint.js';
 import * as dhke from './DHKE.js';
 import { BlindedMessage } from './model/BlindedMessage.js';
@@ -30,7 +30,6 @@ import {
 	getDefaultAmountPreference,
 	splitAmount
 } from './utils.js';
-import { bytesToHex } from '@noble/curves/abstract/utils';
 import { deriveBlindingFactor, deriveSecret, deriveSeedFromMnemonic } from './secrets.js';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
@@ -557,15 +556,17 @@ class CashuWallet {
 		const rs: Array<bigint> = [];
 		for (let i = 0; i < amounts.length; i++) {
 			let deterministicR = undefined;
-			let secret = undefined;
+			let secretBytes = undefined;
 			if (this._seed && counter != undefined) {
-				secret = deriveSecret(this._seed, keysetId ?? this.keysetId, counter + i);
+				secretBytes = deriveSecret(this._seed, keysetId ?? this.keysetId, counter + i);
 				deterministicR = bytesToNumber(
 					deriveBlindingFactor(this._seed, keysetId ?? this.keysetId, counter + i)
 				);
 			} else {
-				secret = randomBytes(32);
+				secretBytes = randomBytes(32);
 			}
+			const secretHex = bytesToHex(secretBytes);
+			const secret = new TextEncoder().encode(secretHex);
 			secrets.push(secret);
 			const { B_, r } = dhke.blindMessage(secret, deterministicR);
 			rs.push(r);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -9,9 +9,7 @@ import {
 	MeltPayload,
 	MeltQuoteResponse,
 	MintKeys,
-	MintKeyset,
 	MeltTokensResponse,
-	PaymentPayload,
 	PostMintPayload,
 	Proof,
 	ReceiveResponse,
@@ -25,7 +23,6 @@ import {
 } from './model/types/index.js';
 import {
 	cleanToken,
-	deriveKeysetId,
 	getDecodedToken,
 	getDefaultAmountPreference,
 	splitAmount

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -265,7 +265,7 @@ class CashuWallet {
 			const splitProofsToSend: Array<Proof> = [];
 			let amountKeepCounter = 0;
 			proofs.forEach((proof) => {
-				if (amountKeepCounter < amount - amountSend) {
+				if (amountKeepCounter < amountKeep) {
 					amountKeepCounter += proof.amount;
 					splitProofsToKeep.push(proof);
 					return;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -99,7 +99,6 @@ class CashuWallet {
 	 */
 	async getMeltQuote(invoice: string): Promise<MeltQuoteResponse> {
 		const meltQuote = await this.mint.meltQuote({ unit: this.unit, request: invoice });
-		// const { fee } = await this.mint.checkFees({ pr: invoice });
 		return meltQuote;
 	}
 	/**
@@ -217,12 +216,12 @@ class CashuWallet {
 				tokenEntry.proofs,
 				preference
 			);
-			const { promises, error } = await CashuMint.split(tokenEntry.mint, payload);
+			const { signatures, error } = await CashuMint.split(tokenEntry.mint, payload);
 			const newProofs = dhke.constructProofs(
-				promises,
+				signatures,
 				blindedMessages.rs,
 				blindedMessages.secrets,
-				await this.getKeys(promises, tokenEntry.mint)
+				await this.getKeys(signatures, tokenEntry.mint)
 			);
 			proofs.push(...newProofs);
 		} catch (error) {
@@ -271,12 +270,12 @@ class CashuWallet {
 		if (amount < amountAvailable || preference) {
 			const { amountKeep, amountSend } = this.splitReceive(amount, amountAvailable);
 			const { payload, blindedMessages } = this.createSplitPayload(amountSend, proofsToSend, preference);
-			const { promises } = await this.mint.split(payload);
+			const { signatures } = await this.mint.split(payload);
 			const proofs = dhke.constructProofs(
-				promises,
+				signatures,
 				blindedMessages.rs,
 				blindedMessages.secrets,
-				await this.getKeys(promises)
+				await this.getKeys(signatures)
 			);
 			// sum up proofs until amount2 is reached
 			const splitProofsToKeep: Array<Proof> = [];
@@ -392,7 +391,7 @@ class CashuWallet {
 		};
 
 		const payload = {
-			proofs: proofsToSend,
+			inputs: proofsToSend,
 			outputs: [...blindedMessages.blindedMessages]
 		};
 		return { payload, blindedMessages };

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -264,13 +264,14 @@ class CashuWallet {
 			const splitProofsToKeep: Array<Proof> = [];
 			const splitProofsToSend: Array<Proof> = [];
 			let amountSendCounter = 0;
-			proofs.reverse().forEach((proof) => {
-				if (amountSendCounter >= amountSend) {
-					splitProofsToKeep.push(proof);
+			proofs.forEach((proof) => {
+				if (amountSendCounter < amountSend) {
+					amountSendCounter = amountSendCounter + proof.amount;
+					splitProofsToSend.push(proof);
 					return;
+
 				}
-				amountSendCounter = amountSendCounter + proof.amount;
-				splitProofsToSend.push(proof);
+				splitProofsToKeep.push(proof);
 			});
 			return {
 				returnChange: [...splitProofsToKeep, ...proofsToKeep],

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -30,6 +30,7 @@ import {
 	getDefaultAmountPreference,
 	splitAmount
 } from './utils.js';
+import { bytesToHex } from '@noble/curves/abstract/utils';
 
 /**
  * Class that represents a Cashu wallet.
@@ -424,7 +425,7 @@ class CashuWallet {
 		const rs: Array<bigint> = [];
 		const amounts = splitAmount(amount, amountPreference);
 		for (let i = 0; i < amounts.length; i++) {
-			const secret = randomBytes(32);
+			const secret = new TextEncoder().encode(bytesToHex(randomBytes(32)));
 			secrets.push(secret);
 			const { B_, r } = dhke.blindMessage(secret);
 			rs.push(r);
@@ -446,7 +447,7 @@ class CashuWallet {
 		const rs: Array<bigint> = [];
 		const count = Math.ceil(Math.log2(feeReserve)) || 1;
 		for (let i = 0; i < count; i++) {
-			const secret = randomBytes(32);
+			const secret = new TextEncoder().encode(bytesToHex(randomBytes(32)));
 			secrets.push(secret);
 			const { B_, r } = dhke.blindMessage(secret);
 			rs.push(r);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -7,6 +7,7 @@ import {
 	BlindedMessageData,
 	BlindedTransaction,
 	MintKeys,
+	MintKeyset,
 	PayLnInvoiceResponse,
 	PaymentPayload,
 	Proof,
@@ -31,7 +32,7 @@ import {
  * This class should act as the entry point for this library
  */
 class CashuWallet {
-	private _keys: MintKeys;
+	private _keys = {} as MintKeys;
 	private _keysetId = '';
 	mint: CashuMint;
 
@@ -40,9 +41,9 @@ class CashuWallet {
 	 * @param mint Cashu mint instance is used to make api calls
 	 */
 	constructor(mint: CashuMint, keys?: MintKeys) {
-		this._keys = keys || {};
 		this.mint = mint;
 		if (keys) {
+			this._keys = keys;
 			this._keysetId = deriveKeysetId(this._keys);
 		}
 	}
@@ -357,8 +358,9 @@ class CashuWallet {
 
 		const keys =
 			!mint || mint === this.mint.mintUrl
-				? await this.mint.getKeys(arr[0].id)
-				: await CashuMint.getKeys(mint, arr[0].id);
+				? await this.mint.getKeys(keysetId)
+				: await this.mint.getKeys(keysetId, mint);
+
 		return keys;
 	}
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -263,15 +263,15 @@ class CashuWallet {
 			// sum up proofs until amount2 is reached
 			const splitProofsToKeep: Array<Proof> = [];
 			const splitProofsToSend: Array<Proof> = [];
-			let amountSendCounter = 0;
+			let amountKeepCounter = 0;
 			proofs.forEach((proof) => {
-				if (amountSendCounter < amountSend) {
-					amountSendCounter = amountSendCounter + proof.amount;
-					splitProofsToSend.push(proof);
+				if (amountKeepCounter < amount - amountSend) {
+					amountKeepCounter += proof.amount;
+					splitProofsToKeep.push(proof);
 					return;
 
 				}
-				splitProofsToKeep.push(proof);
+				splitProofsToSend.push(proof);
 			});
 			return {
 				returnChange: [...splitProofsToKeep, ...proofsToKeep],

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -27,9 +27,7 @@ export function pointFromHex(hex: string) {
 	return secp256k1.ProjectivePoint.fromAffine(h2c.toAffine());
 } */
 function blindMessage(secret: Uint8Array, r?: bigint): { B_: ProjPointType<bigint>; r: bigint } {
-	const secretMessageBase64 = encodeUint8toBase64(secret);
-	const secretMessage = new TextEncoder().encode(secretMessageBase64);
-	const Y = hashToCurve(secretMessage);
+	const Y = hashToCurve(secret);
 	if (!r) {
 		r = bytesToNumber(secp256k1.utils.randomPrivateKey());
 	}
@@ -57,10 +55,12 @@ function constructProofs(
 		const C_ = pointFromHex(p.C_);
 		const A = pointFromHex(keyset.keys[p.amount]);
 		const C = unblindSignature(C_, rs[i], A);
+		// Encode Uint8Array byte array as hex string:
+		const secret = Buffer.from(secrets[i]).toString('hex');
 		const proof = {
 			id: p.id,
 			amount: p.amount,
-			secret: encodeUint8toBase64(secrets[i]),
+			secret: secret,
 			C: C.toHex(true)
 		};
 		return proof;

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -51,11 +51,11 @@ function constructProofs(
 	promises: Array<SerializedBlindedSignature>,
 	rs: Array<bigint>,
 	secrets: Array<Uint8Array>,
-	keys: MintKeys
+	keyset: MintKeys
 ): Array<Proof> {
 	return promises.map((p: SerializedBlindedSignature, i: number) => {
 		const C_ = pointFromHex(p.C_);
-		const A = pointFromHex(keys[p.amount]);
+		const A = pointFromHex(keyset.keys[p.amount]);
 		const C = unblindSignature(C_, rs[i], A);
 		const proof = {
 			id: p.id,

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -26,7 +26,7 @@ export function pointFromHex(hex: string) {
 	return secp256k1.ProjectivePoint.fromAffine(h2c.toAffine());
 } */
 function blindMessage(secret: Uint8Array, r?: bigint): { B_: ProjPointType<bigint>; r: bigint } {
-	const secretMessage = new TextEncoder().encode(bytesToHex(secret));
+	const secretMessage = new TextEncoder().encode(new TextDecoder().decode(secret));
 	const Y = hashToCurve(secretMessage);
 	if (!r) {
 		r = bytesToNumber(secp256k1.utils.randomPrivateKey());
@@ -55,7 +55,7 @@ function constructProofs(
 		const C_ = pointFromHex(p.C_);
 		const A = pointFromHex(keyset.keys[p.amount]);
 		const C = unblindSignature(C_, rs[i], A);
-		const secret = bytesToHex(secrets[i])
+		const secret = new TextDecoder().decode(secrets[i])
 		const proof = {
 			id: p.id,
 			amount: p.amount,

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -1,6 +1,5 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { encodeUint8toBase64 } from './base64.js';
 import { MintKeys, Proof, SerializedBlindedSignature } from './model/types/index.js';
 import { bytesToNumber } from './utils.js';
 import { sha256 } from '@noble/hashes/sha256';
@@ -27,7 +26,8 @@ export function pointFromHex(hex: string) {
 	return secp256k1.ProjectivePoint.fromAffine(h2c.toAffine());
 } */
 function blindMessage(secret: Uint8Array, r?: bigint): { B_: ProjPointType<bigint>; r: bigint } {
-	const Y = hashToCurve(secret);
+	const secretMessage = new TextEncoder().encode(bytesToHex(secret));
+	const Y = hashToCurve(secretMessage);
 	if (!r) {
 		r = bytesToNumber(secp256k1.utils.randomPrivateKey());
 	}
@@ -55,8 +55,7 @@ function constructProofs(
 		const C_ = pointFromHex(p.C_);
 		const A = pointFromHex(keyset.keys[p.amount]);
 		const C = unblindSignature(C_, rs[i], A);
-		// Encode Uint8Array byte array as hex string:
-		const secret = Buffer.from(secrets[i]).toString('hex');
+		const secret = bytesToHex(secrets[i])
 		const proof = {
 			id: p.id,
 			amount: p.amount,

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -1,5 +1,6 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
+import { encodeUint8toBase64 } from './base64.js';
 import { MintKeys, Proof, SerializedBlindedSignature } from './model/types/index.js';
 import { bytesToNumber } from './utils.js';
 import { sha256 } from '@noble/hashes/sha256';
@@ -26,7 +27,8 @@ export function pointFromHex(hex: string) {
 	return secp256k1.ProjectivePoint.fromAffine(h2c.toAffine());
 } */
 function blindMessage(secret: Uint8Array, r?: bigint): { B_: ProjPointType<bigint>; r: bigint } {
-	const secretMessage = new TextEncoder().encode(new TextDecoder().decode(secret));
+	const secretMessageBase64 = encodeUint8toBase64(secret);
+	const secretMessage = new TextEncoder().encode(secretMessageBase64);
 	const Y = hashToCurve(secretMessage);
 	if (!r) {
 		r = bytesToNumber(secp256k1.utils.randomPrivateKey());
@@ -55,11 +57,10 @@ function constructProofs(
 		const C_ = pointFromHex(p.C_);
 		const A = pointFromHex(keyset.keys[p.amount]);
 		const C = unblindSignature(C_, rs[i], A);
-		const secret = new TextDecoder().decode(secrets[i])
 		const proof = {
 			id: p.id,
 			amount: p.amount,
-			secret: secret,
+			secret: encodeUint8toBase64(secrets[i]),
 			C: C.toHex(true)
 		};
 		return proof;

--- a/src/model/BlindedMessage.ts
+++ b/src/model/BlindedMessage.ts
@@ -4,12 +4,14 @@ import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 class BlindedMessage {
 	amount: number;
 	B_: ProjPointType<bigint>;
-	constructor(amount: number, B_: ProjPointType<bigint>) {
+	id: string;
+	constructor(amount: number, B_: ProjPointType<bigint>, id: string) {
 		this.amount = amount;
 		this.B_ = B_;
+		this.id = id;
 	}
 	getSerializedBlindedMessage(): SerializedBlindedMessage {
-		return { amount: this.amount, B_: this.B_.toHex(true) };
+		return { amount: this.amount, B_: this.B_.toHex(true), id: this.id };
 	}
 }
 export { BlindedMessage };

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -144,18 +144,50 @@ export type PaymentPayload = {
 	proofs: Array<Proof>;
 };
 
+/** 
+ * Payload that needs to be send to the mint to request a melt quote
+ */
+export type MeltQuotePayload = {
+	/** 
+	 * Unit to be melted
+	 */
+	unit: string;
+	/**
+	 * Request to be melted to
+	 */
+	request: string;
+};
+
+/**
+ * Response from the mint after requesting a melt quote
+ */
+export type MeltQuoteResponse = {
+	/**
+	 * Quote ID
+	 */
+	quote: string;
+	/**
+	 * Amount to be melted
+	 */
+	amount: number;
+	/**
+	 * Fee reserve to be added to the amount
+	 */
+	fee_reserve: number;
+} & ApiError;
+
 /**
  * Payload that needs to be sent to the mint when melting. Includes Return for overpaid fees
  */
 export type MeltPayload = {
 	/**
-	 * Payment request/Lighting invoice that should get paid by the mint.
+	 * ID of the melt quote
 	 */
-	pr: string;
+	quote: string;
 	/**
-	 * Proofs, matching Lightning invoices amount + fees.
+	 * Inputs (Proofs) to be melted
 	 */
-	proofs: Array<Proof>;
+	inputs: Array<Proof>;
 	/**
 	 * Blank outputs (blinded messages) that can be filled by the mint to return overpaid fees
 	 */
@@ -173,7 +205,7 @@ export type MeltResponse = {
 	/**
 	 * preimage of the paid invoice. can be null, depending on which LN-backend the mint uses
 	 */
-	preimage: string | null;
+	proof: string | null;
 	/**
 	 * Return/Change from overpaid fees. This happens due to Lighting fee estimation being inaccurate
 	 */

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -203,7 +203,7 @@ export type MeltResponse = {
 /**
  * Response after paying a Lightning invoice
  */
-export type PayLnInvoiceResponse = {
+export type MeltTokensResponse = {
 	/**
 	 * if false, the proofs have not been invalidated and the payment can be tried later again with the same proofs
 	 */

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -89,10 +89,6 @@ export type ReceiveTokenEntryResponse = {
 	 * Proofs that could not be received. Doesn't throw an error, but if this field is populated it should be handled by the implementation accordingly
 	 */
 	proofsWithError: Array<Proof> | undefined;
-	/**
-	 * If the mint has rotated keys, this field will be populated with the new keys.
-	 */
-	newKeys?: MintKeys;
 };
 
 /**
@@ -107,10 +103,6 @@ export type SendResponse = {
 	 * Proofs to be sent, matching the chosen amount
 	 */
 	send: Array<Proof>;
-	/**
-	 * If the mint has rotated keys, this field will be populated with the new keys.
-	 */
-	newKeys?: MintKeys;
 };
 /**
  * Response when receiving a complete token.
@@ -124,10 +116,6 @@ export type ReceiveResponse = {
 	 * TokenEntries that had errors. No error will be thrown, but clients can choose to handle tokens with errors accordingly.
 	 */
 	tokensWithErrors: Token | undefined;
-	/**
-	 * If the mint has rotated keys, this field will be populated with the new keys.
-	 */
-	newKeys?: MintKeys;
 };
 
 /**
@@ -228,10 +216,6 @@ export type PayLnInvoiceResponse = {
 	 * Return/Change from overpaid fees. This happens due to Lighting fee estimation being inaccurate
 	 */
 	change: Array<Proof>;
-	/**
-	 * If the mint has rotated keys, this field will be populated with the new keys.
-	 */
-	newKeys?: MintKeys;
 };
 
 /**
@@ -239,11 +223,11 @@ export type PayLnInvoiceResponse = {
  */
 export type SplitPayload = {
 	/**
-	 * Proofs to be split
+	 * Inputs to the split operation
 	 */
-	proofs: Array<Proof>;
+	inputs: Array<Proof>;
 	/**
-	 * Fresh blinded messages to be signed by the mint to create the split proofs
+	 * Outputs (blinded messages) to be signed by the mint 
 	 */
 	outputs: Array<SerializedBlindedMessage>;
 };
@@ -254,7 +238,7 @@ export type SplitResponse = {
 	/**
 	 * represents the outputs after the split
 	 */
-	promises: Array<SerializedBlindedSignature>;
+	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 /**

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -193,7 +193,7 @@ export type MeltResponse = {
 	/**
 	 * preimage of the paid invoice. can be null, depending on which LN-backend the mint uses
 	 */
-	proof: string | null;
+	payment_preimage: string | null;
 	/**
 	 * Return/Change from overpaid fees. This happens due to Lighting fee estimation being inaccurate
 	 */
@@ -304,22 +304,40 @@ export type PostMintResponse = {
 /**
  * Payload that needs to be sent to the mint when checking for spendable proofs
  */
-export type CheckSpendablePayload = {
+export type CheckStatePayload = {
 	/**
 	 * array of proofs. Only the secret is strictly needed.
 	 * If the whole object is passed, it will be stripped of other objects before sending it to the mint.
 	 */
-	proofs: Array<{ secret: string }>;
+	secrets: Array<string>;
 };
+
+/**
+ * Enum for the state of a proof
+ */
+export enum CheckStateEnum {
+	UNSPENT = "UNSPENT",
+	PENDING = "PENDING",
+	SPENT = "SPENT",
+}
+
+/**
+ * Entries of CheckStateResponse with state of the proof
+ */
+export type CheckStateEntry = {
+	secret: string;
+	state: CheckStateEnum;
+	witness: string | null;
+}
 
 /**
  * Response when checking proofs if they are spendable. Should not rely on this for receiving, since it can be easily cheated.
  */
-export type CheckSpendableResponse = {
+export type CheckStateResponse = {
 	/**
-	 * Ordered list for checked proofs. True if the secret has not been redeemed at the mint before
+	 * 
 	 */
-	spendable: Array<boolean>;
+	states: Array<CheckStateEntry>;
 } & ApiError;
 /**
  * blinded message for sending to the mint

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -23,7 +23,12 @@ export type Proof = {
 /**
  * An array of mint keysets
  */
-export type MintActiveKeys = Array<MintKeys>;
+export type MintActiveKeys = {
+	/**
+	 * Keysets
+	 */
+	keysets: Array<MintKeys>;
+};
 
 /**
  * A mint keyset.
@@ -47,7 +52,12 @@ export type MintKeys = {
 /**
  * An array of mint keyset entries.
  */
-export type MintAllKeysets = Array<MintKeyset>;
+export type MintAllKeysets = {
+	/**
+	 * Keysets
+	 */
+	keysets: Array<MintKeyset>;
+};
 
 /**
  * A mint keyset entry.
@@ -233,10 +243,47 @@ export type ApiError = {
 	detail?: string;
 };
 
+/**
+ * Payload that needs to be sent to the mint when requesting a mint
+ */
+export type RequestMintPayload = {
+	/**
+	 * Unit to be minted
+	 */
+	unit: string;
+	/**
+	 * Amount to be minted
+	 */
+	amount: number;
+};
+/**
+ * Response from the mint after requesting a mint
+ */
 export type RequestMintResponse = {
-	pr: string;
-	hash: string;
+	request: string;
+	quote: string;
 } & ApiError;
+
+/**
+ * Payload that needs to be sent to the mint when requesting a mint
+ */
+export type PostMintPayload = {
+	/**
+	 * Quote ID received from the mint.
+	 */
+	quote: string;
+	/**
+	 * Outputs (blinded messages) to be signed by the mint.
+	 */
+	outputs: Array<SerializedBlindedMessage>
+};
+/**
+ * Response from the mint after requesting a mint
+ */
+export type PostMintResponse = {
+	signatures: Array<SerializedBlindedSignature>;
+} & ApiError;
+
 
 /**
  * Payload that needs to be sent to the mint when checking for spendable proofs
@@ -270,6 +317,10 @@ export type SerializedBlindedMessage = {
 	 * Blinded message
 	 */
 	B_: string;
+	/**	
+	 * Keyset id
+	 */
+	id: string;
 };
 /**
  * Blinded signature as it is received from the mint

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -21,9 +21,51 @@ export type Proof = {
 };
 
 /**
- * A mints publickey-set.
+ * An array of mint keysets
  */
-export type MintKeys = { [k: number]: string };
+export type MintActiveKeys = Array<MintKeys>;
+
+/**
+ * A mint keyset.
+ */
+export type MintKeys = {
+	/**
+	 * Keyset ID
+	 */
+	id: string;
+	/**
+	 * Unit of the keyset.
+	 */
+	unit: string;
+	/**
+	 * Public keys are a dictionary of number and string. The number represents the amount that the key signs for.
+	 */
+	keys: { [amount: number]: string };
+
+};
+
+/**
+ * An array of mint keyset entries.
+ */
+export type MintAllKeysets = Array<MintKeyset>;
+
+/**
+ * A mint keyset entry.
+ */
+export type MintKeyset = {
+	/**
+	 * Keyset ID
+	 */
+	id: string;
+	/**
+	 * Unit of the keyset.
+	 */
+	unit: string;
+	/**
+	 * Whether the keyset is active or not.
+	 */
+	active: boolean;
+};
 
 /**
  * response when after receiving a single TokenEntry

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,12 +127,13 @@ function handleTokens(token: string): Token {
  * @returns
  */
 export function deriveKeysetId(keys: MintKeys) {
-	const pubkeysConcat = Object.entries(keys)
+	const pubkeysConcat = Object.entries(keys.keys)
 		.sort((a, b) => +a[0] - +b[0])
 		.map(([, pubKey]) => pubKey)
 		.join('');
 	const hash = sha256(new TextEncoder().encode(pubkeysConcat));
-	return Buffer.from(hash).toString('base64').slice(0, 12);
+	const hashHex = bytesToHex(hash);
+	return "00" + hashHex.slice(0, 12);
 }
 /**
  * merge proofs from same mint,

--- a/test/crypto.scheme.test.ts
+++ b/test/crypto.scheme.test.ts
@@ -50,7 +50,7 @@ class Wallet {
 	private rG: ProjPointType<bigint> | undefined;
 	private B_: ProjPointType<bigint> | undefined;
 	private secret = new Uint8Array();
-	constructor() {}
+	constructor() { }
 
 	async createBlindedMessage(message: string): Promise<ProjPointType<bigint>> {
 		const enc = new TextEncoder();

--- a/test/dhke.test.ts
+++ b/test/dhke.test.ts
@@ -22,14 +22,30 @@ describe('testing hash to curve', () => {
 
 describe('test blinding message', () => {
 	test('testing string 0000....01', async () => {
-		var enc = new TextEncoder();
-		let secretUInt8 = enc.encode(SECRET_MESSAGE);
+		let secretUInt8 = new TextEncoder().encode(SECRET_MESSAGE);
+		expect(secretUInt8).toStrictEqual(
+			new Uint8Array([
+				116,
+				101,
+				115,
+				116,
+				95,
+				109,
+				101,
+				115,
+				115,
+				97,
+				103,
+				101
+			])
+		);
+		const r = bytesToNumber(hexToBytes('0000000000000000000000000000000000000000000000000000000000000001'))
 		let { B_ } = await dhke.blindMessage(
 			secretUInt8,
-			bytesToNumber(hexToBytes('0000000000000000000000000000000000000000000000000000000000000001'))
+			r
 		);
 		expect(B_.toHex(true)).toBe(
-			'03c509bbdd8aaa81d5e67468d07b4b7dffd5769ac596ff3964e151adcefc6b06d0'
+			'02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2'
 		);
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -118,7 +118,20 @@ describe('mint api', () => {
 		expect(returnChangeSpent).toBeDefined();
 		expect(returnChangeSpent).toEqual([]);
 	});
-	test('test send tokens', async () => {
+	test('test send tokens exact without previous split', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(64);
+		const tokens = await wallet.requestTokens(64, request.quote);
+
+		const sendResponse = await wallet.send(64, tokens.proofs);
+		expect(sendResponse).toBeDefined();
+		expect(sendResponse.send).toBeDefined();
+		expect(sendResponse.returnChange).toBeDefined();
+		expect(sendResponse.send.length).toBe(1);
+		expect(sendResponse.returnChange.length).toBe(0);
+	});
+	test('test send tokens with change', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
 		const request = await wallet.requestMint(100);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -33,16 +33,16 @@ describe('mint api', () => {
 	test('request mint', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(100);
+		const request = await wallet.getMintQuote(100);
 		expect(request).toBeDefined();
 	});
 	test('mint tokens', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(1337);
+		const request = await wallet.getMintQuote(1337);
 		expect(request).toBeDefined();
 		expect(request.request).toContain('lnbc1337');
-		const tokens = await wallet.requestTokens(1337, request.quote);
+		const tokens = await wallet.mintTokens(1337, request.quote);
 		expect(tokens).toBeDefined();
 		// expect that the sum of all tokens.proofs.amount is equal to the requested amount
 		expect(tokens.proofs.reduce((a, b) => a + b.amount, 0)).toBe(1337);
@@ -50,7 +50,7 @@ describe('mint api', () => {
 	test('get fee for local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(100);
+		const request = await wallet.getMintQuote(100);
 		const fee = (await wallet.getMeltQuote(request.request)).fee_reserve;
 		expect(fee).toBeDefined();
 		// because local invoice, fee should be 0
@@ -67,11 +67,11 @@ describe('mint api', () => {
 	test('pay local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(100);
-		const tokens = await wallet.requestTokens(100, request.quote);
+		const request = await wallet.getMintQuote(100);
+		const tokens = await wallet.mintTokens(100, request.quote);
 
 		// expect no fee because local invoice
-		const requestToPay = await wallet.requestMint(10);
+		const requestToPay = await wallet.getMintQuote(10);
 		const quote = await wallet.getMeltQuote(requestToPay.request);
 		const fee = quote.fee_reserve
 		expect(fee).toBe(0);
@@ -95,8 +95,8 @@ describe('mint api', () => {
 	test('pay external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(3000);
-		const tokens = await wallet.requestTokens(3000, request.quote);
+		const request = await wallet.getMintQuote(3000);
+		const tokens = await wallet.mintTokens(3000, request.quote);
 
 		const fee = (await wallet.getMeltQuote(externalInvoice)).fee_reserve;
 		expect(fee).toBeGreaterThan(0);
@@ -121,8 +121,8 @@ describe('mint api', () => {
 	test('test send tokens exact without previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(64);
-		const tokens = await wallet.requestTokens(64, request.quote);
+		const request = await wallet.getMintQuote(64);
+		const tokens = await wallet.mintTokens(64, request.quote);
 
 		const sendResponse = await wallet.send(64, tokens.proofs);
 		expect(sendResponse).toBeDefined();
@@ -134,8 +134,8 @@ describe('mint api', () => {
 	test('test send tokens with change', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(100);
-		const tokens = await wallet.requestTokens(100, request.quote);
+		const request = await wallet.getMintQuote(100);
+		const tokens = await wallet.mintTokens(100, request.quote);
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
 		expect(sendResponse).toBeDefined();
@@ -147,8 +147,8 @@ describe('mint api', () => {
 	test('receive tokens with previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(100);
-		const tokens = await wallet.requestTokens(100, request.quote);
+		const request = await wallet.getMintQuote(100);
+		const tokens = await wallet.mintTokens(100, request.quote);
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
 		const encoded = getEncodedToken({
@@ -162,8 +162,8 @@ describe('mint api', () => {
 	test('receive tokens with previous mint', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		const request = await wallet.requestMint(64);
-		const tokens = await wallet.requestTokens(64, request.quote);
+		const request = await wallet.getMintQuote(64);
+		const tokens = await wallet.mintTokens(64, request.quote);
 		const encoded = getEncodedToken({
 			token: [{ mint: mintUrl, proofs: tokens.proofs }]
 		});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,119 @@
+import { CashuMint } from '../src/CashuMint.js';
+import { CashuWallet } from '../src/CashuWallet.js';
+
+import dns from 'node:dns';
+dns.setDefaultResultOrder('ipv4first');
+
+const externalInvoice =
+	'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
+
+let request: Record<string, string> | undefined;
+const mintUrl = 'http://localhost:3338';
+
+describe('mint api', () => {
+	test('get keys', async () => {
+		const mint = new CashuMint(mintUrl);
+		const keys = await mint.getKeys();
+		expect(keys).toBeDefined();
+	});
+	test('get keysets', async () => {
+		const mint = new CashuMint(mintUrl);
+		const keysets = await mint.getKeySets();
+		expect(keysets).toBeDefined();
+		expect(keysets.keysets).toBeDefined();
+		expect(keysets.keysets.length).toBeGreaterThan(0);
+	});
+
+	test('get info', async () => {
+		const mint = new CashuMint(mintUrl);
+		const info = await mint.getInfo();
+		expect(info).toBeDefined();
+	});
+	test('request mint', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(100);
+		expect(request).toBeDefined();
+	});
+	test('mint tokens', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(1337);
+		expect(request).toBeDefined();
+		expect(request.request).toContain('lnbc1337');
+		const tokens = await wallet.requestTokens(1337, request.quote);
+		expect(tokens).toBeDefined();
+		// expect that the sum of all tokens.proofs.amount is equal to the requested amount
+		expect(tokens.proofs.reduce((a, b) => a + b.amount, 0)).toBe(1337);
+	});
+	test('get fee for local invoice', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(100);
+		const fee = await wallet.getFee(request.request);
+		expect(fee).toBeDefined();
+		// because local invoice, fee should be 0
+		expect(fee).toBe(0);
+	});
+	test('get fee for external invoice', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const fee = await wallet.getFee(externalInvoice);
+		expect(fee).toBeDefined();
+		// because external invoice, fee should be > 0
+		expect(fee).toBeGreaterThan(0);
+	});
+	test('pay local invoice', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(100);
+		const tokens = await wallet.requestTokens(100, request.quote);
+
+		// expect no fee because local invoice
+		const requestToPay = await wallet.requestMint(10);
+		const fee = await wallet.getFee(requestToPay.request);
+		expect(fee).toBe(0);
+
+		const sendResponse = await wallet.send(10, tokens.proofs);
+		const response = await wallet.payLnInvoice(requestToPay.request, sendResponse.send);
+		expect(response).toBeDefined();
+		// expect that we have received the fee back, since it was internal
+		expect(response.change.reduce((a, b) => a + b.amount, 0)).toBe(fee);
+
+		// check states of spent and kept proofs after payment
+		const sentProofsSpent = await wallet.checkProofsSpent(sendResponse.send)
+		expect(sentProofsSpent).toBeDefined();
+		// expect that all proofs are spent, i.e. sendProofsSpent == sendResponse.send
+		expect(sentProofsSpent).toEqual(sendResponse.send);
+		// expect none of the sendResponse.returnChange to be spent
+		const returnChangeSpent = await wallet.checkProofsSpent(sendResponse.returnChange)
+		expect(returnChangeSpent).toBeDefined();
+		expect(returnChangeSpent).toEqual([]);
+	});
+	test('pay external invoice', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(3000);
+		const tokens = await wallet.requestTokens(3000, request.quote);
+
+		const fee = await wallet.getFee(externalInvoice);
+		expect(fee).toBeGreaterThan(0);
+
+		const sendResponse = await wallet.send(2000 + fee, tokens.proofs);
+		const response = await wallet.payLnInvoice(externalInvoice, sendResponse.send);
+
+		expect(response).toBeDefined();
+		// expect that we have received the fee back, since it was internal
+		expect(response.change.reduce((a, b) => a + b.amount, 0)).toBe(fee);
+
+		// check states of spent and kept proofs after payment
+		const sentProofsSpent = await wallet.checkProofsSpent(sendResponse.send)
+		expect(sentProofsSpent).toBeDefined();
+		// expect that all proofs are spent, i.e. sendProofsSpent == sendResponse.send
+		expect(sentProofsSpent).toEqual(sendResponse.send);
+		// expect none of the sendResponse.returnChange to be spent
+		const returnChangeSpent = await wallet.checkProofsSpent(sendResponse.returnChange)
+		expect(returnChangeSpent).toBeDefined();
+		expect(returnChangeSpent).toEqual([]);
+	});
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2,7 +2,7 @@ import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
 
 import dns from 'node:dns';
-import { getEncodedToken } from '../src/utils.js';
+import { deriveKeysetId, getEncodedToken } from '../src/utils.js';
 dns.setDefaultResultOrder('ipv4first');
 
 const externalInvoice =

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -144,7 +144,7 @@ describe('mint api', () => {
 		expect(sendResponse.send.length).toBe(2);
 		expect(sendResponse.returnChange.length).toBe(4);
 	});
-	test('receive tokens', async () => {
+	test('receive tokens with previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
 		const request = await wallet.requestMint(100);
@@ -153,6 +153,19 @@ describe('mint api', () => {
 		const sendResponse = await wallet.send(10, tokens.proofs);
 		const encoded = getEncodedToken({
 			token: [{ mint: mintUrl, proofs: sendResponse.send }]
+		});
+		const response = await wallet.receive(encoded);
+		expect(response).toBeDefined();
+		expect(response.token).toBeDefined();
+		expect(response.tokensWithErrors).toBeUndefined();
+	});
+	test('receive tokens with previous mint', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const request = await wallet.requestMint(64);
+		const tokens = await wallet.requestTokens(64, request.quote);
+		const encoded = getEncodedToken({
+			token: [{ mint: mintUrl, proofs: tokens.proofs }]
 		});
 		const response = await wallet.receive(encoded);
 		expect(response).toBeDefined();

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -4,7 +4,7 @@ import { CashuWallet } from '../src/CashuWallet.js';
 import { setGlobalRequestOptions } from '../src/request.js';
 
 let request: Record<string, string> | undefined;
-const mintUrl = 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC';
+const mintUrl = 'https://localhost:3338';
 const invoice =
 	'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -21,14 +21,18 @@ describe('requests', () => {
 	test('request with body contains the correct headers', async () => {
 		const mint = new CashuMint(mintUrl);
 		nock(mintUrl)
-			.post('/checkfees')
+			.post('/v1/melt/quote/bolt11')
 			.reply(200, function () {
 				request = this.req.headers;
-				return { fee: 20 };
+				return {
+					quote: 'test_melt_quote_id',
+					amount: 2000,
+					fee_reserve: 20
+				};
 			});
 
 		const wallet = new CashuWallet(mint);
-		await wallet.getFee(invoice);
+		await wallet.getMeltQuote(invoice);
 
 		expect(request).toBeDefined();
 		expect(request!['content-type']).toContain('application/json');
@@ -37,15 +41,19 @@ describe('requests', () => {
 	test('global custom headers can be set', async () => {
 		const mint = new CashuMint(mintUrl);
 		nock(mintUrl)
-			.post('/checkfees')
+			.post('/v1/melt/quote/bolt11')
 			.reply(200, function () {
 				request = this.req.headers;
-				return { fee: 20 };
+				return {
+					quote: 'test_melt_quote_id',
+					amount: 2000,
+					fee_reserve: 20
+				};
 			});
 
 		const wallet = new CashuWallet(mint);
 		setGlobalRequestOptions({ headers: { 'x-cashu': 'xyz-123-abc' } });
-		await wallet.getFee(invoice);
+		await wallet.getMeltQuote(invoice);
 
 		expect(request).toBeDefined();
 		expect(request!['x-cashu']).toContain('xyz-123-abc');

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -93,7 +93,7 @@ describe('test decode token', () => {
 							C: '02a42140d1bbd59ca4c5ba9eb73d020f31f68f4e3078fd3af1ee64ebece52b6eda'
 						}
 					],
-					mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
+					mint: 'https://localhost:3338'
 				}
 			]
 		});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -93,7 +93,7 @@ describe('test decode token', () => {
 							C: '02a42140d1bbd59ca4c5ba9eb73d020f31f68f4e3078fd3af1ee64ebece52b6eda'
 						}
 					],
-					mint: 'https://localhost:3338'
+					mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 				}
 			]
 		});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -33,32 +33,67 @@ describe('test fees', () => {
 describe('receive', () => {
 	const tokenInput =
 		'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19';
-	test('test receive', async () => {
-		nock(mintUrl)
-			.post('/split')
-			.reply(200, {
-				promises: [
-					{
-						id: 'z32vUtKgNCm1',
-						amount: 1,
-						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-					}
-				]
+		test('test receive', async () => {
+			nock(mintUrl)
+				.post('/split')
+				.reply(200, {
+					promises: [
+						{
+							id: 'z32vUtKgNCm1',
+							amount: 1,
+							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+						}
+					]
+				});
+			const wallet = new CashuWallet(mint);
+	
+			const { token: t, tokensWithErrors } = await wallet.receive(tokenInput);
+	
+			expect(t.token).toHaveLength(1);
+			expect(t.token[0].proofs).toHaveLength(1);
+			expect(t.token[0]).toMatchObject({
+				proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
+				mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 			});
-		const wallet = new CashuWallet(mint);
-
-		const { token: t, tokensWithErrors } = await wallet.receive(tokenInput);
-
-		expect(t.token).toHaveLength(1);
-		expect(t.token[0].proofs).toHaveLength(1);
-		expect(t.token[0]).toMatchObject({
-			proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
-			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
+			expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+			expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+			expect(tokensWithErrors).toBe(undefined);
 		});
-		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-		expect(tokensWithErrors).toBe(undefined);
-	});
+		test('test receive custom split', async () => {
+			nock(mintUrl)
+				.post('/split')
+				.reply(200, {
+					promises: [
+						{
+							id: 'z32vUtKgNCm1',
+							amount: 1,
+							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+						},
+						{
+							id: 'z32vUtKgNCm1',
+							amount: 1,
+							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+						},
+						{
+							id: 'z32vUtKgNCm1',
+							amount: 1,
+							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+						}
+					]
+				});
+			const wallet = new CashuWallet(mint);
+			const token3sat = 'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19'
+			const { token: t, tokensWithErrors } = await wallet.receive(token3sat, [{amount:1, count:3}]);
+	
+			expect(t.token).toHaveLength(1);
+			expect(t.token[0].proofs).toHaveLength(3);
+			expect(t.token[0]).toMatchObject({
+				proofs: [{ amount: 1, id: 'z32vUtKgNCm1' },{ amount: 1, id: 'z32vUtKgNCm1' },{ amount: 1, id: 'z32vUtKgNCm1' }],
+			});
+			expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+			expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+			expect(tokensWithErrors).toBe(undefined);
+		});
 	test('test receive tokens already spent', async () => {
 		const msg = 'tokens already spent. Secret: oEpEuViVHUV2vQH81INUbq++Yv2w3u5H0LhaqXJKeR0=';
 		nock(mintUrl).post('/split').reply(200, { detail: msg });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -287,7 +287,7 @@ describe('send', () => {
 	});
 	test('test send over paying. Should return change', async () => {
 		nock(mintUrl)
-			.post('/split')
+			.post('/v1/split')
 			.reply(200, {
 				signatures: [
 					{
@@ -325,7 +325,7 @@ describe('send', () => {
 
 	test('test send over paying2', async () => {
 		nock(mintUrl)
-			.post('/split')
+			.post('/v1/split')
 			.reply(200, {
 				signatures: [
 					{
@@ -363,7 +363,7 @@ describe('send', () => {
 	});
 	test('test send preference', async () => {
 		nock(mintUrl)
-			.post('/split')
+			.post('/v1/split')
 			.reply(200, {
 				signatures: [
 					{
@@ -418,7 +418,7 @@ describe('send', () => {
 
 	test('test send preference overpay', async () => {
 		nock(mintUrl)
-			.post('/split')
+			.post('/v1/split')
 			.reply(200, {
 				signatures: [
 					{
@@ -473,7 +473,7 @@ describe('send', () => {
 
 	test('test send not enough funds', async () => {
 		nock(mintUrl)
-			.post('/split')
+			.post('/v1/split')
 			.reply(200, {
 				signatures: [
 					{
@@ -490,7 +490,7 @@ describe('send', () => {
 		expect(result).toEqual(new Error('Not enough funds available'));
 	});
 	test('test send bad response', async () => {
-		nock(mintUrl).post('/split').reply(200, {});
+		nock(mintUrl).post('/v1/split').reply(200, {});
 		const wallet = new CashuWallet(mint);
 
 		const result = await wallet

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -152,7 +152,7 @@ describe('checkProofsSpent', () => {
 	];
 	test('test checkProofsSpent - get proofs that are NOT spendable', async () => {
 		nock(mintUrl)
-			.post('/check')
+			.post('/v1/check')
 			.reply(200, { spendable: [true] });
 		const wallet = new CashuWallet(mint);
 
@@ -237,7 +237,7 @@ describe('requestTokens', () => {
 			});
 		const wallet = new CashuWallet(mint);
 
-		const { proofs } = await wallet.requestTokens(1, '');
+		const { proofs } = await wallet.mintTokens(1, '');
 
 		expect(proofs).toHaveLength(1);
 		expect(proofs[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -248,7 +248,7 @@ describe('requestTokens', () => {
 		nock(mintUrl).post('/v1/mint/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint);
 
-		const result = await wallet.requestTokens(1, '').catch((e) => e);
+		const result = await wallet.mintTokens(1, '').catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));
 	});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -2,9 +2,14 @@ import { decode } from '@gandlaf21/bolt11-decode';
 import nock from 'nock';
 import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
+import { ReceiveResponse } from '../src/model/types/index.js';
 
-const dummyKeysResp = { 1: '02f970b6ee058705c0dddc4313721cffb7efd3d142d96ea8e01d31c2b2ff09f181' };
-const mintUrl = 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC';
+const dummyKeysResp = {
+	keysets: [{
+		id: '009a1f293253e41e', unit: 'sat', keys: { 1: '02f970b6ee058705c0dddc4313721cffb7efd3d142d96ea8e01d31c2b2ff09f181' }
+	},]
+};
+const mintUrl = 'http://localhost:3338';
 const mint = new CashuMint(mintUrl);
 const invoice =
 	'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
@@ -15,7 +20,8 @@ beforeAll(() => {
 
 beforeEach(() => {
 	nock.cleanAll();
-	nock(mintUrl).get('/keys').reply(200, dummyKeysResp);
+	nock(mintUrl).get('/v1/keys').reply(200, dummyKeysResp);
+	nock(mintUrl).get('/v1/keys/009a1f293253e41e').reply(200, dummyKeysResp);
 });
 
 describe('test fees', () => {
@@ -36,14 +42,14 @@ describe('test fees', () => {
 
 describe('receive', () => {
 	const tokenInput =
-		'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19';
+		'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICI4ZTRlODU1NmZkODBkZGY1NDk4Y2JmOTY4ZjcxZGRkMDZiMTc2MDBkYTJmOWU1MWE4NTc1YmVjN2U3N2Q0YjgxIiwgIkMiOiAiMDJmZWM1ZGQzNzk3YmRhZTBiMzk3ZmFmZjkyOTAzYzEzZmQ2ZWVhZGQzN2NlNjJjZGJmODAwNGI1MTNjZDAzZmRmIn1dLCAibWludCI6ICJodHRwOi8vbG9jYWxob3N0OjMzMzgifV19';
 	test('test receive', async () => {
 		nock(mintUrl)
 			.post('/v1/split')
 			.reply(200, {
 				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -51,96 +57,96 @@ describe('receive', () => {
 			});
 		const wallet = new CashuWallet(mint);
 
-		const response = await wallet.receive(tokenInput);
+		const response: ReceiveResponse = await wallet.receive(tokenInput);
 
-		expect(response.token).toHaveLength(1);
-		expect(response.token[0].proofs).toHaveLength(1);
-		expect(response.token[0]).toMatchObject({
-			proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
-			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
+		expect(response.token.token).toHaveLength(1);
+		expect(response.token.token[0].proofs).toHaveLength(1);
+		expect(response.token.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: '009a1f293253e41e' }],
+			mint: mintUrl
 		});
-		expect(/[0-9a-f]{64}/.test(response.token[0].proofs[0].C)).toBe(true);
-		// expect(/[A-Za-z0-9+/]{43}=/.test(response.token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(response.token.token[0].proofs[0].C)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(response.token.token[0].proofs[0].secret)).toBe(true);
 		expect(response.tokensWithErrors).toBe(undefined);
 	});
-	// test('test receive custom split', async () => {
-	// 	nock(mintUrl)
-	// 		.post('/split')
-	// 		.reply(200, {
-	// 			promises: [
-	// 				{
-	// 					id: 'z32vUtKgNCm1',
-	// 					amount: 1,
-	// 					C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-	// 				},
-	// 				{
-	// 					id: 'z32vUtKgNCm1',
-	// 					amount: 1,
-	// 					C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-	// 				},
-	// 				{
-	// 					id: 'z32vUtKgNCm1',
-	// 					amount: 1,
-	// 					C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-	// 				}
-	// 			]
-	// 		});
-	// 	const wallet = new CashuWallet(mint);
-	// 	const token3sat = 'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19'
-	// 	const { token: t, tokensWithErrors } = await wallet.receive(token3sat, [{ amount: 1, count: 3 }]);
+	test('test receive custom split', async () => {
+		nock(mintUrl)
+			.post('/v1/split')
+			.reply(200, {
+				signatures: [
+					{
+						id: '009a1f293253e41e',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					},
+					{
+						id: '009a1f293253e41e',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					},
+					{
+						id: '009a1f293253e41e',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					}
+				]
+			});
+		const wallet = new CashuWallet(mint);
+		const token3sat = 'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDA5YTFmMjkzMjUzZTQxZSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0='
+		const response: ReceiveResponse = await wallet.receive(token3sat, [{ amount: 1, count: 3 }]);
 
-	// 	expect(t.token).toHaveLength(1);
-	// 	expect(t.token[0].proofs).toHaveLength(3);
-	// 	expect(t.token[0]).toMatchObject({
-	// 		proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }, { amount: 1, id: 'z32vUtKgNCm1' }, { amount: 1, id: 'z32vUtKgNCm1' }],
-	// 	});
-	// 	expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-	// 	expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-	// 	expect(tokensWithErrors).toBe(undefined);
-	// });
-	// test('test receive tokens already spent', async () => {
-	// 	const msg = 'tokens already spent. Secret: oEpEuViVHUV2vQH81INUbq++Yv2w3u5H0LhaqXJKeR0=';
-	// 	nock(mintUrl).post('/split').reply(200, { detail: msg });
-	// 	const wallet = new CashuWallet(mint);
+		expect(response.token.token).toHaveLength(1);
+		expect(response.token.token[0].proofs).toHaveLength(3);
+		expect(response.token.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: '009a1f293253e41e' }, { amount: 1, id: '009a1f293253e41e' }, { amount: 1, id: '009a1f293253e41e' }],
+		});
+		expect(/[0-9a-f]{64}/.test(response.token.token[0].proofs[0].C)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(response.token.token[0].proofs[0].secret)).toBe(true);
+		expect(response.tokensWithErrors).toBe(undefined);
+	});
+	test('test receive tokens already spent', async () => {
+		const msg = 'tokens already spent. Secret: asdasdasd';
+		nock(mintUrl).post('/v1/split').reply(200, { detail: msg });
+		const wallet = new CashuWallet(mint);
 
-	// 	const { tokensWithErrors } = await wallet.receive(tokenInput);
-	// 	const t = tokensWithErrors!;
+		const { tokensWithErrors } = await wallet.receive(tokenInput);
+		const t = tokensWithErrors!;
 
-	// 	expect(tokensWithErrors).toBeDefined();
-	// 	expect(t.token).toHaveLength(1);
-	// 	expect(t.token[0].proofs).toHaveLength(1);
-	// 	expect(t.token[0]).toMatchObject({
-	// 		proofs: [{ amount: 1, id: '/uYB/6wWnYkU' }],
-	// 		mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
-	// 	});
-	// 	expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-	// 	expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-	// });
-	// test('test receive could not verify proofs', async () => {
-	// 	nock(mintUrl).post('/split').reply(200, { code: 0, error: 'could not verify proofs.' });
-	// 	const wallet = new CashuWallet(mint);
+		expect(tokensWithErrors).toBeDefined();
+		expect(t.token).toHaveLength(1);
+		expect(t.token[0].proofs).toHaveLength(1);
+		expect(t.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: '009a1f293253e41e' }],
+			mint: 'http://localhost:3338'
+		});
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
+	});
+	test('test receive could not verify proofs', async () => {
+		nock(mintUrl).post('/v1/split').reply(200, { code: 0, error: 'could not verify proofs.' });
+		const wallet = new CashuWallet(mint);
 
-	// 	const { tokensWithErrors } = await wallet.receive(tokenInput);
-	// 	const t = tokensWithErrors!;
+		const { tokensWithErrors } = await wallet.receive(tokenInput);
+		const t = tokensWithErrors!;
 
-	// 	expect(tokensWithErrors).toBeDefined();
-	// 	expect(t.token).toHaveLength(1);
-	// 	expect(t.token[0].proofs).toHaveLength(1);
-	// 	expect(t.token[0]).toMatchObject({
-	// 		proofs: [{ amount: 1, id: '/uYB/6wWnYkU' }],
-	// 		mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
-	// 	});
-	// 	expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-	// 	expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-	// });
+		expect(tokensWithErrors).toBeDefined();
+		expect(t.token).toHaveLength(1);
+		expect(t.token[0].proofs).toHaveLength(1);
+		expect(t.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: '009a1f293253e41e' }],
+			mint: 'http://localhost:3338'
+		});
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
+	});
 });
 
 describe('checkProofsSpent', () => {
 	const proofs = [
 		{
-			id: '0NI3TUAs1Sfy',
+			id: '009a1f293253e41e',
 			amount: 1,
-			secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+			secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
@@ -159,15 +165,15 @@ describe('checkProofsSpent', () => {
 describe('payLnInvoice', () => {
 	const proofs = [
 		{
-			id: '0NI3TUAs1Sfy',
+			id: '009a1f293253e41e',
 			amount: 1,
-			secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+			secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
 	test('test payLnInvoice base case', async () => {
-		nock(mintUrl).post('/checkfees').reply(200, { fee: 0 });
-		nock(mintUrl).post('/melt').reply(200, { paid: true, preimage: '' });
+		nock(mintUrl).post('/v1/melt/quote/bolt11').reply(200, { quote: "quote_id", amount: 123, fee_reserve: 0 });
+		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, proof: '' });
 		const wallet = new CashuWallet(mint);
 
 		const result = await wallet.payLnInvoice(invoice, proofs);
@@ -176,19 +182,23 @@ describe('payLnInvoice', () => {
 	});
 	test('test payLnInvoice change', async () => {
 		nock.cleanAll();
-		nock(mintUrl).get('/keys').reply(200, {
-			1: '02f970b6ee058705c0dddc4313721cffb7efd3d142d96ea8e01d31c2b2ff09f181',
-			2: '03361cd8bd1329fea797a6add1cf1990ffcf2270ceb9fc81eeee0e8e9c1bd0cdf5'
+		nock(mintUrl).get('/v1/keys').reply(200, {
+			keysets: [{
+				id: '009a1f293253e41e', unit: 'sat', keys: {
+					1: '02f970b6ee058705c0dddc4313721cffb7efd3d142d96ea8e01d31c2b2ff09f181',
+					2: '03361cd8bd1329fea797a6add1cf1990ffcf2270ceb9fc81eeee0e8e9c1bd0cdf5'
+				}
+			},]
 		});
-		nock(mintUrl).post('/checkfees').reply(200, { fee: 2 });
+		nock(mintUrl).post('/v1/melt/quote/bolt11').reply(200, { quote: "quote_id", amount: 123, fee_reserve: 2 });
 		nock(mintUrl)
-			.post('/melt')
+			.post('/v1/melt/bolt11')
 			.reply(200, {
 				paid: true,
-				preimage: '',
+				proof: 'asd',
 				change: [
 					{
-						id: '+GmhrYs64zDj',
+						id: '009a1f293253e41e',
 						amount: 2,
 						C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625'
 					}
@@ -199,11 +209,11 @@ describe('payLnInvoice', () => {
 		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }]);
 
 		expect(result.isPaid).toBe(true);
-		expect(result.preimage).toBe('');
+		expect(result.preimage).toBe('asd');
 		expect(result.change).toHaveLength(1);
 	});
 	test('test payLnInvoice bad resonse', async () => {
-		nock(mintUrl).post('/checkfees').reply(200, {});
+		nock(mintUrl).post('/v1/melt/quote/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint);
 
 		const result = await wallet.payLnInvoice(invoice, proofs).catch((e) => e);
@@ -217,9 +227,9 @@ describe('requestTokens', () => {
 		nock(mintUrl)
 			.post('/v1/mint/bolt11')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625'
 					}
@@ -230,12 +240,12 @@ describe('requestTokens', () => {
 		const { proofs } = await wallet.requestTokens(1, '');
 
 		expect(proofs).toHaveLength(1);
-		expect(proofs[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(proofs[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
 	});
 	test('test requestTokens bad resonse', async () => {
-		nock(mintUrl).post('/mint?hash=').reply(200, {});
+		nock(mintUrl).post('/v1/mint/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint);
 
 		const result = await wallet.requestTokens(1, '').catch((e) => e);
@@ -247,9 +257,9 @@ describe('requestTokens', () => {
 describe('send', () => {
 	const proofs = [
 		{
-			id: '0NI3TUAs1Sfy',
+			id: '009a1f293253e41e',
 			amount: 1,
-			secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+			secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
@@ -257,9 +267,9 @@ describe('send', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: '0NI3TUAs1Sfy',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -271,22 +281,22 @@ describe('send', () => {
 
 		expect(result.returnChange).toHaveLength(0);
 		expect(result.send).toHaveLength(1);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: '0NI3TUAs1Sfy' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 	});
 	test('test send over paying. Should return change', async () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -296,35 +306,35 @@ describe('send', () => {
 
 		const result = await wallet.send(1, [
 			{
-				id: '0NI3TUAs1Sfy',
+				id: '009a1f293253e41e',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		]);
 
 		expect(result.send).toHaveLength(1);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(1);
-		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.returnChange[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.returnChange[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.returnChange[0].secret)).toBe(true);
 	});
 
 	test('test send over paying2', async () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -334,45 +344,45 @@ describe('send', () => {
 
 		const overpayProofs = [
 			{
-				id: 'z32vUtKgNCm1',
+				id: '009a1f293253e41e',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
 		const result = await wallet.send(1, overpayProofs);
 
 		expect(result.send).toHaveLength(1);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(1);
-		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.returnChange[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.returnChange[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.returnChange[0].secret)).toBe(true);
 	});
 	test('test send preference', async () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -382,27 +392,27 @@ describe('send', () => {
 
 		const overpayProofs = [
 			{
-				id: 'z32vUtKgNCm1',
+				id: '009a1f293253e41e',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			},
 			{
-				id: 'z32vUtKgNCm1',
+				id: '009a1f293253e41e',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
 		const result = await wallet.send(4, overpayProofs, [{ amount: 1, count: 4 }]);
 
 		expect(result.send).toHaveLength(4);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
-		expect(result.send[1]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
-		expect(result.send[2]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
-		expect(result.send[3]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[1]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[2]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[3]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(0);
 	});
 
@@ -410,24 +420,24 @@ describe('send', () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					},
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -437,37 +447,37 @@ describe('send', () => {
 
 		const overpayProofs = [
 			{
-				id: 'z32vUtKgNCm1',
+				id: '009a1f293253e41e',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			},
 			{
-				id: 'z32vUtKgNCm1',
+				id: '009a1f293253e41e',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
 		const result = await wallet.send(4, overpayProofs, [{ amount: 1, count: 3 }]);
 
 		expect(result.send).toHaveLength(3);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
-		expect(result.send[1]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
-		expect(result.send[2]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[1]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[2]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(1);
-		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
+		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
 	});
 
 	test('test send not enough funds', async () => {
 		nock(mintUrl)
 			.post('/split')
 			.reply(200, {
-				promises: [
+				signatures: [
 					{
-						id: 'z32vUtKgNCm1',
+						id: '009a1f293253e41e',
 						amount: 1,
 						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 					}
@@ -486,9 +496,9 @@ describe('send', () => {
 		const result = await wallet
 			.send(1, [
 				{
-					id: 'z32vUtKgNCm1',
+					id: '009a1f293253e41e',
 					amount: 2,
-					secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+					secret: 'e7c1b76d1b31e2bca2b229d160bdf6046f33bc4570222304b65110d926f7af89',
 					C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 				}
 			])

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -33,67 +33,67 @@ describe('test fees', () => {
 describe('receive', () => {
 	const tokenInput =
 		'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19';
-		test('test receive', async () => {
-			nock(mintUrl)
-				.post('/split')
-				.reply(200, {
-					promises: [
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						}
-					]
-				});
-			const wallet = new CashuWallet(mint);
-	
-			const { token: t, tokensWithErrors } = await wallet.receive(tokenInput);
-	
-			expect(t.token).toHaveLength(1);
-			expect(t.token[0].proofs).toHaveLength(1);
-			expect(t.token[0]).toMatchObject({
-				proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
-				mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
+	test('test receive', async () => {
+		nock(mintUrl)
+			.post('/split')
+			.reply(200, {
+				promises: [
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					}
+				]
 			});
-			expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-			expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-			expect(tokensWithErrors).toBe(undefined);
+		const wallet = new CashuWallet(mint);
+
+		const { token: t, tokensWithErrors } = await wallet.receive(tokenInput);
+
+		expect(t.token).toHaveLength(1);
+		expect(t.token[0].proofs).toHaveLength(1);
+		expect(t.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }],
+			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 		});
-		test('test receive custom split', async () => {
-			nock(mintUrl)
-				.post('/split')
-				.reply(200, {
-					promises: [
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						},
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						},
-						{
-							id: 'z32vUtKgNCm1',
-							amount: 1,
-							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-						}
-					]
-				});
-			const wallet = new CashuWallet(mint);
-			const token3sat = 'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19'
-			const { token: t, tokensWithErrors } = await wallet.receive(token3sat, [{amount:1, count:3}]);
-	
-			expect(t.token).toHaveLength(1);
-			expect(t.token[0].proofs).toHaveLength(3);
-			expect(t.token[0]).toMatchObject({
-				proofs: [{ amount: 1, id: 'z32vUtKgNCm1' },{ amount: 1, id: 'z32vUtKgNCm1' },{ amount: 1, id: 'z32vUtKgNCm1' }],
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(tokensWithErrors).toBe(undefined);
+	});
+	test('test receive custom split', async () => {
+		nock(mintUrl)
+			.post('/split')
+			.reply(200, {
+				promises: [
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					},
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					},
+					{
+						id: 'z32vUtKgNCm1',
+						amount: 1,
+						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
+					}
+				]
 			});
-			expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-			expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-			expect(tokensWithErrors).toBe(undefined);
+		const wallet = new CashuWallet(mint);
+		const token3sat = 'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifSx7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19'
+		const { token: t, tokensWithErrors } = await wallet.receive(token3sat, [{ amount: 1, count: 3 }]);
+
+		expect(t.token).toHaveLength(1);
+		expect(t.token[0].proofs).toHaveLength(3);
+		expect(t.token[0]).toMatchObject({
+			proofs: [{ amount: 1, id: 'z32vUtKgNCm1' }, { amount: 1, id: 'z32vUtKgNCm1' }, { amount: 1, id: 'z32vUtKgNCm1' }],
 		});
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
+		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(tokensWithErrors).toBe(undefined);
+	});
 	test('test receive tokens already spent', async () => {
 		const msg = 'tokens already spent. Secret: oEpEuViVHUV2vQH81INUbq++Yv2w3u5H0LhaqXJKeR0=';
 		nock(mintUrl).post('/split').reply(200, { detail: msg });
@@ -128,41 +128,6 @@ describe('receive', () => {
 		});
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
 		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
-	});
-	test('test receive keys changed', async () => {
-		nock(mintUrl)
-			.post('/split')
-			.reply(200, {
-				promises: [
-					{
-						id: 'test',
-						amount: 1,
-						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-					}
-				]
-			});
-		nock(mintUrl).get('/keys/test').reply(200, {
-			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
-		});
-		nock(mintUrl).get('/keys').reply(200, {
-			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
-		});
-		const wallet = new CashuWallet(mint);
-
-		const {
-			token: { token },
-			tokensWithErrors,
-			newKeys
-		} = await wallet.receive(tokenInput);
-
-		expect(token[0].proofs).toHaveLength(1);
-		expect(token[0].proofs[0]).toMatchObject({ amount: 1, id: 'test' });
-		expect(/[0-9a-f]{64}/.test(token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(token[0].proofs[0].secret)).toBe(true);
-		expect(tokensWithErrors).toBe(undefined);
-		expect(newKeys).toStrictEqual({
-			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
-		});
 	});
 });
 
@@ -240,38 +205,6 @@ describe('payLnInvoice', () => {
 		const result = await wallet.payLnInvoice(invoice, proofs).catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));
-	});
-	test('test payLnInvoice key changed', async () => {
-		nock(mintUrl).post('/checkfees').reply(200, { fee: 2 });
-		nock(mintUrl)
-			.post('/melt')
-			.reply(200, {
-				paid: true,
-				preimage: '',
-				change: [
-					{
-						id: 'test',
-						amount: 1,
-						C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
-					}
-				]
-			});
-		nock(mintUrl).get('/keys/test').reply(200, {
-			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
-		});
-		nock(mintUrl).get('/keys').reply(200, {
-			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
-		});
-		const wallet = new CashuWallet(mint);
-
-		const { isPaid, preimage, change, newKeys } = await wallet.payLnInvoice(invoice, proofs);
-
-		expect(isPaid).toEqual(true);
-		expect(preimage).toEqual('');
-		expect(change).toHaveLength(1);
-		expect(newKeys).toStrictEqual({
-			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
-		});
 	});
 });
 


### PR DESCRIPTION
Updates to the V1 API in Cashu-TS. 

Todo:
- [x] Implement all v1 endpoints and models
  - [x] `GET /v1/info`
  - [x] `GET /v1/keys`
  - [x] `GET /v1/keys/{keyset_id}`
  - [x] `GET /v1/keysets`
  - [x] `GET /v1/check`
  - [x] `POST /v1/split`
  - [x] `POST /v1/melt/quote/bolt11`
  - [x] `POST /v1/melt/bolt11`
  - [x] `POST /v1/mint/quote/bolt11`
  - [x] `POST /v1/mint/bolt11`
- [x] `BlindedMessage` now has `id` field
- [x] Use 64-char hex string for generating secrets
- [x] Update tests to new hex keyset IDs and secrets
- [x] Add Nutshell mint end-to-end integration tests (Docker pipeline not working yet, but tests are green)
- [ ] Implement keyset ID derivation. Right now, it simply trusts the mint to respond with the correct keyset ID.