### PR TITLE
use sendOption type in function argument

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -11,6 +11,7 @@ import { DLEQ, type Proof as NUT11Proof } from '@cashu/crypto/modules/common/ind
 import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
 import { CashuMint } from './CashuMint.js';
 import { BlindedMessage } from './model/BlindedMessage.js';
+import { MintInfo } from './model/MintInfo.js';
 import {
 	BlindingData,
 	GetInfoResponse,
@@ -52,18 +53,6 @@ import {
 	stripDleq,
 	sumProofs
 } from './utils.js';
-import { hashToCurve, pointFromHex } from '@cashu/crypto/modules/common';
-import {
-	blindMessage,
-	constructProofFromPromise,
-	serializeProof
-} from '@cashu/crypto/modules/client';
-import { deriveBlindingFactor, deriveSecret } from '@cashu/crypto/modules/client/NUT09';
-import { createP2PKsecret, getSignedProofs } from '@cashu/crypto/modules/client/NUT11';
-import { type Proof as NUT11Proof, DLEQ } from '@cashu/crypto/modules/common/index';
-import { SubscriptionCanceller } from './model/types/wallet/websocket.js';
-import { verifyDLEQProof_reblind } from '@cashu/crypto/modules/client/NUT12';
-import { MintInfo } from './model/MintInfo.js';
 
 /**
  * The default number of proofs per denomination to keep in a wallet.

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -251,14 +251,7 @@ class CashuWallet {
 	/**
 	 * Receive an encoded or raw Cashu token (only supports single tokens. It will only process the first token in the token array)
 	 * @param {(string|Token)} token - Cashu token, either as string or decoded
-	 * @param {SendOptions} [options] - Optional configuration for token processing:
-	 *   - `keysetId`: Override the default keyset ID with a custom one fetched from the `/keysets` endpoint.
-	 *   - `outputAmounts`: Specify output amounts for keeping or sending.
-	 *   - `proofsWeHave`: Provide stored proofs for optimal output derivation.
-	 *   - `counter`: Set a counter to deterministically derive secrets (requires CashuWallet initialized with a seed phrase).
-	 *   - `pubkey`: Lock eCash to a public key (non-deterministic, even with a counter set).
-	 *   - `privkey`: Create a signature for token secrets.
-	 *   - `requireDleq`: Verify DLEQ proofs for all provided proofs; reject the token if any proof fails verification.
+	 * @param {ReceiveOptions} [options] - Optional configuration for token processing
 	 * @returns New token with newly created proofs, token entries that had errors
 	 */
 	async receive(token: string | Token, options?: ReceiveOptions): Promise<Array<Proof>> {
@@ -297,16 +290,7 @@ class CashuWallet {
 	 * Send proofs of a given amount, by providing at least the required amount of proofs
 	 * @param amount amount to send
 	 * @param proofs array of proofs (accumulated amount of proofs must be >= than amount)
-	 * @param {SendOptions} [options] - Optional parameters for configuring the send operation:
-	 *   - `outputAmounts` (OutputAmounts): Specify the amounts to keep and send in the output.
-	 *   - `counter` (number): Set a counter to derive secrets deterministically. Requires the `CashuWallet` class to be initialized with a seed phrase.
-	 *   - `proofsWeHave` (Array<Proof>): Provide all currently stored proofs for the mint. Used to derive optimal output amounts.
-	 *   - `pubkey` (string): Lock eCash to a specified public key. Note that this will not be deterministic, even if a counter is set.
-	 *   - `privkey` (string): Create a signature for the output secrets if provided.
-	 *   - `keysetId` (string): Override the keyset ID derived from the current mint keys with a custom one. The keyset ID should be fetched from the `/keysets` endpoint.
-	 *   - `offline` (boolean): Send proofs offline, if enabled.
-	 *   - `includeFees` (boolean): Include fees in the response, if enabled.
-	 *   - `includeDleq` (boolean): Include DLEQ proofs in the proofs to be sent, if enabled.
+	 * @param {SendOptions} [options] - Optional parameters for configuring the send operation
 	 * @returns {SendResponse}
 	 */
 	async send(amount: number, proofs: Array<Proof>, options?: SendOptions): Promise<SendResponse> {
@@ -473,15 +457,7 @@ class CashuWallet {
 	 * Splits and creates sendable tokens
 	 * if no amount is specified, the amount is implied by the cumulative amount of all proofs
 	 * if both amount and preference are set, but the preference cannot fulfill the amount, then we use the default split
-	 * @param amount amount to send while performing the optimal split (least proofs possible). can be set to undefined if preference is set
-	 * @param proofs proofs matching that amount
-	 * @param options.outputAmounts? optionally specify the output's amounts to keep and to send.
-	 * @param options.counter? optionally set counter to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
-	 * @param options.keysetId? override the keysetId derived from the current mintKeys with a custom one. This should be a keyset that was fetched from the `/keysets` endpoint
-	 * @param options.includeFees? include estimated fees for the receiver to receive the proofs
-	 * @param options.proofsWeHave? optionally provide all currently stored proofs of this mint. Cashu-ts will use them to derive the optimal output amounts
-	 * @param options.pubkey? optionally locks ecash to pubkey. Will not be deterministic, even if counter is set!
-	 * @param options.privkey? will create a signature on the @param proofs secrets if set
+	 *  @param {SwapOptions} [options] - Optional parameters for configuring the swap operation
 	 * @returns promise of the change- and send-proofs
 	 */
 	async swap(amount: number, proofs: Array<Proof>, options?: SwapOptions): Promise<SendResponse> {
@@ -646,11 +622,7 @@ class CashuWallet {
 	 * Mint proofs for a given mint quote
 	 * @param amount amount to request
 	 * @param quote ID of mint quote
-	 * @param options.keysetId? optionally set keysetId for blank outputs for returned change.
-	 * @param options.preference? Deprecated. Use `outputAmounts` instead. Optional preference for splitting proofs into specific amounts.
-	 * @param options.outputAmounts? optionally specify the output's amounts to keep and to send.
-	 * @param options.counter? optionally set counter to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
-	 * @param options.pubkey? optionally locks ecash to pubkey. Will not be deterministic, even if counter is set!
+	 * @param {MintProofOptions} [options] - Optional parameters for configuring the Mint Proof operation
 	 * @returns proofs
 	 */
 	async mintProofs(
@@ -711,9 +683,7 @@ class CashuWallet {
 	 * Returns melt quote and change proofs
 	 * @param meltQuote ID of the melt quote
 	 * @param proofsToSend proofs to melt
-	 * @param options.keysetId? optionally set keysetId for blank outputs for returned change.
-	 * @param options.counter? optionally set counter to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
-	 * @param options.privkey? optionally set a private key to unlock P2PK locked secrets
+	 * @param {MeltProofOptions} [options] - Optional parameters for configuring the Melting Proof operation
 	 * @returns
 	 */
 	async meltProofs(

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -8,6 +8,16 @@ export type OutputAmounts = {
 	keepAmounts?: Array<number>;
 };
 
+/**
+ * @param {ReceiveOptions} [options] - Optional configuration for token processing:
+ *   - `keysetId`: Override the default keyset ID with a custom one fetched from the `/keysets` endpoint.
+ *   - `outputAmounts`: Specify output amounts for keeping or sending.
+ *   - `proofsWeHave`: Provide stored proofs for optimal output derivation.
+ *   - `counter`: Set a counter to deterministically derive secrets (requires CashuWallet initialized with a seed phrase).
+ *   - `pubkey`: Lock eCash to a public key (non-deterministic, even with a counter set).
+ *   - `privkey`: Create a signature for token secrets.
+ *   - `requireDleq`: Verify DLEQ proofs for all provided proofs; reject the token if any proof fails verification.
+ */
 export type ReceiveOptions = {
 	keysetId?: string;
 	outputAmounts?: OutputAmounts;
@@ -18,6 +28,18 @@ export type ReceiveOptions = {
 	requireDleq?: boolean;
 };
 
+/**
+ * @param {SendOptions} [options] - Optional parameters for configuring the send operation:
+ *   - `outputAmounts` (OutputAmounts): Specify the amounts to keep and send in the output.
+ *   - `counter` (number): Set a counter to derive secrets deterministically. Requires the `CashuWallet` class to be initialized with a seed phrase.
+ *   - `proofsWeHave` (Array<Proof>): Provide all currently stored proofs for the mint. Used to derive optimal output amounts.
+ *   - `pubkey` (string): Lock eCash to a specified public key. Note that this will not be deterministic, even if a counter is set.
+ *   - `privkey` (string): Create a signature for the output secrets if provided.
+ *   - `keysetId` (string): Override the keyset ID derived from the current mint keys with a custom one. The keyset ID should be fetched from the `/keysets` endpoint.
+ *   - `offline` (boolean): Send proofs offline, if enabled.
+ *   - `includeFees` (boolean): Include fees in the response, if enabled.
+ *   - `includeDleq` (boolean): Include DLEQ proofs in the proofs to be sent, if enabled.
+ */
 export type SendOptions = {
 	outputAmounts?: OutputAmounts;
 	proofsWeHave?: Array<Proof>;
@@ -30,6 +52,18 @@ export type SendOptions = {
 	includeDleq?: boolean;
 };
 
+/**
+ * @param {SwapOptions} [options] - Optional parameters for configuring the swap operation:
+ * - `amount`: amount to send while performing the optimal split (least proofs possible). can be set to undefined if preference is set
+ * - proofs proofs matching that amount
+ * - outputAmounts? optionally specify the output's amounts to keep and to send.
+ * - counter? optionally set counter to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
+ * - keysetId? override the keysetId derived from the current mintKeys with a custom one. This should be a keyset that was fetched from the `/keysets` endpoint
+ * - includeFees? include estimated fees for the receiver to receive the proofs
+ * - proofsWeHave? optionally provide all currently stored proofs of this mint. Cashu-ts will use them to derive the optimal output amounts
+ * - pubkey? optionally locks ecash to pubkey. Will not be deterministic, even if counter is set!
+ * - privkey? will create a signature on the  proofs secrets if set
+ */
 export type SwapOptions = {
 	outputAmounts?: OutputAmounts;
 	proofsWeHave?: Array<Proof>;
@@ -44,6 +78,14 @@ export type RestoreOptions = {
 	keysetId?: string;
 };
 
+/**
+ * @param {MintProofOptions} [options] - Optional parameters for configuring the Mint Proof operation:
+ * - `keysetId`: override the keysetId derived from the current mintKeys with a custom one. This should be a keyset that was fetched from the `/keysets` endpoint
+ * - `outputAmounts`:  optionally specify the output's amounts to keep and to send.
+ * - `counter`: optionally set counter to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
+ * - `proofsWeHave`: optionally provide all currently stored proofs of this mint. Cashu-ts will use them to derive the optimal output amounts
+ * - `pubkey`: optionally locks ecash to pubkey. Will not be deterministic, even if counter is set!
+ */
 export type MintProofOptions = {
 	keysetId?: string;
 	outputAmounts?: OutputAmounts;
@@ -52,6 +94,12 @@ export type MintProofOptions = {
 	pubkey?: string;
 };
 
+/**
+ * @param {MeltProofOptions} [options] - Optional parameters for configuring the Melting Proof operation:
+ * - `keysetId`: override the keysetId derived from the current mintKeys with a custom one. This should be a keyset that was fetched from the `/keysets` endpoint
+ * - `counter`: optionally set counter to derive secret deterministically. CashuWallet class must be initialized with seed phrase to take effect
+ * - `privkey`: will create a signature on the  proofs secrets if set
+ */
 export type MeltProofOptions = {
 	keysetId?: string;
 	counter?: number;

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -1,3 +1,5 @@
+import { Proof } from './wallet/index';
+
 export * from './mint/index';
 export * from './wallet/index';
 
@@ -6,6 +8,55 @@ export type OutputAmounts = {
 	keepAmounts?: Array<number>;
 };
 
+export type ReceiveOptions = {
+	keysetId?: string;
+	outputAmounts?: OutputAmounts;
+	proofsWeHave?: Array<Proof>;
+	counter?: number;
+	pubkey?: string;
+	privkey?: string;
+	requireDleq?: boolean;
+};
+
+export type SendOptions = {
+	outputAmounts?: OutputAmounts;
+	proofsWeHave?: Array<Proof>;
+	counter?: number;
+	pubkey?: string;
+	privkey?: string;
+	keysetId?: string;
+	offline?: boolean;
+	includeFees?: boolean;
+	includeDleq?: boolean;
+};
+
+export type SwapOptions = {
+	outputAmounts?: OutputAmounts;
+	proofsWeHave?: Array<Proof>;
+	counter?: number;
+	pubkey?: string;
+	privkey?: string;
+	keysetId?: string;
+	includeFees?: boolean;
+};
+
+export type RestoreOptions = {
+	keysetId?: string;
+};
+
+export type MintProofOptions = {
+	keysetId?: string;
+	outputAmounts?: OutputAmounts;
+	proofsWeHave?: Array<Proof>;
+	counter?: number;
+	pubkey?: string;
+};
+
+export type MeltProofOptions = {
+	keysetId?: string;
+	counter?: number;
+	privkey?: string;
+};
 // deprecated
 
 export type InvoiceData = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,15 @@
+import { verifyDLEQProof_reblind } from '@cashu/crypto/modules/client/NUT12';
+import { DLEQ, pointFromHex } from '@cashu/crypto/modules/common';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
+import { sha256 } from '@noble/hashes/sha256';
 import {
 	encodeBase64ToJson,
 	encodeBase64toUint8,
 	encodeJsonToBase64,
 	encodeUint8toBase64Url
 } from './base64.js';
+import { decodeCBOR, encodeCBOR } from './cbor.js';
+import { PaymentRequest } from './model/PaymentRequest.js';
 import {
 	DeprecatedToken,
 	Keys,
@@ -17,12 +23,6 @@ import {
 	V4ProofTemplate
 } from './model/types/index.js';
 import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants.js';
-import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
-import { sha256 } from '@noble/hashes/sha256';
-import { decodeCBOR, encodeCBOR } from './cbor.js';
-import { PaymentRequest } from './model/PaymentRequest.js';
-import { DLEQ, pointFromHex } from '@cashu/crypto/modules/common';
-import { verifyDLEQProof_reblind } from '@cashu/crypto/modules/client/NUT12';
 
 /**
  * Splits the amount into denominations of the provided @param keyset
@@ -521,3 +521,21 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean {
 
 	return true;
 }
+
+type OutputAmounts = {
+	sendAmounts: Array<number>;
+	keepAmounts?: Array<number>;
+};
+
+export type SendOptions = {
+	outputAmounts?: OutputAmounts;
+	proofsWeHave?: Array<Proof>;
+	counter?: number;
+	pubkey?: string;
+	privkey?: string;
+	keysetId?: string;
+	offline?: boolean;
+	includeFees?: boolean;
+	includeDleq?: boolean;
+	requireDleq?: boolean;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -526,16 +526,3 @@ type OutputAmounts = {
 	sendAmounts: Array<number>;
 	keepAmounts?: Array<number>;
 };
-
-export type SendOptions = {
-	outputAmounts?: OutputAmounts;
-	proofsWeHave?: Array<Proof>;
-	counter?: number;
-	pubkey?: string;
-	privkey?: string;
-	keysetId?: string;
-	offline?: boolean;
-	includeFees?: boolean;
-	includeDleq?: boolean;
-	requireDleq?: boolean;
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -521,8 +521,3 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean {
 
 	return true;
 }
-
-type OutputAmounts = {
-	sendAmounts: Array<number>;
-	keepAmounts?: Array<number>;
-};


### PR DESCRIPTION
# Fixes: #210 

## Description

Some Functions in `CashuWallet` take optional paramaters, they have grown overtime, this PR move the option paramaters into a type and use the type in the function argument instead of the long object with different type,

this way we can add more optional parameters in the type and still used there ever they are need in a function 
...

## Changes

- Create SendOption Type with different option parameters
- Pass SendOption as option value in function that require it. 

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
