### PR TITLE
add missing paymentRequest, update InvoiceData type

### DIFF
--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -351,10 +351,10 @@ export type AmountPreference = {
 
 export type InvoiceData = {
 	paymentRequest: string;
-	amountInSats: number;
-	amountInMSats: number;
-	timestamp: number;
-	paymentHash: string;
-	memo: string;
-	expiry: number;
+	amountInSats?: number;
+	amountInMSats?: number;
+	timestamp?: number;
+	paymentHash?: string;
+	memo?: string;
+	expiry?: number;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,6 +193,7 @@ export function joinUrls(...parts: Array<string>): string {
 export function decodeInvoice(bolt11Invoice: string): InvoiceData {
 	const invoiceData: InvoiceData = {} as InvoiceData;
 	const decodeResult = decode(bolt11Invoice);
+	invoiceData.paymentRequest = decodeResult.paymentRequest;
 	for (let i = 0; i < decodeResult.sections.length; i++) {
 		const decodedSection = decodeResult.sections[i];
 		if (decodedSection.name === 'amount') {


### PR DESCRIPTION
## Description

After updating to 0.9.0 and testing out the util function "decodeInvoice", I noticed that the property "paymentRequest" is undefined. I assume that it should hold the invoice string.

Since the variable "invoiceData" is initialized as empty object, I've also updated the type "InvoiceData" because all properties (except "paymentRequest") could be undefined for whatever reason.

Please let me know if I am missing something @Egge21M @BilligsterUser @gandlafbtc