### PR TITLE
Update Nutshell Docker image for integration tests

### DIFF
--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Pull and start mint
         run: |
-          docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.15.2 poetry run mint
+          docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:latest poetry run mint
 
       - name: Check running containers
         run: docker ps

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ const tokens = await wallet.mintTokens(64, mintQuote.quote);
 
 Contributions are very welcome.
 
-If you want to contribute, please open an Issue or a PR. 
-If you open a PR, please do so from the `development` branch as the base branch. 
+If you want to contribute, please open an Issue or a PR.
+If you open a PR, please do so from the `development` branch as the base branch.
 
 ### Version
 
@@ -80,17 +80,17 @@ If you open a PR, please do so from the `development` branch as the base branch.
 | | * `hotfix`
 | |
 | * `staging`
-| |\ 
+| |\
 | |\ \
 | | | * `bugfix`
 | | |
-| | * `development`  
-| | |\ 
+| | * `development`
+| | |\
 | | | * `feature1`
 | | | |
 | | |/
 | | *
-| | |\ 
+| | |\
 | | | * `feature2`
 | | |/
 | |/


### PR DESCRIPTION
This pull request updates the Nutshell Docker image used for integration tests to the latest version. The previous version was 0.15.2, and this PR updates it to the latest version available.