### PR TITLE
mintProofs returns Proofs instead of object

### DIFF
--- a/migration-2.0.0.md
+++ b/migration-2.0.0.md
@@ -53,7 +53,7 @@ To check the state of a `Proof`, call `CashuWallet.checkProofsStates`. `checkPro
 #### renamed functions
 
 - in `SendResponse`, `returnChange` is now called `keep`
-- `CashuWallet.mintTokens()` is now called `CashuWallet.mintProofs()`
+- `CashuWallet.mintTokens()` is now called `CashuWallet.mintProofs()` and returns <Promise<Array<Proof>> instead of Promise<{proofs: Array<Proof>}>
 - `CashuWallet.meltTokens()` is now called `CashuWallet.meltProofs()`
 - `CashuMint.split()` is now called `CashuMint.swap()`
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -675,7 +675,7 @@ class CashuWallet {
 			counter?: number;
 			pubkey?: string;
 		}
-	): Promise<{ proofs: Array<Proof> }> {
+	): Promise<Array<Proof>> {
 		const keyset = await this.getKeys(options?.keysetId);
 		if (!options?.outputAmounts && options?.proofsWeHave) {
 			options.outputAmounts = {
@@ -701,9 +701,7 @@ class CashuWallet {
 			quote: quote
 		};
 		const { signatures } = await this.mint.mint(mintPayload);
-		return {
-			proofs: this.constructProofs(signatures, blindingFactors, secrets, keyset)
-		};
+		return this.constructProofs(signatures, blindingFactors, secrets, keyset);
 	}
 
 	/**

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -247,7 +247,7 @@ describe('requestTokens', () => {
 			});
 		const wallet = new CashuWallet(mint, { unit });
 
-		const { proofs } = await wallet.mintProofs(1, '');
+		const proofs = await wallet.mintProofs(1, '');
 
 		expect(proofs).toHaveLength(1);
 		expect(proofs[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });


### PR DESCRIPTION
## Description

`CashuWallet.mintProofs` used to return an object with a single key `proofs`. This PR adjusts the function to return proofs directly

## Changes

- Make `mintProofs` return promised-wrapped `Array<Proof>` instead of `{proofs: Array<Proof>}`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
