### PR TITLE
Support for NUT-12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.0.0-rc1",
 			"license": "MIT",
 			"dependencies": {
-				"@cashu/crypto": "^0.3.3",
+				"@cashu/crypto": "^0.3.4",
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
@@ -620,9 +620,9 @@
 			"dev": true
 		},
 		"node_modules/@cashu/crypto": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.3.tgz",
-			"integrity": "sha512-os/QS74FtrsY5rpnKMFsKlfUSW5g/QB2gcaHm1qYTwhKIND271qhGQGs69mbWE3iBa2s8mEQSmocy6O1J6vgHA==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.4.tgz",
+			"integrity": "sha512-mfv1Pj4iL1PXzUj9NKIJbmncCLMqYfnEDqh/OPxAX0nNBt6BOnVJJLjLWFlQeYxlnEfWABSNkrqPje1t5zcyhA==",
 			"dependencies": {
 				"@noble/curves": "^1.6.0",
 				"@noble/hashes": "^1.5.0",
@@ -6834,9 +6834,9 @@
 			"dev": true
 		},
 		"@cashu/crypto": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.3.tgz",
-			"integrity": "sha512-os/QS74FtrsY5rpnKMFsKlfUSW5g/QB2gcaHm1qYTwhKIND271qhGQGs69mbWE3iBa2s8mEQSmocy6O1J6vgHA==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.4.tgz",
+			"integrity": "sha512-mfv1Pj4iL1PXzUj9NKIJbmncCLMqYfnEDqh/OPxAX0nNBt6BOnVJJLjLWFlQeYxlnEfWABSNkrqPje1t5zcyhA==",
 			"requires": {
 				"@noble/curves": "^1.6.0",
 				"@noble/hashes": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0-3",
 			"license": "MIT",
 			"dependencies": {
-				"@cashu/crypto": "^0.2.7",
+				"@cashu/crypto": "^0.3.1",
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
@@ -621,15 +621,14 @@
 			"dev": true
 		},
 		"node_modules/@cashu/crypto": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.2.7.tgz",
-			"integrity": "sha512-1aaDfUjiHNXoJqg8nW+341TLWV9W28DsVNXJUKcHL0yAmwLs5+56SSnb8LLDJzPamLVoYL0U0bda91klAzptig==",
-			"license": "MIT",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.1.tgz",
+			"integrity": "sha512-lxzUQgcz3lD/z2vFHgyPV5zZ/7kGdeJQDjvC5coReDD1eRRnZv1pBLEJTApGx3g0ZK3MD4ScCsLpnGJHNNq5sQ==",
 			"dependencies": {
-				"@noble/curves": "^1.3.0",
-				"@noble/hashes": "^1.3.3",
-				"@scure/bip32": "^1.3.3",
-				"@scure/bip39": "^1.2.2",
+				"@noble/curves": "^1.6.0",
+				"@noble/hashes": "^1.5.0",
+				"@scure/bip32": "^1.5.0",
+				"@scure/bip39": "^1.4.0",
 				"buffer": "^6.0.3"
 			}
 		},
@@ -1168,22 +1167,25 @@
 			}
 		},
 		"node_modules/@noble/curves": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-			"integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+			"integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
 			"dependencies": {
-				"@noble/hashes": "1.3.3"
+				"@noble/hashes": "1.5.0"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@noble/hashes": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-			"integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+			"integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
 			"engines": {
-				"node": ">= 16"
+				"node": "^14.21.3 || >=16"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
@@ -1225,33 +1227,33 @@
 			}
 		},
 		"node_modules/@scure/base": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
-			"integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+			"integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@scure/bip32": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
-			"integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+			"integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
 			"dependencies": {
-				"@noble/curves": "~1.3.0",
-				"@noble/hashes": "~1.3.2",
-				"@scure/base": "~1.1.4"
+				"@noble/curves": "~1.6.0",
+				"@noble/hashes": "~1.5.0",
+				"@scure/base": "~1.1.7"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@scure/bip39": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
-			"integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+			"integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
 			"dependencies": {
-				"@noble/hashes": "~1.3.2",
-				"@scure/base": "~1.1.4"
+				"@noble/hashes": "~1.5.0",
+				"@scure/base": "~1.1.8"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
@@ -6833,14 +6835,14 @@
 			"dev": true
 		},
 		"@cashu/crypto": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.2.7.tgz",
-			"integrity": "sha512-1aaDfUjiHNXoJqg8nW+341TLWV9W28DsVNXJUKcHL0yAmwLs5+56SSnb8LLDJzPamLVoYL0U0bda91klAzptig==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.1.tgz",
+			"integrity": "sha512-lxzUQgcz3lD/z2vFHgyPV5zZ/7kGdeJQDjvC5coReDD1eRRnZv1pBLEJTApGx3g0ZK3MD4ScCsLpnGJHNNq5sQ==",
 			"requires": {
-				"@noble/curves": "^1.3.0",
-				"@noble/hashes": "^1.3.3",
-				"@scure/bip32": "^1.3.3",
-				"@scure/bip39": "^1.2.2",
+				"@noble/curves": "^1.6.0",
+				"@noble/hashes": "^1.5.0",
+				"@scure/bip32": "^1.5.0",
+				"@scure/bip39": "^1.4.0",
 				"buffer": "^6.0.3"
 			}
 		},
