### PR TITLE
Fix: Handle trailing slashes in mint urls supplied to the CashuMint class

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -19,7 +19,7 @@ import type {
 	MeltQuoteResponse
 } from './model/types/index.js';
 import request from './request.js';
-import { isObj, joinUrls } from './utils.js';
+import { isObj, joinUrls, sanitizeUrl } from './utils.js';
 
 /**
  * Class represents Cashu Mint API. This class contains Lower level functions that are implemented by CashuWallet.
@@ -32,7 +32,7 @@ class CashuMint {
 	constructor(private _mintUrl: string, private _customRequest?: typeof request) {}
 
 	get mintUrl() {
-		return this._mintUrl;
+		return sanitizeUrl(this._mintUrl);
 	}
 
 	/**

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -29,10 +29,13 @@ class CashuMint {
 	 * @param _mintUrl requires mint URL to create this object
 	 * @param _customRequest if passed, use custom request implementation for network communication with the mint
 	 */
-	constructor(private _mintUrl: string, private _customRequest?: typeof request) {}
+	constructor(private _mintUrl: string, private _customRequest?: typeof request) {
+		this._mintUrl = sanitizeUrl(_mintUrl);
+		this._customRequest = _customRequest;
+	}
 
 	get mintUrl() {
-		return sanitizeUrl(this._mintUrl);
+		return this._mintUrl;
 	}
 
 	/**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -189,7 +189,11 @@ export function checkResponse(data: { error?: string; detail?: string }) {
 
 export function joinUrls(...parts: Array<string>): string {
 	return parts.map((part) => part.replace(/(^\/+|\/+$)/g, '')).join('/');
-}
+};
+
+export function sanitizeUrl(url:string): string{
+	return url.replace(/\/$/, '');
+};
 
 export function decodeInvoice(bolt11Invoice: string): InvoiceData {
 	const invoiceData: InvoiceData = {} as InvoiceData;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -189,11 +189,11 @@ export function checkResponse(data: { error?: string; detail?: string }) {
 
 export function joinUrls(...parts: Array<string>): string {
 	return parts.map((part) => part.replace(/(^\/+|\/+$)/g, '')).join('/');
-};
+}
 
-export function sanitizeUrl(url:string): string{
+export function sanitizeUrl(url: string): string {
 	return url.replace(/\/$/, '');
-};
+}
 
 export function decodeInvoice(bolt11Invoice: string): InvoiceData {
 	const invoiceData: InvoiceData = {} as InvoiceData;


### PR DESCRIPTION
# Fixes: #124 

## Description
Mint URLS containing a trailing slash at the end fail to connect because of that slash. this fix includes a sanitizeurl function that removes the trailing slash when it it exists
...

## Changes

- ...sanitizeURL function in /src/utils.ts for handling trailing slash
- ...utilize sanitizeUrl function in /src/CashuMint.ts in the `get MintUrl` method in the CashuMint class

