### PR TITLE
fix h2c

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -23,10 +23,7 @@ class CashuMint {
 	 * @param _mintUrl requires mint URL to create this object
 	 * @param _customRequest if passed, use custom request implementation for network communication with the mint
 	 */
-	constructor(
-		private _mintUrl: string,
-		private _customRequest?: typeof request
-	) {}
+	constructor(private _mintUrl: string, private _customRequest?: typeof request) {}
 
 	get mintUrl() {
 		return this._mintUrl;

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -4,22 +4,27 @@ import { encodeUint8toBase64 } from './base64.js';
 import { MintKeys, Proof, SerializedBlindedSignature } from './model/types/index.js';
 import { bytesToNumber } from './utils.js';
 import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex } from '@noble/curves/abstract/utils';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
+import { Buffer } from 'buffer/';
+
+const DOMAIN_SEPARATOR = hexToBytes('536563703235366b315f48617368546f43757276655f43617368755f');
 
 function hashToCurve(secret: Uint8Array): ProjPointType<bigint> {
-	let point: ProjPointType<bigint> | undefined;
-	while (!point) {
-		const hash = sha256(secret);
-		const hashHex = bytesToHex(hash);
-		const pointX = '02' + hashHex;
+	const msgToHash = sha256(Buffer.concat([DOMAIN_SEPARATOR, secret]));
+	const counter = new Uint32Array(1);
+	const maxIterations = 2 ** 16;
+	for (let i = 0; i < maxIterations; i++) {
+		const counterBytes = new Uint8Array(counter.buffer);
+		const hash = sha256(Buffer.concat([msgToHash, counterBytes]));
 		try {
-			point = pointFromHex(pointX);
+			return pointFromHex(bytesToHex(Buffer.concat([new Uint8Array([0x02]), hash])));
 		} catch (error) {
-			secret = sha256(secret);
+			counter[0]++;
 		}
 	}
-	return point;
+	throw new Error('No valid point found');
 }
+
 export function pointFromHex(hex: string) {
 	return secp256k1.ProjectivePoint.fromHex(hex);
 }

--- a/test/dhke.test.ts
+++ b/test/dhke.test.ts
@@ -9,14 +9,14 @@ describe('testing hash to curve', () => {
 		let secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000000');
 		let Y = dhke.hashToCurve(secret);
 		let hexY = Y.toHex(true);
-		expect(hexY).toBe('0266687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925');
+		expect(hexY).toBe('024cce997d3b518f739663b757deaec95bcd9473c30a14ac2fd04023a739d1a725');
 	});
 
 	test('testing string 0000....01', async () => {
 		let secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
 		let Y = dhke.hashToCurve(secret);
 		let hexY = Y.toHex(true);
-		expect(hexY).toBe('02ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5');
+		expect(hexY).toBe('022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf');
 	});
 });
 
@@ -29,7 +29,7 @@ describe('test blinding message', () => {
 			bytesToNumber(hexToBytes('0000000000000000000000000000000000000000000000000000000000000001'))
 		);
 		expect(B_.toHex(true)).toBe(
-			'03c509bbdd8aaa81d5e67468d07b4b7dffd5769ac596ff3964e151adcefc6b06d0'
+			'030eded094dc2b0e3c78aae9fac76c1ad426a43e1f57fb32d2e64ca5dc82a85791'
 		);
 	});
 });


### PR DESCRIPTION
⚠️ This PR will affect the restore process of wallets that implement determinsitic secrets. Wallets that implement this PR will have to initiate a 'self-spend' of all ecash after upgrading, in order to ensure the ecash will be recoverable. ⚠️


## Changes

- change to new H2C function

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