@@ -7257,17 +7259,17 @@
 			}
 		},
 		"@noble/curves": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-			"integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+			"integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
 			"requires": {
-				"@noble/hashes": "1.3.3"
+				"@noble/hashes": "1.5.0"
 			}
 		},
 		"@noble/hashes": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-			"integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+			"integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -7296,27 +7298,27 @@
 			}
 		},
 		"@scure/base": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
-			"integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ=="
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+			"integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
 		},
 		"@scure/bip32": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
-			"integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+			"integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
 			"requires": {
-				"@noble/curves": "~1.3.0",
-				"@noble/hashes": "~1.3.2",
-				"@scure/base": "~1.1.4"
+				"@noble/curves": "~1.6.0",
+				"@noble/hashes": "~1.5.0",
+				"@scure/base": "~1.1.7"
 			}
 		},
 		"@scure/bip39": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
-			"integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+			"integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
 			"requires": {
-				"@noble/hashes": "~1.3.2",
-				"@scure/base": "~1.1.4"
+				"@noble/hashes": "~1.5.0",
+				"@scure/base": "~1.1.8"
 			}
 		},
 		"@sinclair/typebox": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0-3",
 			"license": "MIT",
 			"dependencies": {
-				"@cashu/crypto": "^0.3.1",
+				"@cashu/crypto": "^0.3.3",
 				"@noble/curves": "^1.3.0",
 				"@noble/hashes": "^1.3.3",
 				"@scure/bip32": "^1.3.3",
@@ -621,9 +621,9 @@
 			"dev": true
 		},
 		"node_modules/@cashu/crypto": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.1.tgz",
-			"integrity": "sha512-lxzUQgcz3lD/z2vFHgyPV5zZ/7kGdeJQDjvC5coReDD1eRRnZv1pBLEJTApGx3g0ZK3MD4ScCsLpnGJHNNq5sQ==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.3.tgz",
+			"integrity": "sha512-os/QS74FtrsY5rpnKMFsKlfUSW5g/QB2gcaHm1qYTwhKIND271qhGQGs69mbWE3iBa2s8mEQSmocy6O1J6vgHA==",
 			"dependencies": {
 				"@noble/curves": "^1.6.0",
 				"@noble/hashes": "^1.5.0",
@@ -6835,9 +6835,9 @@
 			"dev": true
 		},
 		"@cashu/crypto": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.1.tgz",
