### PR TITLE
Get unit method

### DIFF
--- a/migration-1.0.0.md
+++ b/migration-1.0.0.md
@@ -25,7 +25,7 @@ Decoding LN invoices is no longer used inside the lib.
 
 ### `CashuWallet` interface changes
 
-**optional parameters are now in an onpional `options?` Object**
+**optional function AND constructor parameters are now in an onpional `options?` Object**
 
 Utility functions now have an `options` object for optional parameters, instead of passing them directly
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -80,6 +80,10 @@ class CashuWallet {
 		this._seed = deriveSeedFromMnemonic(options.mnemonicOrSeed);
 	}
 
+	get unit(): string {
+		return this._unit;
+	}
+
 	get keys(): MintKeys {
 		if (!this._keys) {
 			throw new Error('Keys are not set');

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -47,33 +47,37 @@ class CashuWallet {
 	mint: CashuMint;
 
 	/**
-	 * @param keys public keys from the mint
+	 * @param unit optionally set unit
+	 * @param keys public keys from the mint. If set, it will override the unit with the keysets unit
 	 * @param mint Cashu mint instance is used to make api calls
 	 * @param mnemonicOrSeed mnemonic phrase or Seed to initial derivation key for this wallets deterministic secrets. When the mnemonic is provided, the seed will be derived from it.
 	 * This can lead to poor performance, in which case the seed should be directly provided
 	 */
 	constructor(
 		mint: CashuMint,
-		unit?: string,
-		keys?: MintKeys,
-		mnemonicOrSeed?: string | Uint8Array
+		options?: {
+			unit?: string;
+			keys?: MintKeys;
+			mnemonicOrSeed?: string | Uint8Array;
+		}
 	) {
 		this.mint = mint;
-		if (unit) this._unit = unit;
-		if (keys) {
-			this._keys = keys;
+		if (options?.unit) this._unit = options?.unit;
+		if (options?.keys) {
+			this._keys = options.keys;
+			this._unit = options.keys.unit;
 		}
-		if (!mnemonicOrSeed) {
+		if (!options?.mnemonicOrSeed) {
 			return;
 		}
-		if (mnemonicOrSeed instanceof Uint8Array) {
-			this._seed = mnemonicOrSeed;
+		if (options?.mnemonicOrSeed instanceof Uint8Array) {
+			this._seed = options.mnemonicOrSeed;
 			return;
 		}
-		if (!validateMnemonic(mnemonicOrSeed, wordlist)) {
+		if (!validateMnemonic(options.mnemonicOrSeed, wordlist)) {
 			throw new Error('Tried to instantiate with mnemonic, but mnemonic was invalid');
 		}
-		this._seed = deriveSeedFromMnemonic(mnemonicOrSeed);
+		this._seed = deriveSeedFromMnemonic(options.mnemonicOrSeed);
 	}
 
 	get keys(): MintKeys {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -35,13 +35,13 @@ describe('mint api', () => {
 	});
 	test('request mint', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(100);
 		expect(request).toBeDefined();
 	});
 	test('mint tokens', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(1337);
 		expect(request).toBeDefined();
 		expect(request.request).toContain('lnbc1337');
@@ -52,7 +52,7 @@ describe('mint api', () => {
 	});
 	test('get fee for local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(100);
 		const fee = (await wallet.getMeltQuote(request.request)).fee_reserve;
 		expect(fee).toBeDefined();
@@ -61,7 +61,7 @@ describe('mint api', () => {
 	});
 	test('get fee for external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const fee = (await wallet.getMeltQuote(externalInvoice)).fee_reserve;
 		expect(fee).toBeDefined();
 		// because external invoice, fee should be > 0
@@ -69,7 +69,7 @@ describe('mint api', () => {
 	});
 	test('pay local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
@@ -97,7 +97,7 @@ describe('mint api', () => {
 	});
 	test('pay external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(3000);
 		const tokens = await wallet.mintTokens(3000, request.quote);
 
@@ -124,7 +124,7 @@ describe('mint api', () => {
 	});
 	test('test send tokens exact without previous split', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 
@@ -137,7 +137,7 @@ describe('mint api', () => {
 	});
 	test('test send tokens with change', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
@@ -150,7 +150,7 @@ describe('mint api', () => {
 	});
 	test('receive tokens with previous split', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
@@ -165,7 +165,7 @@ describe('mint api', () => {
 	});
 	test('receive tokens with previous mint', async () => {
 		const mint = new CashuMint(mintUrl);
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.getMintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 		const encoded = getEncodedToken({

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -32,7 +32,7 @@ describe('requests', () => {
 				};
 			});
 
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		await wallet.getMeltQuote(invoice);
 
 		expect(request).toBeDefined();
@@ -52,7 +52,7 @@ describe('requests', () => {
 				};
 			});
 
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		setGlobalRequestOptions({ headers: { 'x-cashu': 'xyz-123-abc' } });
 		await wallet.getMeltQuote(invoice);
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -39,7 +39,7 @@ describe('test fees', () => {
 			amount: 2000,
 			fee_reserve: 20
 		});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const fee = await wallet.getMeltQuote(invoice);
 		const amount = 2000;
@@ -63,7 +63,7 @@ describe('receive', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const response: ReceiveResponse = await wallet.receive(tokenInput);
 
@@ -129,7 +129,7 @@ describe('receive', () => {
 				]
 			});
 
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const token3sat =
 			'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDA5YTFmMjkzMjUzZTQxZSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0=';
 
@@ -154,7 +154,7 @@ describe('receive', () => {
 		const msg = 'tokens already spent. Secret: asdasdasd';
 
 		nock(mintUrl).post('/v1/swap').reply(200, { detail: msg });
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const { tokensWithErrors } = await wallet.receive(tokenInput);
 		const t = tokensWithErrors!;
@@ -171,7 +171,7 @@ describe('receive', () => {
 	});
 	test('test receive could not verify proofs', async () => {
 		nock(mintUrl).post('/v1/split').reply(200, { code: 0, error: 'could not verify proofs.' });
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const { tokensWithErrors } = await wallet.receive(tokenInput);
 		const t = tokensWithErrors!;
@@ -201,7 +201,7 @@ describe('checkProofsSpent', () => {
 		nock(mintUrl)
 			.post('/v1/checkstate')
 			.reply(200, { states: [{ Y: 'asd', state: 'UNSPENT', witness: 'witness-asd' }] });
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet.checkProofsSpent(proofs);
 
@@ -224,7 +224,7 @@ describe('payLnInvoice', () => {
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 0 });
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, payment_preimage: '' });
 
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
 
 		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
@@ -264,7 +264,7 @@ describe('payLnInvoice', () => {
 				]
 			});
 
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
 		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
 
@@ -274,7 +274,7 @@ describe('payLnInvoice', () => {
 	});
 	test('test payLnInvoice bad resonse', async () => {
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, {});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 		const result = await wallet
 			.payLnInvoice(invoice, proofs, {} as MeltQuoteResponse)
 			.catch((e) => e);
@@ -296,7 +296,7 @@ describe('requestTokens', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const { proofs } = await wallet.mintTokens(1, '');
 
@@ -307,7 +307,7 @@ describe('requestTokens', () => {
 	});
 	test('test requestTokens bad resonse', async () => {
 		nock(mintUrl).post('/v1/mint/bolt11').reply(200, {});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet.mintTokens(1, '').catch((e) => e);
 
@@ -336,7 +336,7 @@ describe('send', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet.send(1, proofs);
 
@@ -363,7 +363,7 @@ describe('send', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet.send(1, [
 			{
@@ -401,7 +401,7 @@ describe('send', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const overpayProofs = [
 			{
@@ -449,7 +449,7 @@ describe('send', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const overpayProofs = [
 			{
@@ -504,7 +504,7 @@ describe('send', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const overpayProofs = [
 			{
@@ -544,7 +544,7 @@ describe('send', () => {
 					}
 				]
 			});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet.send(2, proofs).catch((e) => e);
 
@@ -552,7 +552,7 @@ describe('send', () => {
 	});
 	test('test send bad response', async () => {
 		nock(mintUrl).post('/v1/swap').reply(200, {});
-		const wallet = new CashuWallet(mint, unit);
+		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet
 			.send(1, [


### PR DESCRIPTION
# Fixes: minor CashuWallet interface 

## Description

- changed constructor to use options param
- added getter for unit field

## Changes

- ...
- ...

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
