### PR TITLE
Add `CashuWallet.checkProofsStates()`

### DIFF
--- a/migration-2.0.0.md
+++ b/migration-2.0.0.md
@@ -36,7 +36,7 @@ export type OutputAmounts = {
 
 #### `checkProofsStates` replaces `checkProofsSpent`
 
-To check the state of a `Proof`, call `CashuWallet.checkProofsStates`. `checkProofsStates` now returns an array of `CheckStateEnum` for each proof provided. States are now `CheckStateEnum.SPENT`, `CheckStateEnum.UNSPENT`, and `CheckStateEnum.PENDING`.
+To check the state of a `Proof`, call `CashuWallet.checkProofsStates`. `checkProofsStates` now returns an array of `ProofState`'s, one for each `Proof` provided. The spent states are in `ProofState.state` and can have the values `CheckStateEnum.SPENT`, `CheckStateEnum.UNSPENT`, and `CheckStateEnum.PENDING`. `ProofState` also contains a `witness` if present.
 
 #### renamed functions
 

--- a/migration-2.0.0.md
+++ b/migration-2.0.0.md
@@ -34,6 +34,10 @@ export type OutputAmounts = {
 };
 ```
 
+#### `checkProofsStates` replaces `checkProofsSpent`
+
+To check the state of a `Proof`, call `CashuWallet.checkProofsStates`. `checkProofsStates` now returns an array of `CheckStateEnum` for each proof provided. States are now `CheckStateEnum.SPENT`, `CheckStateEnum.UNSPENT`, and `CheckStateEnum.PENDING`.
+
 #### renamed functions
 
 - in `SendResponse`, `returnChange` is now called `keep`

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -871,29 +871,6 @@ class CashuWallet {
 		};
 		return { payload, blindingData };
 	}
-	/**
-	 * returns proofs that are already spent (use for keeping wallet state clean)
-	 * @param proofs (only the `secret` field is required)
-	 * @returns
-	 */
-	async checkProofsSpent<T extends { secret: string }>(proofs: Array<T>): Promise<Array<T>> {
-		const enc = new TextEncoder();
-		const Ys = proofs.map((p: T) => hashToCurve(enc.encode(p.secret)).toHex(true));
-		// TODO: Replace this with a value from the info endpoint of the mint eventually
-		const BATCH_SIZE = 100;
-		const states: Array<CheckStateEntry> = [];
-		for (let i = 0; i < Ys.length; i += BATCH_SIZE) {
-			const { states: batchStates } = await this.mint.check({
-				Ys: Ys.slice(i, i + BATCH_SIZE)
-			});
-			states.push(...batchStates);
-		}
-
-		return proofs.filter((_: T, i: number) => {
-			const state = states.find((state: CheckStateEntry) => state.Y === Ys[i]);
-			return state && state.state === CheckStateEnum.SPENT;
-		});
-	}
 
 	/**
 	 * Get an array of the states of proofs from the mint (as an array of CheckStateEnum's)

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -857,13 +857,16 @@ class CashuWallet {
 			const { states: batchStates } = await this.mint.check({
 				Ys: YsSlice
 			});
+			const stateMap: { [y: string]: ProofState } = {};
+			batchStates.forEach((s) => {
+				stateMap[s.Y] = s;
+			});
 			for (let j = 0; j < YsSlice.length; j++) {
-				const state = batchStates.find((s: ProofState) => s.Y === YsSlice[j]);
-				if (state) {
-					states.push(state);
-				} else {
+				const state = stateMap[YsSlice[j]];
+				if (!state) {
 					throw new Error('Could not find state for proof with Y: ' + YsSlice[j]);
 				}
+				states.push(state);
 			}
 		}
 		return states;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -452,7 +452,7 @@ class CashuWallet {
 					0
 				) +
 					999) /
-				1000,
+					1000,
 				0
 			)
 		);
@@ -470,7 +470,7 @@ class CashuWallet {
 			Math.max(
 				(nInputs * (this._keysets.find((k: MintKeyset) => k.id === keysetId)?.input_fee_ppk || 0) +
 					999) /
-				1000,
+					1000,
 				0
 			)
 		);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -452,7 +452,7 @@ class CashuWallet {
 					0
 				) +
 					999) /
-					1000,
+				1000,
 				0
 			)
 		);
@@ -470,7 +470,7 @@ class CashuWallet {
 			Math.max(
 				(nInputs * (this._keysets.find((k: MintKeyset) => k.id === keysetId)?.input_fee_ppk || 0) +
 					999) /
-					1000,
+				1000,
 				0
 			)
 		);
@@ -879,6 +879,7 @@ class CashuWallet {
 	async checkProofsSpent<T extends { secret: string }>(proofs: Array<T>): Promise<Array<T>> {
 		const enc = new TextEncoder();
 		const Ys = proofs.map((p: T) => hashToCurve(enc.encode(p.secret)).toHex(true));
+		// TODO: Replace this with a value from the info endpoint of the mint eventually
 		const BATCH_SIZE = 100;
 		const states: Array<CheckStateEntry> = [];
 		for (let i = 0; i < Ys.length; i += BATCH_SIZE) {
@@ -902,6 +903,7 @@ class CashuWallet {
 	async checkProofsStates(proofs: Array<Proof>): Promise<Array<CheckStateEnum>> {
 		const enc = new TextEncoder();
 		const Ys = proofs.map((p: Proof) => hashToCurve(enc.encode(p.secret)).toHex(true));
+		// TODO: Replace this with a value from the info endpoint of the mint eventually
 		const BATCH_SIZE = 100;
 		const states: Array<CheckStateEnum> = [];
 		for (let i = 0; i < Ys.length; i += BATCH_SIZE) {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -891,6 +891,20 @@ class CashuWallet {
 		});
 	}
 
+	async checkProofsStates(proofs: Array<Proof>): Promise<Array<CheckStateEnum>> {
+		const enc = new TextEncoder();
+		const Ys = proofs.map((p: Proof) => hashToCurve(enc.encode(p.secret)).toHex(true));
+		const BATCH_SIZE = 100;
+		const states: Array<CheckStateEnum> = [];
+		for (let i = 0; i < Ys.length; i += BATCH_SIZE) {
+			const { states: batchStates } = await this.mint.check({
+				Ys: Ys.slice(i, i + BATCH_SIZE)
+			});
+			states.push(...batchStates.map((state: CheckStateEntry) => state.state));
+		}
+		return states;
+	}
+
 	/**
 	 * Creates blinded messages for a given amount
 	 * @param amount amount to create blinded messages for

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -21,7 +21,7 @@ export type ApiError = {
 /**
  * Entries of CheckStateResponse with state of the proof
  */
-export type CheckStateEntry = {
+export type ProofState = {
 	Y: string;
 	state: CheckStateEnum;
 	witness: string | null;
@@ -43,7 +43,7 @@ export type CheckStateResponse = {
 	/**
 	 *
 	 */
-	states: Array<CheckStateEntry>;
+	states: Array<ProofState>;
 } & ApiError;
 
 /**

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -104,13 +104,15 @@ describe('mint api', () => {
 		expect(sentProofsStates).toBeDefined();
 		// expect that all proofs are spent, i.e. all are CheckStateEnum.SPENT
 		sentProofsStates.forEach((state) => {
-			expect(state).toBe(CheckStateEnum.SPENT);
+			expect(state.state).toBe(CheckStateEnum.SPENT);
+			expect(state.witness).toBeNull();
 		});
 		// expect none of the sendResponse.keep to be spent
 		const keepProofsStates = await wallet.checkProofsStates(sendResponse.keep);
 		expect(keepProofsStates).toBeDefined();
 		keepProofsStates.forEach((state) => {
-			expect(state).toBe(CheckStateEnum.UNSPENT);
+			expect(state.state).toBe(CheckStateEnum.UNSPENT);
+			expect(state.witness).toBeNull();
 		});
 	});
 	test('pay external invoice', async () => {
@@ -139,13 +141,15 @@ describe('mint api', () => {
 		expect(sentProofsStates).toBeDefined();
 		// expect that all proofs are spent, i.e. all are CheckStateEnum.SPENT
 		sentProofsStates.forEach((state) => {
-			expect(state).toBe(CheckStateEnum.SPENT);
+			expect(state.state).toBe(CheckStateEnum.SPENT);
+			expect(state.witness).toBeNull();
 		});
 		// expect none of the sendResponse.keep to be spent
 		const keepProofsStates = await wallet.checkProofsStates(sendResponse.keep);
 		expect(keepProofsStates).toBeDefined();
 		keepProofsStates.forEach((state) => {
-			expect(state).toBe(CheckStateEnum.UNSPENT);
+			expect(state.state).toBe(CheckStateEnum.UNSPENT);
+			expect(state.witness).toBeNull();
 		});
 	});
 	test('test send tokens exact without previous split', async () => {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,10 +1,7 @@
 import nock from 'nock';
 import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
-import {
-	CheckStateEnum,
-	MeltQuoteResponse
-} from '../src/model/types/index.js';
+import { CheckStateEnum, MeltQuoteResponse } from '../src/model/types/index.js';
 import { getDecodedToken } from '../src/utils.js';
 
 const dummyKeysResp = {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -221,12 +221,21 @@ describe('checkProofsStates', () => {
 	test('test checkProofsStates - get proofs that are NOT spendable', async () => {
 		nock(mintUrl)
 			.post('/v1/checkstate')
-			.reply(200, { states: [{ Y: 'asd', state: 'UNSPENT', witness: 'witness-asd' }] });
+			.reply(200, {
+				states: [
+					{
+						Y: '02d5dd71f59d917da3f73defe997928e9459e9d67d8bdb771e4989c2b5f50b2fff',
+						state: 'UNSPENT',
+						witness: 'witness-asd'
+					}
+				]
+			});
 		const wallet = new CashuWallet(mint, { unit });
 
 		const result = await wallet.checkProofsStates(proofs);
 		result.forEach((r) => {
-			expect(r).toEqual(CheckStateEnum.UNSPENT);
+			expect(r.state).toEqual(CheckStateEnum.UNSPENT);
+			expect(r.witness).toEqual('witness-asd');
 		});
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -209,27 +209,6 @@ describe('receive', () => {
 	});
 });
 
-describe('checkProofsSpent', () => {
-	const proofs = [
-		{
-			id: '009a1f293253e41e',
-			amount: 1,
-			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
-			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
-		}
-	];
-	test('test checkProofsSpent - get proofs that are NOT spendable', async () => {
-		nock(mintUrl)
-			.post('/v1/checkstate')
-			.reply(200, { states: [{ Y: 'asd', state: 'UNSPENT', witness: 'witness-asd' }] });
-		const wallet = new CashuWallet(mint, { unit });
-
-		const result = await wallet.checkProofsSpent(proofs);
-
-		expect(result).toStrictEqual([]);
-	});
-});
-
 describe('checkProofsStates', () => {
 	const proofs = [
 		{

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,7 +1,12 @@
 import nock from 'nock';
 import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
-import { MeltQuoteResponse, MeltQuoteState, OutputAmounts } from '../src/model/types/index.js';
+import {
+	CheckStateEnum,
+	MeltQuoteResponse,
+	MeltQuoteState,
+	OutputAmounts
+} from '../src/model/types/index.js';
 import { getDecodedToken } from '../src/utils.js';
 import { Proof } from '@cashu/crypto/modules/common';
 
@@ -222,6 +227,28 @@ describe('checkProofsSpent', () => {
 		const result = await wallet.checkProofsSpent(proofs);
 
 		expect(result).toStrictEqual([]);
+	});
+});
+
+describe('checkProofsStates', () => {
+	const proofs = [
+		{
+			id: '009a1f293253e41e',
+			amount: 1,
+			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
+		}
+	];
+	test('test checkProofsStates - get proofs that are NOT spendable', async () => {
+		nock(mintUrl)
+			.post('/v1/checkstate')
+			.reply(200, { states: [{ Y: 'asd', state: 'UNSPENT', witness: 'witness-asd' }] });
+		const wallet = new CashuWallet(mint, { unit });
+
+		const result = await wallet.checkProofsStates(proofs);
+		result.forEach((r) => {
+			expect(r).toEqual(CheckStateEnum.UNSPENT);
+		});
 	});
 });
 


### PR DESCRIPTION
Add `checkProofsStates` method to `CashuWallet` to get the spent enums from the mint, should retire `checkProofsSpent` which throws most information away.

I would prefer getting rid of `checkProofsSpent` entirely. If you agree, please delete it or let me know.

Edit: we're getting rid of `checkProofsSpent`.