### PR TITLE
Reading V4 Token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
 				"@scure/bip39": "^1.2.2",
-				"buffer": "^6.0.3",
-				"cbor-x": "^1.5.9"
+				"buffer": "^6.0.3"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.1",
@@ -632,78 +631,6 @@
 				"@scure/bip39": "^1.2.2",
 				"buffer": "^6.0.3"
 			}
-		},
-		"node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
-			"integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-darwin-x64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
-			"integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-linux-arm": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
-			"integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-linux-arm64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
-			"integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-linux-x64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
-			"integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@cbor-extract/cbor-extract-win32-x64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
-			"integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -2306,35 +2233,6 @@
 				}
 			]
 		},
-		"node_modules/cbor-extract": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
-			"integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
-			"hasInstallScript": true,
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build-optional-packages": "5.1.1"
-			},
-			"bin": {
-				"download-cbor-prebuilds": "bin/download-prebuilds.js"
-			},
-			"optionalDependencies": {
-				"@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
-				"@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
-				"@cbor-extract/cbor-extract-linux-arm": "2.2.0",
-				"@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
-				"@cbor-extract/cbor-extract-linux-x64": "2.2.0",
-				"@cbor-extract/cbor-extract-win32-x64": "2.2.0"
-			}
-		},
-		"node_modules/cbor-x": {
-			"version": "1.5.9",
-			"resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
-			"integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
-			"optionalDependencies": {
-				"cbor-extract": "^2.2.0"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2557,15 +2455,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-			"optional": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -5130,20 +5019,6 @@
 				}
 			}
 		},
-		"node_modules/node-gyp-build-optional-packages": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
-			"integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
-			"optional": true,
-			"dependencies": {
-				"detect-libc": "^2.0.1"
-			},
-			"bin": {
-				"node-gyp-build-optional-packages": "bin.js",
-				"node-gyp-build-optional-packages-optional": "optional.js",
-				"node-gyp-build-optional-packages-test": "build-test.js"
-			}
-		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6968,42 +6843,6 @@
 				"buffer": "^6.0.3"
 			}
 		},
-		"@cbor-extract/cbor-extract-darwin-arm64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
-			"integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
-			"optional": true
-		},
-		"@cbor-extract/cbor-extract-darwin-x64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
-			"integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
-			"optional": true
-		},
-		"@cbor-extract/cbor-extract-linux-arm": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
-			"integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
-			"optional": true
-		},
-		"@cbor-extract/cbor-extract-linux-arm64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
-			"integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
-			"optional": true
-		},
-		"@cbor-extract/cbor-extract-linux-x64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
-			"integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
-			"optional": true
-		},
-		"@cbor-extract/cbor-extract-win32-x64": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
-			"integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
-			"optional": true
-		},
 		"@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -8186,29 +8025,6 @@
 			"integrity": "sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==",
 			"dev": true
 		},
-		"cbor-extract": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
-			"integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
-			"optional": true,
-			"requires": {
-				"@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
-				"@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
-				"@cbor-extract/cbor-extract-linux-arm": "2.2.0",
-				"@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
-				"@cbor-extract/cbor-extract-linux-x64": "2.2.0",
-				"@cbor-extract/cbor-extract-win32-x64": "2.2.0",
-				"node-gyp-build-optional-packages": "5.1.1"
-			}
-		},
-		"cbor-x": {
-			"version": "1.5.9",
-			"resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
-			"integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
-			"requires": {
-				"cbor-extract": "^2.2.0"
-			}
-		},
 		"chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8371,12 +8187,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"dev": true
-		},
-		"detect-libc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-			"optional": true
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -10249,15 +10059,6 @@
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
-			}
-		},
-		"node-gyp-build-optional-packages": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
-			"integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
-			"optional": true,
-			"requires": {
-				"detect-libc": "^2.0.1"
 			}
 		},
 		"node-int64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
 				"@scure/bip39": "^1.2.2",
-				"buffer": "^6.0.3"
+				"buffer": "^6.0.3",
+				"cbor-x": "^1.5.9"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.1",
@@ -51,119 +52,48 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.20.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-			"integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.7.tgz",
-			"integrity": "sha512-t1ZjCluspe5DW24bn2Rr1CDb2v9rn/hROtg9a2tmd0+QYf4bsloYfLQzjG4qHPNMhWtKdGC33R5AxGR2Af2cBw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
 			"dev": true,
 			"dependencies": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.20.7",
-				"@babel/helpers": "^7.20.7",
-				"@babel/parser": "^7.20.7",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7",
-				"convert-source-map": "^1.7.0",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helpers": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/template": "^7.24.7",
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.1",
-				"semver": "^6.3.0"
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -173,21 +103,15 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
-		"node_modules/@babel/core/node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"dev": true
-		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+			"integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.23.6",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
+				"@babel/types": "^7.24.7",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -195,30 +119,96 @@
 			}
 		},
 		"node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.21.3",
+				"@babel/compat-data": "^7.24.7",
+				"@babel/helper-validator-option": "^7.24.7",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
-				"semver": "^6.3.0"
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-function-name": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-hoist-variables": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-module-imports": "^7.24.7",
+				"@babel/helper-simple-access": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -227,154 +217,90 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-			"integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.20.2",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.10",
-				"@babel/types": "^7.20.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-			"integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+			"integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-			"integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.2"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+			"integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-			"integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -452,9 +378,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+			"integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -524,12 +450,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.21.4.tgz",
-			"integrity": "sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+			"integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -626,12 +552,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz",
-			"integrity": "sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
+			"integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -641,33 +567,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+			"integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+			"integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.6",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.6",
-				"@babel/types": "^7.23.6",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-hoist-variables": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -676,13 +602,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+			"integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.23.4",
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-string-parser": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -706,6 +632,78 @@
 				"@scure/bip39": "^1.2.2",
 				"buffer": "^6.0.3"
 			}
+		},
+		"node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
+			"integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
+			"integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@cbor-extract/cbor-extract-linux-arm": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
+			"integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
+			"integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@cbor-extract/cbor-extract-linux-x64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
+			"integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@cbor-extract/cbor-extract-win32-x64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
+			"integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -889,16 +887,16 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.5.0.tgz",
-			"integrity": "sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -906,37 +904,37 @@
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.5.0.tgz",
-			"integrity": "sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^29.5.0",
-				"@jest/reporters": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/console": "^29.7.0",
+				"@jest/reporters": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.5.0",
-				"jest-config": "^29.5.0",
-				"jest-haste-map": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-regex-util": "^29.4.3",
-				"jest-resolve": "^29.5.0",
-				"jest-resolve-dependencies": "^29.5.0",
-				"jest-runner": "^29.5.0",
-				"jest-runtime": "^29.5.0",
-				"jest-snapshot": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
-				"jest-watcher": "^29.5.0",
+				"jest-changed-files": "^29.7.0",
+				"jest-config": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-resolve-dependencies": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"jest-watcher": "^29.7.0",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"strip-ansi": "^6.0.0"
 			},
@@ -953,89 +951,89 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
-			"integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/fake-timers": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.5.0"
+				"jest-mock": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/expect": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.5.0.tgz",
-			"integrity": "sha512-PueDR2HGihN3ciUNGr4uelropW7rqUfTiOn+8u0leg/42UhblPxHkfoh0Ruu3I9Y1962P3u2DY4+h7GVTSVU6g==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
 			"dev": true,
 			"dependencies": {
-				"expect": "^29.5.0",
-				"jest-snapshot": "^29.5.0"
+				"expect": "^29.7.0",
+				"jest-snapshot": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/expect-utils": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
-			"integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
 			"dev": true,
 			"dependencies": {
-				"jest-get-type": "^29.4.3"
+				"jest-get-type": "^29.6.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
-			"integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^29.5.0",
-				"jest-mock": "^29.5.0",
-				"jest-util": "^29.5.0"
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
-			"integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^29.5.0",
-				"@jest/expect": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"jest-mock": "^29.5.0"
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"jest-mock": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.5.0.tgz",
-			"integrity": "sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
 			"dev": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"@jridgewell/trace-mapping": "^0.3.15",
+				"@jest/console": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
@@ -1043,13 +1041,13 @@
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.9",
 				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^5.1.0",
+				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-worker": "^29.5.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
 				"slash": "^3.0.0",
 				"string-length": "^4.0.1",
 				"strip-ansi": "^6.0.0",
@@ -1067,25 +1065,53 @@
 				}
 			}
 		},
-		"node_modules/@jest/schemas": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-			"integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+		"node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+			"integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
 			"dev": true,
 			"dependencies": {
-				"@sinclair/typebox": "^0.25.16"
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/source-map": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.4.3.tgz",
-			"integrity": "sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.15",
+				"@jridgewell/trace-mapping": "^0.3.18",
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.2.9"
 			},
@@ -1094,13 +1120,13 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.5.0.tgz",
-			"integrity": "sha512-fGl4rfitnbfLsrfx1uUpDEESS7zM8JdgZgOCQuxQvL1Sn/I6ijeAVQWGfXI9zb1i9Mzo495cIpVZhA0yr60PkQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/console": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			},
@@ -1109,14 +1135,14 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.5.0.tgz",
-			"integrity": "sha512-yPafQEcKjkSfDXyvtgiV4pevSeyuA6MQr6ZIdVkWJly9vkqjnFfcfhRQqpD5whjoU8EORki752xQmjaqoFjzMQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/test-result": "^29.5.0",
+				"@jest/test-result": "^29.7.0",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1124,22 +1150,22 @@
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
-			"integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.5.0",
-				"@jridgewell/trace-mapping": "^0.3.15",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
 				"babel-plugin-istanbul": "^6.1.1",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
-				"jest-regex-util": "^29.4.3",
-				"jest-util": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
 				"micromatch": "^4.0.4",
 				"pirates": "^4.0.4",
 				"slash": "^3.0.0",
