### PR TITLE
Amount Preferences Fixes

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -21,7 +21,8 @@ import {
 	CheckStateEnum,
 	SerializedBlindedSignature,
 	MeltQuoteState,
-	MintQuoteResponse
+	MintQuoteResponse,
+	Preferences
 } from './model/types/index.js';
 import {
 	bytesToNumber,
@@ -171,11 +172,12 @@ class CashuWallet {
 		if (!preference) {
 			preference = getDefaultAmountPreference(amount, keys);
 		}
+		const pref: Preferences = {sendPreference: preference};
 		const { payload, blindedMessages } = this.createSwapPayload(
 			amount,
 			tokenEntry.proofs,
 			keys,
-			preference,
+			pref,
 			options?.counter,
 			options?.pubkey,
 			options?.privkey
@@ -207,7 +209,7 @@ class CashuWallet {
 		amount: number,
 		proofs: Array<Proof>,
 		options?: {
-			preference?: Array<AmountPreference>;
+			preference?: Preferences;
 			counter?: number;
 			pubkey?: string;
 			privkey?: string;
@@ -215,7 +217,7 @@ class CashuWallet {
 		}
 	): Promise<SendResponse> {
 		if (options?.preference) {
-			amount = options?.preference?.reduce((acc, curr) => acc + curr.amount * curr.count, 0);
+			amount = options?.preference?.sendPreference.reduce((acc, curr) => acc + curr.amount * curr.count, 0);
 		}
 		const keyset = await this.getKeys(options?.keysetId);
 		let amountAvailable = 0;
@@ -538,7 +540,7 @@ class CashuWallet {
 		amount: number,
 		proofsToSend: Array<Proof>,
 		keyset: MintKeys,
-		preference?: Array<AmountPreference>,
+		preference?: Preferences,
 		counter?: number,
 		pubkey?: string,
 		privkey?: string
@@ -550,7 +552,7 @@ class CashuWallet {
 		const keepBlindedMessages = this.createRandomBlindedMessages(
 			totalAmount - amount,
 			keyset,
-			undefined,
+			preference?.keepPreference,
 			counter
 		);
 		if (this._seed && counter) {
@@ -559,7 +561,7 @@ class CashuWallet {
 		const sendBlindedMessages = this.createRandomBlindedMessages(
 			amount,
 			keyset,
-			preference,
+			preference?.sendPreference,
 			counter,
 			pubkey
 		);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -167,10 +167,10 @@ class CashuWallet {
 		const proofs: Array<Proof> = [];
 		const amount = tokenEntry.proofs.reduce((total, curr) => total + curr.amount, 0);
 		let preference = options?.preference;
-		if (!preference) {
-			preference = getDefaultAmountPreference(amount);
-		}
 		const keys = await this.getKeys(options?.keysetId);
+		if (!preference) {
+			preference = getDefaultAmountPreference(amount, keys);
+		}
 		const { payload, blindedMessages } = this.createSwapPayload(
 			amount,
 			tokenEntry.proofs,
@@ -372,7 +372,7 @@ class CashuWallet {
 		const keyset = await this.getKeys(options?.keysetId);
 		const { blindedMessages, secrets, rs } = this.createRandomBlindedMessages(
 			amount,
-			options?.keysetId ?? keyset.id,
+			keyset,
 			options?.preference,
 			options?.counter,
 			options?.pubkey
@@ -549,7 +549,7 @@ class CashuWallet {
 		const totalAmount = proofsToSend.reduce((total, curr) => total + curr.amount, 0);
 		const keepBlindedMessages = this.createRandomBlindedMessages(
 			totalAmount - amount,
-			keyset.id,
+			keyset,
 			undefined,
 			counter
 		);
@@ -558,7 +558,7 @@ class CashuWallet {
 		}
 		const sendBlindedMessages = this.createRandomBlindedMessages(
 			amount,
-			keyset.id,
+			keyset,
 			preference,
 			counter,
 			pubkey
@@ -633,13 +633,13 @@ class CashuWallet {
 	 */
 	private createRandomBlindedMessages(
 		amount: number,
-		keysetId: string,
+		keyset: MintKeys,
 		amountPreference?: Array<AmountPreference>,
 		counter?: number,
 		pubkey?: string
 	): BlindedMessageData & { amounts: Array<number> } {
-		const amounts = splitAmount(amount, amountPreference);
-		return this.createBlindedMessages(amounts, keysetId, counter, pubkey);
+		const amounts = splitAmount(amount, keyset.keys, amountPreference);
+		return this.createBlindedMessages(amounts, keyset.id, counter, pubkey);
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -172,7 +172,7 @@ class CashuWallet {
 		if (!preference) {
 			preference = getDefaultAmountPreference(amount, keys);
 		}
-		const pref: Preferences = {sendPreference: preference};
+		const pref: Preferences = { sendPreference: preference };
 		const { payload, blindedMessages } = this.createSwapPayload(
 			amount,
 			tokenEntry.proofs,
@@ -217,7 +217,10 @@ class CashuWallet {
 		}
 	): Promise<SendResponse> {
 		if (options?.preference) {
-			amount = options?.preference?.sendPreference.reduce((acc, curr) => acc + curr.amount * curr.count, 0);
+			amount = options?.preference?.sendPreference.reduce(
+				(acc, curr) => acc + curr.amount * curr.count,
+				0
+			);
 		}
 		const keyset = await this.getKeys(options?.keysetId);
 		let amountAvailable = 0;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -30,6 +30,7 @@ import {
 	getDefaultAmountPreference,
 	splitAmount
 } from './utils.js';
+import { isAmountPreferenceArray, deprecatedAmountPreferences } from './legacy/cashu-ts';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 import { hashToCurve, pointFromHex } from '@cashu/crypto/modules/common';
@@ -209,7 +210,7 @@ class CashuWallet {
 		amount: number,
 		proofs: Array<Proof>,
 		options?: {
-			preference?: Preferences;
+			preference?: Preferences | Array<AmountPreference>;
 			counter?: number;
 			pubkey?: string;
 			privkey?: string;
@@ -217,6 +218,9 @@ class CashuWallet {
 		}
 	): Promise<SendResponse> {
 		if (options?.preference) {
+			if (isAmountPreferenceArray(options.preference)) {
+				options.preference = deprecatedAmountPreferences(options.preference);
+			}
 			amount = options?.preference?.sendPreference.reduce(
 				(acc: number, curr: AmountPreference) => acc + curr.amount * curr.count,
 				0
@@ -545,7 +549,7 @@ class CashuWallet {
 		amount: number,
 		proofsToSend: Array<Proof>,
 		keyset: MintKeys,
-		preference?: Preferences,
+		preference?: Preferences | Array<AmountPreference>,
 		counter?: number,
 		pubkey?: string,
 		privkey?: string
@@ -553,6 +557,9 @@ class CashuWallet {
 		payload: SwapPayload;
 		blindedMessages: BlindedTransaction;
 	} {
+		if (isAmountPreferenceArray(preference)) {
+			preference = deprecatedAmountPreferences(preference);
+		}
 		const totalAmount = proofsToSend.reduce((total: number, curr: Proof) => total + curr.amount, 0);
 		const keepBlindedMessages = this.createRandomBlindedMessages(
 			totalAmount - amount,

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -223,7 +223,9 @@ class CashuWallet {
 		let amountAvailable = 0;
 		const proofsToSend: Array<Proof> = [];
 		const proofsToKeep: Array<Proof> = [];
-		proofs.forEach((proof) => {
+		// Start from smallest amounts and work your way up.
+		// This limits small change.
+		proofs.reverse().forEach((proof) => {
 			if (amountAvailable >= amount) {
 				proofsToKeep.push(proof);
 				return;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -223,9 +223,7 @@ class CashuWallet {
 		let amountAvailable = 0;
 		const proofsToSend: Array<Proof> = [];
 		const proofsToKeep: Array<Proof> = [];
-		// Start from smallest amounts and work your way up.
-		// This limits small change.
-		proofs.reverse().forEach((proof) => {
+		proofs.forEach((proof) => {
 			if (amountAvailable >= amount) {
 				proofsToKeep.push(proof);
 				return;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -446,7 +446,7 @@ class CashuWallet {
 		);
 		if (options?.privkey != undefined) {
 			proofsToSend = getSignedProofs(
-				proofsToSend.map((p) => {
+				proofsToSend.map((p: Proof) => {
 					return {
 						amount: p.amount,
 						C: pointFromHex(p.C),

--- a/src/legacy/cashu-ts.ts
+++ b/src/legacy/cashu-ts.ts
@@ -1,0 +1,21 @@
+import { AmountPreference, Preferences } from '../model/types/index';
+
+export const deprecatedAmountPreferences = function (pref: Array<AmountPreference>): Preferences {
+    console.warn("[DEPRECATION] Use `Preferences` instead of `Array<AmountPreference>`");
+    return { sendPreference: pref };
+}
+
+export const isAmountPreference = function (obj: any): obj is AmountPreference {
+    return (
+        typeof obj === 'object' &&
+        obj !== null &&
+        'amount' in obj &&
+        'count' in obj &&
+        typeof obj.amount === 'number' &&
+        typeof obj.count === 'number'
+    );
+}
+
+export const isAmountPreferenceArray = function (preference?: any): preference is Array<AmountPreference> {
+    return Array.isArray(preference) && preference.every((item) => isAmountPreference(item));
+}

--- a/src/legacy/cashu-ts.ts
+++ b/src/legacy/cashu-ts.ts
@@ -1,21 +1,23 @@
 import { AmountPreference, Preferences } from '../model/types/index';
 
 export const deprecatedAmountPreferences = function (pref: Array<AmountPreference>): Preferences {
-    console.warn("[DEPRECATION] Use `Preferences` instead of `Array<AmountPreference>`");
-    return { sendPreference: pref };
-}
+	console.warn('[DEPRECATION] Use `Preferences` instead of `Array<AmountPreference>`');
+	return { sendPreference: pref };
+};
 
 export const isAmountPreference = function (obj: any): obj is AmountPreference {
-    return (
-        typeof obj === 'object' &&
-        obj !== null &&
-        'amount' in obj &&
-        'count' in obj &&
-        typeof obj.amount === 'number' &&
-        typeof obj.count === 'number'
-    );
-}
+	return (
+		typeof obj === 'object' &&
+		obj !== null &&
+		'amount' in obj &&
+		'count' in obj &&
+		typeof obj.amount === 'number' &&
+		typeof obj.count === 'number'
+	);
+};
 
-export const isAmountPreferenceArray = function (preference?: any): preference is Array<AmountPreference> {
-    return Array.isArray(preference) && preference.every((item) => isAmountPreference(item));
-}
+export const isAmountPreferenceArray = function (
+	preference?: any
+): preference is Array<AmountPreference> {
+	return Array.isArray(preference) && preference.every((item) => isAmountPreference(item));
+};

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -1,6 +1,11 @@
 export * from './mint/index';
 export * from './wallet/index';
 
+export type Preferences = {
+	sendPreference: Array<AmountPreference>;
+	keepPreference?: Array<AmountPreference>;
+}
+
 export type InvoiceData = {
 	paymentRequest: string;
 	amountInSats?: number;

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -4,7 +4,7 @@ export * from './wallet/index';
 export type Preferences = {
 	sendPreference: Array<AmountPreference>;
 	keepPreference?: Array<AmountPreference>;
-}
+};
 
 export type InvoiceData = {
 	paymentRequest: string;

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -1,3 +1,5 @@
+import { AmountPreference } from './wallet/index';
+
 export * from './mint/index';
 export * from './wallet/index';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,12 @@ import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { decodeCBOR, encodeCBOR } from './cbor.js';
 
-function splitAmount(value: number, keyset: Keys, amountPreference?: Array<AmountPreference>): Array<number> {
+function splitAmount(
+	value: number, 
+	keyset: Keys,
+	amountPreference?: Array<AmountPreference>,
+	order?: string
+): Array<number> {
 	const chunks: Array<number> = [];
 	if (amountPreference) {
 		chunks.push(...getPreference(value, keyset, amountPreference));
@@ -31,13 +36,16 @@ function splitAmount(value: number, keyset: Keys, amountPreference?: Array<Amoun
 				return curr + acc;
 			}, 0);
 	}
-	for (let i = 0; i < 32; i++) {
-		const mask: number = 1 << i;
-		if ((value & mask) !== 0) {
-			chunks.push(Math.pow(2, i));
-		}
-	}
-	return chunks;
+	const sortedKeyAmounts: Array<number> = Object.keys(keyset)
+		.map(k => parseInt(k))
+		.sort((a, b) => b-a);
+	sortedKeyAmounts.forEach(amt => {
+		let q = Math.floor(value / amt);
+		for (let i=0; i<q; ++i)
+			chunks.push(amt);
+		value %= amt;
+	});
+	return chunks.sort((a, b) => (order === "asc") ? (a-b) : (b-a));
 }
 
 function isPowerOfTwo(number: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,15 +21,18 @@ import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { decodeCBOR, encodeCBOR } from './cbor.js';
 
-function splitAmount(value: number, amountPreference?: Array<AmountPreference>): Array<number> {
+function splitAmount(value: number, keyset: Keys, amountPreference?: Array<AmountPreference>): Array<number> {
 	const chunks: Array<number> = [];
 	if (amountPreference) {
-		chunks.push(...getPreference(value, amountPreference));
-		value =
-			value -
-			chunks.reduce((curr, acc) => {
-				return curr + acc;
-			}, 0);
+		if (amountPreference.length > 0) {
+			chunks.push(...getPreference(value, keyset, amountPreference));
+			value =
+				value -
+				chunks.reduce((curr, acc) => {
+					return curr + acc;
+				}, 0);
+			return chunks;
+		}
 	}
 	for (let i = 0; i < 32; i++) {
 		const mask: number = 1 << i;
@@ -44,13 +47,17 @@ function isPowerOfTwo(number: number) {
 	return number && !(number & (number - 1));
 }
 
-function getPreference(amount: number, preferredAmounts: Array<AmountPreference>): Array<number> {
+function hasCorrespondingKey(amount: number, keyset: Keys) {
+	return amount in keyset;
+}
+
+function getPreference(amount: number, keyset: Keys, preferredAmounts: Array<AmountPreference>): Array<number> {
 	const chunks: Array<number> = [];
 	let accumulator = 0;
 	preferredAmounts.forEach((pa) => {
-		if (!isPowerOfTwo(pa.amount)) {
+		if (!hasCorrespondingKey(pa.amount, keyset)) {
 			throw new Error(
-				'Provided amount preferences contain non-power-of-2 numbers. Use only ^2 numbers'
+				'Provided amount preferences do not match the amounts of the mint keyset.'
 			);
 		}
 		for (let i = 1; i <= pa.count; i++) {
@@ -64,8 +71,8 @@ function getPreference(amount: number, preferredAmounts: Array<AmountPreference>
 	return chunks;
 }
 
-function getDefaultAmountPreference(amount: number): Array<AmountPreference> {
-	const amounts = splitAmount(amount);
+function getDefaultAmountPreference(amount: number, keyset: Keys): Array<AmountPreference> {
+	const amounts = splitAmount(amount, keyset);
 	return amounts.map((a) => {
 		return { amount: a, count: 1 };
 	});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,15 +24,12 @@ import { decodeCBOR, encodeCBOR } from './cbor.js';
 function splitAmount(value: number, keyset: Keys, amountPreference?: Array<AmountPreference>): Array<number> {
 	const chunks: Array<number> = [];
 	if (amountPreference) {
-		if (amountPreference.length > 0) {
-			chunks.push(...getPreference(value, keyset, amountPreference));
-			value =
-				value -
-				chunks.reduce((curr, acc) => {
-					return curr + acc;
-				}, 0);
-			return chunks;
-		}
+		chunks.push(...getPreference(value, keyset, amountPreference));
+		value =
+			value -
+			chunks.reduce((curr, acc) => {
+				return curr + acc;
+			}, 0);
 	}
 	for (let i = 0; i < 32; i++) {
 		const mask: number = 1 << i;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ function splitAmount(
 		for (let i = 0; i < q; ++i) chunks.push(amt);
 		value %= amt;
 	});
-	return chunks.sort((a, b) => (order === 'asc' ? a - b : b - a));
+	return chunks.sort((a, b) => (order === 'desc' ? b - a : a - b));
 }
 
 function isPowerOfTwo(number: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,11 +45,13 @@ function splitAmount(
 	return chunks.sort((a, b) => (order === 'desc' ? b - a : a - b));
 }
 
+/*
 function isPowerOfTwo(number: number) {
 	return number && !(number & (number - 1));
 }
+*/
 
-function hasCorrespondingKey(amount: number, keyset: Keys) {
+function hasCorrespondingKey(amount: number, keyset: Keys): boolean {
 	return amount in keyset;
 }
 
@@ -60,7 +62,7 @@ function getPreference(
 ): Array<number> {
 	const chunks: Array<number> = [];
 	let accumulator = 0;
-	preferredAmounts.forEach((pa) => {
+	preferredAmounts.forEach((pa: AmountPreference) => {
 		if (!hasCorrespondingKey(pa.amount, keyset)) {
 			throw new Error('Provided amount preferences do not match the amounts of the mint keyset.');
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { decodeCBOR, encodeCBOR } from './cbor.js';
 
 function splitAmount(
-	value: number, 
+	value: number,
 	keyset: Keys,
 	amountPreference?: Array<AmountPreference>,
 	order?: string
@@ -37,15 +37,14 @@ function splitAmount(
 			}, 0);
 	}
 	const sortedKeyAmounts: Array<number> = Object.keys(keyset)
-		.map(k => parseInt(k))
-		.sort((a, b) => b-a);
-	sortedKeyAmounts.forEach(amt => {
+		.map((k) => parseInt(k))
+		.sort((a, b) => b - a);
+	sortedKeyAmounts.forEach((amt) => {
 		let q = Math.floor(value / amt);
-		for (let i=0; i<q; ++i)
-			chunks.push(amt);
+		for (let i = 0; i < q; ++i) chunks.push(amt);
 		value %= amt;
 	});
-	return chunks.sort((a, b) => (order === "asc") ? (a-b) : (b-a));
+	return chunks.sort((a, b) => (order === 'asc' ? a - b : b - a));
 }
 
 function isPowerOfTwo(number: number) {
@@ -56,14 +55,16 @@ function hasCorrespondingKey(amount: number, keyset: Keys) {
 	return amount in keyset;
 }
 
-function getPreference(amount: number, keyset: Keys, preferredAmounts: Array<AmountPreference>): Array<number> {
+function getPreference(
+	amount: number,
+	keyset: Keys,
+	preferredAmounts: Array<AmountPreference>
+): Array<number> {
 	const chunks: Array<number> = [];
 	let accumulator = 0;
 	preferredAmounts.forEach((pa) => {
 		if (!hasCorrespondingKey(pa.amount, keyset)) {
-			throw new Error(
-				'Provided amount preferences do not match the amounts of the mint keyset.'
-			);
+			throw new Error('Provided amount preferences do not match the amounts of the mint keyset.');
 		}
 		for (let i = 1; i <= pa.count; i++) {
 			accumulator += pa.amount;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ function splitAmount(
 	value: number,
 	keyset: Keys,
 	amountPreference?: Array<AmountPreference>,
-	order?: string
+	isDesc?: boolean
 ): Array<number> {
 	const chunks: Array<number> = [];
 	if (amountPreference) {
@@ -42,7 +42,7 @@ function splitAmount(
 		for (let i = 0; i < q; ++i) chunks.push(amt);
 		value %= amt;
 	});
-	return chunks.sort((a, b) => (order === 'desc' ? b - a : a - b));
+	return chunks.sort((a, b) => ( isDesc ? b - a : a - b));
 }
 
 /*

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,13 +3,23 @@ import * as utils from '../src/utils.js';
 import { PUBKEYS } from './consts.js';
 
 const keys: Keys = {};
-for (let i=1; i<2048; i *= 2) {
+for (let i=1; i<=2048; i *= 2) {
 	keys[i] = "deadbeef";
+}
+
+const keys_base10: Keys = {};
+for (let i=1; i<=10000; i *= 10) {
+	keys_base10[i] = "deadbeef";
+}
+
+const keys_base16: Keys = {};
+for (let i=1; i<=0x10000; i *= 16) {
+	keys_base16[i] = "deadbeef";
 }
 
 describe('test split amounts ', () => {
 	test('testing amount 2561', async () => {
-		const chunks = utils.splitAmount(2561, keys);
+		const chunks = utils.splitAmount(2561, keys, undefined, "asc");
 		expect(chunks).toStrictEqual([1, 512, 2048]);
 	});
 	test('testing amount 0', async () => {
@@ -29,13 +39,13 @@ describe('test split custom amounts ', () => {
 		{ amount: 2, count: 4 }
 	];
 	test('testing amount 10', async () => {
-		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo);
+		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo, "asc");
 		expect(chunks).toStrictEqual([1, 1, 2, 2, 2, 2]);
 	});
 	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
 	test('testing amount 518', async () => {
 		const chunks = utils.splitAmount(518, keys, fiveTwelve);
-		expect(chunks).toStrictEqual([512, 2, 4]);
+		expect(chunks).toStrictEqual([512, 4, 2]);
 	});
 	const illegal: Array<AmountPreference> = [{ amount: 3, count: 2 }];
 	test('testing non pow2', async () => {
@@ -44,12 +54,33 @@ describe('test split custom amounts ', () => {
 	const empty: Array<AmountPreference> = [];
 	test('testing empty', async () => {
 		const chunks = utils.splitAmount(5, keys, empty);
-		expect(chunks).toStrictEqual([1, 4]);
+		expect(chunks).toStrictEqual([4, 1]);
 	});
 	const undef = undefined;
 	test('testing undefined', async () => {
-		const chunks = utils.splitAmount(5, keys, undef);
+		const chunks = utils.splitAmount(5, keys, undef, "asc");
 		expect(chunks).toStrictEqual([1, 4]);
+	});
+});
+
+describe('test split different key amount', () => {
+	test('testing amount 68251', async () => {
+		const chunks = utils.splitAmount(68251, keys_base10);
+		expect(chunks).toStrictEqual([
+			10000, 10000, 10000, 10000, 10000, 10000,
+			1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000,
+			100, 100,
+			10, 10, 10, 10, 10,
+			1
+		]);
+	});
+	test('testing amount 1917', async () => {
+		const chunks = utils.splitAmount(1917, keys_base16);
+		expect(chunks).toStrictEqual([
+			256, 256, 256, 256, 256, 256, 256,
+			16, 16, 16, 16, 16, 16, 16,
+			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+		]);
 	});
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -32,11 +32,7 @@ describe('test split custom amounts ', () => {
 		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo);
 		expect(chunks).toStrictEqual([1, 1, 2, 2, 2, 2]);
 	});
-	const fiveTwelve: Array<AmountPreference> = [
-		{ amount: 512, count: 1 },
-		{ amount: 2, count: 1 },
-		{ amount: 4, count: 1}
-	];
+	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
 	test('testing amount 518', async () => {
 		const chunks = utils.splitAmount(518, keys, fiveTwelve);
 		expect(chunks).toStrictEqual([512, 2, 4]);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,14 +1,19 @@
-import { AmountPreference, Token } from '../src/model/types/index.js';
+import { AmountPreference, Token, Keys } from '../src/model/types/index.js';
 import * as utils from '../src/utils.js';
 import { PUBKEYS } from './consts.js';
 
+const keys: Keys = {};
+for (let i=1; i<2048; i *= 2) {
+	keys[i] = "deadbeef";
+}
+
 describe('test split amounts ', () => {
 	test('testing amount 2561', async () => {
-		const chunks = utils.splitAmount(2561);
+		const chunks = utils.splitAmount(2561, keys);
 		expect(chunks).toStrictEqual([1, 512, 2048]);
 	});
 	test('testing amount 0', async () => {
-		const chunks = utils.splitAmount(0);
+		const chunks = utils.splitAmount(0, keys);
 		expect(chunks).toStrictEqual([]);
 	});
 });
@@ -16,7 +21,7 @@ describe('test split amounts ', () => {
 describe('test split custom amounts ', () => {
 	const fiveToOne: AmountPreference = { amount: 1, count: 5 };
 	test('testing amount 5', async () => {
-		const chunks = utils.splitAmount(5, [fiveToOne]);
+		const chunks = utils.splitAmount(5, keys, [fiveToOne]);
 		expect(chunks).toStrictEqual([1, 1, 1, 1, 1]);
 	});
 	const tenToOneAndTwo: Array<AmountPreference> = [
@@ -24,21 +29,30 @@ describe('test split custom amounts ', () => {
 		{ amount: 2, count: 4 }
 	];
 	test('testing amount 10', async () => {
-		const chunks = utils.splitAmount(10, tenToOneAndTwo);
+		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo);
 		expect(chunks).toStrictEqual([1, 1, 2, 2, 2, 2]);
 	});
-	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
-	test('testing amount 516', async () => {
-		const chunks = utils.splitAmount(518, fiveTwelve);
+	const fiveTwelve: Array<AmountPreference> = [
+		{ amount: 512, count: 1 },
+		{ amount: 2, count: 1 },
+		{ amount: 4, count: 1}
+	];
+	test('testing amount 518', async () => {
+		const chunks = utils.splitAmount(518, keys, fiveTwelve);
 		expect(chunks).toStrictEqual([512, 2, 4]);
 	});
 	const illegal: Array<AmountPreference> = [{ amount: 3, count: 2 }];
 	test('testing non pow2', async () => {
-		expect(() => utils.splitAmount(6, illegal)).toThrowError();
+		expect(() => utils.splitAmount(6, keys, illegal)).toThrowError();
 	});
 	const empty: Array<AmountPreference> = [];
 	test('testing empty', async () => {
-		const chunks = utils.splitAmount(5, empty);
+		const chunks = utils.splitAmount(5, keys, empty);
+		expect(chunks).toStrictEqual([1, 4]);
+	});
+	const undef = undefined;
+	test('testing undefined', async () => {
+		const chunks = utils.splitAmount(5, keys, undef);
 		expect(chunks).toStrictEqual([1, 4]);
 	});
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,23 +3,23 @@ import * as utils from '../src/utils.js';
 import { PUBKEYS } from './consts.js';
 
 const keys: Keys = {};
-for (let i=1; i<=2048; i *= 2) {
-	keys[i] = "deadbeef";
+for (let i = 1; i <= 2048; i *= 2) {
+	keys[i] = 'deadbeef';
 }
 
 const keys_base10: Keys = {};
-for (let i=1; i<=10000; i *= 10) {
-	keys_base10[i] = "deadbeef";
+for (let i = 1; i <= 10000; i *= 10) {
+	keys_base10[i] = 'deadbeef';
 }
 
 const keys_base16: Keys = {};
-for (let i=1; i<=0x10000; i *= 16) {
-	keys_base16[i] = "deadbeef";
+for (let i = 1; i <= 0x10000; i *= 16) {
+	keys_base16[i] = 'deadbeef';
 }
 
 describe('test split amounts ', () => {
 	test('testing amount 2561', async () => {
-		const chunks = utils.splitAmount(2561, keys, undefined, "asc");
+		const chunks = utils.splitAmount(2561, keys, undefined, 'asc');
 		expect(chunks).toStrictEqual([1, 512, 2048]);
 	});
 	test('testing amount 0', async () => {
@@ -39,7 +39,7 @@ describe('test split custom amounts ', () => {
 		{ amount: 2, count: 4 }
 	];
 	test('testing amount 10', async () => {
-		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo, "asc");
+		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo, 'asc');
 		expect(chunks).toStrictEqual([1, 1, 2, 2, 2, 2]);
 	});
 	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
@@ -58,7 +58,7 @@ describe('test split custom amounts ', () => {
 	});
 	const undef = undefined;
 	test('testing undefined', async () => {
-		const chunks = utils.splitAmount(5, keys, undef, "asc");
+		const chunks = utils.splitAmount(5, keys, undef, 'asc');
 		expect(chunks).toStrictEqual([1, 4]);
 	});
 });
@@ -67,19 +67,15 @@ describe('test split different key amount', () => {
 	test('testing amount 68251', async () => {
 		const chunks = utils.splitAmount(68251, keys_base10);
 		expect(chunks).toStrictEqual([
-			10000, 10000, 10000, 10000, 10000, 10000,
-			1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000,
-			100, 100,
-			10, 10, 10, 10, 10,
-			1
+			10000, 10000, 10000, 10000, 10000, 10000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 100,
+			100, 10, 10, 10, 10, 10, 1
 		]);
 	});
 	test('testing amount 1917', async () => {
 		const chunks = utils.splitAmount(1917, keys_base16);
 		expect(chunks).toStrictEqual([
-			256, 256, 256, 256, 256, 256, 256,
-			16, 16, 16, 16, 16, 16, 16,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+			256, 256, 256, 256, 256, 256, 256, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+			1, 1, 1
 		]);
 	});
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -44,7 +44,7 @@ describe('test split custom amounts ', () => {
 	});
 	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
 	test('testing amount 518', async () => {
-		const chunks = utils.splitAmount(518, keys, fiveTwelve, 'desc');
+		const chunks = utils.splitAmount(518, keys, fiveTwelve, true);
 		expect(chunks).toStrictEqual([512, 4, 2]);
 	});
 	const illegal: Array<AmountPreference> = [{ amount: 3, count: 2 }];
@@ -53,7 +53,7 @@ describe('test split custom amounts ', () => {
 	});
 	const empty: Array<AmountPreference> = [];
 	test('testing empty', async () => {
-		const chunks = utils.splitAmount(5, keys, empty, 'desc');
+		const chunks = utils.splitAmount(5, keys, empty, true);
 		expect(chunks).toStrictEqual([4, 1]);
 	});
 	const undef = undefined;
@@ -65,7 +65,7 @@ describe('test split custom amounts ', () => {
 
 describe('test split different key amount', () => {
 	test('testing amount 68251', async () => {
-		const chunks = utils.splitAmount(68251, keys_base10, undefined, 'desc');
+		const chunks = utils.splitAmount(68251, keys_base10, undefined, true);
 		expect(chunks).toStrictEqual([
 			10000, 10000, 10000, 10000, 10000, 10000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 100,
 			100, 10, 10, 10, 10, 10, 1

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -19,7 +19,7 @@ for (let i = 1; i <= 0x10000; i *= 16) {
 
 describe('test split amounts ', () => {
 	test('testing amount 2561', async () => {
-		const chunks = utils.splitAmount(2561, keys, undefined, 'asc');
+		const chunks = utils.splitAmount(2561, keys);
 		expect(chunks).toStrictEqual([1, 512, 2048]);
 	});
 	test('testing amount 0', async () => {
@@ -39,12 +39,12 @@ describe('test split custom amounts ', () => {
 		{ amount: 2, count: 4 }
 	];
 	test('testing amount 10', async () => {
-		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo, 'asc');
+		const chunks = utils.splitAmount(10, keys, tenToOneAndTwo);
 		expect(chunks).toStrictEqual([1, 1, 2, 2, 2, 2]);
 	});
 	const fiveTwelve: Array<AmountPreference> = [{ amount: 512, count: 2 }];
 	test('testing amount 518', async () => {
-		const chunks = utils.splitAmount(518, keys, fiveTwelve);
+		const chunks = utils.splitAmount(518, keys, fiveTwelve, 'desc');
 		expect(chunks).toStrictEqual([512, 4, 2]);
 	});
 	const illegal: Array<AmountPreference> = [{ amount: 3, count: 2 }];
@@ -53,19 +53,19 @@ describe('test split custom amounts ', () => {
 	});
 	const empty: Array<AmountPreference> = [];
 	test('testing empty', async () => {
-		const chunks = utils.splitAmount(5, keys, empty);
+		const chunks = utils.splitAmount(5, keys, empty, 'desc');
 		expect(chunks).toStrictEqual([4, 1]);
 	});
 	const undef = undefined;
 	test('testing undefined', async () => {
-		const chunks = utils.splitAmount(5, keys, undef, 'asc');
+		const chunks = utils.splitAmount(5, keys, undef);
 		expect(chunks).toStrictEqual([1, 4]);
 	});
 });
 
 describe('test split different key amount', () => {
 	test('testing amount 68251', async () => {
-		const chunks = utils.splitAmount(68251, keys_base10);
+		const chunks = utils.splitAmount(68251, keys_base10, undefined, 'desc');
 		expect(chunks).toStrictEqual([
 			10000, 10000, 10000, 10000, 10000, 10000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 100,
 			100, 10, 10, 10, 10, 10, 1
@@ -74,8 +74,8 @@ describe('test split different key amount', () => {
 	test('testing amount 1917', async () => {
 		const chunks = utils.splitAmount(1917, keys_base16);
 		expect(chunks).toStrictEqual([
-			256, 256, 256, 256, 256, 256, 256, 16, 16, 16, 16, 16, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1
+			1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+			1, 1, 1, 16, 16, 16, 16, 16, 16, 16, 256, 256, 256, 256, 256, 256, 256
 		]);
 	});
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -74,8 +74,8 @@ describe('test split different key amount', () => {
 	test('testing amount 1917', async () => {
 		const chunks = utils.splitAmount(1917, keys_base16);
 		expect(chunks).toStrictEqual([
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 16, 16, 16, 16, 16, 16, 16, 256, 256, 256, 256, 256, 256, 256
+			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 16, 16, 16, 16, 16, 16, 16, 256, 256, 256, 256, 256,
+			256, 256
 		]);
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -491,7 +491,9 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, { preference: { sendPreference: [{ amount: 1, count: 4 }] }});
+		const result = await wallet.send(4, overpayProofs, {
+			preference: { sendPreference: [{ amount: 1, count: 4 }] }
+		});
 
 		expect(result.send).toHaveLength(4);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -546,7 +548,9 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, { preference: { sendPreference: [{ amount: 1, count: 3 }]} });
+		const result = await wallet.send(4, overpayProofs, {
+			preference: { sendPreference: [{ amount: 1, count: 3 }] }
+		});
 
 		expect(result.send).toHaveLength(3);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -491,7 +491,7 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, { preference: [{ amount: 1, count: 4 }] });
+		const result = await wallet.send(4, overpayProofs, { preference: { sendPreference: [{ amount: 1, count: 4 }] }});
 
 		expect(result.send).toHaveLength(4);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
@@ -546,7 +546,7 @@ describe('send', () => {
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			}
 		];
-		const result = await wallet.send(4, overpayProofs, { preference: [{ amount: 1, count: 3 }] });
+		const result = await wallet.send(4, overpayProofs, { preference: { sendPreference: [{ amount: 1, count: 3 }]} });
 
 		expect(result.send).toHaveLength(3);
 		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });


### PR DESCRIPTION
# Fixes: #129 

## Changes

- getPreferences checks input amouts against the amounts of the keys
- keepPreferences and sendPreferences as different optional parameters in createSplitPayload.
- modify splitAmount behaviour -in case of no specified preference- to create amounts not from powers of 2
    but from the amounts of the keyset instead.
- splitAmount reorders its outputs by descending/ascending order.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
