### PR TITLE
Bug/send keyset + make meltQuote optional in payLnInvoice

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -449,7 +449,7 @@ class CashuWallet {
 	async payLnInvoice(
 		invoice: string,
 		proofsToSend: Array<Proof>,
-		meltQuote: MeltQuoteResponse,
+		meltQuote?: MeltQuoteResponse,
 		options?: {
 			keysetId?: string;
 			counter?: number;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -222,12 +222,13 @@ class CashuWallet {
 			counter?: number;
 			pubkey?: string;
 			privkey?: string;
+			keysetId?: string;
 		}
 	): Promise<SendResponse> {
 		if (options?.preference) {
 			amount = options?.preference?.reduce((acc, curr) => acc + curr.amount * curr.count, 0);
 		}
-		const keyset = await this.getKeys();
+		const keyset = await this.getKeys(options?.keysetId);
 		let amountAvailable = 0;
 		const proofsToSend: Array<Proof> = [];
 		const proofsToKeep: Array<Proof> = [];
@@ -319,7 +320,7 @@ class CashuWallet {
 	 * Initialize the wallet with the mints public keys
 	 */
 	private async getKeys(keysetId?: string, unit?: string): Promise<MintKeys> {
-		if (!this._keys || this._keys.id !== keysetId) {
+		if (!this._keys || (keysetId !== undefined && this._keys.id !== keysetId)) {
 			const allKeys = await this.mint.getKeys(keysetId);
 			let keys;
 			if (keysetId) {

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -389,8 +389,8 @@ export type Token = {
 	 */
 	memo?: string;
 	/**
-	  * the unit of the token
-	  */
+	 * the unit of the token
+	 */
 	unit?: string;
 };
 /**


### PR DESCRIPTION
# Fixes: 

- calling `CashuWallet.send()`  with a keyset for units other than 'sat'
-  `payLnInvoice` required a `meltQuote` even though it creates one.

## Description
Very small changes. I just added `keysetId` to the `send` function and passed it to `getKeys`.

I also made it so that in `getKeys`, if the keysetId parameter is`undefined` it will not be compared to `this._keys.id`

...

## Changes

- I add
- ...

## PR Tasks

NOTE: `npm run test` failed all tests even before I made changes:

![image](https://github.com/cashubtc/cashu-ts/assets/108303703/36b2f2ea-5628-4049-a008-f5e9ecce7f3a)


- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