@@ -1150,12 +1176,12 @@
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-			"integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/schemas": "^29.4.3",
+				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
@@ -1189,9 +1215,9 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1204,13 +1230,13 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@noble/curves": {
@@ -1304,27 +1330,27 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.25.24",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-			"integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
 		"node_modules/@sinonjs/commons": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-			"integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
 			"dependencies": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-			"integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"dev": true,
 			"dependencies": {
-				"@sinonjs/commons": "^2.0.0"
+				"@sinonjs/commons": "^3.0.0"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -1352,9 +1378,9 @@
 			"dev": true
 		},
 		"node_modules/@types/babel__core": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-			"integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
@@ -1365,18 +1391,18 @@
 			}
 		},
 		"node_modules/@types/babel__generator": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-			"integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+			"version": "7.6.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"node_modules/@types/babel__template": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-			"integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
@@ -1384,12 +1410,12 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
-			"integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+			"version": "7.20.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+			"integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.3.0"
+				"@babel/types": "^7.20.7"
 			}
 		},
 		"node_modules/@types/graceful-fs": {
@@ -1462,12 +1488,6 @@
 				"@types/node": "*",
 				"form-data": "^3.0.0"
 			}
-		},
-		"node_modules/@types/prettier": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-			"integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
-			"dev": true
 		},
 		"node_modules/@types/semver": {
 			"version": "7.3.13",
@@ -1973,15 +1993,15 @@
 			"dev": true
 		},
 		"node_modules/babel-jest": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
-			"integrity": "sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/transform": "^29.5.0",
+				"@jest/transform": "^29.7.0",
 				"@types/babel__core": "^7.1.14",
 				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.5.0",
+				"babel-preset-jest": "^29.6.3",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"slash": "^3.0.0"
@@ -2010,9 +2030,9 @@
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
-			"integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.3.3",
@@ -2048,12 +2068,12 @@
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
-			"integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
 			"dev": true,
 			"dependencies": {
-				"babel-plugin-jest-hoist": "^29.5.0",
+				"babel-plugin-jest-hoist": "^29.6.3",
 				"babel-preset-current-node-syntax": "^1.0.0"
 			},
 			"engines": {
@@ -2112,9 +2132,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+			"integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2124,13 +2144,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001629",
+				"electron-to-chromium": "^1.4.796",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.16"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -2263,9 +2287,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001441",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-			"integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+			"version": "1.0.30001638",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
+			"integrity": "sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2275,8 +2299,41 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
+		},
+		"node_modules/cbor-extract": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
+			"integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build-optional-packages": "5.1.1"
+			},
+			"bin": {
+				"download-cbor-prebuilds": "bin/download-prebuilds.js"
+			},
+			"optionalDependencies": {
+				"@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
+				"@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
+				"@cbor-extract/cbor-extract-linux-arm": "2.2.0",
+				"@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
+				"@cbor-extract/cbor-extract-linux-x64": "2.2.0",
+				"@cbor-extract/cbor-extract-win32-x64": "2.2.0"
+			}
+		},
+		"node_modules/cbor-x": {
+			"version": "1.5.9",
+			"resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
+			"integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
+			"optionalDependencies": {
+				"cbor-extract": "^2.2.0"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -2313,9 +2370,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+			"integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
 			"dev": true
 		},
 		"node_modules/cliui": {
@@ -2343,9 +2400,9 @@
 			}
 		},
 		"node_modules/collect-v8-coverage": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
 			"dev": true
 		},
 		"node_modules/color-convert": {
@@ -2390,6 +2447,27 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
 		},
+		"node_modules/create-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"prompts": "^2.0.1"
+			},
+			"bin": {
+				"create-jest": "bin/create-jest.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2428,10 +2506,18 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
-			"dev": true
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
+			"integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+			"dev": true,
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -2473,6 +2559,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/detect-libc": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2492,9 +2587,9 @@
 			}
 		},
 		"node_modules/diff-sequences": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-			"integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
 			"dev": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2525,9 +2620,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"version": "1.4.814",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.814.tgz",
+			"integrity": "sha512-GVulpHjFu1Y9ZvikvbArHmAhZXtm3wHlpjTMcXNGKl4IQ4jMQjlnz8yMQYYqdLHKi/jEL2+CBC2akWVCoIGUdw==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -2623,9 +2718,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -3253,16 +3348,16 @@
 			}
 		},
 		"node_modules/expect": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
-			"integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/expect-utils": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"jest-matcher-utils": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0"
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4077,17 +4172,17 @@
 			}
 		},
 		"node_modules/istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
 			"dev": true,
 			"dependencies": {
 				"istanbul-lib-coverage": "^3.0.0",
-				"make-dir": "^3.0.0",
+				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-lib-source-maps": {
@@ -4105,9 +4200,9 @@
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-			"integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
 			"dev": true,
 			"dependencies": {
 				"html-escaper": "^2.0.0",
@@ -4118,15 +4213,15 @@
 			}
 		},
 		"node_modules/jest": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
-			"integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/core": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/core": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"import-local": "^3.0.2",
-				"jest-cli": "^29.5.0"
+				"jest-cli": "^29.7.0"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -4144,12 +4239,13 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.5.0.tgz",
-			"integrity": "sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
 			"dev": true,
 			"dependencies": {
 				"execa": "^5.0.0",
+				"jest-util": "^29.7.0",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
@@ -4157,28 +4253,28 @@
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.5.0.tgz",
-			"integrity": "sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^29.5.0",
-				"@jest/expect": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"dedent": "^0.7.0",
+				"dedent": "^1.0.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.5.0",
-				"jest-matcher-utils": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-runtime": "^29.5.0",
-				"jest-snapshot": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-each": "^29.7.0",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"p-limit": "^3.1.0",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"pure-rand": "^6.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
@@ -4188,22 +4284,21 @@
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.5.0.tgz",
-			"integrity": "sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/core": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/core": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"chalk": "^4.0.0",
+				"create-jest": "^29.7.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
 				"import-local": "^3.0.2",
-				"jest-config": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
-				"prompts": "^2.0.1",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
 				"yargs": "^17.3.1"
 			},
 			"bin": {
@@ -4222,31 +4317,31 @@
 			}
 		},
 		"node_modules/jest-config": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.5.0.tgz",
-			"integrity": "sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"babel-jest": "^29.5.0",
+				"@jest/test-sequencer": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-jest": "^29.7.0",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.5.0",
-				"jest-environment-node": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"jest-regex-util": "^29.4.3",
-				"jest-resolve": "^29.5.0",
-				"jest-runner": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
+				"jest-circus": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
 				"micromatch": "^4.0.4",
 				"parse-json": "^5.2.0",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -4267,24 +4362,24 @@
 			}
 		},
 		"node_modules/jest-diff": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
-			"integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
-				"diff-sequences": "^29.4.3",
-				"jest-get-type": "^29.4.3",
-				"pretty-format": "^29.5.0"
+				"diff-sequences": "^29.6.3",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
-			"integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
 			"dev": true,
 			"dependencies": {
 				"detect-newline": "^3.0.0"
@@ -4294,62 +4389,62 @@
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.5.0.tgz",
-			"integrity": "sha512-HM5kIJ1BTnVt+DQZ2ALp3rzXEl+g726csObrW/jpEGl+CDSSQpOJJX2KE/vEg8cxcMXdyEPu6U4QX5eruQv5hA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"chalk": "^4.0.0",
-				"jest-get-type": "^29.4.3",
-				"jest-util": "^29.5.0",
-				"pretty-format": "^29.5.0"
+				"jest-get-type": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"pretty-format": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.5.0.tgz",
-			"integrity": "sha512-ExxuIK/+yQ+6PRGaHkKewYtg6hto2uGCgvKdb2nfJfKXgZ17DfXjvbZ+jA1Qt9A8EQSfPnt5FKIfnOO3u1h9qw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^29.5.0",
-				"@jest/fake-timers": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.5.0",
-				"jest-util": "^29.5.0"
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-get-type": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-			"integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
 			"dev": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
-			"integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/graceful-fs": "^4.1.3",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.4.3",
-				"jest-util": "^29.5.0",
-				"jest-worker": "^29.5.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
 				"micromatch": "^4.0.4",
 				"walker": "^1.0.8"
 			},
@@ -4361,46 +4456,46 @@
 			}
 		},
 		"node_modules/jest-leak-detector": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.5.0.tgz",
-			"integrity": "sha512-u9YdeeVnghBUtpN5mVxjID7KbkKE1QU4f6uUwuxiY0vYRi9BUCLKlPEZfDGR67ofdFmDz9oPAy2G92Ujrntmow==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
 			"dev": true,
 			"dependencies": {
-				"jest-get-type": "^29.4.3",
-				"pretty-format": "^29.5.0"
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
-			"integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"pretty-format": "^29.5.0"
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
-			"integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			},
@@ -4409,14 +4504,14 @@
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
-			"integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-util": "^29.5.0"
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4440,26 +4535,26 @@
 			}
 		},
 		"node_modules/jest-regex-util": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
-			"integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
 			"dev": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.5.0.tgz",
-			"integrity": "sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
 				"resolve": "^1.20.0",
 				"resolve.exports": "^2.0.0",
 				"slash": "^3.0.0"
@@ -4469,43 +4564,43 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.5.0.tgz",
-			"integrity": "sha512-sjV3GFr0hDJMBpYeUuGduP+YeCRbd7S/ck6IvL3kQ9cpySYKqcqhdLLC2rFwrcL7tz5vYibomBrsFYWkIGGjOg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
 			"dev": true,
 			"dependencies": {
-				"jest-regex-util": "^29.4.3",
-				"jest-snapshot": "^29.5.0"
+				"jest-regex-util": "^29.6.3",
+				"jest-snapshot": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.5.0.tgz",
-			"integrity": "sha512-m7b6ypERhFghJsslMLhydaXBiLf7+jXy8FwGRHO3BGV1mcQpPbwiqiKUR2zU2NJuNeMenJmlFZCsIqzJCTeGLQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^29.5.0",
-				"@jest/environment": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/console": "^29.7.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.13.1",
 				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.4.3",
-				"jest-environment-node": "^29.5.0",
-				"jest-haste-map": "^29.5.0",
-				"jest-leak-detector": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-resolve": "^29.5.0",
-				"jest-runtime": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-watcher": "^29.5.0",
-				"jest-worker": "^29.5.0",
+				"jest-docblock": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-leak-detector": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-resolve": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"jest-worker": "^29.7.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
@@ -4514,31 +4609,31 @@
 			}
 		},
 		"node_modules/jest-runtime": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.5.0.tgz",
