### PR TITLE
Add `GET quote` methods and rename methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Implemented [NUTs](https://github.com/cashubtc/nuts/):
 - [x] [NUT-07](https://github.com/cashubtc/nuts/blob/main/07.md)
 - [x] [NUT-08](https://github.com/cashubtc/nuts/blob/main/08.md)
 - [x] [NUT-09](https://github.com/cashubtc/nuts/blob/main/09.md)
+- [x] [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md)
 
 Supported token formats:
 
@@ -59,8 +60,8 @@ import { CashuMint, CashuWallet, getEncodedToken } from '@cashu/cashu-ts';
 
 const mint = new CashuMint(mintUrl);
 const wallet = new CashuWallet(mint);
-const request = await wallet.getMintQuote(64);
-const tokens = await wallet.mintTokens(64, request.quote);
+const mintQuote = await wallet.mintQuote(64);
+const tokens = await wallet.mintTokens(64, mintQuote.quote);
 ```
 
 ## Contribute

--- a/migration-1.0.0.md
+++ b/migration-1.0.0.md
@@ -29,13 +29,15 @@ Decoding LN invoices is no longer used inside the lib.
 
 Utility functions now have an `options` object for optional parameters, instead of passing them directly
 
-**`requestMint(amount: number)` --> `getMintQuote(amount: number)`**
+**`requestMint(amount: number)` --> `mintQuote(amount: number)`**
 Now returns the following:
 
 ```typescript
 type MintQuoteResponse = {
 	request: string;
 	quote: string;
+	paid: boolean;
+	expiry: number;
 };
 ```
 
@@ -52,6 +54,8 @@ type MeltQuoteResponse = {
 	quote: string;
 	amount: number;
 	fee_reserve: number;
+	paid: boolean;
+	expiry: number;
 };
 ```
 

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -9,8 +9,8 @@ import type {
 	PostRestoreResponse,
 	MintQuoteResponse,
 	SerializedBlindedMessage,
-	SplitPayload,
-	SplitResponse,
+	SwapPayload,
+	SwapResponse,
 	MintQuotePayload,
 	MintPayload,
 	MintResponse,
@@ -56,12 +56,47 @@ class CashuMint {
 	async getInfo(): Promise<GetInfoResponse> {
 		return CashuMint.getInfo(this._mintUrl, this._customRequest);
 	}
+
 	/**
-	 * Starts a minting process by requesting an invoice from the mint
+	 * Performs a swap operation with ecash inputs and outputs.
 	 * @param mintUrl
-	 * @param amount Amount requesting for mint.
+	 * @param swapPayload payload containing inputs and outputs
 	 * @param customRequest
-	 * @returns the mint will create and return a Lightning invoice for the specified amount
+	 * @returns signed outputs
+	 */
+	public static async split(
+		mintUrl: string,
+		swapPayload: SwapPayload,
+		customRequest?: typeof request
+	): Promise<SwapResponse> {
+		const requestInstance = customRequest || request;
+		const data = await requestInstance<SwapResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/swap'),
+			method: 'POST',
+			requestBody: swapPayload
+		});
+
+		if (!isObj(data) || !Array.isArray(data?.signatures)) {
+			throw new Error(data.detail ?? 'bad response');
+		}
+
+		return data;
+	}
+	/**
+	 * Performs a swap operation with ecash inputs and outputs.
+	 * @param swapPayload payload containing inputs and outputs
+	 * @returns signed outputs
+	 */
+	async split(swapPayload: SwapPayload): Promise<SwapResponse> {
+		return CashuMint.split(this._mintUrl, swapPayload, this._customRequest);
+	}
+
+	/**
+	 * Requests a new mint quote from the mint.
+	 * @param mintUrl
+	 * @param mintQuotePayload Payload for creating a new mint quote
+	 * @param customRequest
+	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
 	public static async mintQuote(
 		mintUrl: string,
@@ -75,20 +110,46 @@ class CashuMint {
 			requestBody: mintQuotePayload
 		});
 	}
-
 	/**
-	 * Starts a minting process by requesting an invoice from the mint
-	 * @param amount Amount requesting for mint.
-	 * @returns the mint will create and return a Lightning invoice for the specified amount
+	 * Requests a new mint quote from the mint.
+	 * @param mintQuotePayload Payload for creating a new mint quote
+	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
 	async mintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
 		return CashuMint.mintQuote(this._mintUrl, mintQuotePayload, this._customRequest);
 	}
+
 	/**
-	 * Requests the mint to perform token minting after the LN invoice has been paid
+	 * Gets an existing mint quote from the mint.
 	 * @param mintUrl
-	 * @param payloads outputs (Blinded messages) that can be written
-	 * @param hash hash (id) used for by the mint to keep track of wether the invoice has been paid yet
+	 * @param quoteId Quote ID
+	 * @param customRequest
+	 * @returns the mint will create and return a Lightning invoice for the specified amount
+	 */
+	public static async getMintQuote(
+		mintUrl: string,
+		quoteId: string,
+		customRequest?: typeof request
+	): Promise<MintQuoteResponse> {
+		const requestInstance = customRequest || request;
+		return requestInstance<MintQuoteResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11', quoteId),
+			method: 'GET',
+		});
+	}
+	/**
+	 * Gets an existing mint quote from the mint.
+	 * @param quoteId Quote ID
+	 * @returns the mint will create and return a Lightning invoice for the specified amount
+	 */
+	async getMintQuote(quoteId: string): Promise<MintQuoteResponse> {
+		return CashuMint.getMintQuote(this._mintUrl, quoteId, this._customRequest);
+	}
+
+	/**
+	 * Mints new tokens by requesting blind signatures on the provided outputs.
+	 * @param mintUrl
+	 * @param mintPayload Payload containing the outputs to get blind signatures on
 	 * @param customRequest
 	 * @returns serialized blinded signatures
 	 */
@@ -111,14 +172,151 @@ class CashuMint {
 		return data;
 	}
 	/**
-	 * Requests the mint to perform token minting after the LN invoice has been paid
-	 * @param payloads outputs (Blinded messages) that can be written
-	 * @param hash hash (id) used for by the mint to keep track of wether the invoice has been paid yet
+	 * Mints new tokens by requesting blind signatures on the provided outputs.
+	 * @param mintPayload Payload containing the outputs to get blind signatures on
 	 * @returns serialized blinded signatures
 	 */
 	async mint(mintPayload: MintPayload) {
 		return CashuMint.mint(this._mintUrl, mintPayload, this._customRequest);
 	}
+
+	/**
+	 * Requests a new melt quote from the mint.
+	 * @param mintUrl
+	 * @param MeltQuotePayload
+	 * @returns
+	 */
+	public static async meltQuote(
+		mintUrl: string,
+		meltQuotePayload: MeltQuotePayload,
+		customRequest?: typeof request
+	): Promise<MeltQuoteResponse> {
+		const requestInstance = customRequest || request;
+		const data = await requestInstance<MeltQuoteResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/melt/quote/bolt11'),
+			method: 'POST',
+			requestBody: meltQuotePayload
+		});
+
+		if (
+			!isObj(data) ||
+			typeof data?.amount !== 'number' ||
+			typeof data?.fee_reserve !== 'number' ||
+			typeof data?.quote !== 'string'
+		) {
+			throw new Error('bad response');
+		}
+		return data;
+	}
+	/**
+	 * Requests a new melt quote from the mint.
+	 * @param MeltQuotePayload
+	 * @returns
+	 */
+	async meltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
+		return CashuMint.meltQuote(this._mintUrl, meltQuotePayload, this._customRequest);
+	}
+
+	/**
+	 * Gets an existing melt quote.
+	 * @param mintUrl
+	 * @param quoteId Quote ID
+	 * @returns
+	 */
+	public static async getMeltQuote(
+		mintUrl: string,
+		quoteId: string,
+		customRequest?: typeof request
+	): Promise<MeltQuoteResponse> {
+		const requestInstance = customRequest || request;
+		const data = await requestInstance<MeltQuoteResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/melt/quote/bolt11', quoteId),
+			method: 'GET',
+		});
+
+		if (
+			!isObj(data) ||
+			typeof data?.amount !== 'number' ||
+			typeof data?.fee_reserve !== 'number' ||
+			typeof data?.quote !== 'string'
+		) {
+			throw new Error('bad response');
+		}
+
+		return data;
+	}
+	/**
+	 * Gets an existing melt quote.
+	 * @param quoteId Quote ID
+	 * @returns
+	 */
+	async getMeltQuote(quoteId: string): Promise<MeltQuoteResponse> {
+		return CashuMint.getMeltQuote(this._mintUrl, quoteId, this._customRequest);
+	}
+
+	/**
+	 * Requests the mint to pay for a Bolt11 payment request by providing ecash as inputs to be spent. The inputs contain the amount and the fee_reserves for a Lightning payment. The payload can also contain blank outputs in order to receive back overpaid Lightning fees.
+	 * @param mintUrl
+	 * @param meltPayload
+	 * @param customRequest
+	 * @returns
+	 */
+	public static async melt(
+		mintUrl: string,
+		meltPayload: MeltPayload,
+		customRequest?: typeof request
+	): Promise<MeltResponse> {
+		const requestInstance = customRequest || request;
+		const data = await requestInstance<MeltResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/melt/bolt11'),
+			method: 'POST',
+			requestBody: meltPayload
+		});
+
+		if (
+			!isObj(data) ||
+			typeof data?.paid !== 'boolean' ||
+			(data?.payment_preimage !== null && typeof data?.payment_preimage !== 'string')
+		) {
+			throw new Error('bad response');
+		}
+
+		return data;
+	}
+	/**
+	 * Ask mint to perform a melt operation. This pays a lightning invoice and destroys tokens matching its amount + fees
+	 * @param meltPayload
+	 * @returns
+	 */
+	async melt(meltPayload: MeltPayload): Promise<MeltResponse> {
+		return CashuMint.melt(this._mintUrl, meltPayload, this._customRequest);
+	}
+	/**
+	 * Checks if specific proofs have already been redeemed
+	 * @param mintUrl
+	 * @param checkPayload
+	 * @param customRequest
+	 * @returns redeemed and unredeemed ordered list of booleans
+	 */
+	public static async check(
+		mintUrl: string,
+		checkPayload: CheckStatePayload,
+		customRequest?: typeof request
+	): Promise<CheckStateResponse> {
+		const requestInstance = customRequest || request;
+		const data = await requestInstance<CheckStateResponse>({
+			endpoint: joinUrls(mintUrl, '/v1/checkstate'),
+			method: 'POST',
+			requestBody: checkPayload
+		});
+
+		if (!isObj(data) || !Array.isArray(data?.states)) {
+			throw new Error('bad response');
+		}
+
+		return data;
+	}
+
 	/**
 	 * Get the mints public keys
 	 * @param mintUrl
@@ -182,138 +380,6 @@ class CashuMint {
 		return CashuMint.getKeySets(this._mintUrl, this._customRequest);
 	}
 
-	/**
-	 * Ask mint to perform a split operation
-	 * @param mintUrl
-	 * @param splitPayload data needed for performing a token split
-	 * @param customRequest
-	 * @returns split tokens
-	 */
-	public static async split(
-		mintUrl: string,
-		splitPayload: SplitPayload,
-		customRequest?: typeof request
-	): Promise<SplitResponse> {
-		const requestInstance = customRequest || request;
-		const data = await requestInstance<SplitResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/swap'),
-			method: 'POST',
-			requestBody: splitPayload
-		});
-
-		if (!isObj(data) || !Array.isArray(data?.signatures)) {
-			throw new Error(data.detail ?? 'bad response');
-		}
-
-		return data;
-	}
-	/**
-	 * Ask mint to perform a split operation
-	 * @param splitPayload data needed for performing a token split
-	 * @returns split tokens
-	 */
-	async split(splitPayload: SplitPayload): Promise<SplitResponse> {
-		return CashuMint.split(this._mintUrl, splitPayload, this._customRequest);
-	}
-	/**
-	 * Asks the mint for a melt quote
-	 * @param mintUrl
-	 * @param MeltQuotePayload
-	 * @returns
-	 */
-	public static async meltQuote(
-		mintUrl: string,
-		meltQuotePayload: MeltQuotePayload,
-		customRequest?: typeof request
-	): Promise<MeltQuoteResponse> {
-		const requestInstance = customRequest || request;
-		const data = await requestInstance<MeltQuoteResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/melt/quote/bolt11'),
-			method: 'POST',
-			requestBody: meltQuotePayload
-		});
-
-		if (
-			!isObj(data) ||
-			typeof data?.amount !== 'number' ||
-			typeof data?.fee_reserve !== 'number' ||
-			typeof data?.quote !== 'string'
-		) {
-			throw new Error('bad response');
-		}
-
-		return data;
-	}
-	/**
-	 * Asks the mint for a melt quote
-	 * @param MeltQuotePayload
-	 * @returns
-	 */
-	async meltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
-		return CashuMint.meltQuote(this._mintUrl, meltQuotePayload, this._customRequest);
-	}
-	/**
-	 * Ask mint to perform a melt operation. This pays a lightning invoice and destroys tokens matching its amount + fees
-	 * @param mintUrl
-	 * @param meltPayload
-	 * @param customRequest
-	 * @returns
-	 */
-	public static async melt(
-		mintUrl: string,
-		meltPayload: MeltPayload,
-		customRequest?: typeof request
-	): Promise<MeltResponse> {
-		const requestInstance = customRequest || request;
-		const data = await requestInstance<MeltResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/melt/bolt11'),
-			method: 'POST',
-			requestBody: meltPayload
-		});
-
-		if (
-			!isObj(data) ||
-			typeof data?.paid !== 'boolean' ||
-			(data?.payment_preimage !== null && typeof data?.payment_preimage !== 'string')
-		) {
-			throw new Error('bad response');
-		}
-
-		return data;
-	}
-	/**
-	 * Ask mint to perform a melt operation. This pays a lightning invoice and destroys tokens matching its amount + fees
-	 * @param meltPayload
-	 * @returns
-	 */
-	async melt(meltPayload: MeltPayload): Promise<MeltResponse> {
-		return CashuMint.melt(this._mintUrl, meltPayload, this._customRequest);
-	}
-	/**
-	 * Checks if specific proofs have already been redeemed
-	 * @param mintUrl
-	 * @param checkPayload
-	 * @param customRequest
-	 * @returns redeemed and unredeemed ordered list of booleans
-	 */
-	public static async check(
-		mintUrl: string,
-		checkPayload: CheckStatePayload,
-		customRequest?: typeof request
-	): Promise<CheckStateResponse> {
-		const requestInstance = customRequest || request;
-		const data = await requestInstance<CheckStateResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/checkstate'),
-			method: 'POST',
-			requestBody: checkPayload
-		});
-
-		if (!isObj(data) || !Array.isArray(data?.states)) {
-			throw new Error('bad response');
-		}
-
-		return data;
-	}
 	/**
 	 * Checks if specific proofs have already been redeemed
 	 * @param checkPayload

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -122,28 +122,28 @@ class CashuMint {
 	/**
 	 * Gets an existing mint quote from the mint.
 	 * @param mintUrl
-	 * @param quoteId Quote ID
+	 * @param quote Quote ID
 	 * @param customRequest
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
 	public static async getMintQuote(
 		mintUrl: string,
-		quoteId: string,
+		quote: string,
 		customRequest?: typeof request
 	): Promise<MintQuoteResponse> {
 		const requestInstance = customRequest || request;
 		return requestInstance<MintQuoteResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11', quoteId),
+			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11', quote),
 			method: 'GET',
 		});
 	}
 	/**
 	 * Gets an existing mint quote from the mint.
-	 * @param quoteId Quote ID
+	 * @param quote Quote ID
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async getMintQuote(quoteId: string): Promise<MintQuoteResponse> {
-		return CashuMint.getMintQuote(this._mintUrl, quoteId, this._customRequest);
+	async getMintQuote(quote: string): Promise<MintQuoteResponse> {
+		return CashuMint.getMintQuote(this._mintUrl, quote, this._customRequest);
 	}
 
 	/**
@@ -220,17 +220,17 @@ class CashuMint {
 	/**
 	 * Gets an existing melt quote.
 	 * @param mintUrl
-	 * @param quoteId Quote ID
+	 * @param quote Quote ID
 	 * @returns
 	 */
 	public static async getMeltQuote(
 		mintUrl: string,
-		quoteId: string,
+		quote: string,
 		customRequest?: typeof request
 	): Promise<MeltQuoteResponse> {
 		const requestInstance = customRequest || request;
 		const data = await requestInstance<MeltQuoteResponse>({
-			endpoint: joinUrls(mintUrl, '/v1/melt/quote/bolt11', quoteId),
+			endpoint: joinUrls(mintUrl, '/v1/melt/quote/bolt11', quote),
 			method: 'GET',
 		});
 
@@ -247,11 +247,11 @@ class CashuMint {
 	}
 	/**
 	 * Gets an existing melt quote.
-	 * @param quoteId Quote ID
+	 * @param quote Quote ID
 	 * @returns
 	 */
-	async getMeltQuote(quoteId: string): Promise<MeltQuoteResponse> {
-		return CashuMint.getMeltQuote(this._mintUrl, quoteId, this._customRequest);
+	async getMeltQuote(quote: string): Promise<MeltQuoteResponse> {
+		return CashuMint.getMeltQuote(this._mintUrl, quote, this._customRequest);
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -16,11 +16,11 @@ import {
 	type MintQuotePayload,
 	type SendResponse,
 	type SerializedBlindedMessage,
-	type SplitPayload,
 	type Token,
 	type TokenEntry,
 	CheckStateEnum,
-	SerializedBlindedSignature
+	SerializedBlindedSignature,
+	SwapPayload
 } from './model/types/index.js';
 import {
 	bytesToNumber,
@@ -522,7 +522,7 @@ class CashuWallet {
 		pubkey?: string,
 		privkey?: string
 	): {
-		payload: SplitPayload;
+		payload: SwapPayload;
 		blindedMessages: BlindedTransaction;
 	} {
 		const totalAmount = proofsToSend.reduce((total, curr) => total + curr.amount, 0);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -17,15 +17,11 @@ import {
 	type MeltQuotePayload,
 	type SendResponse,
 	type SerializedBlindedMessage,
-<<<<<<< HEAD
-=======
 	type SwapPayload,
->>>>>>> split to swap
 	type Token,
 	type TokenEntry,
 	CheckStateEnum,
 	SerializedBlindedSignature,
-	SwapPayload
 } from './model/types/index.js';
 import {
 	bytesToNumber,

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -16,6 +16,10 @@ import {
 	type MintQuotePayload,
 	type SendResponse,
 	type SerializedBlindedMessage,
+<<<<<<< HEAD
+=======
+	type SwapPayload,
+>>>>>>> split to swap
 	type Token,
 	type TokenEntry,
 	CheckStateEnum,
@@ -187,7 +191,7 @@ class CashuWallet {
 				preference = getDefaultAmountPreference(amount);
 			}
 			const keys = await this.getKeys(options?.keysetId);
-			const { payload, blindedMessages } = this.createSplitPayload(
+			const { payload, blindedMessages } = this.createSwapPayload(
 				amount,
 				tokenEntry.proofs,
 				keys,
@@ -258,7 +262,7 @@ class CashuWallet {
 		}
 		if (amount < amountAvailable || options?.preference || options?.pubkey) {
 			const { amountKeep, amountSend } = this.splitReceive(amount, amountAvailable);
-			const { payload, blindedMessages } = this.createSplitPayload(
+			const { payload, blindedMessages } = this.createSwapPayload(
 				amountSend,
 				proofsToSend,
 				keyset,
@@ -513,7 +517,7 @@ class CashuWallet {
 	 * @param privkey? will create a signature on the @param proofsToSend secrets if set
 	 * @returns
 	 */
-	private createSplitPayload(
+	private createSwapPayload(
 		amount: number,
 		proofsToSend: Array<Proof>,
 		keyset: MintKeys,

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -14,6 +14,7 @@ import {
 	type ReceiveResponse,
 	type ReceiveTokenEntryResponse,
 	type MintQuotePayload,
+	type MeltQuotePayload,
 	type SendResponse,
 	type SerializedBlindedMessage,
 <<<<<<< HEAD
@@ -359,15 +360,25 @@ class CashuWallet {
 	/**
 	 * Requests a mint quote form the mint. Response returns a Lightning payment request for the requested given amount and unit.
 	 * @param amount Amount requesting for mint.
-	 * @returns the mint will create and return a Lightning invoice for the specified amount
+	 * @returns the mint will return a mint quote with a Lightning invoice for minting tokens of the specified amount and unit
 	 */
-	async getMintQuote(amount: number) {
+	async mintQuote(amount: number) {
 		const mintQuotePayload: MintQuotePayload = {
 			unit: this._unit,
 			amount: amount
 		};
 		return await this.mint.mintQuote(mintQuotePayload);
 	}
+
+	/**
+	 * Gets an existing mint quote from the mint.
+	 * @param quote Quote ID
+	 * @returns the mint will create and return a Lightning invoice for the specified amount
+	 */
+	async getMintQuote(quote: string) {
+		return await this.mint.getMintQuote(quote);
+	}
+
 
 	/**
 	 * Mint tokens for a given mint quote
@@ -406,12 +417,27 @@ class CashuWallet {
 	/**
 	 * Requests a melt quote from the mint. Response returns amount and fees for a given unit in order to pay a Lightning invoice.
 	 * @param invoice LN invoice that needs to get a fee estimate
-	 * @returns estimated Fee
+	 * @returns the mint will create and return a melt quote for the invoice with an amount and fee reserve
 	 */
-	async getMeltQuote(invoice: string): Promise<MeltQuoteResponse> {
-		const meltQuote = await this.mint.meltQuote({ unit: this._unit, request: invoice });
+	async meltQuote(invoice: string): Promise<MeltQuoteResponse> {
+		const meltQuotePayload: MeltQuotePayload = {
+			unit: this._unit,
+			request: invoice
+		};
+		const meltQuote = await this.mint.meltQuote(meltQuotePayload);
 		return meltQuote;
 	}
+
+	/**
+	 * Return an existing melt quote from the mint.
+	 * @param quote ID of the melt quote
+	 * @returns the mint will return an existing melt quote
+	 */
+	async getMeltQuote(quote: string): Promise<MeltQuoteResponse> {
+		const meltQuote = await this.mint.getMeltQuote(quote);
+		return meltQuote;
+	}
+
 	/**
 	 * Melt tokens for a melt quote. proofsToSend must be at least amount+fee_reserve form the melt quote.
 	 * Returns payment proof and change proofs

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -166,6 +166,15 @@ export type MeltQuoteResponse = {
 	 * Fee reserve to be added to the amount
 	 */
 	fee_reserve: number;
+	/**
+	 * Whether the quote has been paid.
+	 */
+	paid: boolean;
+	/**
+	 * Timestamp of when the quote expires
+	 */
+	expiry: number;
+
 } & ApiError;
 
 /**
@@ -280,8 +289,22 @@ export type MintQuotePayload = {
  * Response from the mint after requesting a mint
  */
 export type MintQuoteResponse = {
+	/**
+	 * Payment request 
+	 */
 	request: string;
+	/**
+	 * Quote ID
+	 */
 	quote: string;
+	/**
+	 * Whether the quote has been paid.
+	*/
+	paid: boolean;
+	/**
+	 * Timestamp of when the quote expires
+	 */
+	expiry: number;
 } & ApiError;
 
 /**

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -225,7 +225,7 @@ export type MeltTokensResponse = {
 /**
  * Payload that needs to be sent to the mint when performing a split action
  */
-export type SplitPayload = {
+export type SwapPayload = {
 	/**
 	 * Inputs to the split operation
 	 */
@@ -238,7 +238,7 @@ export type SplitPayload = {
 /**
  * Response from the mint after performing a split action
  */
-export type SplitResponse = {
+export type SwapResponse = {
 	/**
 	 * represents the outputs after the split
 	 */

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -36,13 +36,15 @@ describe('mint api', () => {
 	test('request mint', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(100);
+		const request = await wallet.mintQuote(100);
 		expect(request).toBeDefined();
+		const mintQuote = await wallet.getMeltQuote(request.quote);
+		expect(mintQuote).toBeDefined();
 	});
 	test('mint tokens', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(1337);
+		const request = await wallet.mintQuote(1337);
 		expect(request).toBeDefined();
 		expect(request.request).toContain('lnbc1337');
 		const tokens = await wallet.mintTokens(1337, request.quote);
@@ -53,8 +55,8 @@ describe('mint api', () => {
 	test('get fee for local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(100);
-		const fee = (await wallet.getMeltQuote(request.request)).fee_reserve;
+		const request = await wallet.mintQuote(100);
+		const fee = (await wallet.meltQuote(request.request)).fee_reserve;
 		expect(fee).toBeDefined();
 		// because local invoice, fee should be 0
 		expect(fee).toBe(0);
@@ -62,7 +64,7 @@ describe('mint api', () => {
 	test('get fee for external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const fee = (await wallet.getMeltQuote(externalInvoice)).fee_reserve;
+		const fee = (await wallet.meltQuote(externalInvoice)).fee_reserve;
 		expect(fee).toBeDefined();
 		// because external invoice, fee should be > 0
 		expect(fee).toBeGreaterThan(0);
@@ -70,17 +72,21 @@ describe('mint api', () => {
 	test('pay local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(100);
+		const request = await wallet.mintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		// expect no fee because local invoice
-		const requestToPay = await wallet.getMintQuote(10);
-		const quote = await wallet.getMeltQuote(requestToPay.request);
+		const meltQuote = await wallet.mintQuote(10);
+		const quote = await wallet.meltQuote(meltQuote.request);
 		const fee = quote.fee_reserve;
 		expect(fee).toBe(0);
 
+		// get the quote from the mint
+		const quote_ = await wallet.getMeltQuote(meltQuote.quote);
+		expect(quote_).toBeDefined();
+
 		const sendResponse = await wallet.send(10, tokens.proofs);
-		const response = await wallet.payLnInvoice(requestToPay.request, sendResponse.send, quote);
+		const response = await wallet.payLnInvoice(meltQuote.request, sendResponse.send, quote);
 		expect(response).toBeDefined();
 		// expect that we have received the fee back, since it was internal
 		expect(response.change.reduce((a, b) => a + b.amount, 0)).toBe(fee);
@@ -98,12 +104,16 @@ describe('mint api', () => {
 	test('pay external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(3000);
+		const request = await wallet.mintQuote(3000);
 		const tokens = await wallet.mintTokens(3000, request.quote);
 
-		const meltQuote = await wallet.getMeltQuote(externalInvoice);
+		const meltQuote = await wallet.meltQuote(externalInvoice);
 		const fee = meltQuote.fee_reserve;
 		expect(fee).toBeGreaterThan(0);
+
+		// get the quote from the mint
+		const quote_ = await wallet.getMeltQuote(meltQuote.quote);
+		expect(quote_).toBeDefined();
 
 		const sendResponse = await wallet.send(2000 + fee, tokens.proofs);
 		const response = await wallet.payLnInvoice(externalInvoice, sendResponse.send, meltQuote);
@@ -125,7 +135,7 @@ describe('mint api', () => {
 	test('test send tokens exact without previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(64);
+		const request = await wallet.mintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 
 		const sendResponse = await wallet.send(64, tokens.proofs);
@@ -138,7 +148,7 @@ describe('mint api', () => {
 	test('test send tokens with change', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(100);
+		const request = await wallet.mintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
@@ -151,7 +161,7 @@ describe('mint api', () => {
 	test('receive tokens with previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(100);
+		const request = await wallet.mintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
@@ -166,7 +176,7 @@ describe('mint api', () => {
 	test('receive tokens with previous mint', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.getMintQuote(64);
+		const request = await wallet.mintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 		const encoded = getEncodedToken({
 			token: [{ mint: mintUrl, proofs: tokens.proofs }]
@@ -186,7 +196,7 @@ describe('mint api', () => {
 		const privKeyBob = secp256k1.utils.randomPrivateKey();
 		const pubKeyBob = secp256k1.getPublicKey(privKeyBob);
 
-		const request = await wallet.getMintQuote(64);
+		const request = await wallet.mintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 
 		const { send } = await wallet.send(64, tokens.proofs, { pubkey: bytesToHex(pubKeyBob) });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -38,7 +38,7 @@ describe('mint api', () => {
 		const wallet = new CashuWallet(mint, { unit });
 		const request = await wallet.mintQuote(100);
 		expect(request).toBeDefined();
-		const mintQuote = await wallet.getMeltQuote(request.quote);
+		const mintQuote = await wallet.getMintQuote(request.quote);
 		expect(mintQuote).toBeDefined();
 	});
 	test('mint tokens', async () => {
@@ -76,17 +76,17 @@ describe('mint api', () => {
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		// expect no fee because local invoice
-		const meltQuote = await wallet.mintQuote(10);
-		const quote = await wallet.meltQuote(meltQuote.request);
+		const mintQuote = await wallet.mintQuote(10);
+		const quote = await wallet.meltQuote(mintQuote.request);
 		const fee = quote.fee_reserve;
 		expect(fee).toBe(0);
 
 		// get the quote from the mint
-		const quote_ = await wallet.getMeltQuote(meltQuote.quote);
+		const quote_ = await wallet.getMeltQuote(quote.quote);
 		expect(quote_).toBeDefined();
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
-		const response = await wallet.payLnInvoice(meltQuote.request, sendResponse.send, quote);
+		const response = await wallet.payLnInvoice(mintQuote.request, sendResponse.send, quote);
 		expect(response).toBeDefined();
 		// expect that we have received the fee back, since it was internal
 		expect(response.change.reduce((a, b) => a + b.amount, 0)).toBe(fee);

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -22,9 +22,10 @@ describe('requests', () => {
 	test('request with body contains the correct headers', async () => {
 		const mint = new CashuMint(mintUrl);
 		nock(mintUrl)
-			.post('/v1/melt/quote/bolt11')
+			.get('/v1/melt/quote/bolt11/test')
 			.reply(200, function () {
-				request = this.req.headers;
+				request = this.req.headers
+				console.log(this.req.headers)
 				return {
 					quote: 'test_melt_quote_id',
 					amount: 2000,
@@ -33,16 +34,16 @@ describe('requests', () => {
 			});
 
 		const wallet = new CashuWallet(mint, { unit });
-		await wallet.getMeltQuote(invoice);
+		await wallet.getMeltQuote('test');
 
 		expect(request).toBeDefined();
-		expect(request!['content-type']).toContain('application/json');
+		// expect(request!['content-type']).toContain('application/json');
 		expect(request!['accept']).toContain('application/json, text/plain, */*');
 	});
 	test('global custom headers can be set', async () => {
 		const mint = new CashuMint(mintUrl);
 		nock(mintUrl)
-			.post('/v1/melt/quote/bolt11')
+			.get('/v1/melt/quote/bolt11/test')
 			.reply(200, function () {
 				request = this.req.headers;
 				return {
@@ -54,7 +55,8 @@ describe('requests', () => {
 
 		const wallet = new CashuWallet(mint, { unit });
 		setGlobalRequestOptions({ headers: { 'x-cashu': 'xyz-123-abc' } });
-		await wallet.getMeltQuote(invoice);
+		
+		await wallet.getMeltQuote('test');
 
 		expect(request).toBeDefined();
 		expect(request!['x-cashu']).toContain('xyz-123-abc');

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -34,14 +34,14 @@ beforeEach(() => {
 
 describe('test fees', () => {
 	test('test melt quote fees', async () => {
-		nock(mintUrl).post('/v1/melt/quote/bolt11').reply(200, {
+		nock(mintUrl).get('/v1/melt/quote/bolt11/test').reply(200, {
 			quote: 'test_melt_quote_id',
 			amount: 2000,
 			fee_reserve: 20
 		});
 		const wallet = new CashuWallet(mint, { unit });
 
-		const fee = await wallet.getMeltQuote(invoice);
+		const fee = await wallet.getMeltQuote('test');
 		const amount = 2000;
 
 		expect(fee.fee_reserve + amount).toEqual(2020);
@@ -220,12 +220,12 @@ describe('payLnInvoice', () => {
 	];
 	test('test payLnInvoice base case', async () => {
 		nock(mintUrl)
-			.post('/v1/melt/quote/bolt11')
+			.get('/v1/melt/quote/bolt11/test')
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 0 });
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, payment_preimage: '' });
 
 		const wallet = new CashuWallet(mint, { unit });
-		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
+		const meltQuote = await wallet.getMeltQuote('test');
 
 		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
 
@@ -248,7 +248,7 @@ describe('payLnInvoice', () => {
 				]
 			});
 		nock(mintUrl)
-			.post('/v1/melt/quote/bolt11')
+			.get('/v1/melt/quote/bolt11/test')
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 2 });
 		nock(mintUrl)
 			.post('/v1/melt/bolt11')
@@ -265,7 +265,7 @@ describe('payLnInvoice', () => {
 			});
 
 		const wallet = new CashuWallet(mint, { unit });
-		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
+		const meltQuote = await wallet.getMeltQuote('test');
 		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
 
 		expect(result.isPaid).toBe(true);


### PR DESCRIPTION
This PR adds the `GET quote` methods from the v1 api and the `expiry` and `paid` attributes to the models that are defined in NUT-4 and 5. 

**Attention! This PR changes method names!!!!** 

### Rename `getMintQuote` and `getMintQuote` to `mintQuote` and `meltQuote`

`getMintQuote` is **REPLACED** as this method creates a new quote and the old naming is confusing with relation to the API.

```ts
getMintQuote(amount: number); -> mintQuote(amount: number)
getmeltQuote(request: string) -> meltQuote(request: string)
```

### Add new 

New GET methods
```ts
getMintQuote(quoteId: string)
getMeltQuote(quoteId: string)
```

### Rename Split to Swap

```ts
SplitPayload -> SwapPayload
SplitResponse -> SwapResponse
```

# Upgrade notes

For minting new tokens, most wallets used this flow: request mint quote, and then keep calling the `mint` function until it doesn't return an error anymore (but returns ecash). This is not very elegant since we're using an error case to control the flow of the application. 

It's better to request a mint (with `mintQuote()`), then keep checking if the mint quote is `paid === true` by calling `getMintQuote(quoteId: string)`. If the quote is `paid`, then call `mint()`. This should not entail any errors and can be controlled more precisely.