### PR TITLE
NUT-17: WebSocket updates

### DIFF
--- a/.github/workflows/nutshell-integration.yml
+++ b/.github/workflows/nutshell-integration.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Pull and start mint
         run: |
-          docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_INPUT_FEE_PPK=100 -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.16.0 poetry run mint
+          docker run -d -p 3338:3338 --name nutshell -e MINT_LIGHTNING_BACKEND=FakeWallet -e MINT_INPUT_FEE_PPK=100 -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.16.2 poetry run mint
 
       - name: Check running containers
         run: docker ps

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 			"devDependencies": {
 				"@types/jest": "^29.5.1",
 				"@types/node-fetch": "^2.6.4",
+				"@types/ws": "^8.5.10",
 				"@typescript-eslint/eslint-plugin": "^5.59.2",
 				"@typescript-eslint/parser": "^5.59.2",
 				"eslint": "^8.39.0",
@@ -26,6 +27,7 @@
 				"eslint-plugin-n": "^15.7.0",
 				"eslint-plugin-promise": "^6.1.1",
 				"jest": "^29.5.0",
+				"mock-socket": "^9.3.1",
 				"nock": "^13.3.3",
 				"node-fetch": "^2.7.0",
 				"prettier": "^2.8.8",
@@ -1428,6 +1430,15 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
 			"dev": true
+		},
+		"node_modules/@types/ws": {
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+			"integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.17",
@@ -4967,6 +4978,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/mock-socket": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+			"integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7512,6 +7532,15 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
 			"dev": true
 		},
+		"@types/ws": {
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+			"integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/yargs": {
 			"version": "17.0.17",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
@@ -10042,6 +10071,12 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
 			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"dev": true
+		},
+		"mock-socket": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+			"integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
 			"dev": true
 		},
 		"ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
 				"ts-jest-resolver": "^2.0.1",
 				"ts-node": "^10.9.1",
 				"typedoc": "^0.24.7",
-				"typescript": "^5.0.4"
+				"typescript": "^5.0.4",
+				"ws": "^8.16.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -6327,6 +6328,27 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/ws": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10965,6 +10987,13 @@
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.7"
 			}
