### PR TITLE
P2PK, cashu-crypto lib, options object

### DIFF
--- a/migration-1.0.0.md
+++ b/migration-1.0.0.md
@@ -27,7 +27,7 @@ Decoding LN invoices is no longer used inside the lib.
 
 **optional parameters are now in an onpional `options?` Object**
 
-Utility functions now have an `options` object for optional parameters, instead of passing them directly  
+Utility functions now have an `options` object for optional parameters, instead of passing them directly
 
 **`requestMint(amount: number)` --> `getMintQuote(amount: number)`**
 Now returns the following:

--- a/migration-1.0.0.md
+++ b/migration-1.0.0.md
@@ -25,6 +25,10 @@ Decoding LN invoices is no longer used inside the lib.
 
 ### `CashuWallet` interface changes
 
+**optional parameters are now in an onpional `options?` Object**
+
+Utility functions now have an `options` object for optional parameters, instead of passing them directly  
+
 **`requestMint(amount: number)` --> `getMintQuote(amount: number)`**
 Now returns the following:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
 			"version": "1.0.0-rc.1",
 			"license": "MIT",
 			"dependencies": {
+				"@gandlaf21/cashu-crypto": "^0.2.5",
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
 				"@scure/bip39": "^1.2.2",
-				"buffer": "^6.0.3"
+				"buffer": "^6.0.3",
+				"js-base64": "^3.7.7"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.1",
@@ -815,6 +817,18 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@gandlaf21/cashu-crypto": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@gandlaf21/cashu-crypto/-/cashu-crypto-0.2.5.tgz",
+			"integrity": "sha512-MvXHAKvNDREzTsHzK4M9LOsK3S/BwAtbyZ+myFkNFS68z9IhQVfUKP+lQgLXdiQdf5i64LQRkzLV+OpOXg6dHg==",
+			"dependencies": {
+				"@noble/curves": "^1.3.0",
+				"@noble/hashes": "^1.3.3",
+				"@scure/bip32": "^1.3.3",
+				"@scure/bip39": "^1.2.2",
+				"buffer": "^6.0.3"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -4692,6 +4706,11 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/js-base64": {
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+			"integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+		},
 		"node_modules/js-sdsl": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
@@ -6998,6 +7017,18 @@
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
 			"integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
 			"dev": true
+		},
+		"@gandlaf21/cashu-crypto": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@gandlaf21/cashu-crypto/-/cashu-crypto-0.2.5.tgz",
+			"integrity": "sha512-MvXHAKvNDREzTsHzK4M9LOsK3S/BwAtbyZ+myFkNFS68z9IhQVfUKP+lQgLXdiQdf5i64LQRkzLV+OpOXg6dHg==",
+			"requires": {
+				"@noble/curves": "^1.3.0",
+				"@noble/hashes": "^1.3.3",
+				"@scure/bip32": "^1.3.3",
+				"@scure/bip39": "^1.2.2",
+				"buffer": "^6.0.3"
+			}
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -9846,6 +9877,11 @@
 					}
 				}
 			}
+		},
+		"js-base64": {
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+			"integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
 		},
 		"js-sdsl": {
 			"version": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
 			"version": "1.0.0-rc.1",
 			"license": "MIT",
 			"dependencies": {
-				"@gandlaf21/cashu-crypto": "^0.2.5",
+				"@gandlaf21/cashu-crypto": "^0.2.6",
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
 				"@scure/bip39": "^1.2.2",
-				"buffer": "^6.0.3",
-				"js-base64": "^3.7.7"
+				"buffer": "^6.0.3"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.1",
@@ -820,9 +819,9 @@
 			}
 		},
 		"node_modules/@gandlaf21/cashu-crypto": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@gandlaf21/cashu-crypto/-/cashu-crypto-0.2.5.tgz",
-			"integrity": "sha512-MvXHAKvNDREzTsHzK4M9LOsK3S/BwAtbyZ+myFkNFS68z9IhQVfUKP+lQgLXdiQdf5i64LQRkzLV+OpOXg6dHg==",
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/@gandlaf21/cashu-crypto/-/cashu-crypto-0.2.6.tgz",
+			"integrity": "sha512-BwiaSAhk98XSgy+BXAeGNRLfjOh1CsGNQGi957wF7u+dfPH5EkOqnd7tnynmWi8yx0xdk0eF9EFwdKryjzEQrA==",
 			"dependencies": {
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
@@ -4706,11 +4705,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/js-base64": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-			"integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
-		},
 		"node_modules/js-sdsl": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