-			"integrity": "sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^29.5.0",
-				"@jest/fake-timers": "^29.5.0",
-				"@jest/globals": "^29.5.0",
-				"@jest/source-map": "^29.4.3",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/globals": "^29.7.0",
+				"@jest/source-map": "^29.6.3",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"cjs-module-lexer": "^1.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-mock": "^29.5.0",
-				"jest-regex-util": "^29.4.3",
-				"jest-resolve": "^29.5.0",
-				"jest-snapshot": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
@@ -4547,59 +4642,41 @@
 			}
 		},
 		"node_modules/jest-snapshot": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.5.0.tgz",
-			"integrity": "sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.11.6",
 				"@babel/generator": "^7.7.2",
 				"@babel/plugin-syntax-jsx": "^7.7.2",
 				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/traverse": "^7.7.2",
 				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"@types/babel__traverse": "^7.0.6",
-				"@types/prettier": "^2.1.5",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"babel-preset-current-node-syntax": "^1.0.0",
 				"chalk": "^4.0.0",
-				"expect": "^29.5.0",
+				"expect": "^29.7.0",
 				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"jest-matcher-utils": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.5.0",
-				"semver": "^7.3.5"
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-snapshot/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4607,19 +4684,13 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/jest-snapshot/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
-		},
 		"node_modules/jest-util": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-			"integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
@@ -4631,17 +4702,17 @@
 			}
 		},
 		"node_modules/jest-validate": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.5.0.tgz",
-			"integrity": "sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"camelcase": "^6.2.0",
 				"chalk": "^4.0.0",
-				"jest-get-type": "^29.4.3",
+				"jest-get-type": "^29.6.3",
 				"leven": "^3.1.0",
-				"pretty-format": "^29.5.0"
+				"pretty-format": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4660,18 +4731,18 @@
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.5.0.tgz",
-			"integrity": "sha512-KmTojKcapuqYrKDpRwfqcQ3zjMlwu27SYext9pt4GlF5FUgB+7XE1mcCnSm6a4uUpFyQIkb6ZhzZvHl+jiBCiA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
 			"dev": true,
 			"dependencies": {
-				"@jest/test-result": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"emittery": "^0.13.1",
-				"jest-util": "^29.5.0",
+				"jest-util": "^29.7.0",
 				"string-length": "^4.0.1"
 			},
 			"engines": {
@@ -4679,13 +4750,13 @@
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
-			"integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"jest-util": "^29.5.0",
+				"jest-util": "^29.7.0",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.0.0"
 			},
@@ -4874,18 +4945,30 @@
 			"dev": true
 		},
 		"node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
 			"dev": true,
 			"dependencies": {
-				"semver": "^6.0.0"
+				"semver": "^7.5.3"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/make-error": {
@@ -5047,6 +5130,20 @@
 				}
 			}
 		},
+		"node_modules/node-gyp-build-optional-packages": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+			"integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.1"
+			},
+			"bin": {
+				"node-gyp-build-optional-packages": "bin.js",
+				"node-gyp-build-optional-packages-optional": "optional.js",
+				"node-gyp-build-optional-packages-test": "build-test.js"
+			}
+		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5054,9 +5151,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
 		"node_modules/normalize-path": {
@@ -5298,9 +5395,9 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
 			"dev": true
 		},
 		"node_modules/picomatch": {
@@ -5361,12 +5458,12 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-			"integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/schemas": "^29.4.3",
+				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
 				"react-is": "^18.0.0"
 			},
@@ -5418,9 +5515,9 @@
 			}
 		},
 		"node_modules/pure-rand": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
-			"integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
 			"dev": true,
 			"funding": [
 				{
@@ -6184,9 +6281,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+			"integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -6196,14 +6293,18 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.1.2",
+				"picocolors": "^1.0.1"
 			},
 			"bin": {
-				"browserslist-lint": "cli.js"
+				"update-browserslist-db": "cli.js"
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
@@ -6225,24 +6326,18 @@
 			"dev": true
 		},
 		"node_modules/v8-to-istanbul": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-			"integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0"
+				"convert-source-map": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=10.12.0"
 			}
-		},
-		"node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"dev": true
 		},
 		"node_modules/vscode-oniguruma": {
 			"version": "1.7.0",
@@ -6373,9 +6468,9 @@
 			"dev": true
 		},
 		"node_modules/yargs": {
-			"version": "17.7.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dev": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -6433,260 +6528,196 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.20.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-			"integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.7.tgz",
-			"integrity": "sha512-t1ZjCluspe5DW24bn2Rr1CDb2v9rn/hROtg9a2tmd0+QYf4bsloYfLQzjG4qHPNMhWtKdGC33R5AxGR2Af2cBw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
 			"dev": true,
 			"requires": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.20.7",
-				"@babel/helpers": "^7.20.7",
-				"@babel/parser": "^7.20.7",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7",
-				"convert-source-map": "^1.7.0",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helpers": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/template": "^7.24.7",
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.1",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"convert-source-map": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-					"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-					"dev": true
-				}
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+			"integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.23.6",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
+				"@babel/types": "^7.24.7",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
 			},
 			"dependencies": {
 				"@jridgewell/gen-mapping": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+					"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 					"dev": true,
 					"requires": {
-						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/set-array": "^1.2.1",
 						"@jridgewell/sourcemap-codec": "^1.4.10",
-						"@jridgewell/trace-mapping": "^0.3.9"
+						"@jridgewell/trace-mapping": "^0.3.24"
 					}
 				}
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.21.3",
+				"@babel/compat-data": "^7.24.7",
+				"@babel/helper-validator-option": "^7.24.7",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
-				"semver": "^6.3.0"
+				"semver": "^6.3.1"
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-			"dev": true
-		},
-		"@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
+				"@babel/types": "^7.24.7"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-			"integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.20.2",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.10",
-				"@babel/types": "^7.20.7"
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-module-imports": "^7.24.7",
+				"@babel/helper-simple-access": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-			"integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+			"integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
 			"dev": true
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-			"integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.2"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+			"integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
-			"integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6748,9 +6779,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+			"integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
 			"dev": true
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -6799,12 +6830,12 @@
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.21.4.tgz",
-			"integrity": "sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+			"integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			}
 		},
 		"@babel/plugin-syntax-logical-assignment-operators": {
@@ -6871,51 +6902,51 @@
 			}
 		},
 		"@babel/plugin-syntax-typescript": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz",
-			"integrity": "sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
+			"integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.20.2"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			}
 		},
 		"@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+			"integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+			"integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.6",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.6",
-				"@babel/types": "^7.23.6",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-hoist-variables": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+			"integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.23.4",
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-string-parser": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -6936,6 +6967,42 @@
 				"@scure/bip39": "^1.2.2",
 				"buffer": "^6.0.3"
 			}
+		},
+		"@cbor-extract/cbor-extract-darwin-arm64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
+			"integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
+			"optional": true
+		},
+		"@cbor-extract/cbor-extract-darwin-x64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
+			"integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
+			"optional": true
+		},
+		"@cbor-extract/cbor-extract-linux-arm": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
+			"integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
+			"optional": true
+		},
+		"@cbor-extract/cbor-extract-linux-arm64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
+			"integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
+			"optional": true
+		},
+		"@cbor-extract/cbor-extract-linux-x64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
+			"integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
+			"optional": true
+		},
+		"@cbor-extract/cbor-extract-win32-x64": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
+			"integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
+			"optional": true
 		},
 		"@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -7071,124 +7138,124 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.5.0.tgz",
-			"integrity": "sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"@jest/core": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.5.0.tgz",
-			"integrity": "sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^29.5.0",
-				"@jest/reporters": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/console": "^29.7.0",
+				"@jest/reporters": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.5.0",
-				"jest-config": "^29.5.0",
-				"jest-haste-map": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-regex-util": "^29.4.3",
-				"jest-resolve": "^29.5.0",
-				"jest-resolve-dependencies": "^29.5.0",
-				"jest-runner": "^29.5.0",
-				"jest-runtime": "^29.5.0",
-				"jest-snapshot": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
-				"jest-watcher": "^29.5.0",
+				"jest-changed-files": "^29.7.0",
+				"jest-config": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-resolve-dependencies": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"jest-watcher": "^29.7.0",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"strip-ansi": "^6.0.0"
 			}
 		},
 		"@jest/environment": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
-			"integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.5.0"
+				"jest-mock": "^29.7.0"
 			}
 		},
 		"@jest/expect": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.5.0.tgz",
-			"integrity": "sha512-PueDR2HGihN3ciUNGr4uelropW7rqUfTiOn+8u0leg/42UhblPxHkfoh0Ruu3I9Y1962P3u2DY4+h7GVTSVU6g==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
 			"dev": true,
 			"requires": {
-				"expect": "^29.5.0",
-				"jest-snapshot": "^29.5.0"
+				"expect": "^29.7.0",
+				"jest-snapshot": "^29.7.0"
 			}
 		},
 		"@jest/expect-utils": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
-			"integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^29.4.3"
+				"jest-get-type": "^29.6.3"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
-			"integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^29.5.0",
-				"jest-mock": "^29.5.0",
-				"jest-util": "^29.5.0"
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			}
 		},
 		"@jest/globals": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
-			"integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.5.0",
-				"@jest/expect": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"jest-mock": "^29.5.0"
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"jest-mock": "^29.7.0"
 			}
 		},
 		"@jest/reporters": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.5.0.tgz",