-			"integrity": "sha512-lxzUQgcz3lD/z2vFHgyPV5zZ/7kGdeJQDjvC5coReDD1eRRnZv1pBLEJTApGx3g0ZK3MD4ScCsLpnGJHNNq5sQ==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@cashu/crypto/-/crypto-0.3.3.tgz",
+			"integrity": "sha512-os/QS74FtrsY5rpnKMFsKlfUSW5g/QB2gcaHm1qYTwhKIND271qhGQGs69mbWE3iBa2s8mEQSmocy6O1J6vgHA==",
 			"requires": {
 				"@noble/curves": "^1.6.0",
 				"@noble/hashes": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
-		"@cashu/crypto": "^0.3.1",
+		"@cashu/crypto": "^0.3.3",
 		"@noble/curves": "^1.3.0",
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
-		"@cashu/crypto": "^0.3.3",
+		"@cashu/crypto": "^0.3.4",
 		"@noble/curves": "^1.3.0",
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
-		"@cashu/crypto": "^0.2.7",
+		"@cashu/crypto": "^0.3.1",
 		"@noble/curves": "^1.3.0",
 		"@noble/hashes": "^1.3.3",
 		"@scure/bip32": "^1.3.3",

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -30,8 +30,6 @@ import {
 	getKeepAmounts,
 	hexToNumber
 } from './utils.js';
-import { validateMnemonic } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
 import { hashToCurve, pointFromHex } from '@cashu/crypto/modules/common';
 import {
 	blindMessage,

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -353,7 +353,7 @@ class CashuWallet {
 			// strip dleq if explicitly told so
 			if (!options?.includeDleq) {
 				send = send.map((p: Proof) => {
-					return {...p, dleq: undefined };
+					return { ...p, dleq: undefined };
 				});
 			}
 
@@ -407,7 +407,7 @@ class CashuWallet {
 			const { keep, send } = this.selectProofsToSend(
 				smallerProofs.slice(1),
 				remainder,
-				includeFees,
+				includeFees
 			);
 			selectedProofs.push(...send);
 			returnedProofs.push(...keep);
@@ -417,7 +417,7 @@ class CashuWallet {
 		if (sumProofs(selectedProofs) < amountToSend + selectedFeePPK && nextBigger) {
 			selectedProofs = [nextBigger];
 		}
-		
+
 		return {
 			keep: proofs.filter((p: Proof) => !selectedProofs.includes(p)),
 			send: selectedProofs
@@ -1038,7 +1038,7 @@ class CashuWallet {
 					: ({
 							s: bytesToHex(dleq.s),
 							e: bytesToHex(dleq.e),
-							r: numberToHexPadded64(dleq.r ?? BigInt(0)),
+							r: numberToHexPadded64(dleq.r ?? BigInt(0))
 					  } as SerializedDLEQ);
 			return serializedProof;
 		});

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -767,10 +767,9 @@ class CashuWallet {
 				options.privkey
 			).map((p: NUT11Proof) => serializeProof(p));
 		}
-		// Strip DLEQs if any
-		proofsToSend = proofsToSend.map((p: Proof) => {
-			return { ...p, dleq: undefined };
-		});
+
+		proofsToSend = stripDleq(proofsToSend);
+
 		const meltPayload: MeltPayload = {
 			quote: meltQuote.quote,
 			inputs: proofsToSend,
@@ -846,10 +845,7 @@ class CashuWallet {
 			).map((p: NUT11Proof) => serializeProof(p));
 		}
 
-		// Strip DLEQs if any
-		proofsToSend = proofsToSend.map((p: Proof) => {
-			return { ...p, dleq: undefined };
-		});
+		proofsToSend = stripDleq(proofsToSend);
 
 		// join keepBlindedMessages and sendBlindedMessages
 		const blindingData: BlindingData = {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -266,7 +266,7 @@ class CashuWallet {
 		const keys = await this.getKeys(options?.keysetId);
 		if (options?.requireDleq) {
 			if (token.proofs.some((p: Proof) => !hasValidDleq(p, keys))) {
-				throw new Error("Token contains proofs with invalid DLEQ")
+				throw new Error('Token contains proofs with invalid DLEQ');
 			}
 		}
 		const amount = sumProofs(token.proofs) - this.getFeesForProofs(token.proofs);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -28,7 +28,8 @@ import {
 	splitAmount,
 	sumProofs,
 	getKeepAmounts,
-	hexToNumber
+	hexToNumber,
+	numberToHexPadded64
 } from './utils.js';
 import { hashToCurve, pointFromHex } from '@cashu/crypto/modules/common';
 import {
@@ -40,7 +41,6 @@ import { deriveBlindingFactor, deriveSecret } from '@cashu/crypto/modules/client
 import { createP2PKsecret, getSignedProofs } from '@cashu/crypto/modules/client/NUT11';
 import { type Proof as NUT11Proof, DLEQ } from '@cashu/crypto/modules/common/index';
 import { verifyDLEQProof_reblind } from '@cashu/crypto/modules/client/NUT12';
-
 /**
  * The default number of proofs per denomination to keep in a wallet.
  */
@@ -1039,7 +1039,7 @@ class CashuWallet {
 					: ({
 							s: bytesToHex(dleq.s),
 							e: bytesToHex(dleq.e),
-							r: dleq.r?.toString(16)
+							r: numberToHexPadded64(dleq.r ?? BigInt(0)),
 					  } as SerializedDLEQ);
 			return serializedProof;
 		});

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -761,6 +761,11 @@ class CashuWallet {
 				options.privkey
 			).map((p: NUT11Proof) => serializeProof(p));
 		}
+		// Strip DLEQs if any
+		proofsToSend.map((p: Proof) => {
+			p.dleq = undefined;
+			return p;
+		});
 		const meltPayload: MeltPayload = {
 			quote: meltQuote.quote,
 			inputs: proofsToSend,
@@ -840,6 +845,12 @@ class CashuWallet {
 				privkey
 			).map((p: NUT11Proof) => serializeProof(p));
 		}
+
+		// Strip DLEQs if any
+		proofsToSend.map((p: Proof) => {
+			p.dleq = undefined;
+			return p;
+		});
 
 		// join keepBlindedMessages and sendBlindedMessages
 		const blindingData: BlindingData = {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1062,6 +1062,9 @@ class CashuWallet {
 				r: hexToNumber(p.dleq.r ?? '00')
 			} as DLEQ;
 			const key = keys.keys[p.amount];
+			if (key == undefined) {
+				throw new Error(`undefined key for amount ${p.amount}`);
+			}
 			if (
 				!verifyDLEQProof_reblind(
 					new TextEncoder().encode(p.secret),

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -21,7 +21,8 @@ import {
 	GetInfoResponse,
 	OutputAmounts,
 	CheckStateEntry,
-	BlindingData
+	BlindingData,
+	SerializedDLEQ
 } from './model/types/index.js';
 import { bytesToNumber, getDecodedToken, splitAmount, sumProofs, getKeepAmounts } from './utils.js';
 import { validateMnemonic } from '@scure/bip39';
@@ -1058,20 +1059,15 @@ class CashuWallet {
 					throw new Error('DLEQ verification failed');
 				}
 			}
-			return {
-				id: proof.id,
-				amount: proof.amount,
-				secret: bytesToHex(proof.secret),
-				C: proof.C.toHex(true),
-				dleq:
-					dleq == undefined
-						? undefined
-						: {
-								s: bytesToHex(dleq.s),
-								e: bytesToHex(dleq.e),
-								r: dleq.r?.toString(16)
-						}
-			} as Proof;
+			const serializedProof = serializeProof(proof) as Proof;
+			serializedProof.dleq = dleq == undefined
+				? undefined
+				: {
+						s: bytesToHex(dleq.s),
+						e: bytesToHex(dleq.e),
+						r: dleq.r?.toString(16)
+				} as SerializedDLEQ;
+			return serializedProof;
 		});
 	}
 }

--- a/src/model/BlindedSignature.ts
+++ b/src/model/BlindedSignature.ts
@@ -2,6 +2,7 @@ import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { SerializedBlindedSignature } from './types/index.js';
 import { DLEQ } from '@cashu/crypto/modules/common';
 import { bytesToHex } from '@noble/hashes/utils.js';
+import { numberToHexPadded64 } from '../utils.js';
 
 class BlindedSignature {
 	id: string;
@@ -21,14 +22,13 @@ class BlindedSignature {
 			id: this.id,
 			amount: this.amount,
 			C_: this.C_.toHex(true),
-			dleq:
-				this.dleq == undefined
-					? undefined
-					: {
-							s: bytesToHex(this.dleq.s),
-							e: bytesToHex(this.dleq.e),
-							r: this.dleq.r?.toString(16)
-					  }
+			...(this.dleq && {
+				dleq: {
+					s: bytesToHex(this.dleq.s),
+					e: bytesToHex(this.dleq.e),
+					r: numberToHexPadded64(this.dleq.r ?? BigInt(0))
+				}
+			})
 		};
 	}
 }

--- a/src/model/BlindedSignature.ts
+++ b/src/model/BlindedSignature.ts
@@ -28,7 +28,7 @@ class BlindedSignature {
 							s: bytesToHex(this.dleq.s),
 							e: bytesToHex(this.dleq.e),
 							r: this.dleq.r?.toString(16)
-					}
+					  }
 		};
 	}
 }