@@ -7019,9 +7013,9 @@
 			"dev": true
 		},
 		"@gandlaf21/cashu-crypto": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@gandlaf21/cashu-crypto/-/cashu-crypto-0.2.5.tgz",
-			"integrity": "sha512-MvXHAKvNDREzTsHzK4M9LOsK3S/BwAtbyZ+myFkNFS68z9IhQVfUKP+lQgLXdiQdf5i64LQRkzLV+OpOXg6dHg==",
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/@gandlaf21/cashu-crypto/-/cashu-crypto-0.2.6.tgz",
+			"integrity": "sha512-BwiaSAhk98XSgy+BXAeGNRLfjOh1CsGNQGi957wF7u+dfPH5EkOqnd7tnynmWi8yx0xdk0eF9EFwdKryjzEQrA==",
 			"requires": {
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
@@ -9877,11 +9871,6 @@
 					}
 				}
 			}
-		},
-		"js-base64": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-			"integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
 		},
 		"js-sdsl": {
 			"version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,12 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
+		"@gandlaf21/cashu-crypto": "^0.2.5",
 		"@noble/curves": "^1.3.0",
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",
 		"@scure/bip39": "^1.2.2",
-		"buffer": "^6.0.3"
+		"buffer": "^6.0.3",
+		"js-base64": "^3.7.7"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -46,12 +46,11 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
-		"@gandlaf21/cashu-crypto": "^0.2.5",
+		"@gandlaf21/cashu-crypto": "^0.2.6",
 		"@noble/curves": "^1.3.0",
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",
 		"@scure/bip39": "^1.2.2",
-		"buffer": "^6.0.3",
-		"js-base64": "^3.7.7"
+		"buffer": "^6.0.3"
 	}
 }

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -32,8 +32,8 @@ import {
 import { deriveBlindingFactor, deriveSecret, deriveSeedFromMnemonic } from './secrets.js';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
-import { createP2PKsecret, getSignedProofs } from "@gandlaf21/cashu-crypto/modules/client/NUT11";
-import { serializeProof } from "@gandlaf21/cashu-crypto/modules/client";
+import { createP2PKsecret, getSignedProofs } from '@gandlaf21/cashu-crypto/modules/client/NUT11';
+import { serializeProof } from '@gandlaf21/cashu-crypto/modules/client';
 import { pointFromHex } from './DHKE';
 
 /**
@@ -92,12 +92,12 @@ class CashuWallet {
 	async receive(
 		token: string | Token,
 		options?: {
-			preference?: Array<AmountPreference>,
-			counter?: number,
-			pubkey?: string,
-			privkey?: string
+			preference?: Array<AmountPreference>;
+			counter?: number;
+			pubkey?: string;
+			privkey?: string;
 		}
-			): Promise<ReceiveResponse> {
+	): Promise<ReceiveResponse> {
 		let decodedToken: Array<TokenEntry>;
 		if (typeof token === 'string') {
 			decodedToken = cleanToken(getDecodedToken(token)).token;
@@ -111,15 +111,12 @@ class CashuWallet {
 				continue;
 			}
 			try {
-				const { proofs, proofsWithError } = await this.receiveTokenEntry(
-					tokenEntry,
-					{
-						preference: options?.preference,
-						counter: options?.counter,
-						pubkey: options?.pubkey,
-						privkey: options?.privkey
-					}
-				);
+				const { proofs, proofsWithError } = await this.receiveTokenEntry(tokenEntry, {
+					preference: options?.preference,
+					counter: options?.counter,
+					pubkey: options?.pubkey,
+					privkey: options?.privkey
+				});
 				if (proofsWithError?.length) {
 					tokenEntriesWithError.push(tokenEntry);
 					continue;
@@ -147,18 +144,18 @@ class CashuWallet {
 	 */
 	async receiveTokenEntry(
 		tokenEntry: TokenEntry,
-		options?:{
-			preference?: Array<AmountPreference>,
-			counter?: number,
-			pubkey?: string,
-			privkey?: string
+		options?: {
+			preference?: Array<AmountPreference>;
+			counter?: number;
+			pubkey?: string;
+			privkey?: string;
 		}
 	): Promise<ReceiveTokenEntryResponse> {
 		const proofsWithError: Array<Proof> = [];
 		const proofs: Array<Proof> = [];
 		try {
 			const amount = tokenEntry.proofs.reduce((total, curr) => total + curr.amount, 0);
-			let preference = options?.preference 
+			let preference = options?.preference;
 			if (!preference) {
 				preference = getDefaultAmountPreference(amount);
 			}
@@ -205,11 +202,11 @@ class CashuWallet {
 	async send(
 		amount: number,
 		proofs: Array<Proof>,
-		options?:{
-			preference?: Array<AmountPreference>,
-			counter?: number,
-			pubkey?: string,
-			privkey?: string
+		options?: {
+			preference?: Array<AmountPreference>;
+			counter?: number;
+			pubkey?: string;
+			privkey?: string;
 		}
 	): Promise<SendResponse> {
 		if (options?.preference) {
@@ -279,7 +276,7 @@ class CashuWallet {
 		start: number,
 		count: number,
 		options?: {
-			keysetId?: string
+			keysetId?: string;
 		}
 	): Promise<{ proofs: Array<Proof> }> {
 		const keys = await this.getKeys(options?.keysetId);
@@ -350,10 +347,10 @@ class CashuWallet {
 		amount: number,
 		quote: string,
 		options?: {
-			keysetId?: string,
-			AmountPreference?: Array<AmountPreference>,
-			counter?: number,
-			pubkey?: string
+			keysetId?: string;
+			AmountPreference?: Array<AmountPreference>;
+			counter?: number;
+			pubkey?: string;
 		}
 	): Promise<{ proofs: Array<Proof> }> {
 		const keyset = await this.getKeys(options?.keysetId);
@@ -396,8 +393,8 @@ class CashuWallet {
 		meltQuote: MeltQuoteResponse,
 		proofsToSend: Array<Proof>,
 		options?: {
-			keysetId?: string,
-			counter?: number,
+			keysetId?: string;
+			counter?: number;
 		}
 	): Promise<MeltTokensResponse> {
 		const keys = await this.getKeys(options?.keysetId);
@@ -437,15 +434,18 @@ class CashuWallet {
 		invoice: string,
 		proofsToSend: Array<Proof>,
 		meltQuote: MeltQuoteResponse,
-		options?:{
-			keysetId?: string,
-			counter?: number
+		options?: {
+			keysetId?: string;
+			counter?: number;
 		}
 	): Promise<MeltTokensResponse> {
 		if (!meltQuote) {
 			meltQuote = await this.mint.meltQuote({ unit: this.unit, request: invoice });
 		}
-		return await this.meltTokens(meltQuote, proofsToSend, {keysetId:options?.keysetId, counter: options?.counter});
+		return await this.meltTokens(meltQuote, proofsToSend, {
+			keysetId: options?.keysetId,
+			counter: options?.counter
+		});
 	}
 
 	/**
@@ -461,15 +461,18 @@ class CashuWallet {
 		token: string,
 		meltQuote: MeltQuoteResponse,
 		options?: {
-			keysetId?: string,
-			counter?: number
+			keysetId?: string;
+			counter?: number;
 		}
 	): Promise<MeltTokensResponse> {
 		const decodedToken = getDecodedToken(token);
 		const proofs = decodedToken.token
 			.filter((x) => x.mint === this.mint.mintUrl)
 			.flatMap((t) => t.proofs);
-		return this.payLnInvoice(invoice, proofs, meltQuote, {keysetId: options?.keysetId, counter: options?.counter});
+		return this.payLnInvoice(invoice, proofs, meltQuote, {
+			keysetId: options?.keysetId,
+			counter: options?.counter
+		});
 	}
 
 	/**
@@ -512,7 +515,17 @@ class CashuWallet {
 			pubkey
 		);
 		if (privkey) {
-			proofsToSend = getSignedProofs(proofsToSend.map((p)=>{return {amount:p.amount, C: pointFromHex(p.C), id: p.id, secret: new TextEncoder().encode(p.secret)}}), privkey).map(p=> serializeProof(p))
+			proofsToSend = getSignedProofs(
+				proofsToSend.map((p) => {
+					return {
+						amount: p.amount,
+						C: pointFromHex(p.C),
+						id: p.id,
+						secret: new TextEncoder().encode(p.secret)
+					};
+				}),
+				privkey
+			).map((p) => serializeProof(p));
 		}
 
 		// join keepBlindedMessages and sendBlindedMessages
@@ -607,9 +620,8 @@ class CashuWallet {
 			let deterministicR = undefined;
 			let secretBytes = undefined;
 			if (pubkey) {
-				secretBytes = createP2PKsecret(pubkey)
-			}
-			else if (this._seed && counter != undefined) {
+				secretBytes = createP2PKsecret(pubkey);
+			} else if (this._seed && counter != undefined) {
 				secretBytes = deriveSecret(this._seed, keysetId, counter + i);
 				deterministicR = bytesToNumber(deriveBlindingFactor(this._seed, keysetId, counter + i));
 			} else {

--- a/test/base64.test.ts
+++ b/test/base64.test.ts
@@ -72,4 +72,27 @@ describe('testing uint8 encoding', () => {
 		expect(encodeBase64ToJson(base64url)).toStrictEqual(obj);
 		expect(encodeJsonToBase64(obj)).toStrictEqual(base64url);
 	});
+	test('test script secret to from base64', () => {
+		const base64url = 'eyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IjAwOWExZjI5MzI1M2U0MWUiLCJhbW91bnQiOjEsInNlY3JldCI6IltcIlAyUEtcIix7XCJub25jZVwiOlwiZDU2YWM4MzljMzdiZWRiNGM1MGIxODcxOTY1MDI2N2E2MWIzMTBlZjdhY2Q5ZWFjMzgwZmIxZmRmNmM1ZjkxNlwiLFwiZGF0YVwiOlwiYjM4Y2FjMmY0N2QzZWNjYjY0NmUxYmFiZDBiNDFlMzZhMTc5MmRlZjlhODU5ODRlNWZiZmVkZTU1ZjQ4Yjc4OVwifV0iLCJDIjoiMDM4YTcyZWRmNWRmN2M3ZmNiMTRhMDhjYjhiZDljODVlOTVkZmM0MzY4ZTU5YTk3OTRkZmI5OTAxZWEyZDIxNzI5In1dLCJtaW50IjoiaHR0cHM6Ly90ZXN0bnV0LmNhc2h1LnNwYWNlIn1dfQ';
+		// const base64 = 'eyJ0ZXN0RGF0YSI6IvCfj7PvuI/wn4+z77iPIn0='
+		const obj = {
+			"token": [
+			  {
+				"proofs": [
+				  {
+					"id": "009a1f293253e41e",
+					"amount": 1,
+					"secret": "[\"P2PK\",{\"nonce\":\"d56ac839c37bedb4c50b18719650267a61b310ef7acd9eac380fb1fdf6c5f916\",\"data\":\"b38cac2f47d3eccb646e1babd0b41e36a1792def9a85984e5fbfede55f48b789\"}]",
+					"C": "038a72edf5df7c7fcb14a08cb8bd9c85e95dfc4368e59a9794dfb9901ea2d21729"
+				  }
+				],
+				"mint": "https://testnut.cashu.space"
+			  }
+			]
+		  };
+
+		expect(encodeBase64ToJson(base64url)).toStrictEqual(obj);
+		expect(encodeJsonToBase64(obj)).toStrictEqual(base64url);
+	});
+	
 });

--- a/test/base64.test.ts
+++ b/test/base64.test.ts
@@ -73,26 +73,27 @@ describe('testing uint8 encoding', () => {
 		expect(encodeJsonToBase64(obj)).toStrictEqual(base64url);
 	});
 	test('test script secret to from base64', () => {
-		const base64url = 'eyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IjAwOWExZjI5MzI1M2U0MWUiLCJhbW91bnQiOjEsInNlY3JldCI6IltcIlAyUEtcIix7XCJub25jZVwiOlwiZDU2YWM4MzljMzdiZWRiNGM1MGIxODcxOTY1MDI2N2E2MWIzMTBlZjdhY2Q5ZWFjMzgwZmIxZmRmNmM1ZjkxNlwiLFwiZGF0YVwiOlwiYjM4Y2FjMmY0N2QzZWNjYjY0NmUxYmFiZDBiNDFlMzZhMTc5MmRlZjlhODU5ODRlNWZiZmVkZTU1ZjQ4Yjc4OVwifV0iLCJDIjoiMDM4YTcyZWRmNWRmN2M3ZmNiMTRhMDhjYjhiZDljODVlOTVkZmM0MzY4ZTU5YTk3OTRkZmI5OTAxZWEyZDIxNzI5In1dLCJtaW50IjoiaHR0cHM6Ly90ZXN0bnV0LmNhc2h1LnNwYWNlIn1dfQ';
+		const base64url =
+			'eyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IjAwOWExZjI5MzI1M2U0MWUiLCJhbW91bnQiOjEsInNlY3JldCI6IltcIlAyUEtcIix7XCJub25jZVwiOlwiZDU2YWM4MzljMzdiZWRiNGM1MGIxODcxOTY1MDI2N2E2MWIzMTBlZjdhY2Q5ZWFjMzgwZmIxZmRmNmM1ZjkxNlwiLFwiZGF0YVwiOlwiYjM4Y2FjMmY0N2QzZWNjYjY0NmUxYmFiZDBiNDFlMzZhMTc5MmRlZjlhODU5ODRlNWZiZmVkZTU1ZjQ4Yjc4OVwifV0iLCJDIjoiMDM4YTcyZWRmNWRmN2M3ZmNiMTRhMDhjYjhiZDljODVlOTVkZmM0MzY4ZTU5YTk3OTRkZmI5OTAxZWEyZDIxNzI5In1dLCJtaW50IjoiaHR0cHM6Ly90ZXN0bnV0LmNhc2h1LnNwYWNlIn1dfQ';
 		// const base64 = 'eyJ0ZXN0RGF0YSI6IvCfj7PvuI/wn4+z77iPIn0='
 		const obj = {
-			"token": [
-			  {
-				"proofs": [
-				  {
-					"id": "009a1f293253e41e",
-					"amount": 1,
-					"secret": "[\"P2PK\",{\"nonce\":\"d56ac839c37bedb4c50b18719650267a61b310ef7acd9eac380fb1fdf6c5f916\",\"data\":\"b38cac2f47d3eccb646e1babd0b41e36a1792def9a85984e5fbfede55f48b789\"}]",
-					"C": "038a72edf5df7c7fcb14a08cb8bd9c85e95dfc4368e59a9794dfb9901ea2d21729"
-				  }
-				],
-				"mint": "https://testnut.cashu.space"
-			  }
+			token: [
+				{
+					proofs: [
+						{
+							id: '009a1f293253e41e',
+							amount: 1,
+							secret:
+								'["P2PK",{"nonce":"d56ac839c37bedb4c50b18719650267a61b310ef7acd9eac380fb1fdf6c5f916","data":"b38cac2f47d3eccb646e1babd0b41e36a1792def9a85984e5fbfede55f48b789"}]',
+							C: '038a72edf5df7c7fcb14a08cb8bd9c85e95dfc4368e59a9794dfb9901ea2d21729'
+						}
+					],
+					mint: 'https://testnut.cashu.space'
+				}
 			]
-		  };
+		};
 
 		expect(encodeBase64ToJson(base64url)).toStrictEqual(obj);
 		expect(encodeJsonToBase64(obj)).toStrictEqual(base64url);
 	});
-	
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -98,11 +98,12 @@ describe('mint api', () => {
 		const request = await wallet.getMintQuote(3000);
 		const tokens = await wallet.mintTokens(3000, request.quote);
 
-		const fee = (await wallet.getMeltQuote(externalInvoice)).fee_reserve;
+		const meltQuote = (await wallet.getMeltQuote(externalInvoice));
+		const fee = meltQuote.fee_reserve
 		expect(fee).toBeGreaterThan(0);
 
 		const sendResponse = await wallet.send(2000 + fee, tokens.proofs);
-		const response = await wallet.payLnInvoice(externalInvoice, sendResponse.send);
+		const response = await wallet.payLnInvoice(externalInvoice, sendResponse.send, meltQuote);
 
 		expect(response).toBeDefined();
 		// expect that we have not received the fee back, since it was external

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -98,8 +98,8 @@ describe('mint api', () => {
 		const request = await wallet.getMintQuote(3000);
 		const tokens = await wallet.mintTokens(3000, request.quote);
 
-		const meltQuote = (await wallet.getMeltQuote(externalInvoice));
-		const fee = meltQuote.fee_reserve
+		const meltQuote = await wallet.getMeltQuote(externalInvoice);
+		const fee = meltQuote.fee_reserve;
 		expect(fee).toBeGreaterThan(0);
 
 		const sendResponse = await wallet.send(2000 + fee, tokens.proofs);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -178,28 +178,34 @@ describe('mint api', () => {
 	test('send and receive p2pk', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
-		
-		const privKeyAlice = secp256k1.utils.randomPrivateKey()
-		const pubKeyAlice = secp256k1.getPublicKey(privKeyAlice)
-		
-		const privKeyBob = secp256k1.utils.randomPrivateKey()
-		const pubKeyBob = secp256k1.getPublicKey(privKeyBob)
-		
+
+		const privKeyAlice = secp256k1.utils.randomPrivateKey();
+		const pubKeyAlice = secp256k1.getPublicKey(privKeyAlice);
+
+		const privKeyBob = secp256k1.utils.randomPrivateKey();
+		const pubKeyBob = secp256k1.getPublicKey(privKeyBob);
+
 		const request = await wallet.getMintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
-		
-		const  {send} = await wallet.send(64, tokens.proofs, {pubkey: bytesToHex(pubKeyBob)})
+
+		const { send } = await wallet.send(64, tokens.proofs, { pubkey: bytesToHex(pubKeyBob) });
 		const encoded = getEncodedToken({
 			token: [{ mint: mintUrl, proofs: send }]
 		});
 
-		const res = await wallet.receive(encoded,{privkey:bytesToHex(privKeyAlice)}).catch()
-		expect(res.token.token).toEqual([])
-		expect(res.tokensWithErrors?.token.length).toBe(1)
+		const res = await wallet.receive(encoded, { privkey: bytesToHex(privKeyAlice) }).catch();
+		expect(res.token.token).toEqual([]);
+		expect(res.tokensWithErrors?.token.length).toBe(1);
 
-		const  { token } = await wallet.receive(encoded,{privkey:bytesToHex(privKeyBob)})
+		const { token } = await wallet.receive(encoded, { privkey: bytesToHex(privKeyBob) });
 
-		expect(token.token.map(t=>t.proofs).flat().reduce((curr,acc)=>{return curr+acc.amount},0)).toBe(64)
-		
+		expect(
+			token.token
+				.map((t) => t.proofs)
+				.flat()
+				.reduce((curr, acc) => {
+					return curr + acc.amount;
+				}, 0)
+		).toBe(64);
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,8 +1,9 @@
 import nock from 'nock';
 import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
-import { ReceiveResponse } from '../src/model/types/index.js';
+import { MeltQuoteResponse, ReceiveResponse } from '../src/model/types/index.js';
 import { cleanToken, getDecodedToken } from '../src/utils.js';
+import { AmountPreference } from '../src/model/types/index';
 
 const dummyKeysResp = {
 	keysets: [
@@ -129,7 +130,7 @@ describe('receive', () => {
 		const wallet = new CashuWallet(mint);
 		const token3sat =
 			'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDA5YTFmMjkzMjUzZTQxZSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0=';
-		const response: ReceiveResponse = await wallet.receive(token3sat, [{ amount: 1, count: 3 }]);
+		const response: ReceiveResponse = await wallet.receive(token3sat, {preference:[{ amount: 1, count: 3 }]});
 
 		expect(response.token.token).toHaveLength(1);
 		expect(response.token.token[0].proofs).toHaveLength(3);
@@ -217,8 +218,9 @@ describe('payLnInvoice', () => {
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 0 });
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, payment_preimage: '' });
 		const wallet = new CashuWallet(mint);
+		const meltQuote = await wallet.getMeltQuote("lnbcabbc")
 
-		const result = await wallet.payLnInvoice(invoice, proofs);
+		const result = await wallet.payLnInvoice(invoice, proofs,meltQuote);
 
 		expect(result).toEqual({ isPaid: true, preimage: '', change: [] });
 	});
@@ -255,18 +257,17 @@ describe('payLnInvoice', () => {
 				]
 			});
 		const wallet = new CashuWallet(mint);
-
-		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }]);
+		const meltQuote = await wallet.getMeltQuote("lnbcabbc")
+		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }],meltQuote);
 
 		expect(result.isPaid).toBe(true);
 		expect(result.preimage).toBe('asd');
 		expect(result.change).toHaveLength(1);
 	});
 	test('test payLnInvoice bad resonse', async () => {
-		nock(mintUrl).post('/v1/melt/quote/bolt11').reply(200, {});
+		nock(mintUrl).post('/v1/melt/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint);
-
-		const result = await wallet.payLnInvoice(invoice, proofs).catch((e) => e);
+		const result = await wallet.payLnInvoice(invoice, proofs, {} as MeltQuoteResponse).catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));
 	});
@@ -454,7 +455,7 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, [{ amount: 1, count: 4 }]);
+		const result = await wallet.send(4, overpayProofs, {preference:[{ amount: 1, count: 4 }]});
 
 		expect(result.send).toHaveLength(4);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -509,7 +510,7 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, [{ amount: 1, count: 3 }]);
+		const result = await wallet.send(4, overpayProofs, {preference:[{ amount: 1, count: 3 }]});
 
 		expect(result.send).toHaveLength(3);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -572,8 +573,7 @@ describe('deterministic', () => {
 						C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 					}
 				],
-				undefined,
-				1
+				{counter: 1}
 			)
 			.catch((e) => e);
 		expect(result).toEqual(

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -130,7 +130,9 @@ describe('receive', () => {
 		const wallet = new CashuWallet(mint);
 		const token3sat =
 			'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDA5YTFmMjkzMjUzZTQxZSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0=';
-		const response: ReceiveResponse = await wallet.receive(token3sat, {preference:[{ amount: 1, count: 3 }]});
+		const response: ReceiveResponse = await wallet.receive(token3sat, {
+			preference: [{ amount: 1, count: 3 }]
+		});
 
 		expect(response.token.token).toHaveLength(1);
 		expect(response.token.token[0].proofs).toHaveLength(3);
@@ -218,9 +220,9 @@ describe('payLnInvoice', () => {
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 0 });
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, payment_preimage: '' });
 		const wallet = new CashuWallet(mint);
-		const meltQuote = await wallet.getMeltQuote("lnbcabbc")
+		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
 
-		const result = await wallet.payLnInvoice(invoice, proofs,meltQuote);
+		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
 
 		expect(result).toEqual({ isPaid: true, preimage: '', change: [] });
 	});
@@ -257,8 +259,8 @@ describe('payLnInvoice', () => {
 				]
 			});
 		const wallet = new CashuWallet(mint);
-		const meltQuote = await wallet.getMeltQuote("lnbcabbc")
-		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }],meltQuote);
+		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
+		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
 
 		expect(result.isPaid).toBe(true);
 		expect(result.preimage).toBe('asd');
@@ -267,7 +269,9 @@ describe('payLnInvoice', () => {
 	test('test payLnInvoice bad resonse', async () => {
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint);
-		const result = await wallet.payLnInvoice(invoice, proofs, {} as MeltQuoteResponse).catch((e) => e);
+		const result = await wallet
+			.payLnInvoice(invoice, proofs, {} as MeltQuoteResponse)
+			.catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));
 	});
@@ -455,7 +459,7 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, {preference:[{ amount: 1, count: 4 }]});
+		const result = await wallet.send(4, overpayProofs, { preference: [{ amount: 1, count: 4 }] });
 
 		expect(result.send).toHaveLength(4);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -510,7 +514,7 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, {preference:[{ amount: 1, count: 3 }]});
+		const result = await wallet.send(4, overpayProofs, { preference: [{ amount: 1, count: 3 }] });
 
 		expect(result.send).toHaveLength(3);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -573,7 +577,7 @@ describe('deterministic', () => {
 						C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 					}
 				],
-				{counter: 1}
+				{ counter: 1 }
 			)
 			.catch((e) => e);
 		expect(result).toEqual(


### PR DESCRIPTION
# P2PK, cashu-crypto lib, options object

## Description

This PR contains a few changes that I would like to add to v1 release, because they contain some interface changes.

## Changes

- support for simple P2PK send and receives 
- change optional function parameters  to `options` object
- add cashu-crypto library

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
