### PR TITLE
Nut-06-fix-contact

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -51,12 +51,17 @@ class CashuMint {
 		const data = await requestInstance<GetInfoResponse>({
 			endpoint: joinUrls(mintUrl, '/v1/info')
 		});
-		// BEGIN DEPRECATED 
+		// BEGIN DEPRECATED
 		// Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
 		// This is to maintain backwards compatibility with older versions of the mint
 		if (Array.isArray(data?.contact) && data?.contact.length > 0) {
 			data.contact = data.contact.map((contact: any) => {
-				if (Array.isArray(contact) && contact.length === 2 && typeof contact[0] === 'string' && typeof contact[1] === 'string') {
+				if (
+					Array.isArray(contact) &&
+					contact.length === 2 &&
+					typeof contact[0] === 'string' &&
+					typeof contact[1] === 'string'
+				) {
 					return { method: contact[0], info: contact[1] };
 				}
 				return contact;

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -29,7 +29,7 @@ import {
 	MintQuoteResponsePaidDeprecated,
 	handleMintQuoteResponseDeprecated
 } from './legacy/nut-04.js';
-import { handeMintInfoContactFieldDeprecated } from './legacy/nut-06.js';
+import { handleMintInfoContactFieldDeprecated } from './legacy/nut-06.js';
 /**
  * Class represents Cashu Mint API. This class contains Lower level functions that are implemented by CashuWallet.
  */
@@ -60,7 +60,7 @@ class CashuMint {
 		const response = await requestInstance<GetInfoResponse>({
 			endpoint: joinUrls(mintUrl, '/v1/info')
 		});
-		const data = handeMintInfoContactFieldDeprecated(response);
+		const data = handleMintInfoContactFieldDeprecated(response);
 		return data;
 	}
 	/**

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -16,7 +16,8 @@ import type {
 	MintResponse,
 	PostRestorePayload,
 	MeltQuotePayload,
-	MeltQuoteResponse
+	MeltQuoteResponse,
+	MintContactInfo
 } from './model/types/index.js';
 import request from './request.js';
 import { isObj, joinUrls, sanitizeUrl } from './utils.js';
@@ -55,14 +56,14 @@ class CashuMint {
 		// Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
 		// This is to maintain backwards compatibility with older versions of the mint
 		if (Array.isArray(data?.contact) && data?.contact.length > 0) {
-			data.contact = data.contact.map((contact: any) => {
+			data.contact = data.contact.map((contact: MintContactInfo) => {
 				if (
 					Array.isArray(contact) &&
 					contact.length === 2 &&
 					typeof contact[0] === 'string' &&
 					typeof contact[1] === 'string'
 				) {
-					return { method: contact[0], info: contact[1] };
+					return { method: contact[0], info: contact[1] } as MintContactInfo;
 				}
 				return contact;
 			});

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -29,6 +29,7 @@ import {
 	MintQuoteResponsePaidDeprecated,
 	handleMintQuoteResponseDeprecated
 } from './legacy/nut-04.js';
+import { handeMintInfoContactFieldDeprecated } from './legacy/nut-06.js';
 /**
  * Class represents Cashu Mint API. This class contains Lower level functions that are implemented by CashuWallet.
  */
@@ -56,27 +57,10 @@ class CashuMint {
 		customRequest?: typeof request
 	): Promise<GetInfoResponse> {
 		const requestInstance = customRequest || request;
-		const data = await requestInstance<GetInfoResponse>({
+		const response = await requestInstance<GetInfoResponse>({
 			endpoint: joinUrls(mintUrl, '/v1/info')
 		});
-		// BEGIN DEPRECATED
-		// Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
-		// This is to maintain backwards compatibility with older versions of the mint
-		if (Array.isArray(data?.contact) && data?.contact.length > 0) {
-			data.contact = data.contact.map((contact: MintContactInfo) => {
-				if (
-					Array.isArray(contact) &&
-					contact.length === 2 &&
-					typeof contact[0] === 'string' &&
-					typeof contact[1] === 'string'
-				) {
-					return { method: contact[0], info: contact[1] } as MintContactInfo;
-				}
-				return contact;
-			});
-		}
-		// END DEPRECATED
-
+		const data = handeMintInfoContactFieldDeprecated(response);
 		return data;
 	}
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -103,6 +103,14 @@ class CashuWallet {
 	}
 
 	/**
+	 * Get information about the mint
+	 * @returns mint info
+	 */
+	async getMintInfo() {
+		return this.mint.getInfo();
+	}
+
+	/**
 	 * Receive an encoded or raw Cashu token (only supports single tokens. It will only process the first token in the token array)
 	 * @param {(string|Token)} token - Cashu token
 	 * @param preference optional preference for splitting proofs into specific amounts

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -20,12 +20,12 @@ function encodeBase64ToJson<T extends object>(base64String: string): T {
 }
 
 function base64urlToBase64(str: string) {
-	return str.replace(/-/g, '+').replace(/_/g, '/').split('=')[0]
+	return str.replace(/-/g, '+').replace(/_/g, '/').split('=')[0];
 	// .replace(/./g, '=');
 }
 
 function base64urlFromBase64(str: string) {
-	return str.replace(/\+/g, '-').replace(/\//g, '_').split('=')[0]
+	return str.replace(/\+/g, '-').replace(/\//g, '_').split('=')[0];
 	// .replace(/=/g, '.');
 }
 

--- a/src/legacy/nut-06.ts
+++ b/src/legacy/nut-06.ts
@@ -1,6 +1,6 @@
 import type { MintContactInfo, GetInfoResponse } from '../model/types/index.js';
 
-export function handeMintInfoContactFieldDeprecated(data: GetInfoResponse) {
+export function handleMintInfoContactFieldDeprecated(data: GetInfoResponse) {
     // Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
     // This is to maintain backwards compatibility with older versions of the mint
     if (Array.isArray(data?.contact) && data?.contact.length > 0) {

--- a/src/legacy/nut-06.ts
+++ b/src/legacy/nut-06.ts
@@ -1,21 +1,23 @@
 import type { MintContactInfo, GetInfoResponse } from '../model/types/index.js';
 
 export function handleMintInfoContactFieldDeprecated(data: GetInfoResponse) {
-    // Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
-    // This is to maintain backwards compatibility with older versions of the mint
-    if (Array.isArray(data?.contact) && data?.contact.length > 0) {
-        data.contact = data.contact.map((contact: MintContactInfo) => {
-            if (
-                Array.isArray(contact) &&
-                contact.length === 2 &&
-                typeof contact[0] === 'string' &&
-                typeof contact[1] === 'string'
-            ) {
-                return { method: contact[0], info: contact[1] } as MintContactInfo;
-            }
-            console.warn("Mint returned deprecated 'contact' field. Update NUT-06: https://github.com/cashubtc/nuts/pull/117");
-            return contact;
-        });
-    }
-    return data;
+	// Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
+	// This is to maintain backwards compatibility with older versions of the mint
+	if (Array.isArray(data?.contact) && data?.contact.length > 0) {
+		data.contact = data.contact.map((contact: MintContactInfo) => {
+			if (
+				Array.isArray(contact) &&
+				contact.length === 2 &&
+				typeof contact[0] === 'string' &&
+				typeof contact[1] === 'string'
+			) {
+				return { method: contact[0], info: contact[1] } as MintContactInfo;
+			}
+			console.warn(
+				"Mint returned deprecated 'contact' field. Update NUT-06: https://github.com/cashubtc/nuts/pull/117"
+			);
+			return contact;
+		});
+	}
+	return data;
 }

--- a/src/legacy/nut-06.ts
+++ b/src/legacy/nut-06.ts
@@ -1,0 +1,21 @@
+import type { MintContactInfo, GetInfoResponse } from '../model/types/index.js';
+
+export function handeMintInfoContactFieldDeprecated(data: GetInfoResponse) {
+    // Monkey patch old contact field ["email", "me@mail.com"] Array<[string, string]>; to new contact field [{method: "email", info: "me@mail.com"}] Array<MintContactInfo>
+    // This is to maintain backwards compatibility with older versions of the mint
+    if (Array.isArray(data?.contact) && data?.contact.length > 0) {
+        data.contact = data.contact.map((contact: MintContactInfo) => {
+            if (
+                Array.isArray(contact) &&
+                contact.length === 2 &&
+                typeof contact[0] === 'string' &&
+                typeof contact[1] === 'string'
+            ) {
+                return { method: contact[0], info: contact[1] } as MintContactInfo;
+            }
+            console.warn("Mint returned deprecated 'contact' field. Update NUT-06: https://github.com/cashubtc/nuts/pull/117");
+            return contact;
+        });
+    }
+    return data;
+}

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -473,6 +473,11 @@ export type BlindedMessageData = {
 	rs: Array<bigint>;
 };
 
+export type MintContactInfo = {
+	method: string;
+	info: string;
+};
+
 /**
  * Response from mint at /info endpoint
  */
@@ -482,7 +487,7 @@ export type GetInfoResponse = {
 	version: string;
 	description?: string;
 	description_long?: string;
-	contact: Array<[string, string]>;
+	contact: Array<MintContactInfo>;
 	nuts: {
 		'4': {
 			methods: Array<SwapMethod>;

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -34,22 +34,34 @@ beforeEach(() => {
 });
 
 describe('test info', () => {
-	const mintInfoResp = JSON.parse('{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[{"method":"email","info":"contact@me.com"},{"method":"twitter","info":"@me"},{"method":"nostr","info":"npub..."}],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}');
+	const mintInfoResp = JSON.parse(
+		'{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[{"method":"email","info":"contact@me.com"},{"method":"twitter","info":"@me"},{"method":"nostr","info":"npub..."}],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}'
+	);
 	test('test info', async () => {
 		nock(mintUrl).get('/v1/info').reply(200, mintInfoResp);
 		const wallet = new CashuWallet(mint, { unit });
 
 		const info = await wallet.getMintInfo();
-		expect(info.contact).toEqual([{ method: 'email', info: 'contact@me.com' }, { method: 'twitter', info: '@me' }, { method: 'nostr', info: 'npub...' }]);
+		expect(info.contact).toEqual([
+			{ method: 'email', info: 'contact@me.com' },
+			{ method: 'twitter', info: '@me' },
+			{ method: 'nostr', info: 'npub...' }
+		]);
 		expect(info).toEqual(mintInfoResp);
 	});
 	test('test info with deprecated contact field', async () => {
 		// mintInfoRespDeprecated is the same as mintInfoResp but with the contact field in the old format
-		const mintInfoRespDeprecated = JSON.parse('{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[["email","contact@me.com"],["twitter","@me"],["nostr","npub..."]],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}');
+		const mintInfoRespDeprecated = JSON.parse(
+			'{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[["email","contact@me.com"],["twitter","@me"],["nostr","npub..."]],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}'
+		);
 		nock(mintUrl).get('/v1/info').reply(200, mintInfoRespDeprecated);
 		const wallet = new CashuWallet(mint, { unit });
 		const info = await wallet.getMintInfo();
-		expect(info.contact).toEqual([{ method: 'email', info: 'contact@me.com' }, { method: 'twitter', info: '@me' }, { method: 'nostr', info: 'npub...' }]);
+		expect(info.contact).toEqual([
+			{ method: 'email', info: 'contact@me.com' },
+			{ method: 'twitter', info: '@me' },
+			{ method: 'nostr', info: 'npub...' }
+		]);
 		expect(info).toEqual(mintInfoResp);
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -33,6 +33,27 @@ beforeEach(() => {
 	nock(mintUrl).get('/v1/keys/009a1f293253e41e').reply(200, dummyKeysResp);
 });
 
+describe('test info', () => {
+	const mintInfoResp = JSON.parse('{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[{"method":"email","info":"contact@me.com"},{"method":"twitter","info":"@me"},{"method":"nostr","info":"npub..."}],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}');
+	test('test info', async () => {
+		nock(mintUrl).get('/v1/info').reply(200, mintInfoResp);
+		const wallet = new CashuWallet(mint, { unit });
+
+		const info = await wallet.getMintInfo();
+		expect(info.contact).toEqual([{ method: 'email', info: 'contact@me.com' }, { method: 'twitter', info: '@me' }, { method: 'nostr', info: 'npub...' }]);
+		expect(info).toEqual(mintInfoResp);
+	});
+	test('test info with deprecated contact field', async () => {
+		// mintInfoRespDeprecated is the same as mintInfoResp but with the contact field in the old format
+		const mintInfoRespDeprecated = JSON.parse('{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[["email","contact@me.com"],["twitter","@me"],["nostr","npub..."]],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}');
+		nock(mintUrl).get('/v1/info').reply(200, mintInfoRespDeprecated);
+		const wallet = new CashuWallet(mint, { unit });
+		const info = await wallet.getMintInfo();
+		expect(info.contact).toEqual([{ method: 'email', info: 'contact@me.com' }, { method: 'twitter', info: '@me' }, { method: 'nostr', info: 'npub...' }]);
+		expect(info).toEqual(mintInfoResp);
+	});
+});
+
 describe('test fees', () => {
 	test('test melt quote fees', async () => {
 		nock(mintUrl).get('/v1/melt/quote/bolt11/test').reply(200, {


### PR DESCRIPTION
## Description

Implements changes for the contact field in NUT-06 (https://github.com/cashubtc/nuts/pull/117) and monkey-patches responses from old mints so that they can be deserialized. Deprecated code block can be removed once all mints upgraded.

## Changes

- new wallet method `getMintInfo` 
- tests

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`