### PR TITLE
Deprecate `payLnInvoice` helpers, rename `CashuWallet.meltTokens` to `CashuWallet.melt`

### DIFF
--- a/migration-1.0.0.md
+++ b/migration-1.0.0.md
@@ -63,7 +63,7 @@ type MeltQuoteResponse = {
 };
 ```
 
-where `quote` is the identifier to pass to `meltTokens()`
+where `quote` is the identifier to pass to `melt()`
 
 ---
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -420,6 +420,20 @@ class CashuWallet {
 	}
 
 	/**
+	 * @deprecated use {@link CashuWallet.melt} instead
+	 */
+	async meltTokens(
+		meltQuote: MeltQuoteResponse,
+		proofsToSend: Array<Proof>,
+		options?: {
+			keysetId?: string;
+			counter?: number;
+		}
+	): Promise<MeltTokensResponse> {
+		return this.melt(meltQuote, proofsToSend, options);
+	}
+
+	/**
 	 * Melt tokens for a melt quote. proofsToSend must be at least amount+fee_reserve form the melt quote.
 	 * Returns payment proof and change proofs
 	 * @param meltQuote ID of the melt quote

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -241,7 +241,10 @@ class CashuWallet {
 			throw new Error('Not enough funds available');
 		}
 		if (amount < amountAvailable || options?.preference || options?.pubkey) {
-			const { amountKeep, amountSend } = { amountKeep: amountAvailable - amount, amountSend: amount };
+			const { amountKeep, amountSend } = {
+				amountKeep: amountAvailable - amount,
+				amountSend: amount
+			};
 			const { payload, blindedMessages } = this.createSwapPayload(
 				amountSend,
 				proofsToSend,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -86,7 +86,8 @@ describe('mint api', () => {
 		expect(quote_).toBeDefined();
 
 		const sendResponse = await wallet.send(10, tokens.proofs);
-		const response = await wallet.payLnInvoice(mintQuote.request, sendResponse.send, quote);
+		const meltQuote = await wallet.createMeltQuote(mintQuote.request);
+		const response = await wallet.melt(meltQuote, sendResponse.send);
 		expect(response).toBeDefined();
 		// expect that we have received the fee back, since it was internal
 		expect(response.change.reduce((a, b) => a + b.amount, 0)).toBe(fee);
@@ -116,7 +117,9 @@ describe('mint api', () => {
 		expect(quote_).toBeDefined();
 
 		const sendResponse = await wallet.send(2000 + fee, tokens.proofs);
-		const response = await wallet.payLnInvoice(externalInvoice, sendResponse.send, meltQuote);
+
+		const meltQuote2 = await wallet.createMeltQuote(externalInvoice);
+		const response = await wallet.melt(meltQuote2, sendResponse.send);
 
 		expect(response).toBeDefined();
 		// expect that we have not received the fee back, since it was external

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -300,9 +300,7 @@ describe('melt', () => {
 	test('test melt bad resonse', async () => {
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint, { unit });
-		const result = await wallet
-			.melt({} as MeltQuoteResponse, proofs)
-			.catch((e) => e);
+		const result = await wallet.melt({} as MeltQuoteResponse, proofs).catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));
 	});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -212,7 +212,7 @@ describe('checkProofsSpent', () => {
 	});
 });
 
-describe('payLnInvoice', () => {
+describe('melt', () => {
 	const proofs = [
 		{
 			id: '009a1f293253e41e',
@@ -221,7 +221,7 @@ describe('payLnInvoice', () => {
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 		}
 	];
-	test('test payLnInvoice base case', async () => {
+	test('test melt base case', async () => {
 		nock(mintUrl)
 			.get('/v1/melt/quote/bolt11/test')
 			.reply(200, {
@@ -243,12 +243,11 @@ describe('payLnInvoice', () => {
 
 		const wallet = new CashuWallet(mint, { unit });
 		const meltQuote = await wallet.checkMeltQuote('test');
-
-		const result = await wallet.payLnInvoice(invoice, proofs, meltQuote);
+		const result = await wallet.melt(meltQuote, proofs);
 
 		expect(result).toEqual({ isPaid: true, preimage: null, change: [] });
 	});
-	test('test payLnInvoice change', async () => {
+	test('test melt change', async () => {
 		nock.cleanAll();
 		nock(mintUrl)
 			.get('/v1/keys')
@@ -292,17 +291,17 @@ describe('payLnInvoice', () => {
 
 		const wallet = new CashuWallet(mint, { unit });
 		const meltQuote = await wallet.checkMeltQuote('test');
-		const result = await wallet.payLnInvoice(invoice, [{ ...proofs[0], amount: 3 }], meltQuote);
+		const result = await wallet.melt(meltQuote, [{ ...proofs[0], amount: 3 }]);
 
 		expect(result.isPaid).toBe(true);
 		expect(result.preimage).toBe('asd');
 		expect(result.change).toHaveLength(1);
 	});
-	test('test payLnInvoice bad resonse', async () => {
+	test('test melt bad resonse', async () => {
 		nock(mintUrl).post('/v1/melt/bolt11').reply(200, {});
 		const wallet = new CashuWallet(mint, { unit });
 		const result = await wallet
-			.payLnInvoice(invoice, proofs, {} as MeltQuoteResponse)
+			.melt({} as MeltQuoteResponse, proofs)
 			.catch((e) => e);
 
 		expect(result).toEqual(new Error('bad response'));


### PR DESCRIPTION
Removes LnInvoice helper functions (closes #157) and renames `CashuWallet.meltTokens` to `CashuWallet.melt`.

Todo:
- [ ] re-add removed methods and deprecate them so that we don't break implementations. 
- [ ] do the same with `meltTokens`
- [ ] `CashuMint.split` -> `CashuMint.swap` and deprecate split