### PR TITLE
add `computeTxId` as a utility function

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -234,12 +234,18 @@ export function sanitizeUrl(url: string): string {
 	return url.replace(/\/$/, '');
 }
 
+export const getProofsFromToken = (token: Token | string) => {
+	const decodedToken = typeof token === 'string' ? getDecodedToken(token) : token;
+	return decodedToken.token[0].proofs;
+};
+
 /**
  * Sorts Ys of a set of proofs in descending order, concatenates them and returns the SHA256 hash of the concatenated string
  * @param proofs - Array of proofs
  * @returns hex string of the SHA256 hash
  */
-export function computeTxId(proofs: Array<Proof>): string {
+export function computeTxId(tx: Array<Proof> | string | Token): string {
+	const proofs: Array<Proof> = !Array.isArray(tx) ? getProofsFromToken(tx) : tx;
 	const enc = new TextEncoder();
 	const Ys = proofs.map((p) => hashToCurve(enc.encode(p.secret)).toRawBytes(true));
 	Ys.sort((a, b) => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -252,3 +252,13 @@ describe('test v4 encoding', () => {
 		expect(decodedExpectedToken).toEqual(decodedEncodedToken);
 	});
 });
+
+describe('test computeTxId', () => {
+	test('compute', () => {
+		const proofs = JSON.parse(
+			'[{"id":"009a1f293253e41e","amount":2,"secret":"407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837","C":"02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea"},{"id":"009a1f293253e41e","amount":8,"secret":"fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be","C":"029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059"}]'
+		);
+		const txId = utils.computeTxId(proofs);
+		expect(txId).toBe('dac0748828d855ac4bc0e0a008cbc4b02e7d4238af06d730461cc559a5ae24b1');
+	});
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -253,12 +253,70 @@ describe('test v4 encoding', () => {
 	});
 });
 
+describe('test getProofsFromToken', () => {
+	const token = {
+		token: [
+			{
+				mint: 'http://localhost:3338',
+				proofs: [
+					{
+						id: '009a1f293253e41e',
+						amount: 2,
+						secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
+						C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea'
+					},
+					{
+						id: '009a1f293253e41e',
+						amount: 8,
+						secret: 'fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be',
+						C: '029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059'
+					}
+				]
+			}
+		]
+	};
+	test('testing decoded token', async () => {
+		const proofs = utils.getProofsFromToken(token);
+		expect(proofs).toStrictEqual(token.token[0].proofs);
+	});
+
+	test('testing encoded token', async () => {
+		const encodedToken = utils.getEncodedToken(token);
+		const proofs = utils.getProofsFromToken(encodedToken);
+		expect(proofs).toStrictEqual(token.token[0].proofs);
+	});
+});
+
 describe('test computeTxId', () => {
-	test('compute', () => {
-		const proofs = JSON.parse(
-			'[{"id":"009a1f293253e41e","amount":2,"secret":"407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837","C":"02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea"},{"id":"009a1f293253e41e","amount":8,"secret":"fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be","C":"029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059"}]'
-		);
+	const proofs = JSON.parse(
+		'[{"id":"009a1f293253e41e","amount":2,"secret":"407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837","C":"02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea"},{"id":"009a1f293253e41e","amount":8,"secret":"fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be","C":"029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059"}]'
+	);
+	const token = {
+		token: [
+			{
+				mint: 'http://localhost:3338',
+				proofs: proofs
+			}
+		]
+	};
+	test('compute with proofs', () => {
 		const txId = utils.computeTxId(proofs);
+		expect(txId).toBe('dac0748828d855ac4bc0e0a008cbc4b02e7d4238af06d730461cc559a5ae24b1');
+	});
+
+	test('compute with encoded token', () => {
+		const encodedToken = utils.getEncodedToken(token);
+		const txId = utils.computeTxId(encodedToken);
+		expect(txId).toBe('dac0748828d855ac4bc0e0a008cbc4b02e7d4238af06d730461cc559a5ae24b1');
+	});
+
+	test('compute with decoded token', () => {
+		const txId = utils.computeTxId(token);
+		expect(txId).toBe('dac0748828d855ac4bc0e0a008cbc4b02e7d4238af06d730461cc559a5ae24b1');
+	});
+
+	test('compute with proofs reversed', () => {
+		const txId = utils.computeTxId(proofs.reverse());
 		expect(txId).toBe('dac0748828d855ac4bc0e0a008cbc4b02e7d4238af06d730461cc559a5ae24b1');
 	});
 });


### PR DESCRIPTION
## Description

Discussion of this [here](https://discord.com/channels/1182354492868538449/1182361157768589312/1270797114011549696), and related [CDK PR](https://github.com/cashubtc/cdk/pull/285/files)

I am opening this PR because I want to ability to create an identifier for a "transaction" that can be embedded in a URL rather than an entire token. We will then store tokens locked to a pubkey in our database and map this txid to that token.

...

## Changes

Adds a utility function `computeTxId` that accepts `Array<Proof> and 
- orders all Y's in descending order
- concatenate them
- sha256 hash


## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [X] run `npm run format`
