### PR TITLE
add token v4 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Supported token formats:
 - [x] v1 read
 - [x] v2 read (deprecated)
 - [x] v3 read/write
+- [x] v4 read/write
 
 ## Usage
 


### PR DESCRIPTION
token v4 was not mentioned in the readme

reading added in https://github.com/cashubtc/cashu-ts/pull/144
writing added in https://github.com/cashubtc/cashu-ts/pull/166