### PR TITLE
Fix error handling in `receive`

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -130,22 +130,18 @@ class CashuWallet {
 			privkey?: string;
 		}
 	): Promise<Array<Proof>> {
-		try {
-			if (typeof token === 'string') {
-				token = getDecodedToken(token);
-			}
-			const tokenEntries: Array<TokenEntry> = token.token;
-			const proofs = await this.receiveTokenEntry(tokenEntries[0], {
-				keysetId: options?.keysetId,
-				preference: options?.preference,
-				counter: options?.counter,
-				pubkey: options?.pubkey,
-				privkey: options?.privkey
-			});
-			return proofs;
-		} catch (error) {
-			throw new Error('Error when receiving');
+		if (typeof token === 'string') {
+			token = getDecodedToken(token);
 		}
+		const tokenEntries: Array<TokenEntry> = token.token;
+		const proofs = await this.receiveTokenEntry(tokenEntries[0], {
+			keysetId: options?.keysetId,
+			preference: options?.preference,
+			counter: options?.counter,
+			pubkey: options?.pubkey,
+			privkey: options?.privkey
+		});
+		return proofs;
 	}
 
 	/**
@@ -168,33 +164,29 @@ class CashuWallet {
 		}
 	): Promise<Array<Proof>> {
 		const proofs: Array<Proof> = [];
-		try {
-			const amount = tokenEntry.proofs.reduce((total, curr) => total + curr.amount, 0);
-			let preference = options?.preference;
-			if (!preference) {
-				preference = getDefaultAmountPreference(amount);
-			}
-			const keys = await this.getKeys(options?.keysetId);
-			const { payload, blindedMessages } = this.createSwapPayload(
-				amount,
-				tokenEntry.proofs,
-				keys,
-				preference,
-				options?.counter,
-				options?.pubkey,
-				options?.privkey
-			);
-			const { signatures } = await CashuMint.split(tokenEntry.mint, payload);
-			const newProofs = this.constructProofs(
-				signatures,
-				blindedMessages.rs,
-				blindedMessages.secrets,
-				keys
-			);
-			proofs.push(...newProofs);
-		} catch (error) {
-			throw new Error('Error receiving token entry');
+		const amount = tokenEntry.proofs.reduce((total, curr) => total + curr.amount, 0);
+		let preference = options?.preference;
+		if (!preference) {
+			preference = getDefaultAmountPreference(amount);
 		}
+		const keys = await this.getKeys(options?.keysetId);
+		const { payload, blindedMessages } = this.createSwapPayload(
+			amount,
+			tokenEntry.proofs,
+			keys,
+			preference,
+			options?.counter,
+			options?.pubkey,
+			options?.privkey
+		);
+		const { signatures } = await CashuMint.split(tokenEntry.mint, payload);
+		const newProofs = this.constructProofs(
+			signatures,
+			blindedMessages.rs,
+			blindedMessages.secrets,
+			keys
+		);
+		proofs.push(...newProofs);
 		return proofs;
 	}
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -203,7 +203,7 @@ describe('mint api', () => {
 		const result = await wallet
 			.receive(encoded, { privkey: bytesToHex(privKeyAlice) })
 			.catch((e) => e);
-		expect(result).toEqual(new Error('Error when receiving'));
+		expect(result).toEqual(new Error('no valid signature provided for input.'));
 
 		const proofs = await wallet.receive(encoded, { privkey: bytesToHex(privKeyBob) });
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -180,14 +180,14 @@ describe('receive', () => {
 		nock(mintUrl).post('/v1/swap').reply(400, { detail: msg });
 		const wallet = new CashuWallet(mint, { unit });
 		const result = await wallet.receive(tokenInput).catch((e) => e);
-		expect(result).toEqual(new Error('Error when receiving'));
+		expect(result).toEqual(new Error('tokens already spent. Secret: asdasdasd'));
 	});
 
 	test('test receive could not verify proofs', async () => {
 		nock(mintUrl).post('/v1/swap').reply(400, { code: 0, error: 'could not verify proofs.' });
 		const wallet = new CashuWallet(mint, { unit });
 		const result = await wallet.receive(tokenInput).catch((e) => e);
-		expect(result).toEqual(new Error('Error when receiving'));
+		expect(result).toEqual(new Error('could not verify proofs.'));
 	});
 });
 


### PR DESCRIPTION
The `receiveTokenEntry` and `receive` methods in the `CashuWallet` class now properly handles errors and returns specific error messages instead of a generic one. 

Changes look more than they are. I'm only removing the `try {} catch {}` block because we aren't doing anything with the error. This lets the error be handled downstream.