### PR TITLE
nut-17: read support flags from info endpoint

### DIFF
--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -57,39 +57,50 @@ export type GetInfoResponse = {
 	description_long?: string;
 	contact: Array<MintContactInfo>;
 	nuts: {
-		'4': { // Minting
+		'4': {
+			// Minting
 			methods: Array<SwapMethod>;
 			disabled: boolean;
 		};
-		'5': { // Melting
+		'5': {
+			// Melting
 			methods: Array<SwapMethod>;
 			disabled: boolean;
 		};
-		'7'?: { // Token state check
+		'7'?: {
+			// Token state check
 			supported: boolean;
 		};
-		'8'?: { // Overpaid melt fees
+		'8'?: {
+			// Overpaid melt fees
 			supported: boolean;
 		};
-		'9'?: { // Restore
+		'9'?: {
+			// Restore
 			supported: boolean;
 		};
-		'10'?: { // Spending conditions
+		'10'?: {
+			// Spending conditions
 			supported: boolean;
 		};
-		'11'?: { // P2PK
+		'11'?: {
+			// P2PK
 			supported: boolean;
 		};
-		'12'?: { // DLEQ
+		'12'?: {
+			// DLEQ
 			supported: boolean;
 		};
-		'14'?: { // HTLCs
+		'14'?: {
+			// HTLCs
 			supported: boolean;
 		};
-		'15'?: { // MPP
+		'15'?: {
+			// MPP
 			methods: Array<MPPMethod>;
 		};
-		'17'?: { // WebSockets
+		'17'?: {
+			// WebSockets
 			supported: Array<WebSocketSupport>;
 		};
 	};

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -87,7 +87,7 @@ export type GetInfoResponse = {
 			supported: boolean;
 		};
 		'15'?: { // MPP
-			supported: boolean;
+			methods: Array<MPPMethod>;
 		};
 		'17'?: { // WebSockets
 			supported: Array<WebSocketSupport>;
@@ -221,6 +221,15 @@ export type SwapResponse = {
 	 */
 	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
+
+/**
+ * MPP supported methods
+ */
+export type MPPMethod = {
+	method: string;
+	unit: string;
+	mpp: boolean;
+};
 
 /**
  * WebSocket supported methods

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -239,7 +239,6 @@ export type SwapResponse = {
 export type MPPMethod = {
 	method: string;
 	unit: string;
-	mpp: boolean;
 };
 
 /**

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -57,34 +57,40 @@ export type GetInfoResponse = {
 	description_long?: string;
 	contact: Array<MintContactInfo>;
 	nuts: {
-		'4': {
+		'4': { // Minting
 			methods: Array<SwapMethod>;
 			disabled: boolean;
 		};
-		'5': {
+		'5': { // Melting
 			methods: Array<SwapMethod>;
 			disabled: boolean;
 		};
-		'7'?: {
+		'7'?: { // Token state check
 			supported: boolean;
 		};
-		'8'?: {
+		'8'?: { // Overpaid melt fees
 			supported: boolean;
 		};
-		'9'?: {
+		'9'?: { // Restore
 			supported: boolean;
 		};
-		'10'?: {
+		'10'?: { // Spending conditions
 			supported: boolean;
 		};
-		'11'?: {
+		'11'?: { // P2PK
 			supported: boolean;
 		};
-		'12'?: {
+		'12'?: { // DLEQ
 			supported: boolean;
 		};
-		'13'?: {
+		'14'?: { // HTLCs
 			supported: boolean;
+		};
+		'15'?: { // MPP
+			supported: boolean;
+		};
+		'17'?: { // WebSockets
+			supported: Array<WebSocketSupport>;
 		};
 	};
 	motd?: string;
@@ -215,3 +221,12 @@ export type SwapResponse = {
 	 */
 	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
+
+/**
+ * WebSocket supported methods
+ */
+export type WebSocketSupport = {
+	method: string;
+	unit: string;
+	commands: Array<string>;
+};

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 
 describe('test info', () => {
 	const mintInfoResp = JSON.parse(
-		'{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[{"method":"email","info":"contact@me.com"},{"method":"twitter","info":"@me"},{"method":"nostr","info":"npub..."}],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}'
+		'{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.3","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. It uses a FakeWallet, all your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[{"method":"email","info":"contact@me.com"},{"method":"twitter","info":"@me"},{"method":"nostr","info":"npub1337"}],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","icon_url":"https://image.nostr.build/46ee47763c345d2cfa3317f042d332003f498ee281fb42808d47a7d3b9585911.png","time":1731684933,"nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat","description":true},{"method":"bolt11","unit":"usd","description":true},{"method":"bolt11","unit":"eur","description":true}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"},{"method":"bolt11","unit":"eur"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"14":{"supported":true},"17":{"supported":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"eur","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}}'
 	);
 	test('test info', async () => {
 		nock(mintUrl).get('/v1/info').reply(200, mintInfoResp);
@@ -55,14 +55,33 @@ describe('test info', () => {
 		expect(info.contact).toEqual([
 			{ method: 'email', info: 'contact@me.com' },
 			{ method: 'twitter', info: '@me' },
-			{ method: 'nostr', info: 'npub...' }
+			{ method: 'nostr', info: 'npub1337' }
 		]);
+		expect(info.nuts?.['17']).toEqual({
+			supported: [
+				{
+					method: 'bolt11',
+					unit: 'sat',
+					commands: ['bolt11_melt_quote', 'proof_state', 'bolt11_mint_quote']
+				},
+				{
+					method: 'bolt11',
+					unit: 'usd',
+					commands: ['bolt11_melt_quote', 'proof_state', 'bolt11_mint_quote']
+				},
+				{
+					method: 'bolt11',
+					unit: 'eur',
+					commands: ['bolt11_melt_quote', 'proof_state', 'bolt11_mint_quote']
+				}
+			]
+		});
 		expect(info).toEqual(mintInfoResp);
 	});
 	test('test info with deprecated contact field', async () => {
 		// mintInfoRespDeprecated is the same as mintInfoResp but with the contact field in the old format
 		const mintInfoRespDeprecated = JSON.parse(
-			'{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.0","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[["email","contact@me.com"],["twitter","@me"],["nostr","npub..."]],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}'
+			'{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.3","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. All your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[["email","contact@me.com"],["twitter","@me"],["nostr","npub1337"]],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"17":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]}]}}'
 		);
 		nock(mintUrl).get('/v1/info').reply(200, mintInfoRespDeprecated);
 		const wallet = new CashuWallet(mint, { unit });
@@ -70,9 +89,8 @@ describe('test info', () => {
 		expect(info.contact).toEqual([
 			{ method: 'email', info: 'contact@me.com' },
 			{ method: 'twitter', info: '@me' },
-			{ method: 'nostr', info: 'npub...' }
+			{ method: 'nostr', info: 'npub1337' }
 		]);
-		expect(info).toEqual(mintInfoResp);
 	});
 });
 


### PR DESCRIPTION
# Fixes: #[issue]

## Description

...

## Changes

- ...
- ...

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run format`
