### PR TITLE
Naming Methods Mint/Melt

### DIFF
--- a/migration-1.0.0.md
+++ b/migration-1.0.0.md
@@ -33,7 +33,7 @@ To reduce complexity, simplify error handling and to prepare for token V4, this 
 
 Utility functions now have an `options` object for optional parameters, instead of passing them directly
 
-**`requestMint(amount: number)` --> `mintQuote(amount: number)`**
+**`requestMint(amount: number)` --> `createMintQuote(amount: number)`**
 Now returns the following:
 
 ```typescript
@@ -51,7 +51,7 @@ where `request` is the invoice to be paid, and `quote` is the identifier used to
 
 ---
 
-**`getMeltQuote(invoice: string)`** is now used to get fee estimation and conversion quotes instead of `getFee()` and returns:
+**`createMeltQuote(invoice: string)`** is now used to get fee estimation and conversion quotes instead of `getFee()` and returns:
 
 ```typescript
 type MeltQuoteResponse = {

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -111,7 +111,7 @@ class CashuMint {
 	 * @param customRequest
 	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
-	public static async mintQuote(
+	public static async postMintQuote(
 		mintUrl: string,
 		mintQuotePayload: MintQuotePayload,
 		customRequest?: typeof request
@@ -130,8 +130,8 @@ class CashuMint {
 	 * @param mintQuotePayload Payload for creating a new mint quote
 	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
-	async mintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
-		return CashuMint.mintQuote(this._mintUrl, mintQuotePayload, this._customRequest);
+	async postMintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
+		return CashuMint.postMintQuote(this._mintUrl, mintQuotePayload, this._customRequest);
 	}
 
 	/**
@@ -204,7 +204,7 @@ class CashuMint {
 	 * @param MeltQuotePayload
 	 * @returns
 	 */
-	public static async meltQuote(
+	public static async postMeltQuote(
 		mintUrl: string,
 		meltQuotePayload: MeltQuotePayload,
 		customRequest?: typeof request
@@ -233,8 +233,8 @@ class CashuMint {
 	 * @param MeltQuotePayload
 	 * @returns
 	 */
-	async meltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
-		return CashuMint.meltQuote(this._mintUrl, meltQuotePayload, this._customRequest);
+	async postMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
+		return CashuMint.postMeltQuote(this._mintUrl, meltQuotePayload, this._customRequest);
 	}
 
 	/**

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -111,7 +111,7 @@ class CashuMint {
 	 * @param customRequest
 	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
-	public static async postMintQuote(
+	public static async createMintQuote(
 		mintUrl: string,
 		mintQuotePayload: MintQuotePayload,
 		customRequest?: typeof request
@@ -130,8 +130,8 @@ class CashuMint {
 	 * @param mintQuotePayload Payload for creating a new mint quote
 	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
-	async postMintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
-		return CashuMint.postMintQuote(this._mintUrl, mintQuotePayload, this._customRequest);
+	async createMintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
+		return CashuMint.createMintQuote(this._mintUrl, mintQuotePayload, this._customRequest);
 	}
 
 	/**
@@ -141,7 +141,7 @@ class CashuMint {
 	 * @param customRequest
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	public static async getMintQuote(
+	public static async checkMintQuote(
 		mintUrl: string,
 		quote: string,
 		customRequest?: typeof request
@@ -160,8 +160,8 @@ class CashuMint {
 	 * @param quote Quote ID
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async getMintQuote(quote: string): Promise<MintQuoteResponse> {
-		return CashuMint.getMintQuote(this._mintUrl, quote, this._customRequest);
+	async checkMintQuote(quote: string): Promise<MintQuoteResponse> {
+		return CashuMint.checkMintQuote(this._mintUrl, quote, this._customRequest);
 	}
 
 	/**
@@ -204,7 +204,7 @@ class CashuMint {
 	 * @param MeltQuotePayload
 	 * @returns
 	 */
-	public static async postMeltQuote(
+	public static async createMeltQuote(
 		mintUrl: string,
 		meltQuotePayload: MeltQuotePayload,
 		customRequest?: typeof request
@@ -233,8 +233,8 @@ class CashuMint {
 	 * @param MeltQuotePayload
 	 * @returns
 	 */
-	async postMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
-		return CashuMint.postMeltQuote(this._mintUrl, meltQuotePayload, this._customRequest);
+	async createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
+		return CashuMint.createMeltQuote(this._mintUrl, meltQuotePayload, this._customRequest);
 	}
 
 	/**
@@ -243,7 +243,7 @@ class CashuMint {
 	 * @param quote Quote ID
 	 * @returns
 	 */
-	public static async getMeltQuote(
+	public static async checkMeltQuote(
 		mintUrl: string,
 		quote: string,
 		customRequest?: typeof request
@@ -274,8 +274,8 @@ class CashuMint {
 	 * @param quote Quote ID
 	 * @returns
 	 */
-	async getMeltQuote(quote: string): Promise<MeltQuoteResponse> {
-		return CashuMint.getMeltQuote(this._mintUrl, quote, this._customRequest);
+	async checkMeltQuote(quote: string): Promise<MeltQuoteResponse> {
+		return CashuMint.checkMeltQuote(this._mintUrl, quote, this._customRequest);
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -341,12 +341,12 @@ class CashuWallet {
 	 * @param amount Amount requesting for mint.
 	 * @returns the mint will return a mint quote with a Lightning invoice for minting tokens of the specified amount and unit
 	 */
-	async mintQuote(amount: number) {
+	async createMintQuote(amount: number) {
 		const mintQuotePayload: MintQuotePayload = {
 			unit: this._unit,
 			amount: amount
 		};
-		return await this.mint.mintQuote(mintQuotePayload);
+		return await this.mint.postMintQuote(mintQuotePayload);
 	}
 
 	/**
@@ -354,7 +354,7 @@ class CashuWallet {
 	 * @param quote Quote ID
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async getMintQuote(quote: string) {
+	async checkMintQuote(quote: string) {
 		return await this.mint.getMintQuote(quote);
 	}
 
@@ -397,12 +397,12 @@ class CashuWallet {
 	 * @param invoice LN invoice that needs to get a fee estimate
 	 * @returns the mint will create and return a melt quote for the invoice with an amount and fee reserve
 	 */
-	async meltQuote(invoice: string): Promise<MeltQuoteResponse> {
+	async createMeltQuote(invoice: string): Promise<MeltQuoteResponse> {
 		const meltQuotePayload: MeltQuotePayload = {
 			unit: this._unit,
 			request: invoice
 		};
-		const meltQuote = await this.mint.meltQuote(meltQuotePayload);
+		const meltQuote = await this.mint.postMeltQuote(meltQuotePayload);
 		return meltQuote;
 	}
 
@@ -411,7 +411,7 @@ class CashuWallet {
 	 * @param quote ID of the melt quote
 	 * @returns the mint will return an existing melt quote
 	 */
-	async getMeltQuote(quote: string): Promise<MeltQuoteResponse> {
+	async checkMeltQuote(quote: string): Promise<MeltQuoteResponse> {
 		const meltQuote = await this.mint.getMeltQuote(quote);
 		return meltQuote;
 	}
@@ -476,7 +476,7 @@ class CashuWallet {
 		}
 	): Promise<MeltTokensResponse> {
 		if (!meltQuote) {
-			meltQuote = await this.mint.meltQuote({ unit: this._unit, request: invoice });
+			meltQuote = await this.mint.postMeltQuote({ unit: this._unit, request: invoice });
 		}
 		return await this.meltTokens(meltQuote, proofsToSend, {
 			keysetId: options?.keysetId,

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -346,7 +346,7 @@ class CashuWallet {
 			unit: this._unit,
 			amount: amount
 		};
-		return await this.mint.postMintQuote(mintQuotePayload);
+		return await this.mint.createMintQuote(mintQuotePayload);
 	}
 
 	/**
@@ -355,7 +355,7 @@ class CashuWallet {
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
 	async checkMintQuote(quote: string) {
-		return await this.mint.getMintQuote(quote);
+		return await this.mint.checkMintQuote(quote);
 	}
 
 	/**
@@ -402,7 +402,7 @@ class CashuWallet {
 			unit: this._unit,
 			request: invoice
 		};
-		const meltQuote = await this.mint.postMeltQuote(meltQuotePayload);
+		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
 		return meltQuote;
 	}
 
@@ -412,7 +412,7 @@ class CashuWallet {
 	 * @returns the mint will return an existing melt quote
 	 */
 	async checkMeltQuote(quote: string): Promise<MeltQuoteResponse> {
-		const meltQuote = await this.mint.getMeltQuote(quote);
+		const meltQuote = await this.mint.checkMeltQuote(quote);
 		return meltQuote;
 	}
 
@@ -476,7 +476,7 @@ class CashuWallet {
 		}
 	): Promise<MeltTokensResponse> {
 		if (!meltQuote) {
-			meltQuote = await this.mint.postMeltQuote({ unit: this._unit, request: invoice });
+			meltQuote = await this.mint.createMeltQuote({ unit: this._unit, request: invoice });
 		}
 		return await this.meltTokens(meltQuote, proofsToSend, {
 			keysetId: options?.keysetId,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { encodeBase64ToJson, encodeJsonToBase64 } from './base64.js';
-import { AmountPreference, Keys, Proof, Token, TokenEntry, TokenV2 } from './model/types/index.js';
+import { AmountPreference, Keys, Proof, Token, TokenV2 } from './model/types/index.js';
 import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants.js';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -36,15 +36,15 @@ describe('mint api', () => {
 	test('request mint', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(100);
+		const request = await wallet.createMintQuote(100);
 		expect(request).toBeDefined();
-		const mintQuote = await wallet.getMintQuote(request.quote);
+		const mintQuote = await wallet.checkMintQuote(request.quote);
 		expect(mintQuote).toBeDefined();
 	});
 	test('mint tokens', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(1337);
+		const request = await wallet.createMintQuote(1337);
 		expect(request).toBeDefined();
 		expect(request.request).toContain('lnbc1337');
 		const tokens = await wallet.mintTokens(1337, request.quote);
@@ -55,8 +55,8 @@ describe('mint api', () => {
 	test('get fee for local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(100);
-		const fee = (await wallet.meltQuote(request.request)).fee_reserve;
+		const request = await wallet.createMintQuote(100);
+		const fee = (await wallet.createMeltQuote(request.request)).fee_reserve;
 		expect(fee).toBeDefined();
 		// because local invoice, fee should be 0
 		expect(fee).toBe(0);
@@ -64,7 +64,7 @@ describe('mint api', () => {
 	test('get fee for external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const fee = (await wallet.meltQuote(externalInvoice)).fee_reserve;
+		const fee = (await wallet.createMeltQuote(externalInvoice)).fee_reserve;
 		expect(fee).toBeDefined();
 		// because external invoice, fee should be > 0
 		expect(fee).toBeGreaterThan(0);
@@ -72,17 +72,17 @@ describe('mint api', () => {
 	test('pay local invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(100);
+		const request = await wallet.createMintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		// expect no fee because local invoice
-		const mintQuote = await wallet.mintQuote(10);
-		const quote = await wallet.meltQuote(mintQuote.request);
+		const mintQuote = await wallet.createMintQuote(10);
+		const quote = await wallet.createMeltQuote(mintQuote.request);
 		const fee = quote.fee_reserve;
 		expect(fee).toBe(0);
 
 		// get the quote from the mint
-		const quote_ = await wallet.getMeltQuote(quote.quote);
+		const quote_ = await wallet.checkMeltQuote(quote.quote);
 		expect(quote_).toBeDefined();
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
@@ -104,15 +104,15 @@ describe('mint api', () => {
 	test('pay external invoice', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(3000);
+		const request = await wallet.createMintQuote(3000);
 		const tokens = await wallet.mintTokens(3000, request.quote);
 
-		const meltQuote = await wallet.meltQuote(externalInvoice);
+		const meltQuote = await wallet.createMeltQuote(externalInvoice);
 		const fee = meltQuote.fee_reserve;
 		expect(fee).toBeGreaterThan(0);
 
 		// get the quote from the mint
-		const quote_ = await wallet.getMeltQuote(meltQuote.quote);
+		const quote_ = await wallet.checkMeltQuote(meltQuote.quote);
 		expect(quote_).toBeDefined();
 
 		const sendResponse = await wallet.send(2000 + fee, tokens.proofs);
@@ -135,7 +135,7 @@ describe('mint api', () => {
 	test('test send tokens exact without previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(64);
+		const request = await wallet.createMintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 
 		const sendResponse = await wallet.send(64, tokens.proofs);
@@ -148,7 +148,7 @@ describe('mint api', () => {
 	test('test send tokens with change', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(100);
+		const request = await wallet.createMintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
@@ -161,7 +161,7 @@ describe('mint api', () => {
 	test('receive tokens with previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(100);
+		const request = await wallet.createMintQuote(100);
 		const tokens = await wallet.mintTokens(100, request.quote);
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
@@ -174,7 +174,7 @@ describe('mint api', () => {
 	test('receive tokens with previous mint', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });
-		const request = await wallet.mintQuote(64);
+		const request = await wallet.createMintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 		const encoded = getEncodedToken({
 			token: [{ mint: mintUrl, proofs: tokens.proofs }]
@@ -192,7 +192,7 @@ describe('mint api', () => {
 		const privKeyBob = secp256k1.utils.randomPrivateKey();
 		const pubKeyBob = secp256k1.getPublicKey(privKeyBob);
 
-		const request = await wallet.mintQuote(64);
+		const request = await wallet.createMintQuote(64);
 		const tokens = await wallet.mintTokens(64, request.quote);
 
 		const { send } = await wallet.send(64, tokens.proofs, { pubkey: bytesToHex(pubKeyBob) });

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -37,7 +37,7 @@ describe('requests', () => {
 			});
 
 		const wallet = new CashuWallet(mint, { unit });
-		await wallet.getMeltQuote('test');
+		await wallet.checkMeltQuote('test');
 
 		expect(request).toBeDefined();
 		// expect(request!['content-type']).toContain('application/json');
@@ -61,7 +61,7 @@ describe('requests', () => {
 		const wallet = new CashuWallet(mint, { unit });
 		setGlobalRequestOptions({ headers: { 'x-cashu': 'xyz-123-abc' } });
 
-		await wallet.getMeltQuote('test');
+		await wallet.checkMeltQuote('test');
 
 		expect(request).toBeDefined();
 		expect(request!['x-cashu']).toContain('xyz-123-abc');

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -79,7 +79,7 @@ describe('test fees', () => {
 			} as MeltQuoteResponse);
 		const wallet = new CashuWallet(mint, { unit });
 
-		const fee = await wallet.getMeltQuote('test');
+		const fee = await wallet.checkMeltQuote('test');
 		const amount = 2000;
 
 		expect(fee.fee_reserve + amount).toEqual(2020);
@@ -242,7 +242,7 @@ describe('payLnInvoice', () => {
 			} as MeltQuoteResponse);
 
 		const wallet = new CashuWallet(mint, { unit });
-		const meltQuote = await wallet.getMeltQuote('test');
+		const meltQuote = await wallet.checkMeltQuote('test');
 
 		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
 
@@ -291,7 +291,7 @@ describe('payLnInvoice', () => {
 			});
 
 		const wallet = new CashuWallet(mint, { unit });
-		const meltQuote = await wallet.getMeltQuote('test');
+		const meltQuote = await wallet.checkMeltQuote('test');
 		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
 
 		expect(result.isPaid).toBe(true);


### PR DESCRIPTION
# Fixes: #143 

## Description

Feedback from the hackday was that naming of some user facing methods of `CashuWallet` were not clearly named. This PR addresses this issue. It also changes the names of corresponding `CashuMint` methods to reflect the protocol spec more closely.

## Changes

- Changed `CashuWallet.mintQuote` to `CashuWallet.createMintQuote`
- Changed `CashuMint.mintQuote` to `CashuMint.postMintQuote`
- Changed `CashuWallet.getmintQuote` to `CashuWallet.checkMintQuote`
- ... The same for `meltQuote` and `getMeltQuote`
## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