--- a/src/model/BlindedSignature.ts
+++ b/src/model/BlindedSignature.ts
@@ -9,7 +9,7 @@ class BlindedSignature {
 	C_: ProjPointType<bigint>;
 	dleq?: DLEQ;
 
-	constructor(id: string, amount: number, C_: ProjPointType<bigint>, dleq: DLEQ) {
+	constructor(id: string, amount: number, C_: ProjPointType<bigint>, dleq?: DLEQ) {
 		this.id = id;
 		this.amount = amount;
 		this.C_ = C_;

--- a/src/model/BlindedSignature.ts
+++ b/src/model/BlindedSignature.ts
@@ -28,7 +28,7 @@ class BlindedSignature {
 							s: bytesToHex(this.dleq.s),
 							e: bytesToHex(this.dleq.e),
 							r: this.dleq.r?.toString(16)
-					  }
+					}
 		};
 	}
 }

--- a/src/model/BlindedSignature.ts
+++ b/src/model/BlindedSignature.ts
@@ -1,19 +1,35 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { SerializedBlindedSignature } from './types/index.js';
+import { DLEQ } from '@cashu/crypto/modules/common';
+import { bytesToHex } from '@noble/hashes/utils.js';
 
 class BlindedSignature {
 	id: string;
 	amount: number;
 	C_: ProjPointType<bigint>;
+	dleq?: DLEQ;
 
-	constructor(id: string, amount: number, C_: ProjPointType<bigint>) {
+	constructor(id: string, amount: number, C_: ProjPointType<bigint>, dleq: DLEQ) {
 		this.id = id;
 		this.amount = amount;
 		this.C_ = C_;
+		this.dleq = dleq;
 	}
 
 	getSerializedBlindedSignature(): SerializedBlindedSignature {
-		return { id: this.id, amount: this.amount, C_: this.C_.toHex(true) };
+		return {
+			id: this.id,
+			amount: this.amount,
+			C_: this.C_.toHex(true),
+			dleq:
+				this.dleq == undefined
+					? undefined
+					: {
+							s: bytesToHex(this.dleq.s),
+							e: bytesToHex(this.dleq.e),
+							r: this.dleq.r?.toString(16)
+					  }
+		};
 	}
 }
 

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -178,6 +178,16 @@ export type PostRestoreResponse = {
 	promises: Array<SerializedBlindedSignature>;
 };
 
+/*
+ * Zero-Knowledge that BlindedSignature
+ * was generated using a specific public key
+ */
+export type SerializedDLEQ = {
+	s: string;
+	e: string;
+	r?: string;
+};
+
 /**
  * Blinded signature as it is received from the mint
  */
@@ -194,6 +204,10 @@ export type SerializedBlindedSignature = {
 	 * Blinded signature
 	 */
 	C_: string;
+	/**
+	 * DLEQ Proof
+	 */
+	dleq?: SerializedDLEQ;
 };
 
 /**

--- a/src/model/types/wallet/index.ts
+++ b/src/model/types/wallet/index.ts
@@ -29,6 +29,10 @@ export type Proof = {
 	 * DLEQ proof
 	 */
 	dleq?: SerializedDLEQ;
+	/**
+	 * Is the associated DLEQ proof valid?
+	 */
+	dleqValid?: boolean;
 };
 
 /**

--- a/src/model/types/wallet/index.ts
+++ b/src/model/types/wallet/index.ts
@@ -1,3 +1,5 @@
+import { SerializedDLEQ } from '../mint';
+
 export * from './payloads';
 export * from './responses';
 export * from './tokens';
@@ -23,6 +25,10 @@ export type Proof = {
 	 * The unblinded signature for this secret, signed by the mints private key.
 	 */
 	C: string;
+	/**
+	 * DLEQ proof
+	 */
+	dleq?: SerializedDLEQ;
 };
 
 /**

--- a/src/model/types/wallet/tokens.ts
+++ b/src/model/types/wallet/tokens.ts
@@ -22,6 +22,21 @@ export type Token = {
 	unit?: string;
 };
 
+export type V4DLEQTemplate = {
+	/**
+	 * challenge
+	 */
+	e: Uint8Array;
+	/**
+	 * response
+	 */
+	s: Uint8Array;
+	/**
+	 * blinding factor
+	 */
+	r: Uint8Array;
+}
+
 /**
  * Template for a Proof inside a V4 Token
  */