-			"integrity": "sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"@jridgewell/trace-mapping": "^0.3.15",
+				"@jest/console": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
@@ -7196,80 +7263,101 @@
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.9",
 				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^5.1.0",
+				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-worker": "^29.5.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
 				"slash": "^3.0.0",
 				"string-length": "^4.0.1",
 				"strip-ansi": "^6.0.0",
 				"v8-to-istanbul": "^9.0.1"
+			},
+			"dependencies": {
+				"istanbul-lib-instrument": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+					"integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.23.9",
+						"@babel/parser": "^7.23.9",
+						"@istanbuljs/schema": "^0.1.3",
+						"istanbul-lib-coverage": "^3.2.0",
+						"semver": "^7.5.4"
+					}
+				},
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/schemas": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-			"integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"dev": true,
 			"requires": {
-				"@sinclair/typebox": "^0.25.16"
+				"@sinclair/typebox": "^0.27.8"
 			}
 		},
 		"@jest/source-map": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.4.3.tgz",
-			"integrity": "sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.15",
+				"@jridgewell/trace-mapping": "^0.3.18",
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.2.9"
 			}
 		},
 		"@jest/test-result": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.5.0.tgz",
-			"integrity": "sha512-fGl4rfitnbfLsrfx1uUpDEESS7zM8JdgZgOCQuxQvL1Sn/I6ijeAVQWGfXI9zb1i9Mzo495cIpVZhA0yr60PkQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/console": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.5.0.tgz",
-			"integrity": "sha512-yPafQEcKjkSfDXyvtgiV4pevSeyuA6MQr6ZIdVkWJly9vkqjnFfcfhRQqpD5whjoU8EORki752xQmjaqoFjzMQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^29.5.0",
+				"@jest/test-result": "^29.7.0",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"@jest/transform": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
-			"integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.5.0",
-				"@jridgewell/trace-mapping": "^0.3.15",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
 				"babel-plugin-istanbul": "^6.1.1",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
-				"jest-regex-util": "^29.4.3",
-				"jest-util": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
 				"micromatch": "^4.0.4",
 				"pirates": "^4.0.4",
 				"slash": "^3.0.0",
@@ -7277,12 +7365,12 @@
 			}
 		},
 		"@jest/types": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-			"integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
 			"requires": {
-				"@jest/schemas": "^29.4.3",
+				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
@@ -7307,9 +7395,9 @@
 			"dev": true
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
@@ -7319,13 +7407,13 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"@noble/curves": {
@@ -7392,27 +7480,27 @@
 			}
 		},
 		"@sinclair/typebox": {
-			"version": "0.25.24",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-			"integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-			"integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"@sinonjs/fake-timers": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-			"integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^2.0.0"
+				"@sinonjs/commons": "^3.0.0"
 			}
 		},
 		"@tsconfig/node10": {
@@ -7440,9 +7528,9 @@
 			"dev": true
 		},
 		"@types/babel__core": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-			"integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.20.7",
@@ -7453,18 +7541,18 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-			"integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+			"version": "7.6.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-			"integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -7472,12 +7560,12 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
-			"integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+			"version": "7.20.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+			"integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0"
+				"@babel/types": "^7.20.7"
 			}
 		},
 		"@types/graceful-fs": {
@@ -7550,12 +7638,6 @@
 				"@types/node": "*",
 				"form-data": "^3.0.0"
 			}
-		},
-		"@types/prettier": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-			"integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
-			"dev": true
 		},
 		"@types/semver": {
 			"version": "7.3.13",
@@ -7897,15 +7979,15 @@
 			"dev": true
 		},
 		"babel-jest": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
-			"integrity": "sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^29.5.0",
+				"@jest/transform": "^29.7.0",
 				"@types/babel__core": "^7.1.14",
 				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.5.0",
+				"babel-preset-jest": "^29.6.3",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"slash": "^3.0.0"
@@ -7925,9 +8007,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
-			"integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.3.3",
@@ -7957,12 +8039,12 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
-			"integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^29.5.0",
+				"babel-plugin-jest-hoist": "^29.6.3",
 				"babel-preset-current-node-syntax": "^1.0.0"
 			}
 		},
@@ -7997,15 +8079,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+			"integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001629",
+				"electron-to-chromium": "^1.4.796",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.16"
 			}
 		},
 		"bs-logger": {
@@ -8099,10 +8181,33 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001441",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-			"integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+			"version": "1.0.30001638",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
+			"integrity": "sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==",
 			"dev": true
+		},
+		"cbor-extract": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
+			"integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
+			"optional": true,
+			"requires": {
+				"@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
+				"@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
+				"@cbor-extract/cbor-extract-linux-arm": "2.2.0",
+				"@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
+				"@cbor-extract/cbor-extract-linux-x64": "2.2.0",
+				"@cbor-extract/cbor-extract-win32-x64": "2.2.0",
+				"node-gyp-build-optional-packages": "5.1.1"
+			}
+		},
+		"cbor-x": {
+			"version": "1.5.9",
+			"resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
+			"integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
+			"requires": {
+				"cbor-extract": "^2.2.0"
+			}
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -8127,9 +8232,9 @@
 			"dev": true
 		},
 		"cjs-module-lexer": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+			"integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
 			"dev": true
 		},
 		"cliui": {
@@ -8150,9 +8255,9 @@
 			"dev": true
 		},
 		"collect-v8-coverage": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
 			"dev": true
 		},
 		"color-convert": {
@@ -8191,6 +8296,21 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
 		},
+		"create-jest": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.6.3",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"prompts": "^2.0.1"
+			}
+		},
 		"create-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8218,10 +8338,11 @@
 			}
 		},
 		"dedent": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
-			"dev": true
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
+			"integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -8251,6 +8372,12 @@
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"dev": true
 		},
+		"detect-libc": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+			"optional": true
+		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -8264,9 +8391,9 @@
 			"dev": true
 		},
 		"diff-sequences": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-			"integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -8288,9 +8415,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"version": "1.4.814",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.814.tgz",
+			"integrity": "sha512-GVulpHjFu1Y9ZvikvbArHmAhZXtm3wHlpjTMcXNGKl4IQ4jMQjlnz8yMQYYqdLHKi/jEL2+CBC2akWVCoIGUdw==",
 			"dev": true
 		},
 		"emittery": {
@@ -8368,9 +8495,9 @@
 			}
 		},
 		"escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -8807,16 +8934,16 @@
 			"dev": true
 		},
 		"expect": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
-			"integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
 			"dev": true,
 			"requires": {
-				"@jest/expect-utils": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"jest-matcher-utils": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0"
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
 			}
 		},
 		"fast-deep-equal": {
@@ -9390,13 +9517,13 @@
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
 			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "^3.0.0",
-				"make-dir": "^3.0.0",
+				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
 			}
 		},
@@ -9412,9 +9539,9 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-			"integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0",
@@ -9422,227 +9549,227 @@
 			}
 		},
 		"jest": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
-			"integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/core": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"import-local": "^3.0.2",
-				"jest-cli": "^29.5.0"
+				"jest-cli": "^29.7.0"
 			}
 		},
 		"jest-changed-files": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.5.0.tgz",
-			"integrity": "sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
 			"dev": true,
 			"requires": {
 				"execa": "^5.0.0",
+				"jest-util": "^29.7.0",
 				"p-limit": "^3.1.0"
 			}
 		},
 		"jest-circus": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.5.0.tgz",
-			"integrity": "sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.5.0",
-				"@jest/expect": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"dedent": "^0.7.0",
+				"dedent": "^1.0.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.5.0",
-				"jest-matcher-utils": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-runtime": "^29.5.0",
-				"jest-snapshot": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-each": "^29.7.0",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"p-limit": "^3.1.0",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"pure-rand": "^6.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			}
 		},
 		"jest-cli": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.5.0.tgz",
-			"integrity": "sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/core": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"chalk": "^4.0.0",
+				"create-jest": "^29.7.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
 				"import-local": "^3.0.2",
-				"jest-config": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
-				"prompts": "^2.0.1",
+				"jest-config": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
 				"yargs": "^17.3.1"
 			}
 		},
 		"jest-config": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.5.0.tgz",
-			"integrity": "sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"babel-jest": "^29.5.0",
+				"@jest/test-sequencer": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-jest": "^29.7.0",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.5.0",
-				"jest-environment-node": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"jest-regex-util": "^29.4.3",
-				"jest-resolve": "^29.5.0",
-				"jest-runner": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
+				"jest-circus": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
 				"micromatch": "^4.0.4",
 				"parse-json": "^5.2.0",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			}
 		},
 		"jest-diff": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
-			"integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
-				"diff-sequences": "^29.4.3",
-				"jest-get-type": "^29.4.3",
-				"pretty-format": "^29.5.0"
+				"diff-sequences": "^29.6.3",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
-			"integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^3.0.0"
 			}
 		},
 		"jest-each": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.5.0.tgz",
-			"integrity": "sha512-HM5kIJ1BTnVt+DQZ2ALp3rzXEl+g726csObrW/jpEGl+CDSSQpOJJX2KE/vEg8cxcMXdyEPu6U4QX5eruQv5hA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"chalk": "^4.0.0",
-				"jest-get-type": "^29.4.3",
-				"jest-util": "^29.5.0",
-				"pretty-format": "^29.5.0"
+				"jest-get-type": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"pretty-format": "^29.7.0"
 			}
 		},
 		"jest-environment-node": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.5.0.tgz",
-			"integrity": "sha512-ExxuIK/+yQ+6PRGaHkKewYtg6hto2uGCgvKdb2nfJfKXgZ17DfXjvbZ+jA1Qt9A8EQSfPnt5FKIfnOO3u1h9qw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.5.0",
-				"@jest/fake-timers": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.5.0",
-				"jest-util": "^29.5.0"
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-			"integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
-			"integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/graceful-fs": "^4.1.3",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^2.3.2",
 				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.4.3",
