### PR TITLE
Bug: fix `keyset` or `keysetId` for `receiveTokenEntry()`

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -176,7 +176,7 @@ class CashuWallet {
 				preference = getDefaultAmountPreference(amount);
 			}
 			let keys = options?.keyset
-			if (keys === undefined) {
+			if (!keys) {
 				keys = await this.getKeys(options?.keysetId);
 			}
 


### PR DESCRIPTION
Bug related to #123. 

`getKeys()` used to fetch `sat` unit keysets per default which leads to errors when receiving a different unit.