@@ -38,6 +53,10 @@ export type V4ProofTemplate = {
 	 * Signature
 	 */
 	c: Uint8Array;
+	/**
+	 * DLEQ
+	 */
+	d?: V4DLEQTemplate;
 };
 
 /**

--- a/src/model/types/wallet/tokens.ts
+++ b/src/model/types/wallet/tokens.ts
@@ -35,7 +35,7 @@ export type V4DLEQTemplate = {
 	 * blinding factor
 	 */
 	r: Uint8Array;
-}
+};
 
 /**
  * Template for a Proof inside a V4 Token

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,13 +183,11 @@ export function getEncodedToken(token: Token): string {
  * @param token to encode
  * @returns encoded token
  */
-export function getEncodedTokenV4(
-	token: Token,
-): string {
+export function getEncodedTokenV4(token: Token): string {
 	// Make sure each DLEQ has its blinding factor
-	token.proofs.forEach(p => {
+	token.proofs.forEach((p) => {
 		if (p.dleq && p.dleq.r == undefined) {
-			throw new Error("Missing blinding factor in included DLEQ proof");
+			throw new Error('Missing blinding factor in included DLEQ proof');
 		}
 	});
 	const idMap: { [id: string]: Array<Proof> } = {};
@@ -213,13 +211,14 @@ export function getEncodedTokenV4(
 						a: p.amount,
 						s: p.secret,
 						c: hexToBytes(p.C),
-						d: p.dleq == undefined
-							? undefined
-							: {
-								e: hexToBytes(p.dleq.e),
-								s: hexToBytes(p.dleq.s),
-								r: hexToBytes(p.dleq.r ?? "00"),
-							} as V4DLEQTemplate
+						d:
+							p.dleq == undefined
+								? undefined
+								: ({
+										e: hexToBytes(p.dleq.e),
+										s: hexToBytes(p.dleq.s),
+										r: hexToBytes(p.dleq.r ?? '00')
+								  } as V4DLEQTemplate)
 					})
 				)
 			})
@@ -288,13 +287,14 @@ export function handleTokens(token: string): Token {
 					C: bytesToHex(p.c),
 					amount: p.a,
 					id: bytesToHex(t.i),
-					dleq: p.d == undefined
-						? undefined
-						: {
-							e: bytesToHex(p.d.e),
-							s: bytesToHex(p.d.s),
-							r: bytesToHex(p.d.r)
-						} as SerializedDLEQ,
+					dleq:
+						p.d == undefined
+							? undefined
+							: ({
+									e: bytesToHex(p.d.e),
+									s: bytesToHex(p.d.s),
+									r: bytesToHex(p.d.r)
+							  } as SerializedDLEQ)
 				});
 			})
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -400,6 +400,19 @@ export function decodePaymentRequest(paymentRequest: string) {
 }
 
 /**
+ * Removes all traces of DLEQs from a list of proofs
+ * @param proofs The list of proofs that dleq should be stripped from
+ */
+export function stripDleq(proofs: Array<Proof>): Array<Omit<Proof, 'dleq' | 'dleqValid'>> {
+	return proofs.map((p) => {
+		const newP = { ...p };
+		delete newP['dleq'];
+		delete newP['dleqValid'];
+		return newP;
+	});
+}
+
+/**
  * Checks that the proof has a valid DLEQ proof according to
  * keyset `keys`
  * @param proof The proof subject to verification

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,8 +153,8 @@ export function hexToNumber(hex: string): bigint {
 }
 
 /**
- * 
- * @param number (bigint) to conver to hex 
+ * Converts a number to a hex string of 64 characters.
+ * @param number (bigint) to conver to hex
  * @returns hex string start-padded to 64 characters
  */
 export function numberToHexPadded64(number: bigint): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
 	DeprecatedToken,
 	Keys,
 	Proof,
+	SerializedDLEQ,
 	Token,
 	TokenV4Template,
 	V4DLEQTemplate,
@@ -286,7 +287,14 @@ export function handleTokens(token: string): Token {
 					secret: p.s,
 					C: bytesToHex(p.c),
 					amount: p.a,
-					id: bytesToHex(t.i)
+					id: bytesToHex(t.i),
+					dleq: p.d == undefined
+						? undefined
+						: {
+							e: bytesToHex(p.d.e),
+							s: bytesToHex(p.d.s),
+							r: bytesToHex(p.d.r)
+						} as SerializedDLEQ,
 				});
 			})
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,6 +152,15 @@ export function hexToNumber(hex: string): bigint {
 	return BigInt(`0x${hex}`);
 }
 
+/**
+ * 
+ * @param number (bigint) to conver to hex 
+ * @returns hex string start-padded to 64 characters
+ */
+export function numberToHexPadded64(number: bigint): string {
+	return number.toString(16).padStart(64, '0');
+}
+
 function isValidHex(str: string) {
 	return /^[a-f0-9]*$/i.test(str);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,7 +255,7 @@ export function getEncodedTokenV4(token: Token): string {
 								s: hexToBytes(p.dleq.s),
 								r: hexToBytes(p.dleq.r ?? '00')
 							} as V4DLEQTemplate
-						}),
+						})
 					})
 				)
 			})
@@ -328,7 +328,7 @@ export function handleTokens(token: string): Token {
 						dleq: {
 							r: bytesToHex(p.d.r),
 							s: bytesToHex(p.d.s),
-							e: bytesToHex(p.d.e),
+							e: bytesToHex(p.d.e)
 						} as SerializedDLEQ
 					})
 				});
