### PR TITLE
Fix: rename `amountPreference` to `preference`

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -362,7 +362,7 @@ class CashuWallet {
 		quote: string,
 		options?: {
 			keysetId?: string;
-			amountPreference?: Array<AmountPreference>;
+			preference?: Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
 		}
@@ -371,7 +371,7 @@ class CashuWallet {
 		const { blindedMessages, secrets, rs } = this.createRandomBlindedMessages(
 			amount,
 			options?.keysetId ?? keyset.id,
-			options?.amountPreference,
+			options?.preference,
 			options?.counter,
 			options?.pubkey
 		);


### PR DESCRIPTION
Option in `mintTokens` was called `amountPreference` but it's `preference` everywhere else.