### PR TITLE
Default to v4 Token

### DIFF
--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -86,7 +86,7 @@ describe('test split different key amount', () => {
 });
 
 describe('test token v3 encoding', () => {
-	test('encode a v3 token', () => {
+	test('encode a v3 token with getEncodedToken', () => {
 		const tokenObj = {
 			token: [
 				{
@@ -110,7 +110,44 @@ describe('test token v3 encoding', () => {
 			unit: 'sat',
 			memo: 'Thank you.'
 		};
-		const encoded = utils.getEncodedToken({
+		const encoded = utils.getEncodedToken(
+			{
+				mint: tokenObj.token[0].mint,
+				memo: tokenObj.memo,
+				unit: tokenObj.unit,
+				proofs: tokenObj.token[0].proofs
+			},
+			{ version: 3 }
+		);
+		expect(encoded).toBe(
+			'cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJhbW91bnQiOjIsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6IjQwNzkxNWJjMjEyYmU2MWE3N2UzZTZkMmFlYjRjNzI3OTgwYmRhNTFjZDA2YTZhZmMyOWUyODYxNzY4YTc4MzciLCJDIjoiMDJiYzkwOTc5OTdkODFhZmIyY2M3MzQ2YjVlNDM0NWE5MzQ2YmQyYTUwNmViNzk1ODU5OGE3MmYwY2Y4NTE2M2VhIn0seyJhbW91bnQiOjgsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6ImZlMTUxMDkzMTRlNjFkNzc1NmIwZjhlZTBmMjNhNjI0YWNhYTNmNGUwNDJmNjE0MzNjNzI4YzcwNTdiOTMxYmUiLCJDIjoiMDI5ZThlNTA1MGI4OTBhN2Q2YzA5NjhkYjE2YmMxZDVkNWZhMDQwZWExZGUyODRmNmVjNjlkNjEyOTlmNjcxMDU5In1dfV0sInVuaXQiOiJzYXQiLCJtZW1vIjoiVGhhbmsgeW91LiJ9'
+		);
+	});
+	test('encode a v3 token with getEncodedTokenV3', () => {
+		const tokenObj = {
+			token: [
+				{
+					mint: 'https://8333.space:3338',
+					proofs: [
+						{
+							amount: 2,
+							id: '009a1f293253e41e',
+							secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
+							C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea'
+						},
+						{
+							amount: 8,
+							id: '009a1f293253e41e',
+							secret: 'fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be',
+							C: '029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059'
+						}
+					]
+				}
+			],
+			unit: 'sat',
+			memo: 'Thank you.'
+		};
+		const encoded = utils.getEncodedTokenV3({
 			mint: tokenObj.token[0].mint,
 			memo: tokenObj.memo,
 			unit: tokenObj.unit,


### PR DESCRIPTION
## Description

This PR changes the encoding utils to default to v4 encoding if the keyset ID allows it.

Closes #198 

## Changes

- added getEncodedTokenV3
- changed getEncodedToken to return v4 if possible

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run format`