@@ -405,7 +405,7 @@ export function decodePaymentRequest(paymentRequest: string) {
  * @param proof The proof subject to verification
  * @param keyset The Mint's keyset to be used for verification
  * @returns true if verification succeeded, false otherwise
- * @throws Error if @param proof does not match any key in @param keyset 
+ * @throws Error if @param proof does not match any key in @param keyset
  */
 export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean {
 	if (proof.dleq == undefined) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -416,10 +416,10 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean {
 		s: hexToBytes(proof.dleq.s),
 		r: hexToNumber(proof.dleq.r ?? '00')
 	} as DLEQ;
-	const key = keyset.keys[proof.amount];
-	if (key == undefined) {
+	if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
 		throw new Error(`undefined key for amount ${proof.amount}`);
 	}
+	const key = keyset.keys[proof.amount];
 	if (
 		!verifyDLEQProof_reblind(
 			new TextEncoder().encode(proof.secret),

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -321,4 +321,23 @@ describe('dleq', () => {
 			expect(p.dleq?.r).toBeDefined();
 		});
 	});
+	test('send not enough proofs when dleq is required', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+		const NUT12 = (await mint.getInfo()).nuts['12'];
+		if (NUT12 == undefined || !NUT12.supported) {
+			throw new Error("Cannot run this test: mint does not support NUT12");
+		}
+
+		const mintRequest = await wallet.createMintQuote(8);
+		let { proofs } = await wallet.mintProofs(8, mintRequest.quote);
+
+		// strip dleq 
+		proofs = proofs.map(p => {
+			return { ...p, dleq: undefined };
+		});
+
+		const exc = await wallet.send(4, proofs, { includeDleq: true }).catch(e => e);
+		expect(exc).toEqual(new Error("Not enough funds available to send"));
+	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -259,14 +259,14 @@ describe('dleq', () => {
 		const mint = new CashuMint(mintUrl);
 		const NUT12 = (await mint.getInfo()).nuts['12'];
 		if (NUT12 == undefined || !NUT12.supported) {
-			throw new Error("Cannot run this test: mint does not support NUT12");
+			throw new Error('Cannot run this test: mint does not support NUT12');
 		}
 		const wallet = new CashuWallet(mint);
 
 		const mintRequest = await wallet.createMintQuote(3000);
 		const { proofs } = await wallet.mintProofs(3000, mintRequest.quote);
 
-		proofs.forEach(p => {
+		proofs.forEach((p) => {
 			expect(p).toHaveProperty('dleq');
 			expect(p.dleq).toHaveProperty('s');
 			expect(p.dleq).toHaveProperty('e');
@@ -279,7 +279,7 @@ describe('dleq', () => {
 		const wallet = new CashuWallet(mint);
 		const NUT12 = (await mint.getInfo()).nuts['12'];
 		if (NUT12 == undefined || !NUT12.supported) {
-			throw new Error("Cannot run this test: mint does not support NUT12");
+			throw new Error('Cannot run this test: mint does not support NUT12');
 		}
 
 		const mintRequest = await wallet.createMintQuote(8);
@@ -287,36 +287,36 @@ describe('dleq', () => {
 
 		const { keep, send } = await wallet.send(4, proofs, { includeDleq: true });
 
-		send.forEach(p => {
+		send.forEach((p) => {
 			expect(p.dleq).toBeDefined();
 			expect(p.dleq?.r).toBeDefined();
 		});
-		
+
 		const token = {
 			mint: mint.mintUrl,
 			proofs: send
 		} as Token;
 		const encodedToken = getEncodedTokenV4(token);
-		const newProofs = await wallet.receive(encodedToken, { requireDleq: true })
+		const newProofs = await wallet.receive(encodedToken, { requireDleq: true });
 		console.log(getEncodedTokenV4(token));
 		expect(newProofs).toBeDefined();
- 	});
-	test('send strip dleq', async() => {
+	});
+	test('send strip dleq', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
 		const NUT12 = (await mint.getInfo()).nuts['12'];
 		if (NUT12 == undefined || !NUT12.supported) {
-			throw new Error("Cannot run this test: mint does not support NUT12");
+			throw new Error('Cannot run this test: mint does not support NUT12');
 		}
 
 		const mintRequest = await wallet.createMintQuote(8);
 		const { proofs } = await wallet.mintProofs(8, mintRequest.quote);
 
 		const { keep, send } = await wallet.send(4, proofs, { includeDleq: false });
-		send.forEach(p => {
+		send.forEach((p) => {
 			expect(p.dleq).toBeUndefined();
 		});
-		keep.forEach(p => {
+		keep.forEach((p) => {
 			expect(p.dleq).toBeDefined();
 			expect(p.dleq?.r).toBeDefined();
 		});
@@ -326,18 +326,18 @@ describe('dleq', () => {
 		const wallet = new CashuWallet(mint);
 		const NUT12 = (await mint.getInfo()).nuts['12'];
 		if (NUT12 == undefined || !NUT12.supported) {
-			throw new Error("Cannot run this test: mint does not support NUT12");
+			throw new Error('Cannot run this test: mint does not support NUT12');
 		}
 
 		const mintRequest = await wallet.createMintQuote(8);
 		let { proofs } = await wallet.mintProofs(8, mintRequest.quote);
 
-		// strip dleq 
-		proofs = proofs.map(p => {
+		// strip dleq
+		proofs = proofs.map((p) => {
 			return { ...p, dleq: undefined };
 		});
 
-		const exc = await wallet.send(4, proofs, { includeDleq: true }).catch(e => e);
-		expect(exc).toEqual(new Error("Not enough funds available to send"));
+		const exc = await wallet.send(4, proofs, { includeDleq: true }).catch((e) => e);
+		expect(exc).toEqual(new Error('Not enough funds available to send'));
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -281,7 +281,11 @@ describe('mint api', () => {
 
 		const { keep, send } = await wallet.send(1500, proofs, { includeDleq: true });
 
-		send.forEach(p => {expect(p.dleq).toBeDefined(); expect(p.dleq?.r).toBeDefined()});
+		send.forEach(p => {
+			expect(p.dleq).toBeDefined();
+			expect(p.dleq?.r).toBeDefined();
+		});
+		
 		const token = {
 			mint: mint.mintUrl,
 			proofs: send

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -374,6 +374,6 @@ describe('dleq', () => {
 
 		const key = keys.keysets.filter((k) => k.id === proofs[0].id)[0].keys[proofs[0].amount];
 		const exc = await wallet.receive(token, { requireDleq: true }).catch((e) => e);
-		expect(exc).toEqual(new Error(`0-th DLEQ proof is invalid for key ${key}`));
+		expect(exc).toEqual(new Error("Token contains proofs with invalid DLEQ"));
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -373,6 +373,6 @@ describe('dleq', () => {
 		} as Token;
 
 		const exc = await wallet.receive(token, { requireDleq: true }).catch((e) => e);
-		expect(exc).toEqual(new Error("Token contains proofs with invalid DLEQ"));
+		expect(exc).toEqual(new Error('Token contains proofs with invalid DLEQ'));
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -372,7 +372,6 @@ describe('dleq', () => {
 			proofs: proofs
 		} as Token;
 
-		const key = keys.keysets.filter((k) => k.id === proofs[0].id)[0].keys[proofs[0].amount];
 		const exc = await wallet.receive(token, { requireDleq: true }).catch((e) => e);
 		expect(exc).toEqual(new Error("Token contains proofs with invalid DLEQ"));
 	});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -212,8 +212,7 @@ describe('test decode token', () => {
 					secret: '9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e',
 					C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
 					id: '00ad268c4d1f5826',
-					amount: 1,
-					dleq: undefined
+					amount: 1
 				}
 			]
 		};
@@ -233,22 +232,19 @@ describe('test decode token', () => {
 					secret: 'acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388',
 					C: '0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf',
 					id: '00ffd48b8f5ecf80',
-					amount: 1,
-					dleq: undefined
+					amount: 1
 				},
 				{
 					secret: '1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee',
 					C: '023456aa110d84b4ac747aebd82c3b005aca50bf457ebd5737a4414fac3ae7d94d',
 					id: '00ad268c4d1f5826',
-					amount: 2,
-					dleq: undefined
+					amount: 2
 				},
 				{
 					secret: '56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57',
 					C: '0273129c5719e599379a974a626363c333c56cafc0e6d01abe46d5808280789c63',
 					id: '00ad268c4d1f5826',
-					amount: 1,
-					dleq: undefined
+					amount: 1
 				}
 			]
 		};
@@ -281,8 +277,7 @@ describe('test v4 encoding', () => {
 					secret: '9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e',
 					C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
 					id: '00ad268c4d1f5826',
-					amount: 1,
-					dleq: undefined
+					amount: 1
 				}
 			],
 			unit: 'sat'

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,8 @@
-import { blindMessage, constructProofFromPromise, serializeProof } from '@cashu/crypto/modules/client';
+import {
+	blindMessage,
+	constructProofFromPromise,
+	serializeProof
+} from '@cashu/crypto/modules/client';
 import { Keys, Proof } from '../src/model/types/index.js';
 import * as utils from '../src/utils.js';
 import { PUBKEYS } from './consts.js';
@@ -370,11 +374,11 @@ describe('test zero-knowledge utilities', () => {
 		// make up blinding factor
 		const r = hexToNumber('123456'.padStart(64, '0'));
 		// blind secret
-		const fakeBlindedMessage = blindMessage(fakeSecret, r)
+		const fakeBlindedMessage = blindMessage(fakeSecret, r);
 		// construct DLEQ
 		const fakeDleq = createDLEQProof(fakeBlindedMessage.B_, privkey);
 		// blind signature
-		const fakeBlindSignature = createBlindSignature(fakeBlindedMessage.B_, privkey, 1, '00')
+		const fakeBlindSignature = createBlindSignature(fakeBlindedMessage.B_, privkey, 1, '00');
 		// unblind
 		const proof = constructProofFromPromise(fakeBlindSignature, r, fakeSecret, pubkey);
 		// serialize
@@ -383,16 +387,16 @@ describe('test zero-knowledge utilities', () => {
 			dleq: {
 				r: numberToHexPadded64(r),
 				e: bytesToHex(fakeDleq.e),
-				s: bytesToHex(fakeDleq.s),
+				s: bytesToHex(fakeDleq.s)
 			}
 		} as Proof;
 		// use hasValidDleq to verify DLEQ
 		const keyset = {
 			id: '00',
 			unit: 'sat',
-			keys: {[1]: pubkey.toHex(true)},
+			keys: { [1]: pubkey.toHex(true) }
 		};
 		const validDleq = hasValidDleq(serializedProof, keyset);
 		expect(validDleq).toBe(true);
-	})
+	});
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -175,7 +175,8 @@ describe('test decode token', () => {
 					secret: '9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e',
 					C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
 					id: '00ad268c4d1f5826',
-					amount: 1
+					amount: 1,
+					dleq: undefined,
 				}
 			]
 		};
@@ -195,19 +196,22 @@ describe('test decode token', () => {
 					secret: 'acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388',
 					C: '0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf',
 					id: '00ffd48b8f5ecf80',
-					amount: 1
+					amount: 1,
+					dleq: undefined,
 				},
 				{
 					secret: '1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee',
 					C: '023456aa110d84b4ac747aebd82c3b005aca50bf457ebd5737a4414fac3ae7d94d',
 					id: '00ad268c4d1f5826',
-					amount: 2
+					amount: 2,
+					dleq: undefined,
 				},
 				{
 					secret: '56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57',
 					C: '0273129c5719e599379a974a626363c333c56cafc0e6d01abe46d5808280789c63',
 					id: '00ad268c4d1f5826',
-					amount: 1
+					amount: 1,
+					dleq: undefined,
 				}
 			]
 		};
@@ -240,7 +244,8 @@ describe('test v4 encoding', () => {
 					secret: '9a6dbb847bd232ba76db0df197216b29d3b8cc14553cd27827fc1cc942fedb4e',
 					C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
 					id: '00ad268c4d1f5826',
-					amount: 1
+					amount: 1,
+					dleq: undefined,
 				}
 			],
 			unit: 'sat'

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -176,7 +176,7 @@ describe('test decode token', () => {
 					C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
 					id: '00ad268c4d1f5826',
 					amount: 1,
-					dleq: undefined,
+					dleq: undefined
 				}
 			]
 		};
@@ -197,21 +197,21 @@ describe('test decode token', () => {
 					C: '0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf',
 					id: '00ffd48b8f5ecf80',
 					amount: 1,
-					dleq: undefined,
+					dleq: undefined
 				},
 				{
 					secret: '1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee',
 					C: '023456aa110d84b4ac747aebd82c3b005aca50bf457ebd5737a4414fac3ae7d94d',
 					id: '00ad268c4d1f5826',
 					amount: 2,
-					dleq: undefined,
+					dleq: undefined
 				},
 				{
 					secret: '56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57',
 					C: '0273129c5719e599379a974a626363c333c56cafc0e6d01abe46d5808280789c63',
 					id: '00ad268c4d1f5826',
 					amount: 1,
-					dleq: undefined,
+					dleq: undefined
 				}
 			]
 		};
@@ -245,7 +245,7 @@ describe('test v4 encoding', () => {
 					C: '038618543ffb6b8695df4ad4babcde92a34a96bdcd97dcee0d7ccf98d472126792',
 					id: '00ad268c4d1f5826',
 					amount: 1,
-					dleq: undefined,
+					dleq: undefined
 				}
 			],
 			unit: 'sat'

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -199,13 +199,6 @@ describe('receive', () => {
 		const result = await wallet.receive(tokenInput).catch((e) => e);
 		expect(result).toEqual(new Error('could not verify proofs.'));
 	});
-
-	/*
-	test('test receive with dleq', async() => {
-		nock(mintUrl).post('/v1/swap').reply(200, {});
-		const wallet = new CashuWallet(mint, { unit });
-	})
-	*/
 });
 
 describe('checkProofsStates', () => {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -199,6 +199,13 @@ describe('receive', () => {
 		const result = await wallet.receive(tokenInput).catch((e) => e);
 		expect(result).toEqual(new Error('could not verify proofs.'));
 	});
+
+	/*
+	test('test receive with dleq', async() => {
+		nock(mintUrl).post('/v1/swap').reply(200, {});
+		const wallet = new CashuWallet(mint, { unit });
+	})
+	*/
 });
 
 describe('checkProofsStates', () => {


### PR DESCRIPTION
# Fixes: #156 

## Changes

- added optional `dleq` and `dleqValid` fields to `Proof`. `dleq` holds a `SerializedDLEQ` proof, while `dleqValid`, if present, signals whether it has been correctly verified.
- `CashuWallet.meltProofs` and `CashuWallet.createSwapPayload` strip the `dleq` field off of each `Proof`, if there is any. (No privacy leak).
- `CashuWallet.construct_proofs` now unpacks and verifies DLEQ proofs returned by the Mint, if any. It will create `Proof` with:
   * `dleqValid == true` if the DLEQ is present and verified
   * `dleqValid == undefined` if DLEQ not present
   * `dleqValid == false` if DLEQ present and verification failed. 
- added boolean option `includeDleq` to `CashuWallet.send`:
   * if `includeDleq == true`, makes sure the selected `send` proofs each have a defined `dleq` field;
   * if `includeDleq == false`, strip off the `dleq` field from `send`;
   * if `includeDleq == undefined`, do not intervene.
- added boolean option `requireDleq` to `CashuWallet.receive`:
   * if `requireDleq == true`, verifies each proof's dleq for correctness.
   * if `requireDleq == false || requireDleq == undefined`, does not verify dleq.
- added private helper function `CashuWallet.requireDLEQ`. Separates the logic for requiring valid dleqs from a token from the function `receive`.
- added `numberToHexPadded64` to the utilities. This function takes in a `bigint` and returns an a hex string prefixed to 64 characters with '0'.
- tests 

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
