### PR TITLE
Fix/init wallet with info

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -88,6 +88,7 @@ class CashuWallet {
 		if (keys) keys.forEach((key: MintKeys) => this._keys.set(key.id, key));
 		if (options?.unit) this._unit = options?.unit;
 		if (options?.keysets) this._keysets = options.keysets;
+		if (options?.mintInfo) this._mintInfo = options.mintInfo;
 		if (options?.denominationTarget) {
 			this._denominationTarget = options.denominationTarget;
 		}


### PR DESCRIPTION
# Fixes: mintInfo is not be set on CashuWallet if passed into the constructor.

## Description

If options.mintInfo is passed into new CashuWallet, then the wallet will be initialized with the mintInfo that was passed in.
...

## Changes

- modified CashuWallet constructor

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
