### PR TITLE
Amount `Preferences` fixes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,15 +14,18 @@ import { bytesToHex } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { Buffer } from 'buffer/';
 
-function splitAmount(value: number, amountPreference?: Array<AmountPreference>): Array<number> {
+function splitAmount(value: number, keys: MintKeys, amountPreference?: Array<AmountPreference>): Array<number> {
 	const chunks: Array<number> = [];
 	if (amountPreference) {
-		chunks.push(...getPreference(value, amountPreference));
-		value =
-			value -
-			chunks.reduce((curr, acc) => {
-				return curr + acc;
-			}, 0);
+		if (amountPreference.length > 0) {
+			chunks.push(...getPreference(value, keys, amountPreference));
+			value =
+				value -
+				chunks.reduce((curr, acc) => {
+					return curr + acc;
+				}, 0);
+			return chunks;
+		}
 	}
 	for (let i = 0; i < 32; i++) {
 		const mask: number = 1 << i;
@@ -37,13 +40,17 @@ function isPowerOfTwo(number: number) {
 	return number && !(number & (number - 1));
 }
 
-function getPreference(amount: number, preferredAmounts: Array<AmountPreference>): Array<number> {
+function hasCorrespondingKey(amount: number, keys: MintKeys) {
+	return amount in keys;
+}
+
+function getPreference(amount: number, keys: MintKeys, preferredAmounts: Array<AmountPreference>): Array<number> {
 	const chunks: Array<number> = [];
 	let accumulator = 0;
 	preferredAmounts.forEach((pa) => {
-		if (!isPowerOfTwo(pa.amount)) {
+		if (!hasCorrespondingKey(pa.amount, keys)) {
 			throw new Error(
-				'Provided amount preferences contain non-power-of-2 numbers. Use only ^2 numbers'
+				'Provided amount preferences contain an amount does not match any key!'
 			);
 		}
 		for (let i = 1; i <= pa.count; i++) {
@@ -57,8 +64,8 @@ function getPreference(amount: number, preferredAmounts: Array<AmountPreference>
 	return chunks;
 }
 
-function getDefaultAmountPreference(amount: number): Array<AmountPreference> {
-	const amounts = splitAmount(amount);
+function getDefaultAmountPreference(amount: number, keys: MintKeys): Array<AmountPreference> {
+	const amounts = splitAmount(amount, keys);
 	return amounts.map((a) => {
 		return { amount: a, count: 1 };
 	});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,13 +1,18 @@
-import { AmountPreference } from '../src/model/types/index.js';
+import { AmountPreference, MintKeys } from '../src/model/types/index.js';
 import * as utils from '../src/utils.js';
+
+var keys: MintKeys = {};
+for (let i = 1; i <= 2048; i *= 2) {
+  keys[i] = "deadbeef";
+}
 
 describe('test split amounts ', () => {
 	test('testing amount 2561', async () => {
-		const chunks = utils.splitAmount(2561);
+		const chunks = utils.splitAmount(2561, keys);
 		expect(chunks).toStrictEqual([1, 512, 2048]);
 	});
 	test('testing amount 0', async () => {
-		const chunks = utils.splitAmount(0);
+		const chunks = utils.splitAmount(0, keys);
 		expect(chunks).toStrictEqual([]);
 	});
 });
@@ -15,7 +20,7 @@ describe('test split amounts ', () => {
 describe('test split custom amounts ', () => {
 	const fiveToOne: AmountPreference = { amount: 1, count: 5 };
 	test('testing amount 5', async () => {
-		const chunks = utils.splitAmount(5, [fiveToOne]);
+		const chunks = utils.splitAmount(5, keys, [fiveToOne]);
 		expect(chunks).toStrictEqual([1, 1, 1, 1, 1]);
 	});
 	const tenToOneAndTwo: Array<AmountPreference> = [
@@ -23,21 +28,25 @@ describe('test split custom amounts ', () => {
 		{ amount: 2, count: 4 }
 	];
 	test('testing amount 10', async () => {
-		const chunks = utils.splitAmount(10, tenToOneAndTwo);
+		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo);
 		expect(chunks).toStrictEqual([1, 1, 2, 2, 2, 2]);
 	});
-	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
+	const fiveTwelve: Array<AmountPreference> = [
+		{ amount: 512, count: 1 },
+		{ amount: 4, count: 1 },
+		{ amount: 2, count: 1}
+	];
 	test('testing amount 516', async () => {
-		const chunks = utils.splitAmount(518, fiveTwelve);
-		expect(chunks).toStrictEqual([512, 2, 4]);
+		const chunks = utils.splitAmount(518, keys, fiveTwelve);
+		expect(chunks).toStrictEqual([512, 4, 2]);
 	});
 	const illegal: Array<AmountPreference> = [{ amount: 3, count: 2 }];
 	test('testing non pow2', async () => {
-		expect(() => utils.splitAmount(6, illegal)).toThrowError();
+		expect(() => utils.splitAmount(6, keys, illegal)).toThrowError();
 	});
 	const empty: Array<AmountPreference> = [];
 	test('testing empty', async () => {
-		const chunks = utils.splitAmount(5, empty);
+		const chunks = utils.splitAmount(5, keys, empty);
 		expect(chunks).toStrictEqual([1, 4]);
 	});
 });


### PR DESCRIPTION
# Fixes: #129 

## Changes
* getPreferences verifies preference amounts are in the keyset
* createSplitPayload now accepts a sendPreferences and keepPreferences
* fix splitAmount unintended "fill up the rest" behaviour
* updating tests regarding this part

## PR Tasks

- [x] Open PR
- [x] run `npm test utils` --> no failing tests 
- [ ] run `npm test wallet` --> no failing tests
- [ ] run `npm run test` --> no failing tests
- [ ] run `npm run format`