-				"jest-util": "^29.5.0",
-				"jest-worker": "^29.5.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
 				"micromatch": "^4.0.4",
 				"walker": "^1.0.8"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.5.0.tgz",
-			"integrity": "sha512-u9YdeeVnghBUtpN5mVxjID7KbkKE1QU4f6uUwuxiY0vYRi9BUCLKlPEZfDGR67ofdFmDz9oPAy2G92Ujrntmow==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^29.4.3",
-				"pretty-format": "^29.5.0"
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
-			"integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"pretty-format": "^29.5.0"
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
-			"integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.5.0",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			}
 		},
 		"jest-mock": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
-			"integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-util": "^29.5.0"
+				"jest-util": "^29.7.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -9653,161 +9780,140 @@
 			"requires": {}
 		},
 		"jest-regex-util": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
-			"integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.5.0.tgz",
-			"integrity": "sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.5.0",
-				"jest-validate": "^29.5.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
 				"resolve": "^1.20.0",
 				"resolve.exports": "^2.0.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.5.0.tgz",
-			"integrity": "sha512-sjV3GFr0hDJMBpYeUuGduP+YeCRbd7S/ck6IvL3kQ9cpySYKqcqhdLLC2rFwrcL7tz5vYibomBrsFYWkIGGjOg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^29.4.3",
-				"jest-snapshot": "^29.5.0"
+				"jest-regex-util": "^29.6.3",
+				"jest-snapshot": "^29.7.0"
 			}
 		},
 		"jest-runner": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.5.0.tgz",
-			"integrity": "sha512-m7b6ypERhFghJsslMLhydaXBiLf7+jXy8FwGRHO3BGV1mcQpPbwiqiKUR2zU2NJuNeMenJmlFZCsIqzJCTeGLQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^29.5.0",
-				"@jest/environment": "^29.5.0",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/console": "^29.7.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.13.1",
 				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.4.3",
-				"jest-environment-node": "^29.5.0",
-				"jest-haste-map": "^29.5.0",
-				"jest-leak-detector": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-resolve": "^29.5.0",
-				"jest-runtime": "^29.5.0",
-				"jest-util": "^29.5.0",
-				"jest-watcher": "^29.5.0",
-				"jest-worker": "^29.5.0",
+				"jest-docblock": "^29.7.0",
+				"jest-environment-node": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-leak-detector": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-resolve": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"jest-worker": "^29.7.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			}
 		},
 		"jest-runtime": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.5.0.tgz",
-			"integrity": "sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.5.0",
-				"@jest/fake-timers": "^29.5.0",
-				"@jest/globals": "^29.5.0",
-				"@jest/source-map": "^29.4.3",
-				"@jest/test-result": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/globals": "^29.7.0",
+				"@jest/source-map": "^29.6.3",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"cjs-module-lexer": "^1.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-mock": "^29.5.0",
-				"jest-regex-util": "^29.4.3",
-				"jest-resolve": "^29.5.0",
-				"jest-snapshot": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			}
 		},
 		"jest-snapshot": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.5.0.tgz",
-			"integrity": "sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.11.6",
 				"@babel/generator": "^7.7.2",
 				"@babel/plugin-syntax-jsx": "^7.7.2",
 				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/traverse": "^7.7.2",
 				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.5.0",
-				"@jest/transform": "^29.5.0",
-				"@jest/types": "^29.5.0",
-				"@types/babel__traverse": "^7.0.6",
-				"@types/prettier": "^2.1.5",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"babel-preset-current-node-syntax": "^1.0.0",
 				"chalk": "^4.0.0",
-				"expect": "^29.5.0",
+				"expect": "^29.7.0",
 				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.5.0",
-				"jest-get-type": "^29.4.3",
-				"jest-matcher-utils": "^29.5.0",
-				"jest-message-util": "^29.5.0",
-				"jest-util": "^29.5.0",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.5.0",
-				"semver": "^7.3.5"
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
 			},
 			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
 				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 					"dev": true
 				}
 			}
 		},
 		"jest-util": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-			"integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
@@ -9816,17 +9922,17 @@
 			}
 		},
 		"jest-validate": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.5.0.tgz",
-			"integrity": "sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.5.0",
+				"@jest/types": "^29.6.3",
 				"camelcase": "^6.2.0",
 				"chalk": "^4.0.0",
-				"jest-get-type": "^29.4.3",
+				"jest-get-type": "^29.6.3",
 				"leven": "^3.1.0",
-				"pretty-format": "^29.5.0"
+				"pretty-format": "^29.7.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -9838,29 +9944,29 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.5.0.tgz",
-			"integrity": "sha512-KmTojKcapuqYrKDpRwfqcQ3zjMlwu27SYext9pt4GlF5FUgB+7XE1mcCnSm6a4uUpFyQIkb6ZhzZvHl+jiBCiA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^29.5.0",
-				"@jest/types": "^29.5.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"emittery": "^0.13.1",
-				"jest-util": "^29.5.0",
+				"jest-util": "^29.7.0",
 				"string-length": "^4.0.1"
 			}
 		},
 		"jest-worker": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
-			"integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"jest-util": "^29.5.0",
+				"jest-util": "^29.7.0",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.0.0"
 			},
@@ -10011,12 +10117,20 @@
 			"dev": true
 		},
 		"make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
 			"dev": true,
 			"requires": {
-				"semver": "^6.0.0"
+				"semver": "^7.5.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
+				}
 			}
 		},
 		"make-error": {
@@ -10137,6 +10251,15 @@
 				"whatwg-url": "^5.0.0"
 			}
 		},
+		"node-gyp-build-optional-packages": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+			"integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+			"optional": true,
+			"requires": {
+				"detect-libc": "^2.0.1"
+			}
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10144,9 +10267,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
 		"normalize-path": {
@@ -10318,9 +10441,9 @@
 			"dev": true
 		},
 		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
 			"dev": true
 		},
 		"picomatch": {
@@ -10357,12 +10480,12 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "29.5.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-			"integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"dev": true,
 			"requires": {
-				"@jest/schemas": "^29.4.3",
+				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
 				"react-is": "^18.0.0"
 			},
@@ -10398,9 +10521,9 @@
 			"dev": true
 		},
 		"pure-rand": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
-			"integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
 			"dev": true
 		},
 		"queue-microtask": {
@@ -10915,13 +11038,13 @@
 			}
 		},
 		"update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+			"integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
 			"dev": true,
 			"requires": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.1.2",
+				"picocolors": "^1.0.1"
 			}
 		},
 		"uri-js": {
@@ -10940,22 +11063,14 @@
 			"dev": true
 		},
 		"v8-to-istanbul": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-			"integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0"
-			},
-			"dependencies": {
-				"convert-source-map": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-					"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-					"dev": true
-				}
+				"convert-source-map": "^2.0.0"
 			}
 		},
 		"vscode-oniguruma": {
@@ -11063,9 +11178,9 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "17.7.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dev": true,
 			"requires": {
 				"cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",
 		"@scure/bip39": "^1.2.2",
-		"buffer": "^6.0.3"
+		"buffer": "^6.0.3",
+		"cbor-x": "^1.5.9"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",
 		"@scure/bip39": "^1.2.2",
-		"buffer": "^6.0.3",
-		"cbor-x": "^1.5.9"
+		"buffer": "^6.0.3"
 	}
 }

