### PR TITLE
NUT-05 changes

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -273,7 +273,7 @@ class CashuMint {
 
 		if (
 			!isObj(data) ||
-			typeof data?.paid !== 'boolean' ||
+			typeof data?.state !== 'string' ||
 			(data?.payment_preimage !== null && typeof data?.payment_preimage !== 'string')
 		) {
 			throw new Error('bad response');

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -432,7 +432,8 @@ class CashuWallet {
 		const meltResponse = await this.mint.melt(meltPayload);
 
 		return {
-			isPaid: meltResponse.paid ?? false,
+			isPaid: meltResponse.state === 'PAID',
+			state: meltResponse.state,
 			preimage: meltResponse.payment_preimage,
 			change: meltResponse?.change
 				? dhke.constructProofs(meltResponse.change, rs, secrets, keys)

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -187,13 +187,19 @@ export type MeltPayload = {
 };
 
 /**
+ * Payment state as part of the mints MeltResponse
+ */
+
+type MeltPaymentState = 'UNPAID' | 'PAID' | 'PENDING';
+
+/**
  * Response from the mint after paying a lightning invoice (melt)
  */
 export type MeltResponse = {
 	/**
-	 * if false, the proofs have not been invalidated and the payment can be tried later again with the same proofs
+	 * state of the invoice payment
 	 */
-	paid: boolean;
+	state: MeltPaymentState;
 	/**
 	 * preimage of the paid invoice. can be null, depending on which LN-backend the mint uses
 	 */
@@ -212,6 +218,10 @@ export type MeltTokensResponse = {
 	 * if false, the proofs have not been invalidated and the payment can be tried later again with the same proofs
 	 */
 	isPaid: boolean;
+	/**
+	 * state of the invoice payment
+	 */
+	state: MeltPaymentState;
 	/**
 	 * preimage of the paid invoice. can be null, depending on which LN-backend the mint uses
 	 */

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -222,14 +222,14 @@ describe('payLnInvoice', () => {
 		nock(mintUrl)
 			.post('/v1/melt/quote/bolt11')
 			.reply(200, { quote: 'quote_id', amount: 123, fee_reserve: 0 });
-		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { paid: true, payment_preimage: '' });
+		nock(mintUrl).post('/v1/melt/bolt11').reply(200, { state: 'PAID', payment_preimage: '' });
 
 		const wallet = new CashuWallet(mint, { unit });
 		const meltQuote = await wallet.getMeltQuote('lnbcabbc');
 
 		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
 
-		expect(result).toEqual({ isPaid: true, preimage: '', change: [] });
+		expect(result).toEqual({ isPaid: true, state: 'PAID', preimage: '', change: [] });
 	});
 	test('test payLnInvoice change', async () => {
 		nock.cleanAll();
@@ -253,7 +253,7 @@ describe('payLnInvoice', () => {
 		nock(mintUrl)
 			.post('/v1/melt/bolt11')
 			.reply(200, {
-				paid: true,
+				state: 'PAID',
 				payment_preimage: 'asd',
 				change: [
 					{
@@ -269,6 +269,7 @@ describe('payLnInvoice', () => {
 		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
 
 		expect(result.isPaid).toBe(true);
+		expect(result.state).toBe('PAID');
 		expect(result.preimage).toBe('asd');
 		expect(result.change).toHaveLength(1);
 	});


### PR DESCRIPTION
# Fixes: none

## Description
Implement changes proposed in https://github.com/cashubtc/nuts/pull/136

## Changes

- add state in MeltRepsonse
- alter API to parse state and return stable `isPaid` (backwards compatible)
- add state 

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run format`