+		},
+		"ws": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	"devDependencies": {
 		"@types/jest": "^29.5.1",
 		"@types/node-fetch": "^2.6.4",
+		"@types/ws": "^8.5.10",
 		"@typescript-eslint/eslint-plugin": "^5.59.2",
 		"@typescript-eslint/parser": "^5.59.2",
 		"eslint": "^8.39.0",
@@ -37,6 +38,7 @@
 		"eslint-plugin-n": "^15.7.0",
 		"eslint-plugin-promise": "^6.1.1",
 		"jest": "^29.5.0",
+		"mock-socket": "^9.3.1",
 		"nock": "^13.3.3",
 		"node-fetch": "^2.7.0",
 		"prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 		"ts-jest-resolver": "^2.0.1",
 		"ts-node": "^10.9.1",
 		"typedoc": "^0.24.7",
-		"typescript": "^5.0.4"
+		"typescript": "^5.0.4",
+		"ws": "^8.16.0"
 	},
 	"dependencies": {
 		"@cashu/crypto": "^0.2.7",

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -1,4 +1,4 @@
-import { WSConnection } from './WSConnection.js';
+import { ConnectionManager, WSConnection } from './WSConnection.js';
 import type {
 	CheckStatePayload,
 	CheckStateResponse,
@@ -457,7 +457,7 @@ class CashuMint {
 					mintUrl.pathname += '/' + wsSegment;
 				}
 			}
-			this.ws = new WSConnection(
+			this.ws = ConnectionManager.getInstance().getConnection(
 				`${mintUrl.protocol === 'https:' ? 'wss' : 'ws'}://${mintUrl.host}${mintUrl.pathname}`
 			);
 			try {

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -449,8 +449,16 @@ class CashuMint {
 			await this.ws.ensureConnection();
 		} else {
 			const mintUrl = new URL(this._mintUrl);
+			const wsSegment = 'v1/ws';
+			if (mintUrl.pathname) {
+				if (mintUrl.pathname.endsWith('/')) {
+					mintUrl.pathname += wsSegment;
+				} else {
+					mintUrl.pathname += '/' + wsSegment;
+				}
+			}
 			this.ws = new WSConnection(
-				`${mintUrl.protocol === 'https:' ? 'wss' : 'ws'}://${mintUrl.host}/v1/ws`
+				`${mintUrl.protocol === 'https:' ? 'wss' : 'ws'}://${mintUrl.host}${mintUrl.pathname}`
 			);
 			try {
 				await this.ws.connect();

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -452,10 +452,18 @@ class CashuMint {
 			try {
 				await this.ws.connect();
 			} catch (e) {
+				console.log(e);
 				throw new Error('Failed to connect to WebSocket...');
 			}
 		}
 	}
+
+	disconnectWebSocket() {
+		if (this.ws) {
+			this.ws.close();
+		}
+	}
+
 	get webSocketConnection() {
 		return this.ws;
 	}

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -450,7 +450,7 @@ class CashuMint {
 		} else {
 			const mintUrl = new URL(this._mintUrl);
 			this.ws = new WSConnection(
-				`${mintUrl.protocol === 'https' ? 'wss' : 'ws'}://${mintUrl.host}/v1/ws`
+				`${mintUrl.protocol === 'https:' ? 'wss' : 'ws'}://${mintUrl.host}/v1/ws`
 			);
 			try {
 				await this.ws.connect();

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -1,3 +1,4 @@
+import { WSConnection } from './WSConnection.js';
 import type {
 	CheckStatePayload,
 	CheckStateResponse,
@@ -33,6 +34,7 @@ import { handleMintInfoContactFieldDeprecated } from './legacy/nut-06.js';
  * Class represents Cashu Mint API. This class contains Lower level functions that are implemented by CashuWallet.
  */
 class CashuMint {
+	private ws?: WSConnection;
 	/**
 	 * @param _mintUrl requires mint URL to create this object
 	 * @param _customRequest if passed, use custom request implementation for network communication with the mint
@@ -437,6 +439,21 @@ class CashuMint {
 		outputs: Array<SerializedBlindedMessage>;
 	}): Promise<PostRestoreResponse> {
 		return CashuMint.restore(this._mintUrl, restorePayload, this._customRequest);
+	}
+
+	async connectWebSocket() {
+		if (this.ws) {
+			await this.ws.ensureConnection();
+		} else {
+			const mintUrl = new URL(this._mintUrl);
+			this.ws = new WSConnection(
+				`${mintUrl.protocol === 'https' ? 'wss' : 'ws'}://${mintUrl.host}/v1/ws`
+			);
+			await this.ws.connect();
+		}
+	}
+	get webSocketConnection() {
+		return this.ws;
 	}
 }
 

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -441,6 +441,9 @@ class CashuMint {
 		return CashuMint.restore(this._mintUrl, restorePayload, this._customRequest);
 	}
 
+	/**
+	 * Tries to establish a websocket connection with the websocket mint url according to NUT-17
+	 */
 	async connectWebSocket() {
 		if (this.ws) {
 			await this.ws.ensureConnection();
@@ -458,6 +461,9 @@ class CashuMint {
 		}
 	}
 
+	/**
+	 * Closes a websocket connection
+	 */
 	disconnectWebSocket() {
 		if (this.ws) {
 			this.ws.close();

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -449,7 +449,11 @@ class CashuMint {
 			this.ws = new WSConnection(
 				`${mintUrl.protocol === 'https' ? 'wss' : 'ws'}://${mintUrl.host}/v1/ws`
 			);
-			await this.ws.connect();
+			try {
+				await this.ws.connect();
+			} catch (e) {
+				throw new Error('Failed to connect to WebSocket...');
+			}
 		}
 	}
 	get webSocketConnection() {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -863,6 +863,21 @@ class CashuWallet {
 		return states;
 	}
 
+	async waitOnQuotePaid(quoteId: string, callback: (payload: any) => any) {
+		await this.mint.connectWebSocket();
+		if (!this.mint.webSocketConnection) {
+			throw new Error('failed to establish WebSocket connection.');
+		}
+		this.mint.webSocketConnection.createSubscription(
+			{ kind: 'bolt11_mint_quote', filters: [quoteId] },
+			callback,
+			(e) => {
+				throw new Error(e.message);
+			}
+		);
+		//TODO: Return unsub function
+	}
+
 	/**
 	 * Creates blinded messages for a given amount
 	 * @param amount amount to create blinded messages for

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -19,9 +19,7 @@ import {
 	GetInfoResponse,
 	OutputAmounts,
 	ProofState,
-	BlindingData
-	MeltQuoteState,
-	CheckStateEntry,
+	BlindingData,
 	MintQuoteResponse
 } from './model/types/index.js';
 import { bytesToNumber, getDecodedToken, splitAmount, sumProofs, getKeepAmounts } from './utils.js';

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -863,7 +863,7 @@ class CashuWallet {
 		return states;
 	}
 
-	async onQuotePaid(
+	async onMintQuotePaid(
 		quoteId: string,
 		callback: (payload: any) => any,
 		errorCallback: (e: Error) => void

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -905,22 +905,15 @@ class CashuWallet {
 		callback: (payload: MeltQuoteResponse) => void,
 		errorCallback: (e: Error) => void
 	): Promise<SubscriptionCanceller> {
-		await this.mint.connectWebSocket();
-		if (!this.mint.webSocketConnection) {
-			throw new Error('failed to establish WebSocket connection.');
-		}
-		const subId = this.mint.webSocketConnection.createSubscription(
-			{ kind: 'bolt11_melt_quote', filters: [quoteId] },
-			(p: MeltQuoteResponse) => {
+		return this.onMeltQuoteUpdates(
+			[quoteId],
+			(p) => {
 				if (p.state === MeltQuoteState.PAID) {
 					callback(p);
 				}
 			},
 			errorCallback
 		);
-		return () => {
-			this.mint.webSocketConnection?.cancelSubscription(subId, callback);
-		};
 	}
 
 	/**
@@ -935,22 +928,15 @@ class CashuWallet {
 		callback: (payload: MintQuoteResponse) => void,
 		errorCallback: (e: Error) => void
 	): Promise<SubscriptionCanceller> {
-		await this.mint.connectWebSocket();
-		if (!this.mint.webSocketConnection) {
-			throw new Error('failed to establish WebSocket connection.');
-		}
-		const subId = this.mint.webSocketConnection.createSubscription(
-			{ kind: 'bolt11_mint_quote', filters: [quoteId] },
-			(p: MintQuoteResponse) => {
+		return this.onMintQuoteUpdates(
+			[quoteId],
+			(p) => {
 				if (p.state === MintQuoteState.PAID) {
 					callback(p);
 				}
 			},
 			errorCallback
 		);
-		return () => {
-			this.mint.webSocketConnection?.cancelSubscription(subId, callback);
-		};
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -871,7 +871,6 @@ class CashuWallet {
 		try {
 			await this.mint.connectWebSocket();
 		} catch (e) {
-			console.log('caught in quote paid');
 			if (e instanceof Error) {
 				return errorCallback(e);
 			} else if (e) {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -865,7 +865,7 @@ class CashuWallet {
 
 	async onMintQuotePaid(
 		quoteId: string,
-		callback: (payload: any) => any,
+		callback: (payload: MintQuoteResponse) => any,
 		errorCallback: (e: Error) => void
 	) {
 		try {
@@ -880,8 +880,8 @@ class CashuWallet {
 		if (!this.mint.webSocketConnection) {
 			throw new Error('failed to establish WebSocket connection.');
 		}
-		const subCallback = (payload: any) => {
-			if (payload.paid) {
+		const subCallback = (payload: MintQuoteResponse) => {
+			if (payload.state === 'PAID') {
 				callback(payload);
 			}
 		};

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -863,14 +863,16 @@ class CashuWallet {
 		return states;
 	}
 
-	async waitOnQuotePaid(quoteId: string, callback: (payload: any) => any) {
+	async onQuotePaid(quoteId: string, callback: (payload: any) => any) {
 		await this.mint.connectWebSocket();
 		if (!this.mint.webSocketConnection) {
 			throw new Error('failed to establish WebSocket connection.');
 		}
 		const subId = this.mint.webSocketConnection.createSubscription(
 			{ kind: 'bolt11_mint_quote', filters: [quoteId] },
-			callback,
+			(payload) => {
+				console.log(payload);
+			},
 			(e) => {
 				throw new Error(e.message);
 			}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -867,6 +867,13 @@ class CashuWallet {
 		return states;
 	}
 
+	/**
+	 * Register a callback to be called whenever a mint quote's state changes
+	 * @param quoteIds List of mint quote IDs that should be subscribed to
+	 * @param callback Callback function that will be called whenever a mint quote state changes
+	 * @param errorCallback
+	 * @returns
+	 */
 	async onMintQuoteUpdates(
 		quoteIds: Array<string>,
 		callback: (payload: MintQuoteResponse) => void,
@@ -886,6 +893,13 @@ class CashuWallet {
 		};
 	}
 
+	/**
+	 * Register a callback to be called whenever a melt quote's state changes
+	 * @param quoteIds List of melt quote IDs that should be subscribed to
+	 * @param callback Callback function that will be called whenever a melt quote state changes
+	 * @param errorCallback
+	 * @returns
+	 */
 	async onMeltQuotePaid(
 		quoteId: string,
 		callback: (payload: MeltQuoteResponse) => void,
@@ -909,6 +923,13 @@ class CashuWallet {
 		};
 	}
 
+	/**
+	 * Register a callback to be called when a single mint quote gets paid
+	 * @param quoteId Mint quote id that should be subscribed to
+	 * @param callback Callback function that will be called when this mint quote gets paid
+	 * @param errorCallback
+	 * @returns
+	 */
 	async onMintQuotePaid(
 		quoteId: string,
 		callback: (payload: MintQuoteResponse) => void,
@@ -932,6 +953,13 @@ class CashuWallet {
 		};
 	}
 
+	/**
+	 * Register a callback to be called when a single melt quote gets paid
+	 * @param quoteId Melt quote id that should be subscribed to
+	 * @param callback Callback function that will be called when this melt quote gets paid
+	 * @param errorCallback
+	 * @returns
+	 */
 	async onMeltQuoteUpdates(
 		quoteIds: Array<string>,
 		callback: (payload: MeltQuoteResponse) => void,
@@ -951,6 +979,13 @@ class CashuWallet {
 		};
 	}
 
+	/**
+	 * Register a callback to be called whenever a subscribed proof state changes
+	 * @param proofs List of proofs that should be subscribed to
+	 * @param callback Callback function that will be called whenever a proof's state changes
+	 * @param errorCallback
+	 * @returns
+	 */
 	async onProofStateUpdates(
 		proofs: Array<Proof>,
 		callback: (payload: ProofState & { proof: Proof }) => void,

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -868,14 +868,16 @@ class CashuWallet {
 		if (!this.mint.webSocketConnection) {
 			throw new Error('failed to establish WebSocket connection.');
 		}
-		this.mint.webSocketConnection.createSubscription(
+		const subId = this.mint.webSocketConnection.createSubscription(
 			{ kind: 'bolt11_mint_quote', filters: [quoteId] },
 			callback,
 			(e) => {
 				throw new Error(e.message);
 			}
 		);
-		//TODO: Return unsub function
+		return () => {
+			this.mint.webSocketConnection?.cancelSubscription(subId, callback);
+		};
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -897,6 +897,40 @@ class CashuWallet {
 		};
 	}
 
+	async onMeltQuotePaid(
+		quoteId: string,
+		callback: (payload: MeltQuoteResponse) => any,
+		errorCallback: (e: Error) => void
+	) {
+		try {
+			await this.mint.connectWebSocket();
+		} catch (e) {
+			if (e instanceof Error) {
+				return errorCallback(e);
+			} else if (e) {
+				return errorCallback(new Error('Something went wrong'));
+			}
+		}
+		if (!this.mint.webSocketConnection) {
+			throw new Error('failed to establish WebSocket connection.');
+		}
+		const subCallback = (payload: MeltQuoteResponse) => {
+			if (payload.state === 'PAID') {
+				callback(payload);
+			}
+		};
+		const subId = this.mint.webSocketConnection.createSubscription(
+			{ kind: 'bolt11_melt_quote', filters: [quoteId] },
+			subCallback,
+			(e: Error) => {
+				errorCallback(e);
+			}
+		);
+		return () => {
+			this.mint.webSocketConnection?.cancelSubscription(subId, subCallback);
+		};
+	}
+
 	/**
 	 * Creates blinded messages for a given amount
 	 * @param amount amount to create blinded messages for

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -3,7 +3,7 @@ import { MessageQueue } from './utils';
 
 let _WS: typeof WebSocket;
 
-if (WebSocket) {
+if (typeof WebSocket !== 'undefined') {
 	_WS = WebSocket;
 }
 
@@ -48,7 +48,7 @@ export class WSConnection {
 			this.ws.onmessage = (e) => {
 				this.messageQueue.enqueue(e.data);
 				if (!this.handlingInterval) {
-					this.handlingInterval = setInterval(this.handleNextMesage, 0);
+					this.handlingInterval = setInterval(this.handleNextMesage.bind(this), 0);
 				}
 			};
 		});
@@ -71,6 +71,7 @@ export class WSConnection {
 	handleNextMesage() {
 		if (this.messageQueue.size === 0) {
 			clearInterval(this.handlingInterval);
+			this.handlingInterval = undefined;
 			return;
 		}
 		const message = this.messageQueue.dequeue() as string;

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -25,6 +25,7 @@ class Subscription {
 	onmessage(cb: () => any) {
 		this.connection.addListener(this.subId, cb);
 	}
+	unsub() {}
 }
 
 export class WSConnection {
@@ -59,6 +60,10 @@ export class WSConnection {
 
 	sendCommand(cmd: Command, subId: string, params: any) {
 		this.ws?.send(JSON.stringify(['REQ', subId, cmd, params]));
+	}
+
+	closeSubscription(subId: string) {
+		this.ws?.send(JSON.stringify(['CLOSE', subId]));
 	}
 
 	addListener(subId: string, callback: () => any) {

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -1,6 +1,8 @@
 import { listeners } from 'process';
 import { MessageQueue } from './utils';
 
+type Command = 'check_quote' | 'check_proof';
+
 let _WS: typeof WebSocket;
 
 if (typeof WebSocket !== 'undefined') {
@@ -18,6 +20,7 @@ class Subscription {
 		// HACK: There might be way better ways to create an random string, but I want to create something without dependecies frist
 		this.subId = Math.random().toString(36).slice(-5);
 		this.connection = conn;
+		conn.sendCommand('check_proof', this.subId, { test: true });
 	}
 	onmessage(cb: () => any) {
 		this.connection.addListener(this.subId, cb);
@@ -52,6 +55,10 @@ export class WSConnection {
 				}
 			};
 		});
+	}
+
+	sendCommand(cmd: Command, subId: string, params: any) {
+		this.ws?.send(JSON.stringify(['REQ', subId, cmd, params]));
 	}
 
 	addListener(subId: string, callback: () => any) {
@@ -102,7 +109,7 @@ export class WSConnection {
 		}
 	}
 
-	subscribe() {
+	subscribe(cmd: 'check_proof' | 'check_quote') {
 		return new Subscription(this);
 	}
 }

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -1,0 +1,75 @@
+import { MessageQueue } from './utils';
+
+let _WS: typeof WebSocket;
+
+if (WebSocket) {
+	_WS = WebSocket;
+}
+
+export function injectWebSocketImpl(ws: any) {
+	_WS = ws;
+}
+
+export class WSConnection {
+	public readonly url: URL;
+	private ws: WebSocket | undefined;
+	private listeners: { [reqId: string]: (e: any) => any } = {};
+	private messageQueue: MessageQueue;
+	private handlingInterval?: NodeJS.Timer;
+
+	constructor(url: string) {
+		this.url = new URL(url);
+		this.messageQueue = new MessageQueue();
+	}
+	async connect() {
+		return new Promise((res, rej) => {
+			try {
+				this.ws = new _WS(this.url);
+			} catch (err) {
+				rej(err);
+				return;
+			}
+			this.ws.onopen = res;
+			this.ws.onerror = rej;
+			this.ws.onmessage = (e) => {
+				this.messageQueue.enqueue(e.data);
+				if (!this.handlingInterval) {
+					this.handlingInterval = setInterval(this.handleNextMesage, 0);
+				}
+			};
+		});
+	}
+
+	handleNextMesage() {
+		if (this.messageQueue.size === 0) {
+			clearInterval(this.handlingInterval);
+			return;
+		}
+		const message = this.messageQueue.dequeue() as string;
+		let parsed;
+		try {
+			parsed = JSON.parse(message) as Array<string>;
+		} catch (e) {
+			console.log(e);
+			return;
+		}
+		let subId: string;
+		let data: any;
+		switch (parsed.length) {
+			case 2: {
+				// Must be notice
+				// TODO: Implement NOTICED
+				return;
+			}
+			case 3: {
+				subId = parsed[1];
+				data = parsed[3];
+				break;
+			}
+			default: {
+				return;
+			}
+		}
+		const len = parsed.length;
+	}
+}

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -1,12 +1,5 @@
-import { listeners } from 'process';
 import { MessageQueue } from './utils';
-import {
-	JsonRpcErrorObject,
-	JsonRpcMessage,
-	JsonRpcRequest,
-	JsonRpcResponse,
-	RpcSubId
-} from './model/types';
+import { JsonRpcErrorObject, JsonRpcMessage, RpcSubId } from './model/types';
 
 type Command = 'check_quote' | 'check_proof';
 
@@ -132,6 +125,7 @@ export class WSConnection {
 
 	createSubscription(
 		cmd: 'check_proof' | 'check_quote',
+		params: any,
 		callback: () => any,
 		errorCallback: (e: Error) => any
 	) {
@@ -149,5 +143,6 @@ export class WSConnection {
 			this.rpcId
 		);
 		this.rpcId++;
+		this.sendRequest(cmd, subId, params);
 	}
 }

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -9,6 +9,27 @@ import {
 import { OnOpenError, OnOpenSuccess } from './model/types/wallet/websocket';
 import { getWebSocketImpl } from './ws';
 
+export class ConnectionManager {
+	static instace: ConnectionManager;
+	private connectionMap: Map<string, WSConnection> = new Map();
+
+	static getInstance() {
+		if (!ConnectionManager.instace) {
+			ConnectionManager.instace = new ConnectionManager();
+		}
+		return ConnectionManager.instace;
+	}
+
+	getConnection(url: string): WSConnection {
+		if (this.connectionMap.has(url)) {
+			return this.connectionMap.get(url) as WSConnection;
+		}
+		const newConn = new WSConnection(url);
+		this.connectionMap.set(url, newConn);
+		return newConn;
+	}
+}
+
 export class WSConnection {
 	public readonly url: URL;
 	private readonly _WS: typeof WebSocket;

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -79,7 +79,7 @@ export class WSConnection {
 		delete this.rpcListeners[id];
 	}
 
-	removeListener(subId: string, callback: () => any) {
+	removeListener(subId: string, callback: (payload: any) => any) {
 		(this.subListeners[subId] = this.subListeners[subId] || []).filter((fn) => fn !== callback);
 	}
 
@@ -151,15 +151,11 @@ export class WSConnection {
 		);
 		this.rpcId++;
 		this.sendRequest('subscribe', { ...params, subId });
+		return subId;
 	}
 
-	cancelSubscription(subId: string, callback: () => any, errorCallback: (e: Error) => any) {
+	cancelSubscription(subId: string, callback: (payload: any) => any) {
 		this.removeListener(subId, callback);
-		this.addRpcListener(
-			callback,
-			(e: JsonRpcErrorObject) => errorCallback(new Error(e.message)),
-			this.rpcId
-		);
 		this.rpcId++;
 		this.sendRequest('unsubscribe', { subId });
 	}

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -76,7 +76,7 @@ export class WSConnection {
 		(this.subListeners[subId] = this.subListeners[subId] || []).filter((fn) => fn !== callback);
 	}
 
-	async ensureConenction() {
+	async ensureConnection() {
 		if (this.ws?.readyState !== 1) {
 			await this.connect();
 		}

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -33,9 +33,11 @@ export class WSConnection {
 
 	connect() {
 		return new Promise((res, rej) => {
+			console.log('running connect');
 			try {
 				this.ws = new _WS(this.url);
 			} catch (err) {
+				console.log(err);
 				rej(err);
 				return;
 			}
@@ -56,7 +58,6 @@ export class WSConnection {
 		const id = this.rpcId;
 		this.rpcId++;
 		const message = JSON.stringify({ jsonrpc: '2.0', method, params, id });
-		console.log(message);
 		this.ws?.send(message);
 	}
 
@@ -120,7 +121,7 @@ export class WSConnection {
 					if (!subId) {
 						return;
 					}
-					if (this.subListeners[subId].length > 0) {
+					if (this.subListeners[subId]?.length > 0) {
 						const notification = parsed as JsonRpcNotification;
 						this.subListeners[subId].forEach((cb) => cb(notification.params.payload));
 					}
@@ -150,8 +151,8 @@ export class WSConnection {
 			},
 			this.rpcId
 		);
-		this.rpcId++;
 		this.sendRequest('subscribe', { ...params, subId });
+		this.rpcId++;
 		return subId;
 	}
 

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -1,5 +1,5 @@
 import { MessageQueue } from './utils';
-import { JsonRpcErrorObject, JsonRpcMessage, RpcSubId } from './model/types';
+import { JsonRpcErrorObject, JsonRpcMessage, JsonRpcReqParams, RpcSubId } from './model/types';
 
 type Command = 'check_quote' | 'check_proof';
 
@@ -46,10 +46,10 @@ export class WSConnection {
 		});
 	}
 
-	sendRequest(cmd: Command, subId: string, params: any) {
+	sendRequest(params: JsonRpcReqParams) {
 		const id = this.rpcId;
 		this.rpcId++;
-		this.ws?.send(JSON.stringify({ jsonrpc: '2.0', method: cmd, params: { subId }, id: id }));
+		this.ws?.send(JSON.stringify({ jsonrpc: '2.0', method: 'sub', params, id: id }));
 	}
 
 	closeSubscription(subId: string) {
@@ -124,8 +124,7 @@ export class WSConnection {
 	}
 
 	createSubscription(
-		cmd: 'check_proof' | 'check_quote',
-		params: any,
+		params: JsonRpcReqParams,
 		callback: () => any,
 		errorCallback: (e: Error) => any
 	) {
@@ -143,6 +142,6 @@ export class WSConnection {
 			this.rpcId
 		);
 		this.rpcId++;
-		this.sendRequest(cmd, subId, params);
+		this.sendRequest(params);
 	}
 }

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -20,7 +20,7 @@ export function injectWebSocketImpl(ws: any) {
 export class WSConnection {
 	public readonly url: URL;
 	private ws: WebSocket | undefined;
-	private subListeners: { [subId: string]: Array<any> } = {};
+	private subListeners: { [subId: string]: Array<(payload: any) => any> } = {};
 	private rpcListeners: { [rpsSubId: string]: any } = {};
 	private messageQueue: MessageQueue;
 	private handlingInterval?: NodeJS.Timer;
@@ -62,7 +62,7 @@ export class WSConnection {
 		this.ws?.send(JSON.stringify(['CLOSE', subId]));
 	}
 
-	addSubListener(subId: string, callback: () => any) {
+	addSubListener(subId: string, callback: (payload: any) => any) {
 		(this.subListeners[subId] = this.subListeners[subId] || []).push(callback);
 	}
 
@@ -132,7 +132,7 @@ export class WSConnection {
 
 	createSubscription(
 		params: Omit<JsonRpcReqParams, 'subId'>,
-		callback: () => any,
+		callback: (payload: any) => any,
 		errorCallback: (e: Error) => any
 	) {
 		if (this.ws?.readyState !== 1) {

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -36,7 +36,7 @@ export class WSConnection {
 	private ws: WebSocket | undefined;
 	private connectionPromise: Promise<void> | undefined;
 	private subListeners: { [subId: string]: Array<(payload: any) => any> } = {};
-	private rpcListeners: { [rpsSubId: string]: any } = {};
+	private rpcListeners: { [rpcSubId: string]: any } = {};
 	private messageQueue: MessageQueue;
 	private handlingInterval?: NodeJS.Timer;
 	private rpcId = 0;
@@ -159,7 +159,7 @@ export class WSConnection {
 				}
 			}
 		} catch (e) {
-			console.log(e);
+			console.error(e);
 			return;
 		}
 	}

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -164,4 +164,10 @@ export class WSConnection {
 		this.rpcId++;
 		this.sendRequest('unsubscribe', { subId });
 	}
+
+	close() {
+		if (this.ws) {
+			this.ws?.close();
+		}
+	}
 }

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -47,6 +47,9 @@ export class WSConnection {
 						this.handlingInterval = setInterval(this.handleNextMesage.bind(this), 0);
 					}
 				};
+				this.ws.onclose = () => {
+					this.connectionPromise = undefined;
+				};
 			});
 		}
 		return this.connectionPromise;

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -1,8 +1,6 @@
 import { MessageQueue } from './utils';
 import { JsonRpcErrorObject, JsonRpcMessage, JsonRpcReqParams, RpcSubId } from './model/types';
 
-type Command = 'check_quote' | 'check_proof';
-
 let _WS: typeof WebSocket;
 
 if (typeof WebSocket !== 'undefined') {
@@ -49,7 +47,9 @@ export class WSConnection {
 	sendRequest(params: JsonRpcReqParams) {
 		const id = this.rpcId;
 		this.rpcId++;
-		this.ws?.send(JSON.stringify({ jsonrpc: '2.0', method: 'sub', params, id: id }));
+		const message = JSON.stringify({ jsonrpc: '2.0', method: 'sub', params, id });
+		console.log(message);
+		this.ws?.send(message);
 	}
 
 	closeSubscription(subId: string) {
@@ -92,6 +92,7 @@ export class WSConnection {
 		let parsed;
 		try {
 			parsed = JSON.parse(message) as JsonRpcMessage;
+			console.log(parsed);
 			if ('result' in parsed && parsed.id != undefined) {
 				if (this.rpcListeners[parsed.id]) {
 					this.rpcListeners[parsed.id].callback();
@@ -128,7 +129,7 @@ export class WSConnection {
 		callback: () => any,
 		errorCallback: (e: Error) => any
 	) {
-		if (this.ws?.readyState === 1) {
+		if (this.ws?.readyState !== 1) {
 			return errorCallback(new Error('Socket is not open'));
 		}
 		const subId = (Math.random() + 1).toString(36).substring(7);

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -49,6 +49,7 @@ export class WSConnection {
 			};
 		});
 	}
+
 	sendRequest(method: 'subscribe', params: JsonRpcReqParams): void;
 	sendRequest(method: 'unsubscribe', params: { subId: string }): void;
 	sendRequest(method: 'subscribe' | 'unsubscribe', params: Partial<JsonRpcReqParams>) {
@@ -67,7 +68,8 @@ export class WSConnection {
 		(this.subListeners[subId] = this.subListeners[subId] || []).push(callback);
 	}
 
-	addRpcListener(
+	//TODO: Move to RPCManagerClass
+	private addRpcListener(
 		callback: () => any,
 		errorCallback: (e: JsonRpcErrorObject) => any,
 		id: Exclude<RpcSubId, null>
@@ -75,11 +77,12 @@ export class WSConnection {
 		this.rpcListeners[id] = { callback, errorCallback };
 	}
 
-	removeRpcListener(id: Exclude<RpcSubId, null>) {
+	//TODO: Move to RPCManagerClass
+	private removeRpcListener(id: Exclude<RpcSubId, null>) {
 		delete this.rpcListeners[id];
 	}
 
-	removeListener(subId: string, callback: (payload: any) => any) {
+	private removeListener(subId: string, callback: (payload: any) => any) {
 		(this.subListeners[subId] = this.subListeners[subId] || []).filter((fn) => fn !== callback);
 	}
 
@@ -89,7 +92,7 @@ export class WSConnection {
 		}
 	}
 
-	handleNextMesage() {
+	private handleNextMesage() {
 		if (this.messageQueue.size === 0) {
 			clearInterval(this.handlingInterval);
 			this.handlingInterval = undefined;
@@ -111,7 +114,6 @@ export class WSConnection {
 				}
 			} else if ('method' in parsed) {
 				if ('id' in parsed) {
-					// This is a request
 					// Do nothing as mints should not send requests
 				} else {
 					const subId = parsed.params.subId;
@@ -122,7 +124,6 @@ export class WSConnection {
 						const notification = parsed as JsonRpcNotification;
 						this.subListeners[subId].forEach((cb) => cb(notification.params.payload));
 					}
-					// This is a notification
 				}
 			}
 		} catch (e) {

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -7,19 +7,11 @@ import {
 	RpcSubId
 } from './model/types';
 import { OnOpenError, OnOpenSuccess } from './model/types/wallet/websocket';
-
-let _WS: typeof WebSocket;
-
-if (typeof WebSocket !== 'undefined') {
-	_WS = WebSocket;
-}
-
-export function injectWebSocketImpl(ws: any) {
-	_WS = ws;
-}
+import { getWebSocketImpl } from './ws';
 
 export class WSConnection {
 	public readonly url: URL;
+	private readonly _WS: typeof WebSocket;
 	private ws: WebSocket | undefined;
 	private connectionPromise: Promise<void> | undefined;
 	private subListeners: { [subId: string]: Array<(payload: any) => any> } = {};
@@ -29,6 +21,7 @@ export class WSConnection {
 	private rpcId = 0;
 
 	constructor(url: string) {
+		this._WS = getWebSocketImpl();
 		this.url = new URL(url);
 		this.messageQueue = new MessageQueue();
 	}
@@ -37,7 +30,7 @@ export class WSConnection {
 		if (!this.connectionPromise) {
 			this.connectionPromise = new Promise((res: OnOpenSuccess, rej: OnOpenError) => {
 				try {
-					this.ws = new _WS(this.url);
+					this.ws = new this._WS(this.url);
 				} catch (err) {
 					rej(err);
 					return;

--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -94,7 +94,11 @@ export class WSConnection {
 	}
 
 	private removeListener(subId: string, callback: (payload: any) => any) {
-		(this.subListeners[subId] = this.subListeners[subId] || []).filter((fn) => fn !== callback);
+		if (this.subListeners[subId].length === 1) {
+			delete this.subListeners[subId];
+			return;
+		}
+		this.subListeners[subId] = this.subListeners[subId].filter((fn: any) => fn !== callback);
 	}
 
 	async ensureConnection() {
@@ -170,6 +174,10 @@ export class WSConnection {
 		this.removeListener(subId, callback);
 		this.rpcId++;
 		this.sendRequest('unsubscribe', { subId });
+	}
+
+	get activeSubscriptions() {
+		return Object.keys(this.subListeners);
 	}
 
 	close() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { CashuMint } from './CashuMint.js';
 import { CashuWallet } from './CashuWallet.js';
 import { PaymentRequest } from './model/PaymentRequest.js';
+import { WSConnection } from './WSConnection.js';
 import { setGlobalRequestOptions } from './request.js';
 import {
 	getEncodedToken,

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -26,7 +26,7 @@ type JsonRpcParams = any;
 
 export type JsonRpcReqParams = {
 	kind: RpcSubKinds;
-	filter: Array<string>;
+	filters: Array<string>;
 	subId: string;
 };
 

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -55,7 +55,7 @@ type JsonRpcRequest = {
 	id: Exclude<RpcSubId, null>;
 };
 
-type JsonRpcNotification = {
+export type JsonRpcNotification = {
 	jsonrpc: '2.0';
 	method: string;
 	params?: JsonRpcParams;

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -18,9 +18,17 @@ export type InvoiceData = {
 	expiry?: number;
 };
 
+type RpcSubKinds = 'bolt11_mint_quote' | 'bolt11_melt_quote' | 'proof_state';
+
 export type RpcSubId = string | number | null;
 
 type JsonRpcParams = any;
+
+export type JsonRpcReqParams = {
+	kind: RpcSubKinds;
+	filter: Array<string>;
+	subId: string;
+};
 
 type JsonRpcSuccess<T = any> = {
 	jsonrpc: '2.0';
@@ -42,8 +50,8 @@ type JsonRpcError = {
 
 type JsonRpcRequest = {
 	jsonrpc: '2.0';
-	method: string;
-	params?: JsonRpcParams;
+	method: 'sub';
+	params: JsonRpcReqParams;
 	id: Exclude<RpcSubId, null>;
 };
 

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -17,3 +17,40 @@ export type InvoiceData = {
 	memo?: string;
 	expiry?: number;
 };
+
+export type RpcSubId = string | number | null;
+
+type JsonRpcParams = any;
+
+type JsonRpcSuccess<T = any> = {
+	jsonrpc: '2.0';
+	result: T;
+	id: RpcSubId;
+};
+
+export type JsonRpcErrorObject = {
+	code: number;
+	message: string;
+	data?: any;
+};
+
+type JsonRpcError = {
+	jsonrpc: '2.0';
+	error: JsonRpcErrorObject;
+	id: RpcSubId;
+};
+
+type JsonRpcRequest = {
+	jsonrpc: '2.0';
+	method: string;
+	params?: JsonRpcParams;
+	id: Exclude<RpcSubId, null>;
+};
+
+type JsonRpcNotification = {
+	jsonrpc: '2.0';
+	method: string;
+	params?: JsonRpcParams;
+};
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcSuccess | JsonRpcError;

--- a/src/model/types/wallet/websocket.ts
+++ b/src/model/types/wallet/websocket.ts
@@ -1,0 +1,5 @@
+export type OnOpenSuccess = () => void;
+
+export type OnOpenError = (err: unknown) => void;
+
+export type SubscriptionCanceller = () => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -360,3 +360,90 @@ export function sumProofs(proofs: Array<Proof>) {
 export function decodePaymentRequest(paymentRequest: string) {
 	return PaymentRequest.fromEncodedRequest(paymentRequest);
 }
+
+export class MessageNode {
+	private _value: string;
+	private _next: MessageNode | null;
+
+	public get value(): string {
+		return this._value;
+	}
+	public set value(message: string) {
+		this._value = message;
+	}
+	public get next(): MessageNode | null {
+		return this._next;
+	}
+	public set next(node: MessageNode | null) {
+		this._next = node;
+	}
+
+	constructor(message: string) {
+		this._value = message;
+		this._next = null;
+	}
+}
+
+export class MessageQueue {
+	private _first: MessageNode | null;
+	private _last: MessageNode | null;
+
+	public get first(): MessageNode | null {
+		return this._first;
+	}
+	public set first(messageNode: MessageNode | null) {
+		this._first = messageNode;
+	}
+	public get last(): MessageNode | null {
+		return this._last;
+	}
+	public set last(messageNode: MessageNode | null) {
+		this._last = messageNode;
+	}
+	private _size: number;
+	public get size(): number {
+		return this._size;
+	}
+	public set size(v: number) {
+		this._size = v;
+	}
+
+	constructor() {
+		this._first = null;
+		this._last = null;
+		this._size = 0;
+	}
+	enqueue(message: string): boolean {
+		const newNode = new MessageNode(message);
+		if (this._size === 0 || !this._last) {
+			this._first = newNode;
+			this._last = newNode;
+		} else {
+			this._last.next = newNode;
+			this._last = newNode;
+		}
+		this._size++;
+		return true;
+	}
+	dequeue(): string | null {
+		if (this._size === 0 || !this._first) return null;
+
+		const prev = this._first;
+		this._first = prev.next;
+		prev.next = null;
+
+		this._size--;
+		return prev.value;
+	}
+}
+
+export {
+	bigIntStringify,
+	bytesToNumber,
+	getDecodedToken,
+	getEncodedToken,
+	getEncodedTokenV4,
+	hexToNumber,
+	splitAmount,
+	getDefaultAmountPreference
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -436,14 +436,3 @@ export class MessageQueue {
 		return prev.value;
 	}
 }
-
-export {
-	bigIntStringify,
-	bytesToNumber,
-	getDecodedToken,
-	getEncodedToken,
-	getEncodedTokenV4,
-	hexToNumber,
-	splitAmount,
-	getDefaultAmountPreference
-};

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,0 +1,13 @@
+let _WS: typeof WebSocket;
+
+if (typeof WebSocket !== 'undefined') {
+	_WS = WebSocket;
+}
+
+export function injectWebSocketImpl(ws: any) {
+	_WS = ws;
+}
+
+export function getWebSocketImpl() {
+	return _WS;
+}

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -1,0 +1,17 @@
+import { WSConnection, injectWebSocketImpl } from '../src/WSConnection';
+
+describe('testing WSConnection', () => {
+	test('connecting...', async () => {
+		injectWebSocketImpl(require('ws'));
+		const ws = new WSConnection('https://echo.websocket.org/');
+		await ws.connect();
+		const sub = ws.subscribe();
+		await new Promise((res) => {
+			// @ts-ignore
+			sub.onmessage((e) => {
+				console.log(e);
+				res(e);
+			});
+		});
+	});
+});

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -5,7 +5,7 @@ describe('testing WSConnection', () => {
 		injectWebSocketImpl(require('ws'));
 		const ws = new WSConnection('https://echo.websocket.org/');
 		await ws.connect();
-		const sub = ws.subscribe();
+		const sub = ws.subscribe('check_proof');
 		await new Promise((res) => {
 			// @ts-ignore
 			sub.onmessage((e) => {

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -72,16 +72,13 @@ describe('testing WSConnection', () => {
 		const server = new Server(fakeUrl, { mock: false });
 		server.on('connection', (socket) => {
 			socket.on('message', (m) => {
-				console.log(m);
 				try {
 					const parsed = JSON.parse(m.toString());
 					if (parsed.method === 'subscribe') {
-						const message = `{"jsonrpc": "2.0", "result": {"status": "OK", "subId": "${parsed.params.subId}", "id": ${parsed.id}}}`;
-						console.log(message);
+						const message = `{"jsonrpc": "2.0", "result": {"status": "OK", "subId": "${parsed.params.subId}"}, "id": ${parsed.id}}`;
 						socket.send(message);
 						setTimeout(() => {
 							const message = `{"jsonrpc": "2.0", "method": "subscribe", "params": {"subId": "${parsed.params.subId}", "payload": {"quote": "123", "request": "456", "paid": true, "expiry": 123}}}`;
-							console.log(message);
 							socket.send(message);
 						}, 500);
 					}
@@ -93,17 +90,17 @@ describe('testing WSConnection', () => {
 		const conn = new WSConnection(fakeUrl);
 		await conn.connect();
 
-		await new Promise((res) => {
-			const callback = jest.fn((p) => {
-				console.log('Payload received! ', p);
+		const payload = await new Promise((res) => {
+			const callback = jest.fn((p: any) => {
 				res(p);
 			});
 			const errorCallback = jest.fn();
-			const subId = conn.createSubscription(
+			conn.createSubscription(
 				{ kind: 'bolt11_mint_quote', filters: ['123'] },
 				callback,
 				errorCallback
 			);
 		});
+		expect(payload).toMatchObject({ quote: '123', request: '456', paid: true, expiry: 123 });
 	});
 });

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -1,17 +1,11 @@
 import { WSConnection, injectWebSocketImpl } from '../src/WSConnection';
+import { CashuMint, CashuWallet } from '../src/index';
 
 describe('testing WSConnection', () => {
 	test('connecting...', async () => {
 		injectWebSocketImpl(require('ws'));
-		const ws = new WSConnection('https://echo.websocket.org/');
-		await ws.connect();
-		const sub = ws.subscribe('check_proof');
-		await new Promise((res) => {
-			// @ts-ignore
-			sub.onmessage((e) => {
-				console.log(e);
-				res(e);
-			});
-		});
+		const wallet = new CashuWallet(new CashuMint('ws://localhost:3338'));
+		const quote = await wallet.getMintQuote(21);
+		console.log(quote);
 	});
 });

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -1,5 +1,6 @@
-import { WSConnection, injectWebSocketImpl } from '../src/WSConnection';
+import { WSConnection } from '../src/WSConnection';
 import { Server, WebSocket } from 'mock-socket';
+import { injectWebSocketImpl } from '../src/ws';
 
 injectWebSocketImpl(WebSocket);
 

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -1,22 +1,71 @@
 import { WSConnection, injectWebSocketImpl } from '../src/WSConnection';
-import { CashuMint, CashuWallet } from '../src/index';
+import { Server, WebSocket } from 'mock-socket';
+
+injectWebSocketImpl(WebSocket);
 
 describe('testing WSConnection', () => {
 	test('connecting...', async () => {
-		injectWebSocketImpl(require('ws'));
-		const wallet = new CashuWallet(new CashuMint('http://localhost:3338'));
-		await new Promise((res, rej) => {
-			const unsub = wallet.onQuotePaid(
-				'XCV',
-				(pa) => {
-					console.log(pa);
-					res(pa);
-				},
-				(e: Error) => {
-					rej(e);
-				}
+		const fakeUrl = 'ws://localhost:3338/v1/ws';
+		const server = new Server(fakeUrl, { mock: false });
+		const connectionSpy = jest.fn();
+		server.on('connection', connectionSpy);
+		const conn = new WSConnection(fakeUrl);
+		await conn.connect();
+		expect(connectionSpy).toHaveBeenCalled();
+		server.stop();
+	});
+	test('requesting subscription', async () => {
+		const fakeUrl = 'ws://localhost:3338/v1/ws';
+		const server = new Server(fakeUrl, { mock: false });
+		const message = (await new Promise(async (res) => {
+			server.on('connection', (socket) => {
+				socket.on('message', (m) => {
+					res(m.toString());
+				});
+			});
+			const conn = new WSConnection(fakeUrl);
+			await conn.connect();
+
+			const callback = jest.fn();
+			const errorCallback = jest.fn();
+			conn.createSubscription(
+				{ kind: 'bolt11_mint_quote', filters: ['12345'] },
+				callback,
+				errorCallback
+			);
+		})) as string;
+		expect(JSON.parse(message)).toMatchObject({
+			jsonrpc: '2.0',
+			method: 'subscribe',
+			params: { kind: 'bolt11_mint_quote', filters: ['12345'] }
+		});
+		server.stop();
+	});
+	test('unsubscribing', async () => {
+		const fakeUrl = 'ws://localhost:3338/v1/ws';
+		const server = new Server(fakeUrl, { mock: false });
+		const message = await new Promise(async (res) => {
+			server.on('connection', (socket) => {
+				socket.on('message', (m) => {
+					const parsed = JSON.parse(m.toString());
+					if (parsed.method === 'unsubscribe') res(parsed);
+				});
+			});
+			const conn = new WSConnection(fakeUrl);
+			await conn.connect();
+
+			conn.sendRequest('subscribe', {
+				subId: '12345',
+				kind: 'bolt11_mint_quote',
+				filters: ['12345']
+			});
+			const callback = jest.fn();
+			const errorCallback = jest.fn();
+			conn.createSubscription(
+				{ kind: 'bolt11_mint_quote', filters: ['123'] },
+				callback,
+				errorCallback
 			);
 		});
-		console.log('Ended');
 	});
 });

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -54,14 +54,52 @@ describe('testing WSConnection', () => {
 			const conn = new WSConnection(fakeUrl);
 			await conn.connect();
 
-			conn.sendRequest('subscribe', {
-				subId: '12345',
-				kind: 'bolt11_mint_quote',
-				filters: ['12345']
-			});
 			const callback = jest.fn();
 			const errorCallback = jest.fn();
-			conn.createSubscription(
+			const subId = conn.createSubscription(
+				{ kind: 'bolt11_mint_quote', filters: ['123'] },
+				callback,
+				errorCallback
+			);
+			//TODO: Add assertion for subListenerLength once SubscriptionManager is modularised
+			conn.cancelSubscription(subId, callback);
+		});
+		expect(message).toMatchObject({ jsonrpc: '2.0', method: 'unsubscribe' });
+		server.stop();
+	});
+	test('handing a notification', async () => {
+		const fakeUrl = 'ws://localhost:3338/v1/ws';
+		const server = new Server(fakeUrl, { mock: false });
+		server.on('connection', (socket) => {
+			socket.on('message', (m) => {
+				console.log(m);
+				try {
+					const parsed = JSON.parse(m.toString());
+					if (parsed.method === 'subscribe') {
+						const message = `{"jsonrpc": "2.0", "result": {"status": "OK", "subId": "${parsed.params.subId}", "id": ${parsed.id}}}`;
+						console.log(message);
+						socket.send(message);
+						setTimeout(() => {
+							const message = `{"jsonrpc": "2.0", "method": "subscribe", "params": {"subId": "${parsed.params.subId}", "payload": {"quote": "123", "request": "456", "paid": true, "expiry": 123}}}`;
+							console.log(message);
+							socket.send(message);
+						}, 500);
+					}
+				} catch {
+					console.log('Server parsing failed...');
+				}
+			});
+		});
+		const conn = new WSConnection(fakeUrl);
+		await conn.connect();
+
+		await new Promise((res) => {
+			const callback = jest.fn((p) => {
+				console.log('Payload received! ', p);
+				res(p);
+			});
+			const errorCallback = jest.fn();
+			const subId = conn.createSubscription(
 				{ kind: 'bolt11_mint_quote', filters: ['123'] },
 				callback,
 				errorCallback

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -102,5 +102,6 @@ describe('testing WSConnection', () => {
 			);
 		});
 		expect(payload).toMatchObject({ quote: '123', request: '456', paid: true, expiry: 123 });
+		server.stop();
 	});
 });

--- a/test/WSConnection.test.ts
+++ b/test/WSConnection.test.ts
@@ -4,8 +4,19 @@ import { CashuMint, CashuWallet } from '../src/index';
 describe('testing WSConnection', () => {
 	test('connecting...', async () => {
 		injectWebSocketImpl(require('ws'));
-		const wallet = new CashuWallet(new CashuMint('ws://localhost:3338'));
-		const quote = await wallet.getMintQuote(21);
-		console.log(quote);
+		const wallet = new CashuWallet(new CashuMint('http://localhost:3338'));
+		await new Promise((res, rej) => {
+			const unsub = wallet.onQuotePaid(
+				'XCV',
+				(pa) => {
+					console.log(pa);
+					res(pa);
+				},
+				(e: Error) => {
+					rej(e);
+				}
+			);
+		});
+		console.log('Ended');
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -351,7 +351,7 @@ describe('mint api', () => {
 					console.log(e);
 				}
 			);
-			wallet.swap(63, proofs);
+			wallet.swap(21, proofs);
 		});
 		mint.disconnectWebSocket();
 	}, 10000);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -328,15 +328,8 @@ describe('mint api', () => {
 		const wallet = new CashuWallet(mint);
 
 		const quote = await wallet.createMintQuote(63);
-		await new Promise<void>((res) => {
-			function handleUpdate(p: MintQuoteResponse) {
-				if (p.state === MintQuoteState.PAID) {
-					res();
-				}
-			}
-			wallet.onMintQuoteUpdates([quote.quote], handleUpdate, (e) => {
-				console.log(e);
-			});
+		await new Promise((res, rej) => {
+			wallet.onMintQuotePaid(quote.quote, res, rej);
 		});
 		const { proofs } = await wallet.mintProofs(63, quote.quote);
 		const data = await new Promise<ProofState>((res) => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -5,7 +5,12 @@ import dns from 'node:dns';
 import { deriveKeysetId, getEncodedToken, sumProofs } from '../src/utils.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { bytesToHex } from '@noble/curves/abstract/utils';
-import { CheckStateEnum, MeltQuoteState } from '../src/model/types/index.js';
+import {
+	CheckStateEnum,
+	MeltQuoteState,
+	MintQuotePayload,
+	MintQuoteState
+} from '../src/model/types/index.js';
 import ws from 'ws';
 import { injectWebSocketImpl } from '../src/ws.js';
 dns.setDefaultResultOrder('ipv4first');
@@ -264,10 +269,10 @@ describe('mint api', () => {
 		const mintQuote = await wallet.createMintQuote(21);
 		const callback = jest.fn();
 		const res = await new Promise((res, rej) => {
-			wallet.onMintQuotePaid(
-				mintQuote.quote,
-				() => {
-					callback();
+			wallet.onMintQuoteUpdates(
+				[mintQuote.quote],
+				(p) => {
+					if (p.state === MintQuoteState.PAID) callback();
 					res(1);
 				},
 				(e) => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -274,8 +274,10 @@ describe('mint api', () => {
 			wallet.onMintQuoteUpdates(
 				[mintQuote.quote],
 				(p) => {
-					if (p.state === MintQuoteState.PAID) callback();
-					res(1);
+					if (p.state === MintQuoteState.PAID) {
+						callback();
+						res(1);
+					}
 				},
 				(e) => {
 					console.log(e);
@@ -299,8 +301,7 @@ describe('mint api', () => {
 			let counter = 0;
 			const unsub = await wallet.onMintQuoteUpdates(
 				[mintQuote1.quote, mintQuote2.quote],
-				(p) => {
-					console.log(p);
+				() => {
 					counter++;
 					callbackRef();
 					if (counter === 4) {
@@ -308,9 +309,8 @@ describe('mint api', () => {
 						res(1);
 					}
 				},
-				(e) => {
+				() => {
 					counter++;
-					console.log(e);
 					if (counter === 4) {
 						unsub();
 						rej();
@@ -353,6 +353,6 @@ describe('mint api', () => {
 			);
 			wallet.swap(63, proofs);
 		});
-		console.log('final ws boss', data);
-	});
+		mint.disconnectWebSocket();
+	}, 10000);
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -339,7 +339,7 @@ describe('mint api', () => {
 		await new Promise((res, rej) => {
 			wallet.onMintQuotePaid(quote.quote, res, rej);
 		});
-		const { proofs } = await wallet.mintProofs(63, quote.quote);
+		const proofs = await wallet.mintProofs(63, quote.quote);
 		const data = await new Promise<ProofState>((res) => {
 			wallet.onProofStateUpdates(
 				proofs,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -6,8 +6,8 @@ import { deriveKeysetId, getEncodedToken, sumProofs } from '../src/utils.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { CheckStateEnum, MeltQuoteState } from '../src/model/types/index.js';
-import { injectWebSocketImpl } from '../src/WSConnection.js';
 import ws from 'ws';
+import { injectWebSocketImpl } from '../src/ws.js';
 dns.setDefaultResultOrder('ipv4first');
 
 const externalInvoice =

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2,14 +2,12 @@ import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
 
 import dns from 'node:dns';
-import { deriveKeysetId, getEncodedToken, sumProofs } from '../src/utils.js';
+import { getEncodedToken, sumProofs } from '../src/utils.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import {
 	CheckStateEnum,
 	MeltQuoteState,
-	MintQuotePayload,
-	MintQuoteResponse,
 	MintQuoteState,
 	ProofState
 } from '../src/model/types/index.js';
@@ -270,18 +268,20 @@ describe('mint api', () => {
 
 		const mintQuote = await wallet.createMintQuote(21);
 		const callback = jest.fn();
-		const res = await new Promise((res, rej) => {
-			wallet.onMintQuoteUpdates(
+		const res = await new Promise(async (res, rej) => {
+			const unsub = await wallet.onMintQuoteUpdates(
 				[mintQuote.quote],
 				(p) => {
 					if (p.state === MintQuoteState.PAID) {
 						callback();
 						res(1);
+						unsub();
 					}
 				},
 				(e) => {
 					console.log(e);
 					rej(e);
+					unsub();
 				}
 			);
 		});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -584,7 +584,7 @@ describe('WebSocket Updates', () => {
 				console.log(p);
 				res(p);
 			};
-			const test = wallet.onQuotePaid('123', callback, () => {
+			const test = wallet.onMintQuotePaid('123', callback, () => {
 				console.log('error');
 			});
 		});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -569,7 +569,7 @@ describe('WebSocket Updates', () => {
 						const message = `{"jsonrpc": "2.0", "result": {"status": "OK", "subId": "${parsed.params.subId}"}, "id": ${parsed.id}}`;
 						socket.send(message);
 						setTimeout(() => {
-							const message = `{"jsonrpc": "2.0", "method": "subscribe", "params": {"subId": "${parsed.params.subId}", "payload": {"quote": "123", "request": "456", "paid": true, "expiry": 123}}}`;
+							const message = `{"jsonrpc": "2.0", "method": "subscribe", "params": {"subId": "${parsed.params.subId}", "payload": {"quote": "123", "request": "456", "state": "PAID", "paid": true, "expiry": 123}}}`;
 							socket.send(message);
 						}, 500);
 					}
@@ -579,12 +579,13 @@ describe('WebSocket Updates', () => {
 			});
 		});
 		const wallet = new CashuWallet(mint);
-		await new Promise((res) => {
+		await new Promise((res, rej) => {
 			const callback = (p: any) => {
 				console.log(p);
 				res(p);
 			};
 			const test = wallet.onMintQuotePaid('123', callback, () => {
+				rej();
 				console.log('error');
 			});
 		});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -4,8 +4,8 @@ import { CashuWallet } from '../src/CashuWallet.js';
 import { CheckStateEnum, MeltQuoteResponse } from '../src/model/types/index.js';
 import { getDecodedToken } from '../src/utils.js';
 import { Proof } from '@cashu/crypto/modules/common';
-import { injectWebSocketImpl } from '../src/WSConnection.js';
 import { Server, WebSocket } from 'mock-socket';
+import { injectWebSocketImpl } from '../src/ws.js';
 
 injectWebSocketImpl(WebSocket);
 


### PR DESCRIPTION
# Fixes: none

## Description

This adds WebSocket management, as well as a couple of methods on CashuWallet for full NUT-17 support

## Changes

- Added WSConnection Class
- Handle automatic connects and reconnects
- Added Message Queue
- Added CashuWallet methods
- Added unit and integration tests

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`