### PR TITLE
switch to hex secrets

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -23,10 +23,7 @@ class CashuMint {
 	 * @param _mintUrl requires mint URL to create this object
 	 * @param _customRequest if passed, use custom request implementation for network communication with the mint
 	 */
-	constructor(
-		private _mintUrl: string,
-		private _customRequest?: typeof request
-	) {}
+	constructor(private _mintUrl: string, private _customRequest?: typeof request) {}
 
 	get mintUrl() {
 		return this._mintUrl;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from '@noble/hashes/utils';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
 import { CashuMint } from './CashuMint.js';
 import * as dhke from './DHKE.js';
 import { BlindedMessage } from './model/BlindedMessage.js';
@@ -548,6 +548,8 @@ class CashuWallet {
 			} else {
 				secret = randomBytes(32);
 			}
+			secret = bytesToHex(secret);
+			secret = new TextEncoder().encode(secret);
 			secrets.push(secret);
 			const { B_, r } = dhke.blindMessage(secret, deterministicR);
 			rs.push(r);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -539,17 +539,17 @@ class CashuWallet {
 		const rs: Array<bigint> = [];
 		for (let i = 0; i < amounts.length; i++) {
 			let deterministicR = undefined;
-			let secret = undefined;
+			let secretBytes = undefined;
 			if (this._seed && counter != undefined) {
-				secret = deriveSecret(this._seed, keysetId ?? this.keysetId, counter + i);
+				secretBytes = deriveSecret(this._seed, keysetId ?? this.keysetId, counter + i);
 				deterministicR = bytesToNumber(
 					deriveBlindingFactor(this._seed, keysetId ?? this.keysetId, counter + i)
 				);
 			} else {
-				secret = randomBytes(32);
+				secretBytes = randomBytes(32);
 			}
-			secret = bytesToHex(secret);
-			secret = new TextEncoder().encode(secret);
+			const secretHex = bytesToHex(secretBytes);
+			const secret = new TextEncoder().encode(secretHex);
 			secrets.push(secret);
 			const { B_, r } = dhke.blindMessage(secret, deterministicR);
 			rs.push(r);

--- a/src/DHKE.ts
+++ b/src/DHKE.ts
@@ -1,6 +1,5 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { encodeUint8toBase64 } from './base64.js';
 import { MintKeys, Proof, SerializedBlindedSignature } from './model/types/index.js';
 import { bytesToNumber } from './utils.js';
 import { sha256 } from '@noble/hashes/sha256';
@@ -27,9 +26,7 @@ export function pointFromHex(hex: string) {
 	return secp256k1.ProjectivePoint.fromAffine(h2c.toAffine());
 } */
 function blindMessage(secret: Uint8Array, r?: bigint): { B_: ProjPointType<bigint>; r: bigint } {
-	const secretMessageBase64 = encodeUint8toBase64(secret);
-	const secretMessage = new TextEncoder().encode(secretMessageBase64);
-	const Y = hashToCurve(secretMessage);
+	const Y = hashToCurve(secret);
 	if (!r) {
 		r = bytesToNumber(secp256k1.utils.randomPrivateKey());
 	}
@@ -60,7 +57,7 @@ function constructProofs(
 		const proof = {
 			id: p.id,
 			amount: p.amount,
-			secret: encodeUint8toBase64(secrets[i]),
+			secret: new TextDecoder().decode(secrets[i]),
 			C: C.toHex(true)
 		};
 		return proof;

--- a/test/dhke.test.ts
+++ b/test/dhke.test.ts
@@ -23,13 +23,13 @@ describe('testing hash to curve', () => {
 describe('test blinding message', () => {
 	test('testing string 0000....01', async () => {
 		var enc = new TextEncoder();
-		let secretUInt8 = enc.encode(SECRET_MESSAGE);
+		let secretUInt8 = enc.encode('test_message');
 		let { B_ } = await dhke.blindMessage(
 			secretUInt8,
 			bytesToNumber(hexToBytes('0000000000000000000000000000000000000000000000000000000000000001'))
 		);
 		expect(B_.toHex(true)).toBe(
-			'03c509bbdd8aaa81d5e67468d07b4b7dffd5769ac596ff3964e151adcefc6b06d0'
+			'02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2'
 		);
 	});
 });

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -1,6 +1,7 @@
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { deriveSeedFromMnemonic } from '../src/secrets';
 import { deriveBlindingFactor, deriveSecret } from '../src/secrets';
+import { blindMessage } from '../src/DHKE';
 import { HDKey } from '@scure/bip32';
 
 const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
@@ -26,24 +27,43 @@ describe('testing hdkey from seed', () => {
 
 describe('testing deterministic secrets', () => {
 	const secrets = [
-		'9d32fc57e6fa2942d05ee475d28ba6a56839b8cb8a3f174b05ed0ed9d3a420f6',
-		'1c0f2c32e7438e7cc992612049e9dfcdbffd454ea460901f24cc429921437802',
-		'327c606b761af03cbe26fa13c4b34a6183b868c52cda059fe57fdddcb4e1e1e7',
-		'53476919560398b56c0fdc5dd92cf8628b1e06de6f2652b0f7d6e8ac319de3b7',
-		'b2f5d632229378a716be6752fc79ac8c2b43323b820859a7956f2dfe5432b7b4'
+		'485875df74771877439ac06339e284c3acfcd9be7abf3bc20b516faeadfe77ae',
+		'8f2b39e8e594a4056eb1e6dbb4b0c38ef13b1b2c751f64f810ec04ee35b77270',
+		'bc628c79accd2364fd31511216a0fab62afd4a18ff77a20deded7b858c9860c8',
+		'59284fd1650ea9fa17db2b3acf59ecd0f2d52ec3261dd4152785813ff27a33bf',
+		'576c23393a8b31cc8da6688d9c9a96394ec74b40fdaf1f693a6bb84284334ea0'
 	];
 	test('derive Secret', async () => {
-		const secret1 = deriveSecret(seed, '1cCNIAZ2X/w1', 0);
-		const secret2 = deriveSecret(seed, '1cCNIAZ2X/w1', 1);
-		const secret3 = deriveSecret(seed, '1cCNIAZ2X/w1', 2);
-		const secret4 = deriveSecret(seed, '1cCNIAZ2X/w1', 3);
-		const secret5 = deriveSecret(seed, '1cCNIAZ2X/w1', 4);
+		const secret1 = deriveSecret(seed, '009a1f293253e41e', 0);
+		const secret2 = deriveSecret(seed, '009a1f293253e41e', 1);
+		const secret3 = deriveSecret(seed, '009a1f293253e41e', 2);
+		const secret4 = deriveSecret(seed, '009a1f293253e41e', 3);
+		const secret5 = deriveSecret(seed, '009a1f293253e41e', 4);
+
+		const bf1 = deriveBlindingFactor(seed, '009a1f293253e41e', 0);
+		const bf2 = deriveBlindingFactor(seed, '009a1f293253e41e', 1);
+		const bf3 = deriveBlindingFactor(seed, '009a1f293253e41e', 2);
+		const bf4 = deriveBlindingFactor(seed, '009a1f293253e41e', 3);
+		const bf5 = deriveBlindingFactor(seed, '009a1f293253e41e', 4);
 
 		expect(bytesToHex(secret1)).toBe(secrets[0]);
 		expect(bytesToHex(secret2)).toBe(secrets[1]);
 		expect(bytesToHex(secret3)).toBe(secrets[2]);
 		expect(bytesToHex(secret4)).toBe(secrets[3]);
 		expect(bytesToHex(secret5)).toBe(secrets[4]);
+	});
+});
+
+describe('testing deterministic blindedMessage', () => {
+	const secrets = ['485875df74771877439ac06339e284c3acfcd9be7abf3bc20b516faeadfe77ae'];
+	test('derive Secret', async () => {
+		const secret1 = deriveSecret(seed, '009a1f293253e41e', 0);
+
+		const bf1 = deriveBlindingFactor(seed, '009a1f293253e41e', 0);
+
+		expect(bytesToHex(secret1)).toBe(secrets[0]);
+
+		// blindMessage()
 	});
 });
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -35,7 +35,7 @@ describe('test fees', () => {
 
 describe('receive', () => {
 	const tokenInput =
-		'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiJBZmtRYlJYQUc1UU1tT3ArbG9vRzQ2OXBZWTdiaStqbEcxRXRDT2tIa2hZPSIsIkMiOiIwMmY4NWRkODRiMGY4NDE4NDM2NmNiNjkxNDYxMDZhZjdjMGYyNmYyZWUwYWQyODdhM2U1ZmE4NTI1MjhiYjI5ZGYifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovL2xlZ2VuZC5sbmJpdHMuY29tL2Nhc2h1L2FwaS92MS80Z3I5WGNtejNYRWtVTndpQmlRR29DIiwiaWRzIjpbIi91WUIvNndXbllrVSJdfV19';
+		'eyJwcm9vZnMiOlt7ImlkIjoiL3VZQi82d1duWWtVIiwiYW1vdW50IjoxLCJzZWNyZXQiOiIwMWY5MTA2ZDE1YzAxYjk0MGM5OGVhN2U5NjhhMDZlM2FmNjk2MThlZGI4YmU4ZTUxYjUxMmQwOGU5MDc5MjE2IiwiQyI6IjAyZjg1ZGQ4NGIwZjg0MTg0MzY2Y2I2OTE0NjEwNmFmN2MwZjI2ZjJlZTBhZDI4N2EzZTVmYTg1MjUyOGJiMjlkZiJ9XSwibWludHMiOlt7InVybCI6Imh0dHBzOi8vbGVnZW5kLmxuYml0cy5jb20vY2FzaHUvYXBpL3YxLzRncjlYY216M1hFa1VOd2lCaVFHb0MiLCJpZHMiOlsiL3VZQi82d1duWWtVIl19XX0=';
 	test('test receive encoded token', async () => {
 		nock(mintUrl)
 			.post('/split')
@@ -59,7 +59,7 @@ describe('receive', () => {
 			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 		});
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
 		expect(tokensWithErrors).toBe(undefined);
 	});
 
@@ -88,7 +88,7 @@ describe('receive', () => {
 			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 		});
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
 		expect(tokensWithErrors).toBe(undefined);
 	});
 	test('test receive custom split', async () => {
@@ -130,7 +130,7 @@ describe('receive', () => {
 			]
 		});
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
 		expect(tokensWithErrors).toBe(undefined);
 	});
 	test('test receive tokens already spent', async () => {
@@ -149,7 +149,7 @@ describe('receive', () => {
 			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 		});
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
 	});
 	test('test receive could not verify proofs', async () => {
 		nock(mintUrl).post('/split').reply(500, { code: 0, error: 'could not verify proofs.' });
@@ -166,7 +166,7 @@ describe('receive', () => {
 			mint: 'https://legend.lnbits.com/cashu/api/v1/4gr9Xcmz3XEkUNwiBiQGoC'
 		});
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(t.token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
 	});
 	test('test receive keys changed', async () => {
 		nock(mintUrl)
@@ -197,7 +197,7 @@ describe('receive', () => {
 		expect(token[0].proofs).toHaveLength(1);
 		expect(token[0].proofs[0]).toMatchObject({ amount: 1, id: 'test' });
 		expect(/[0-9a-f]{64}/.test(token[0].proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(token[0].proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(token[0].proofs[0].secret)).toBe(true);
 		expect(tokensWithErrors).toBe(undefined);
 		expect(newKeys).toStrictEqual({
 			1: '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad'
@@ -210,7 +210,7 @@ describe('checkProofsSpent', () => {
 		{
 			id: '0NI3TUAs1Sfy',
 			amount: 1,
-			secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
@@ -231,7 +231,7 @@ describe('payLnInvoice', () => {
 		{
 			id: '0NI3TUAs1Sfy',
 			amount: 1,
-			secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
@@ -334,7 +334,7 @@ describe('requestTokens', () => {
 		expect(proofs).toHaveLength(1);
 		expect(proofs[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(proofs[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
 	});
 	test('test requestTokens bad resonse', async () => {
 		nock(mintUrl).post('/mint?hash=').reply(200, {});
@@ -351,7 +351,7 @@ describe('send', () => {
 		{
 			id: '0NI3TUAs1Sfy',
 			amount: 1,
-			secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
@@ -375,7 +375,7 @@ describe('send', () => {
 		expect(result.send).toHaveLength(1);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '0NI3TUAs1Sfy' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 	});
 	test('test send over paying. Should return change', async () => {
 		nock(mintUrl)
@@ -400,7 +400,7 @@ describe('send', () => {
 			{
 				id: '0NI3TUAs1Sfy',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		]);
@@ -408,11 +408,11 @@ describe('send', () => {
 		expect(result.send).toHaveLength(1);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(1);
 		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(result.returnChange[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.returnChange[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.returnChange[0].secret)).toBe(true);
 	});
 
 	test('test send over paying2', async () => {
@@ -438,7 +438,7 @@ describe('send', () => {
 			{
 				id: 'z32vUtKgNCm1',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
@@ -447,11 +447,11 @@ describe('send', () => {
 		expect(result.send).toHaveLength(1);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(1);
 		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(result.returnChange[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.returnChange[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.returnChange[0].secret)).toBe(true);
 	});
 	test('test send preference', async () => {
 		nock(mintUrl)
@@ -486,13 +486,13 @@ describe('send', () => {
 			{
 				id: 'z32vUtKgNCm1',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			},
 			{
 				id: 'z32vUtKgNCm1',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
@@ -504,7 +504,7 @@ describe('send', () => {
 		expect(result.send[2]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(result.send[3]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(0);
 	});
 
@@ -541,13 +541,13 @@ describe('send', () => {
 			{
 				id: 'z32vUtKgNCm1',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			},
 			{
 				id: 'z32vUtKgNCm1',
 				amount: 2,
-				secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
@@ -558,7 +558,7 @@ describe('send', () => {
 		expect(result.send[1]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(result.send[2]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
-		expect(/[A-Za-z0-9+/]{43}=/.test(result.send[0].secret)).toBe(true);
+		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.returnChange).toHaveLength(1);
 		expect(result.returnChange[0]).toMatchObject({ amount: 1, id: 'z32vUtKgNCm1' });
 	});
@@ -590,7 +590,7 @@ describe('send', () => {
 				{
 					id: 'z32vUtKgNCm1',
 					amount: 2,
-					secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+					secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 					C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 				}
 			])
@@ -610,7 +610,7 @@ describe('deterministic', () => {
 					{
 						id: 'z32vUtKgNCm1',
 						amount: 2,
-						secret: 'H5jmg3pDRkTJQRgl18bW4Tl0uTH48GUiF86ikBBnShM=',
+						secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 						C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 					}
 				],


### PR DESCRIPTION
:warning: This PR will affect the restore process of wallets that implement determinsitic secrets. Wallets that implement this PR will have to initiate a 'self-spend' of all ecash after upgrading, in order to ensure the ecash will be recoverable.  :warning: 

# Fixes: base64 secret format 

## Description
The secrets that cashu-ts uses is a base64 string, which makes it incompatible for restoring ecash accross clients that use hex secrets. The spec recommends to use a hex string, so that's why we switch.

## Changes

- change from b64 to hex
- fix tests

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
