### PR TITLE
Chore: Equalize MintQuote and MeltQuote object names

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,4 +24,3 @@ jobs:
       - run: npm ci
       - run: npm run compile
       - run: npm test
-

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -7,13 +7,13 @@ import type {
 	MintActiveKeys,
 	MintAllKeysets,
 	PostRestoreResponse,
-	RequestMintResponse,
+	MintQuoteResponse,
 	SerializedBlindedMessage,
 	SplitPayload,
 	SplitResponse,
-	RequestMintPayload,
-	PostMintPayload,
-	PostMintResponse,
+	MintQuotePayload,
+	MintPayload,
+	MintResponse,
 	PostRestorePayload,
 	MeltQuotePayload,
 	MeltQuoteResponse
@@ -62,14 +62,14 @@ class CashuMint {
 	 */
 	public static async mintQuote(
 		mintUrl: string,
-		requestMintPayload: RequestMintPayload,
+		MintQuotePayload: MintQuotePayload,
 		customRequest?: typeof request
-	): Promise<RequestMintResponse> {
+	): Promise<MintQuoteResponse> {
 		const requestInstance = customRequest || request;
-		return requestInstance<RequestMintResponse>({
+		return requestInstance<MintQuoteResponse>({
 			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11'),
 			method: 'POST',
-			requestBody: requestMintPayload
+			requestBody: MintQuotePayload
 		});
 	}
 
@@ -78,8 +78,8 @@ class CashuMint {
 	 * @param amount Amount requesting for mint.
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async mintQuote(requestMintPayload: RequestMintPayload): Promise<RequestMintResponse> {
-		return CashuMint.mintQuote(this._mintUrl, requestMintPayload, this._customRequest);
+	async mintQuote(MintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
+		return CashuMint.mintQuote(this._mintUrl, MintQuotePayload, this._customRequest);
 	}
 	/**
 	 * Requests the mint to perform token minting after the LN invoice has been paid
@@ -91,11 +91,11 @@ class CashuMint {
 	 */
 	public static async mint(
 		mintUrl: string,
-		mintPayload: PostMintPayload,
+		mintPayload: MintPayload,
 		customRequest?: typeof request
 	) {
 		const requestInstance = customRequest || request;
-		const data = await requestInstance<PostMintResponse>({
+		const data = await requestInstance<MintResponse>({
 			endpoint: joinUrls(mintUrl, '/v1/mint/bolt11'),
 			method: 'POST',
 			requestBody: mintPayload
@@ -113,7 +113,7 @@ class CashuMint {
 	 * @param hash hash (id) used for by the mint to keep track of wether the invoice has been paid yet
 	 * @returns serialized blinded signatures
 	 */
-	async mint(mintPayload: PostMintPayload) {
+	async mint(mintPayload: MintPayload) {
 		return CashuMint.mint(this._mintUrl, mintPayload, this._customRequest);
 	}
 	/**

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -29,7 +29,7 @@ class CashuMint {
 	 * @param _mintUrl requires mint URL to create this object
 	 * @param _customRequest if passed, use custom request implementation for network communication with the mint
 	 */
-	constructor(private _mintUrl: string, private _customRequest?: typeof request) {}
+	constructor(private _mintUrl: string, private _customRequest?: typeof request) { }
 
 	get mintUrl() {
 		return this._mintUrl;
@@ -62,14 +62,14 @@ class CashuMint {
 	 */
 	public static async mintQuote(
 		mintUrl: string,
-		MintQuotePayload: MintQuotePayload,
+		mintQuotePayload: MintQuotePayload,
 		customRequest?: typeof request
 	): Promise<MintQuoteResponse> {
 		const requestInstance = customRequest || request;
 		return requestInstance<MintQuoteResponse>({
 			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11'),
 			method: 'POST',
-			requestBody: MintQuotePayload
+			requestBody: mintQuotePayload
 		});
 	}
 
@@ -78,8 +78,8 @@ class CashuMint {
 	 * @param amount Amount requesting for mint.
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async mintQuote(MintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
-		return CashuMint.mintQuote(this._mintUrl, MintQuotePayload, this._customRequest);
+	async mintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
+		return CashuMint.mintQuote(this._mintUrl, mintQuotePayload, this._customRequest);
 	}
 	/**
 	 * Requests the mint to perform token minting after the LN invoice has been paid

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -29,7 +29,7 @@ class CashuMint {
 	 * @param _mintUrl requires mint URL to create this object
 	 * @param _customRequest if passed, use custom request implementation for network communication with the mint
 	 */
-	constructor(private _mintUrl: string, private _customRequest?: typeof request) { }
+	constructor(private _mintUrl: string, private _customRequest?: typeof request) {}
 
 	get mintUrl() {
 		return this._mintUrl;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -3,24 +3,24 @@ import { CashuMint } from './CashuMint.js';
 import * as dhke from './DHKE.js';
 import { BlindedMessage } from './model/BlindedMessage.js';
 import {
-	AmountPreference,
-	BlindedMessageData,
-	BlindedTransaction,
-	MeltPayload,
-	MeltQuoteResponse,
-	MintKeys,
-	MeltTokensResponse,
-	MintPayload,
-	Proof,
-	ReceiveResponse,
-	ReceiveTokenEntryResponse,
-	MintQuotePayload,
-	SendResponse,
-	SerializedBlindedMessage,
-	SplitPayload,
-	CheckStateEnum,
-	Token,
-	TokenEntry
+	type AmountPreference,
+	type BlindedMessageData,
+	type BlindedTransaction,
+	type MeltPayload,
+	type MeltQuoteResponse,
+	type MintKeys,
+	type MeltTokensResponse,
+	type MintPayload,
+	type Proof,
+	type ReceiveResponse,
+	type ReceiveTokenEntryResponse,
+	type MintQuotePayload,
+	type SendResponse,
+	type SerializedBlindedMessage,
+	type SplitPayload,
+	type Token,
+	type TokenEntry,
+	CheckStateEnum
 } from './model/types/index.js';
 import {
 	bytesToNumber,
@@ -367,7 +367,7 @@ class CashuWallet {
 			outputs: blindedMessages,
 			quote: quote
 		};
-		const { signatures } = await this.mint.mint(MintPayload);
+		const { signatures } = await this.mint.mint(mintPayload);
 		return {
 			proofs: dhke.constructProofs(signatures, rs, secrets, keyset)
 		};

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -45,7 +45,6 @@ class CashuWallet {
 	private _seed: Uint8Array | undefined;
 	private _unit = 'sat';
 	mint: CashuMint;
-	
 
 	/**
 	 * @param keys public keys from the mint
@@ -53,9 +52,14 @@ class CashuWallet {
 	 * @param mnemonicOrSeed mnemonic phrase or Seed to initial derivation key for this wallets deterministic secrets. When the mnemonic is provided, the seed will be derived from it.
 	 * This can lead to poor performance, in which case the seed should be directly provided
 	 */
-	constructor(mint: CashuMint, unit?:string, keys?: MintKeys, mnemonicOrSeed?: string | Uint8Array) {
+	constructor(
+		mint: CashuMint,
+		unit?: string,
+		keys?: MintKeys,
+		mnemonicOrSeed?: string | Uint8Array
+	) {
 		this.mint = mint;
-		if (unit) this._unit  = unit;
+		if (unit) this._unit = unit;
 		if (keys) {
 			this._keys = keys;
 		}
@@ -332,7 +336,7 @@ class CashuWallet {
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
 	async getMintQuote(amount: number) {
-		const mintQuotePayload: MintQuotePayload = {		
+		const mintQuotePayload: MintQuotePayload = {
 			unit: this._unit,
 			amount: amount
 		};

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -10,11 +10,11 @@ import {
 	MeltQuoteResponse,
 	MintKeys,
 	MeltTokensResponse,
-	PostMintPayload,
+	MintPayload,
 	Proof,
 	ReceiveResponse,
 	ReceiveTokenEntryResponse,
-	RequestMintPayload,
+	MintQuotePayload,
 	SendResponse,
 	SerializedBlindedMessage,
 	SplitPayload,
@@ -332,11 +332,11 @@ class CashuWallet {
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
 	async getMintQuote(amount: number) {
-		const requestMintPayload: RequestMintPayload = {
+		const MintQuotePayload: MintQuotePayload = {
 			unit: this._unit,
 			amount: amount
 		};
-		return await this.mint.mintQuote(requestMintPayload);
+		return await this.mint.mintQuote(MintQuotePayload);
 	}
 
 	/**
@@ -363,11 +363,11 @@ class CashuWallet {
 			options?.counter,
 			options?.pubkey
 		);
-		const postMintPayload: PostMintPayload = {
+		const MintPayload: MintPayload = {
 			outputs: blindedMessages,
 			quote: quote
 		};
-		const { signatures } = await this.mint.mint(postMintPayload);
+		const { signatures } = await this.mint.mint(MintPayload);
 		return {
 			proofs: dhke.constructProofs(signatures, rs, secrets, keyset)
 		};

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -332,11 +332,11 @@ class CashuWallet {
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
 	async getMintQuote(amount: number) {
-		const MintQuotePayload: MintQuotePayload = {
+		const mintQuotePayload: MintQuotePayload = {		
 			unit: this._unit,
 			amount: amount
 		};
-		return await this.mint.mintQuote(MintQuotePayload);
+		return await this.mint.mintQuote(mintQuotePayload);
 	}
 
 	/**
@@ -363,7 +363,7 @@ class CashuWallet {
 			options?.counter,
 			options?.pubkey
 		);
-		const MintPayload: MintPayload = {
+		const mintPayload: MintPayload = {
 			outputs: blindedMessages,
 			quote: quote
 		};

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -266,7 +266,7 @@ export type ApiError = {
 /**
  * Payload that needs to be sent to the mint when requesting a mint
  */
-export type RequestMintPayload = {
+export type MintQuotePayload = {
 	/**
 	 * Unit to be minted
 	 */
@@ -279,7 +279,7 @@ export type RequestMintPayload = {
 /**
  * Response from the mint after requesting a mint
  */
-export type RequestMintResponse = {
+export type MintQuoteResponse = {
 	request: string;
 	quote: string;
 } & ApiError;
@@ -287,7 +287,7 @@ export type RequestMintResponse = {
 /**
  * Payload that needs to be sent to the mint when requesting a mint
  */
-export type PostMintPayload = {
+export type MintPayload = {
 	/**
 	 * Quote ID received from the mint.
 	 */
@@ -300,7 +300,7 @@ export type PostMintPayload = {
 /**
  * Response from the mint after requesting a mint
  */
-export type PostMintResponse = {
+export type MintResponse = {
 	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -12,7 +12,7 @@ const externalInvoice =
 
 let request: Record<string, string> | undefined;
 const mintUrl = 'http://localhost:3338';
-const unit = 'sat'
+const unit = 'sat';
 
 describe('mint api', () => {
 	test('get keys', async () => {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -5,7 +5,7 @@ import { setGlobalRequestOptions } from '../src/request.js';
 
 let request: Record<string, string> | undefined;
 const mintUrl = 'https://localhost:3338';
-const unit = 'sats'; 
+const unit = 'sats';
 const invoice =
 	'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -132,8 +132,8 @@ describe('receive', () => {
 		const wallet = new CashuWallet(mint, unit);
 		const token3sat =
 			'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDA5YTFmMjkzMjUzZTQxZSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0=';
-		
-    const response: ReceiveResponse = await wallet.receive(token3sat, {
+
+		const response: ReceiveResponse = await wallet.receive(token3sat, {
 			preference: [{ amount: 1, count: 3 }]
 		});
 
@@ -156,7 +156,6 @@ describe('receive', () => {
 		nock(mintUrl).post('/v1/swap').reply(200, { detail: msg });
 		const wallet = new CashuWallet(mint, unit);
 
-
 		const { tokensWithErrors } = await wallet.receive(tokenInput);
 		const t = tokensWithErrors!;
 
@@ -171,7 +170,6 @@ describe('receive', () => {
 		expect(/[0-9a-f]{64}/.test(t.token[0].proofs[0].secret)).toBe(true);
 	});
 	test('test receive could not verify proofs', async () => {
-
 		nock(mintUrl).post('/v1/split').reply(200, { code: 0, error: 'could not verify proofs.' });
 		const wallet = new CashuWallet(mint, unit);
 
@@ -211,7 +209,6 @@ describe('checkProofsSpent', () => {
 	});
 });
 
-
 describe('payLnInvoice', () => {
 	const proofs = [
 		{
@@ -222,16 +219,13 @@ describe('payLnInvoice', () => {
 		}
 	];
 	test('test payLnInvoice base case', async () => {
-
-
 		nock(mintUrl)
 			.post('/v1/melt/quote/bolt11')
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 0 });
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, payment_preimage: '' });
 
 		const wallet = new CashuWallet(mint, unit);
-    const meltQuote = await wallet.getMeltQuote('lnbcabbc');
-
+		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
 
 		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
 
@@ -274,13 +268,11 @@ describe('payLnInvoice', () => {
 		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
 		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
 
-
 		expect(result.isPaid).toBe(true);
 		expect(result.preimage).toBe('asd');
 		expect(result.change).toHaveLength(1);
 	});
 	test('test payLnInvoice bad resonse', async () => {
-
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint, unit);
 		const result = await wallet
@@ -559,7 +551,6 @@ describe('send', () => {
 		expect(result).toEqual(new Error('Not enough funds available'));
 	});
 	test('test send bad response', async () => {
-
 		nock(mintUrl).post('/v1/swap').reply(200, {});
 		const wallet = new CashuWallet(mint, unit);
 


### PR DESCRIPTION
Only renamed objects, might need resorting of imports for formatting reasons.