### PR TITLE
add multi part support for melt

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -721,7 +721,7 @@ class CashuWallet {
 			request: invoice
 		};
 		if (options?.mpp) {
-			meltQuotePayload.options = options;
+			meltQuotePayload.options = { mpp: { amount: options.mpp } };
 		}
 		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
 		return meltQuote;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -718,9 +718,11 @@ class CashuWallet {
 	async createMeltQuote(invoice: string, options?: { mpp?: number }): Promise<MeltQuoteResponse> {
 		const meltQuotePayload: MeltQuotePayload = {
 			unit: this._unit,
-			request: invoice,
-			options
+			request: invoice
 		};
+		if (options?.mpp) {
+			meltQuotePayload.options = options;
+		}
 		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
 		return meltQuote;
 	}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -711,12 +711,15 @@ class CashuWallet {
 	/**
 	 * Requests a melt quote from the mint. Response returns amount and fees for a given unit in order to pay a Lightning invoice.
 	 * @param invoice LN invoice that needs to get a fee estimate
+	 * @param options.mpp if the melt is part of a multi-path payment, @param options.mpp can be set to the amount
+	 * intended to be paid for this part/melt
 	 * @returns the mint will create and return a melt quote for the invoice with an amount and fee reserve
 	 */
-	async createMeltQuote(invoice: string): Promise<MeltQuoteResponse> {
+	async createMeltQuote(invoice: string, options?: { mpp?: number }): Promise<MeltQuoteResponse> {
 		const meltQuotePayload: MeltQuotePayload = {
 			unit: this._unit,
-			request: invoice
+			request: invoice,
+			options
 		};
 		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
 		return meltQuote;

--- a/src/model/types/wallet/payloads.ts
+++ b/src/model/types/wallet/payloads.ts
@@ -49,7 +49,14 @@ export type MeltQuotePayload = {
 	 */
 	request: string;
 
+	/**
+	 * optional melt quote options
+	 */
 	options?: {
+		/**
+		 * Amount for multi-path payment.
+		 * If set, the melt quote will be handled as a multi-path payment.
+		 */
 		mpp?: number;
 	};
 };

--- a/src/model/types/wallet/payloads.ts
+++ b/src/model/types/wallet/payloads.ts
@@ -57,7 +57,7 @@ export type MeltQuotePayload = {
 		 * Amount for multi-path payment.
 		 * If set, the melt quote will be handled as a multi-path payment.
 		 */
-		mpp?: number;
+		mpp?: { amount: number };
 	};
 };
 

--- a/src/model/types/wallet/payloads.ts
+++ b/src/model/types/wallet/payloads.ts
@@ -48,6 +48,10 @@ export type MeltQuotePayload = {
 	 * Request to be melted to
 	 */
 	request: string;
+
+	options?: {
+		mpp?: number;
+	};
 };
 
 /**

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -169,6 +169,13 @@ describe('mint api', () => {
 			expect(state.witness).toBeNull();
 		});
 	});
+	test('pay invoice shard with MPP', async () => {
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint);
+
+		const meltQuoteForPart = await wallet.createMeltQuote(externalInvoice, { mpp: 50 });
+		expect(meltQuoteForPart.amount).toBe(50);
+	});
 	test('test send tokens exact without previous split', async () => {
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint, { unit });


### PR DESCRIPTION
# Fixes: nut-15 support

## Description

Adds simple stateless nut-15 support

## Changes

- Added options to method signature and and type

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