--- a/src/cbor.ts
+++ b/src/cbor.ts
@@ -1,0 +1,216 @@
+export function encodeCBOR(value: any) {
+	const buffer: Array<number> = [];
+	encodeItem(value, buffer);
+	return new Uint8Array(buffer);
+}
+
+function encodeItem(value: any, buffer: Array<number>) {
+	if (value === null) {
+		buffer.push(0xf6);
+	} else if (value === undefined) {
+		buffer.push(0xf7);
+	} else if (typeof value === 'boolean') {
+		buffer.push(value ? 0xf5 : 0xf4);
+	} else if (typeof value === 'number') {
+		encodeUnsigned(value, buffer);
+	} else if (typeof value === 'string') {
+		encodeString(value, buffer);
+	} else if (Array.isArray(value)) {
+		encodeArray(value, buffer);
+	} else if (typeof value === 'object') {
+		encodeObject(value, buffer);
+	} else {
+		throw new Error('Unsupported type');
+	}
+}
+
+function encodeUnsigned(value: number, buffer: Array<number>) {
+	if (value < 24) {
+		buffer.push(value);
+	} else if (value < 256) {
+		buffer.push(0x18, value);
+	} else if (value < 65536) {
+		buffer.push(0x19, value >> 8, value & 0xff);
+	} else if (value < 4294967296) {
+		buffer.push(0x1a, value >> 24, (value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff);
+	} else {
+		throw new Error('Unsupported integer size');
+	}
+}
+
+function encodeString(value: string, buffer: Array<number>) {
+	const utf8 = new TextEncoder().encode(value);
+	encodeUnsigned(utf8.length, buffer);
+	buffer[buffer.length - 1] |= 0x60;
+	utf8.forEach((b) => buffer.push(b));
+}
+
+function encodeArray(value: Array<any>, buffer: Array<number>) {
+	encodeUnsigned(value.length, buffer);
+	buffer[buffer.length - 1] |= 0x80;
+	for (const item of value) {
+		encodeItem(item, buffer);
+	}
+}
+
+function encodeObject(value: { [key: string]: any }, buffer: Array<number>) {
+	const keys = Object.keys(value);
+	encodeUnsigned(keys.length, buffer);
+	buffer[buffer.length - 1] |= 0xa0;
+	for (const key of keys) {
+		encodeString(key, buffer);
+		encodeItem(value[key], buffer);
+	}
+}
+type DecodeResult = {
+	value: any;
+	offset: number;
+};
+
+export function decodeCBOR(data: Uint8Array): any {
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+	const result = decodeItem(view, 0);
+	return result.value;
+}
+
+function decodeItem(view: DataView, offset: number): DecodeResult {
+	if (offset >= view.byteLength) {
+		throw new Error('Unexpected end of data');
+	}
+	const initialByte = view.getUint8(offset++);
+	const majorType = initialByte >> 5;
+	const additionalInfo = initialByte & 0x1f;
+
+	switch (majorType) {
+		case 0:
+			return decodeUnsigned(view, offset, additionalInfo);
+		case 1:
+			return decodeSigned(view, offset, additionalInfo);
+		case 2:
+			return decodeByteString(view, offset, additionalInfo);
+		case 3:
+			return decodeString(view, offset, additionalInfo);
+		case 4:
+			return decodeArray(view, offset, additionalInfo);
+		case 5:
+			return decodeMap(view, offset, additionalInfo);
+		case 7:
+			return decodeSimpleAndFloat(view, offset, additionalInfo);
+		default:
+			throw new Error(`Unsupported major type: ${majorType}`);
+	}
+}
+
+function decodeLength(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	if (additionalInfo < 24) return { value: additionalInfo, offset };
+	if (additionalInfo === 24) return { value: view.getUint8(offset++), offset };
+	if (additionalInfo === 25) {
+		const value = view.getUint16(offset, false);
+		offset += 2;
+		return { value, offset };
+	}
+	if (additionalInfo === 26) {
+		const value = view.getUint32(offset, false);
+		offset += 4;
+		return { value, offset };
+	}
+	if (additionalInfo === 27) {
+		const hi = view.getUint32(offset, false);
+		const lo = view.getUint32(offset + 4, false);
+		offset += 8;
+		return { value: hi * 2 ** 32 + lo, offset };
+	}
+	throw new Error(`Unsupported length: ${additionalInfo}`);
+}
+
+function decodeUnsigned(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	const { value, offset: newOffset } = decodeLength(view, offset, additionalInfo);
+	return { value, offset: newOffset };
+}
+
+function decodeSigned(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	const { value, offset: newOffset } = decodeLength(view, offset, additionalInfo);
+	return { value: -1 - value, offset: newOffset };
+}
+
+function decodeByteString(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
+	if (newOffset + length > view.byteLength) {
+		throw new Error('Byte string length exceeds data length');
+	}
+	const value = new Uint8Array(view.buffer, view.byteOffset + newOffset, length);
+	return { value, offset: newOffset + length };
+}
+
+function decodeString(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
+	if (newOffset + length > view.byteLength) {
+		throw new Error('String length exceeds data length');
+	}
+	const bytes = new Uint8Array(view.buffer, view.byteOffset + newOffset, length);
+	const value = new TextDecoder().decode(bytes);
+	return { value, offset: newOffset + length };
+}
+
+function decodeArray(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
+	const array = [];
+	let currentOffset = newOffset;
+	for (let i = 0; i < length; i++) {
+		const result = decodeItem(view, currentOffset);
+		array.push(result.value);
+		currentOffset = result.offset;
+	}
+	return { value: array, offset: currentOffset };
+}
+
+function decodeMap(view: DataView, offset: number, additionalInfo: number): DecodeResult {
+	const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
+	const map: { [key: string]: any } = {};
+	let currentOffset = newOffset;
+	for (let i = 0; i < length; i++) {
+		const keyResult = decodeItem(view, currentOffset);
+		const valueResult = decodeItem(view, keyResult.offset);
+		map[keyResult.value] = valueResult.value;
+		currentOffset = valueResult.offset;
+	}
+	return { value: map, offset: currentOffset };
+}
+
+function decodeSimpleAndFloat(
+	view: DataView,
+	offset: number,
+	additionalInfo: number
+): DecodeResult {
+	if (additionalInfo < 24) {
+		switch (additionalInfo) {
+			case 20:
+				return { value: false, offset };
+			case 21:
+				return { value: true, offset };
+			case 22:
+				return { value: null, offset };
+			case 23:
+				return { value: undefined, offset };
+			default:
+				throw new Error(`Unknown simple value: ${additionalInfo}`);
+		}
+	}
+	if (additionalInfo === 24) return { value: view.getUint8(offset++), offset };
+	if (additionalInfo === 25) {
+		const value = view.getUint16(offset, false);
+		offset += 2;
+		return { value, offset };
+	}
+	if (additionalInfo === 26) {
+		const value = view.getFloat32(offset, false);
+		offset += 4;
+		return { value, offset };
+	}
+	if (additionalInfo === 27) {
+		const value = view.getFloat64(offset, false);
+		offset += 8;
+		return { value, offset };
+	}
+	throw new Error(`Unknown simple or float value: ${additionalInfo}`);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,7 @@ function getDecodedToken(token: string) {
  * @param token
  * @returns
  */
-function handleTokens(token: string): Token | undefined {
+function handleTokens(token: string): Token {
 	const version = token.slice(0, 1);
 	const encodedToken = token.slice(1);
 	if (version === 'A') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,14 +106,19 @@ function handleTokens(token: string): Token | undefined {
 	} else if (version === 'B') {
 		const uInt8Token = encodeBase64toUint8(encodedToken);
 		const tokenData = decodeCBOR(uInt8Token) as {
-			t: { p: { a: number; s: string; c: string }[]; i: string }[];
+			t: { p: { a: number; s: string; c: Uint8Array }[]; i: Uint8Array }[];
 			m: string;
 		};
 		const tokenEntries = tokenData.t.map(
 			(tokenEntry): TokenEntry => ({
 				mint: tokenData.m,
 				proofs: tokenEntry.p.map(
-					(p): Proof => ({ secret: p.s, C: p.c, amount: p.a, id: tokenEntry.i })
+					(p): Proof => ({
+						secret: p.s,
+						C: bytesToHex(p.c),
+						amount: p.a,
+						id: bytesToHex(tokenEntry.i)
+					})
 				)
 			})
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
-import { encodeBase64ToJson, encodeJsonToBase64 } from './base64.js';
-import { AmountPreference, Keys, Proof, Token, TokenV2 } from './model/types/index.js';
+import { encodeBase64ToJson, encodeBase64toUint8, encodeJsonToBase64 } from './base64.js';
+import { AmountPreference, Keys, Proof, Token, TokenEntry, TokenV2 } from './model/types/index.js';
 import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants.js';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
+import { decodeCBOR } from './cbor.js';
 
 function splitAmount(value: number, amountPreference?: Array<AmountPreference>): Array<number> {
 	const chunks: Array<number> = [];
@@ -104,7 +105,7 @@ function handleTokens(token: string): Token | undefined {
 		return encodeBase64ToJson<Token>(encodedToken);
 	} else if (version === 'B') {
 		const uInt8Token = encodeBase64toUint8(encodedToken);
-		const tokenData = decode(uInt8Token) as {
+		const tokenData = decodeCBOR(uInt8Token) as {
 			t: { p: { a: number; s: string; c: string }[]; i: string }[];
 			m: string;
 		};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,21 +108,20 @@ function handleTokens(token: string): Token | undefined {
 		const tokenData = decodeCBOR(uInt8Token) as {
 			t: { p: { a: number; s: string; c: Uint8Array }[]; i: Uint8Array }[];
 			m: string;
+			d: string;
 		};
-		const tokenEntries = tokenData.t.map(
-			(tokenEntry): TokenEntry => ({
-				mint: tokenData.m,
-				proofs: tokenEntry.p.map(
-					(p): Proof => ({
-						secret: p.s,
-						C: bytesToHex(p.c),
-						amount: p.a,
-						id: bytesToHex(tokenEntry.i)
-					})
-				)
+		const mergedTokenEntry: TokenEntry = { mint: tokenData.m, proofs: [] };
+		tokenData.t.forEach((tokenEntry) =>
+			tokenEntry.p.forEach((p) => {
+				mergedTokenEntry.proofs.push({
+					secret: p.s,
+					C: bytesToHex(p.c),
+					amount: p.a,
+					id: bytesToHex(tokenEntry.i)
+				});
 			})
 		);
-		return { token: tokenEntries, memo: '' };
+		return { token: [mergedTokenEntry], memo: tokenData.d || '' };
 	} else {
 		throw new Error('Token version is not supported');
 	}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -115,27 +115,15 @@ describe('test decode token', () => {
 	});
 	test('testing v4 Token', () => {
 		const v3Token = {
-			memo: '',
+			memo: 'Thank you',
 			token: [
 				{
-					mint: 'https://mint.minibits.cash/Bitcoin',
+					mint: 'http://localhost:3338',
 					proofs: [
 						{
-							secret: '7e98535c6f8cd7a5eff150963a2743613a91e9498150fd5af8d2bfcfd5babe68',
-							C: '03022a28d163cf63792c1533e6660112f2b75db2fe46aa840e7f5d0f979a2c6cfd',
-							id: '00500550f0494146',
-							amount: 16
-						},
-						{
-							amount: 4,
-							secret: '96bd8480717673311bc70e92818b5babcb665edee39b639defad5584d8d18b1f',
-							C: '030936759e03235867f9cea58f047c043acdd7455f604c92c75839e5e08a91e198',
-							id: '00500550f0494146'
-						},
-						{
-							secret: 'e145fa7fba21a9cd3c8743c9de5e4de33e0095abc50b262f1b3831b69b8f63df',
-							id: '00500550f0494146',
-							C: '03eba391a31e101e1ba1853db1e4bbb6a166d4fbbb1e181e82892c3301e4e02015',
+							secret: '9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e',
+							C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
+							id: '00ad268c4d1f5826',
 							amount: 1
 						}
 					]
@@ -144,10 +132,45 @@ describe('test decode token', () => {
 		};
 
 		const token =
-			'cashuBuQACYXSBuQACYXCDuQADYWEQYXN4QDdlOTg1MzVjNmY4Y2Q3YTVlZmYxNTA5NjNhMjc0MzYxM2E5MWU5NDk4MTUwZmQ1YWY4ZDJiZmNmZDViYWJlNjhhY3hCMDMwMjJhMjhkMTYzY2Y2Mzc5MmMxNTMzZTY2NjAxMTJmMmI3NWRiMmZlNDZhYTg0MGU3ZjVkMGY5NzlhMmM2Y2ZkuQADYWEEYXN4QDk2YmQ4NDgwNzE3NjczMzExYmM3MGU5MjgxOGI1YmFiY2I2NjVlZGVlMzliNjM5ZGVmYWQ1NTg0ZDhkMThiMWZhY3hCMDMwOTM2NzU5ZTAzMjM1ODY3ZjljZWE1OGYwNDdjMDQzYWNkZDc0NTVmNjA0YzkyYzc1ODM5ZTVlMDhhOTFlMTk4uQADYWEBYXN4QGUxNDVmYTdmYmEyMWE5Y2QzYzg3NDNjOWRlNWU0ZGUzM2UwMDk1YWJjNTBiMjYyZjFiMzgzMWI2OWI4ZjYzZGZhY3hCMDNlYmEzOTFhMzFlMTAxZTFiYTE4NTNkYjFlNGJiYjZhMTY2ZDRmYmJiMWUxODFlODI4OTJjMzMwMWU0ZTAyMDE1YWlwMDA1MDA1NTBmMDQ5NDE0NmFteCJodHRwczovL21pbnQubWluaWJpdHMuY2FzaC9CaXRjb2lu';
+			'cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=';
 
 		const result = utils.getDecodedToken(token);
-		console.log(JSON.stringify(result));
+		expect(result).toStrictEqual(v3Token);
+	});
+	test('testing v4 Token with multi keyset', () => {
+		const v3Token = {
+			memo: '',
+			token: [
+				{
+					mint: 'http://localhost:3338',
+					proofs: [
+						{
+							secret: 'acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388',
+							C: '0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf',
+							id: '00ffd48b8f5ecf80',
+							amount: 1
+						},
+						{
+							secret: '1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee',
+							C: '023456aa110d84b4ac747aebd82c3b005aca50bf457ebd5737a4414fac3ae7d94d',
+							id: '00ad268c4d1f5826',
+							amount: 2
+						},
+						{
+							secret: '56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57',
+							C: '0273129c5719e599379a974a626363c333c56cafc0e6d01abe46d5808280789c63',
+							id: '00ad268c4d1f5826',
+							amount: 1
+						}
+					]
+				}
+			]
+		};
+
+		const token =
+			'cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA==';
+
+		const result = utils.getDecodedToken(token);
 		expect(result).toStrictEqual(v3Token);
 	});
 	test('testing joining urls', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { AmountPreference } from '../src/model/types/index.js';
+import { AmountPreference, Token } from '../src/model/types/index.js';
 import * as utils from '../src/utils.js';
 import { PUBKEYS } from './consts.js';
 
@@ -47,87 +47,20 @@ describe('test decode token', () => {
 	test('testing v1 Token', () => {
 		const token =
 			'W3siaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjIsInNlY3JldCI6Ild6ZC9vNUVHdmVKb3hTQVlGcjZ1U3lnUmFWSUFrOFc4MXNLTlRxdVd4UjQ9IiwiQyI6IjAzNWNiZmQwOTNiOWZlMWRjNjU2MGEwNDM3YzQyNDQxZjA0ZDIyYzk4MDY2NGMyNGExMGZlZGFiNTlmZWY0YmZjOSJ9LHsiaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjQsInNlY3JldCI6InU0N2lWUkhneUNuUFhCNWxOdFpGaTBOeHpPZ1lyRk1WODV2aFpyRThIbWM9IiwiQyI6IjAyNThiYmZkZWJmZGQzYjk0OTljZDk1YzFkMWZiYTVjZTQ1MWFjOGNlZTE0NzM1Yzk2MGFiMDc1ZmI2ZTQ4ZjBkYyJ9LHsiaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjY0LCJzZWNyZXQiOiJ1YTFaT0hjeVB3T0M0UUxPaWthQVV1MThJM2pEUDJCSVNYREFGcW91N1VNPSIsIkMiOiIwMjU2MWNhNjcyNTdlNzdhNjNjN2U3NWQ4MGVkYTI3ZDlhMmEyYzUxZTA0NGM4ZjhmODVlNzc0OTZlMGRlM2U2NWIifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxLCJzZWNyZXQiOiJ5ZTlNRCtaQ25VUHlHOTBscmYyZ2tudnA3N2I4V05wNUxRT2ZtcERjRGNFPSIsIkMiOiIwM2UwN2M1NjExNzcwMmNmODg3MDFlYjAyOTM2YjA5MDNhZmEyMTQwZDcwNTY1N2ZkODVkM2YxZWI5MzRiYTBjYzMifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoyLCJzZWNyZXQiOiJIUHpzRmZPUDFWRU1BMW8vTnFHVXFhRXdaV2RiN3VERzM4T1grLzlZTURzPSIsIkMiOiIwMmQ3ZDE1YTBhZmIyNThjMjlhZDdmOWY4N2ZmMzIxZWRmNTgyOTM0ZWI0NWExNTE2MjhiNTJjMDExZjQ2MWZkOGEifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxLCJzZWNyZXQiOiJnMVR1YXdha1RVQkJBTW9tZGpDVHkrRENNTnBaUmd3dWluNXB5V2xoTVVNPSIsIkMiOiIwMzU4Y2IxMGE5NWEzY2E1YmE5MTc5MTllMWNhODA1NjZmMTg5NTI4Njk1MTJjYWFjMDlmYmQ5MGYxN2QyZTZlYmEifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoyLCJzZWNyZXQiOiJRMTFyamNXWk55Q2dkRmxqRThaNkdwNFhDYllKcndzRGhncXVQOTU1VWU0PSIsIkMiOiIwMjAxNjBmODIwNGU4MGIxNDg4NmFlMzZjMzRiMjI3ODllMzMxZmM5MjVhNGMwOGE3ZWYxZDZjYzMyYTIwNjZjZWUifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50Ijo4LCJzZWNyZXQiOiI1MVZrUXFYT2kwM0k2a0pzM0tlSEI0OVVCQTFSRktrWnMyMFljZEtOSW1JPSIsIkMiOiIwMjZiYWU2YTgzOWE3OTdjNmU5NGZlNGM5MWZlNTIwOGU4MDE3MTg2Y2NkMDk0ZmI4ZTNkZjYyNjAyZWJmMjczMjUifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxNiwic2VjcmV0IjoiVk4ySlMwUENKdGQ3MjJUTXUxdGFxNUZSMXg0dDlXM28xNndWRGVweXBxYz0iLCJDIjoiMDIxMmM4ZGE5NWE4NDEyYjgyMDE4MTgxNzQxZWY1YWQ0ZjYzMTU1NjBhMWFmODM5ZjMxOTU4NTcwZTVlYzI2ZDQyIn1d';
-
-		const result = utils.getDecodedToken(token);
-		expect(result.token[0].proofs.reduce((c, p) => c + p.amount, 0)).toEqual(100);
-		expect(result.token[0].mint).toStrictEqual('');
-	});
-	test('test corrupt v1 token', () => {
-		const token =
-			'W3siaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjIsInNlY3JldCI6Ild6ZC9vNUVHdmVKb3hTQVlGcjZ1U3lnUmFWSUFrOFc4MXNLTlRxdVd4UjQ9IiwiQyI6IjAzNWNiZmQwOTNiOWZlMWRjNjU2MGEwNDM3YzQyNDQxZjA0ZDIyYzk4MDY2NGMyNGExMGZlZGFiNTlmZWY0YmZjOSJ9LHsiaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjQsInNlY3JldCI6InU0N2lWUkhneUNuUFhCNWxOdFpGaTBOIkMiOiIwMmQ3ZDE1YTBhZmIyNThjMjlhZDdmOWY4N2ZmMzIxZWRmNTgyOTM0ZWI0NWExNTE2MjhiNTJjMDExZjQ2MWZkOGEifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxLCJzZWNyZXQiOiJnMVR1YXdha1RVQkJBTW9tZGpDVHkrRENNTnBaUmd3dWluNXB5V2xoTVVNPSIsIkMiOiIwMzU4Y2IxMGE5NWEzY2E1YmE5MTc5MTllMWNhODA1NjZmMTg5NTI4Njk1MTJjYWFjMDlmYmQ5MGYxN2QyZTZlYmEifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoyLCJzZWNyZXQiOiJRMTFyamNXWk55Q2dkRmxqRThaNkdwNFhDYllKcndzRGhncXVQOTU1VWU0PSIsIkMiOiIwMjAxNjBmODIwNGU4MGIxNDg4NmFlMzZjMzRiMjI3ODllMzMxZmM5MjVhNGMwOGE3ZWYxZDZjYzMyYTIwNjZjZWUifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50Ijo4LCJzZWNyZXQiOiI1MVZrUXFYT2kwM0k2a0pzM0tlSEI0OVVCQTFSRktrWnMyMFljZEtOSW1JPSIsIkMiOiIwMjZiYWU2YTgzOWE3OTdjNmU5NGZlNGM5MWZlNTIwOGU4MDE3MTg2Y2NkMDk0ZmI4ZTNkZjYyNjAyZWJmMjczMjUifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxNiwic2VjcmV0IjoiVk4ySlMwUENKdGQ3MjJUTXUxdGFxNUZSMXg0dDlXM28xNndWRGVweXBxYz0iLCJDIjoiMDIxMmM4ZGE5NWE4NDEyYjgyMDE4MTgxNzQxZWY1YWQ0ZjYzMTU1NjBhMWFmODM5ZjMxOTU4NTcwZTVlYzI2ZDQyIn1d';
-		expect(() => utils.getDecodedToken(token)).toThrowError();
+		let result: Token | undefined;
+		expect(() => {
+			result = utils.getDecodedToken(token);
+		}).toThrow();
+		expect(result).toBe(undefined);
 	});
 	test('testing v2 Token', async () => {
 		const token =
 			'eyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IkkyeU4raVJZZmt6VCIsImFtb3VudCI6MSwic2VjcmV0IjoiOTd6Zm1tYUdmNWs4TWcwZ2FqcG5ibXBlcnZUdEVlRTh3d0tyaTdyV3BVcz0iLCJDIjoiMDIxOTUwODFlNjIyZjk4YmZjMTlhMDVlYmUyMzQxZDk1NWMwZDEyNTg4YzU5NDhjODU4ZDA3YWRlYzAwN2JjMWU0In1dLCJtaW50IjoiaHR0cDovL2xvY2FsaG9zdDozMzM4In1dfQ';
-
-		const result = utils.getDecodedToken(token);
-		expect(result).toStrictEqual({
-			token: [
-				{
-					proofs: [
-						{
-							id: 'I2yN+iRYfkzT',
-							amount: 1,
-							secret: '97zfmmaGf5k8Mg0gajpnbmpervTtEeE8wwKri7rWpUs=',
-							C: '02195081e622f98bfc19a05ebe2341d955c0d12588c5948c858d07adec007bc1e4'
-						}
-					],
-					mint: 'http://localhost:3338'
-				}
-			]
-		});
-	});
-	test('testing v2 Token 2', () => {
-		const token =
-			'eyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IjBOSTNUVUFzMVNmeSIsImFtb3VudCI6MSwic2VjcmV0Ijoia3hxWFlwYkNWb0l1eDRsbVdJRFh4M29NMi83S1ZzaHFqSklJZXh0cU1hVT0iLCJDIjoiMDJhNDIxNDBkMWJiZDU5Y2E0YzViYTllYjczZDAyMGYzMWY2OGY0ZTMwNzhmZDNhZjFlZTY0ZWJlY2U1MmI2ZWRhIn1dLCJtaW50IjoiaHR0cDovL2xvY2FsaG9zdDozMzM4In1dfQ';
-
-		const result = utils.getDecodedToken(token);
-		expect(result).toStrictEqual({
-			token: [
-				{
-					proofs: [
-						{
-							id: '0NI3TUAs1Sfy',
-							amount: 1,
-							secret: 'kxqXYpbCVoIux4lmWIDXx3oM2/7KVshqjJIIextqMaU=',
-							C: '02a42140d1bbd59ca4c5ba9eb73d020f31f68f4e3078fd3af1ee64ebece52b6eda'
-						}
-					],
-					mint: 'http://localhost:3338'
-				}
-			]
-		});
-	});
-	test('test corrupt v2 token', () => {
-		const token =
-			'W3siaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjIsInNlY3JldCI6Ild6ZC9vNUVHdmVKb3hTQVlGcjZ1U3lnUmFWSUFrOFc4MXNLTlRxdVd4UjQ9IiwiQyI6IjAzNWNiZmQwOTNiOWZlMWRjNjU2MGEwNDM3YzQyNDQxZjA0ZDIyYzk4MDY2NGMyNGExMGZlZGFiNTlmZWY0YmZjOSJ9LHsiaWQiOiIwTkkzVFVBczFTZnkiLCJhbW91bnQiOjQsInNlY3JldCI6InU0N2lWUkhneUNuUFhCNWxOdFpGaTBOIkMiOiIwMmQ3ZDE1YTBhZmIyNThjMjlhZDdmOWY4N2ZmMzIxZWRmNTgyOTM0ZWI0NWExNTE2MjhiNTJjMDExZjQ2MWZkOGEifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxLCJzZWNyZXQiOiJnMVR1YXdha1RVQkJBTW9tZGpDkMiOiIwMjZiYWU2YTgzOWE3OTdjNmU5NGZlNGM5MWZlNTIwOGU4MDE3MTg2Y2NkMDk0ZmI4ZTNkZjYyNjAyZWJmMjczMjUifSx7ImlkIjoiME5JM1RVQXMxU2Z5IiwiYW1vdW50IjoxNiwic2VjcmV0IjoiVk4ySlMwUENKdGQ3MjJUTXUxdGFxNUZSMXg0dDlXM28xNndWRGVweXBxYz0iLCJDIjoiMDIxMmM4ZGE5NWE4NDEyYjgyMDE4MTgxNzQxZWY1YWQ0ZjYzMTU1NjBhMWFmODM5ZjMxOTU4NTcwZTVlYzI2ZDQyIn1d';
-
-		expect(() => utils.getDecodedToken(token)).toThrowError();
-	});
-});
-
-describe('test encode token', () => {
-	test('testing v3 Token', async () => {
-		const token =
-			'cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
-
-		const obj = {
-			proofs: [
-				{
-					id: 'I2yN+iRYfkzT',
-					amount: 1,
-					secret: '97zfmmaGf5k8Mg0gajpnbmpervTtEeE8wwKri7rWpUs=',
-					C: '02195081e622f98bfc19a05ebe2341d955c0d12588c5948c858d07adec007bc1e4'
-				}
-			],
-			mints: [{ url: 'http://localhost:3338', ids: ['L3zxxRB/I8uE', 'I2yN+iRYfkzT'] }]
-		};
-
-		const result = utils.getEncodedToken({
-			token: [{ mint: obj.mints[0].url, proofs: obj.proofs }]
-		});
-		expect(result).toEqual(token);
+		let result: Token | undefined;
+		expect(() => {
+			result = utils.getDecodedToken(token);
+		}).toThrow();
+		expect(result).toBe(undefined);
 	});
 });
 
@@ -176,9 +109,56 @@ describe('test decode token', () => {
 		};
 
 		const token =
-			'eyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
+			'AeyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
 		const result = utils.getDecodedToken(token);
 		expect(result).toStrictEqual(obj);
+	});
+	test('testing v4 Token', () => {
+		const v3Token = {
+			memo: '',
+			token: [
+				{
+					mint: 'https://mint.minibits.cash/Bitcoin',
+					proofs: [
+						{
+							secret: '7e98535c6f8cd7a5eff150963a2743613a91e9498150fd5af8d2bfcfd5babe68',
+							C: '03022a28d163cf63792c1533e6660112f2b75db2fe46aa840e7f5d0f979a2c6cfd',
+							id: '00500550f0494146',
+							amount: 16
+						},
+						{
+							amount: 4,
+							secret: '96bd8480717673311bc70e92818b5babcb665edee39b639defad5584d8d18b1f',
+							C: '030936759e03235867f9cea58f047c043acdd7455f604c92c75839e5e08a91e198',
+							id: '00500550f0494146'
+						},
+						{
+							secret: 'e145fa7fba21a9cd3c8743c9de5e4de33e0095abc50b262f1b3831b69b8f63df',
+							id: '00500550f0494146',
+							C: '03eba391a31e101e1ba1853db1e4bbb6a166d4fbbb1e181e82892c3301e4e02015',
+							amount: 1
+						}
+					]
+				}
+			]
+		};
+
+		const token =
+			'cashuBuQACYXSBuQACYXCDuQADYWEQYXN4QDdlOTg1MzVjNmY4Y2Q3YTVlZmYxNTA5NjNhMjc0MzYxM2E5MWU5NDk4MTUwZmQ1YWY4ZDJiZmNmZDViYWJlNjhhY3hCMDMwMjJhMjhkMTYzY2Y2Mzc5MmMxNTMzZTY2NjAxMTJmMmI3NWRiMmZlNDZhYTg0MGU3ZjVkMGY5NzlhMmM2Y2ZkuQADYWEEYXN4QDk2YmQ4NDgwNzE3NjczMzExYmM3MGU5MjgxOGI1YmFiY2I2NjVlZGVlMzliNjM5ZGVmYWQ1NTg0ZDhkMThiMWZhY3hCMDMwOTM2NzU5ZTAzMjM1ODY3ZjljZWE1OGYwNDdjMDQzYWNkZDc0NTVmNjA0YzkyYzc1ODM5ZTVlMDhhOTFlMTk4uQADYWEBYXN4QGUxNDVmYTdmYmEyMWE5Y2QzYzg3NDNjOWRlNWU0ZGUzM2UwMDk1YWJjNTBiMjYyZjFiMzgzMWI2OWI4ZjYzZGZhY3hCMDNlYmEzOTFhMzFlMTAxZTFiYTE4NTNkYjFlNGJiYjZhMTY2ZDRmYmJiMWUxODFlODI4OTJjMzMwMWU0ZTAyMDE1YWlwMDA1MDA1NTBmMDQ5NDE0NmFteCJodHRwczovL21pbnQubWluaWJpdHMuY2FzaC9CaXRjb2lu';
+
+		const result = utils.getDecodedToken(token);
+		console.log(JSON.stringify(result));
+		expect(result).toStrictEqual(v3Token);
+	});
+	test('testing joining urls', () => {
+		const mint_url = 'http://localhost:3338';
+		const info_url = utils.joinUrls(mint_url, 'info');
+
+		expect(info_url).toBe('http://localhost:3338/info');
+
+		const mint_url_trailing_slash = 'http://localhost:3338/';
+		const mint_info_url = utils.joinUrls(mint_url_trailing_slash, 'info');
+		expect(mint_info_url).toBe('http://localhost:3338/info');
 	});
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -173,16 +173,6 @@ describe('test decode token', () => {
 		const result = utils.getDecodedToken(token);
 		expect(result).toStrictEqual(v3Token);
 	});
-	test('testing joining urls', () => {
-		const mint_url = 'http://localhost:3338';
-		const info_url = utils.joinUrls(mint_url, 'info');
-
-		expect(info_url).toBe('http://localhost:3338/info');
-
-		const mint_url_trailing_slash = 'http://localhost:3338/';
-		const mint_info_url = utils.joinUrls(mint_url_trailing_slash, 'info');
-		expect(mint_info_url).toBe('http://localhost:3338/info');
-	});
 });
 
 describe('test keyset derivation', () => {


### PR DESCRIPTION
# Fixes: None

## Description
This PR changes the way `handleTokens` works. It also adds reading the newly proposed v4 Token format. V4 token are parsed and mapped to output the exact same structure as v3 Token to make handling easier. Consumers of `getDecodedToken` receive a stable result.

## Changes

- Removed deprecated token format support (pre v3)
- Removed test cases for deprecated token formats
- `handleTokens` now parses the version and decodes accordingly.

## PR Tasks

- [x] Open PR
- [x] Refactoring and remove logs
- [x] run `npm run test` --> no failing unit tests
- [ ] run `npm run format`
