### PR TITLE
P2PK for multiple pubkeys in one operation

### DIFF
--- a/src/model/types/wallet/index.ts
+++ b/src/model/types/wallet/index.ts
@@ -5,6 +5,7 @@ export * from './tokens';
 export type AmountPreference = {
 	amount: number;
 	count: number;
+	pubkey?: string;
 };
 
 /**


### PR DESCRIPTION
adds an optional `pubkey` field to `AmountPreference`

now when the blinded messages are constructed, a P2PK lock can be created for each preference creating ecash locked to many pubkeys
