### PR TITLE
Fixes bug with sending/receiving usd (other units)

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -107,7 +107,7 @@ class CashuWallet {
 	async receive(
 		token: string | Token,
 		options?: {
-      keysetId?: string;
+			keysetId?: string;
 			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
@@ -128,7 +128,7 @@ class CashuWallet {
 			}
 			try {
 				const { proofs, proofsWithError } = await this.receiveTokenEntry(tokenEntry, {
-          keysetId: options?.keysetId,
+					keysetId: options?.keysetId,
 					preference: options?.preference,
 					counter: options?.counter,
 					pubkey: options?.pubkey,
@@ -162,7 +162,7 @@ class CashuWallet {
 	async receiveTokenEntry(
 		tokenEntry: TokenEntry,
 		options?: {
-      keysetId?: string;
+			keysetId?: string;
 			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
@@ -221,7 +221,7 @@ class CashuWallet {
 		amount: number,
 		proofs: Array<Proof>,
 		options?: {
-      keysetId?: string;
+			keysetId?: string;
 			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
@@ -231,7 +231,7 @@ class CashuWallet {
 		if (options?.preference) {
 			amount = options?.preference?.reduce((acc, curr) => acc + curr.amount * curr.count, 0);
 		}
-		const keyset =  await this.getKeys(options?.keysetId);
+		const keyset = await this.getKeys(options?.keysetId);
 		let amountAvailable = 0;
 		const proofsToSend: Array<Proof> = [];
 		const proofsToKeep: Array<Proof> = [];

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -107,6 +107,7 @@ class CashuWallet {
 	async receive(
 		token: string | Token,
 		options?: {
+      keysetId?: string;
 			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
@@ -127,6 +128,7 @@ class CashuWallet {
 			}
 			try {
 				const { proofs, proofsWithError } = await this.receiveTokenEntry(tokenEntry, {
+          keysetId: options?.keysetId,
 					preference: options?.preference,
 					counter: options?.counter,
 					pubkey: options?.pubkey,
@@ -160,6 +162,7 @@ class CashuWallet {
 	async receiveTokenEntry(
 		tokenEntry: TokenEntry,
 		options?: {
+      keysetId?: string;
 			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
@@ -174,7 +177,7 @@ class CashuWallet {
 			if (!preference) {
 				preference = getDefaultAmountPreference(amount);
 			}
-			const keys = await this.getKeys();
+			const keys = await this.getKeys(options?.keysetId);
 			const { payload, blindedMessages } = this.createSplitPayload(
 				amount,
 				tokenEntry.proofs,
@@ -218,6 +221,7 @@ class CashuWallet {
 		amount: number,
 		proofs: Array<Proof>,
 		options?: {
+      keysetId?: string;
 			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
@@ -227,7 +231,7 @@ class CashuWallet {
 		if (options?.preference) {
 			amount = options?.preference?.reduce((acc, curr) => acc + curr.amount * curr.count, 0);
 		}
-		const keyset = await this.getKeys();
+		const keyset =  await this.getKeys(options?.keysetId);
 		let amountAvailable = 0;
 		const proofsToSend: Array<Proof> = [];
 		const proofsToKeep: Array<Proof> = [];


### PR DESCRIPTION
# Fixes: Bug with sending/receiving usd (other units)

## Description

I had some issues working with sending / receiving usd but being able to specify the keysetId made things a lot easier. Otherwise I have to specify the list of keys and it gets rather messy. 

## Changes

- added keysetId to options for `send` and `receive`.

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run format`
