### PR TITLE
handle specific errors cases in request.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { CashuMint } from './CashuMint.js';
 import { CashuWallet } from './CashuWallet.js';
 import { PaymentRequest } from './model/PaymentRequest.js';
-import { OutputData } from './model/OutputData.js';
 import { setGlobalRequestOptions } from './request.js';
 import {
 	getEncodedToken,
@@ -19,7 +18,6 @@ export {
 	CashuMint,
 	CashuWallet,
 	PaymentRequest,
-	OutputData,
 	getDecodedToken,
 	getEncodedToken,
 	getEncodedTokenV4,
@@ -31,3 +29,5 @@ export {
 };
 
 export { injectWebSocketImpl } from './ws.js';
+
+export { MintOperationError, NetworkError, HttpResponseError } from './model/Errors.js';

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -1,4 +1,4 @@
-/** This error is thrown when a HTTP response is not 2XX or 400. */
+/** This error is thrown when a HTTP response is not 2XX nor a protocol error. */
 export class HttpResponseError extends Error {
 	status: number;
 	constructor(message: string, status: number) {
@@ -18,38 +18,14 @@ export class NetworkError extends Error {
 	}
 }
 
-/** This error is thrown when a mint operation returns a 400. */
-export class MintOperationError extends Error {
+/**
+ * This error is thrown when a [protocol error](https://github.com/cashubtc/nuts/blob/main/00.md#errors) occurs.
+ * See error codes [here](https://github.com/cashubtc/nuts/blob/main/error_codes.md).
+ */
+export class MintOperationError extends HttpResponseError {
 	code: number;
-
 	constructor(code: number, detail: string) {
-		const messages: Record<number, string> = {
-			10002: 'Blinded message of output already signed',
-			10003: 'Token could not be verified',
-			11001: 'Token is already spent',
-			11002: 'Transaction is not balanced (inputs != outputs)',
-			11005: 'Unit in request is not supported',
-			11006: 'Amount outside of limit range',
-			12001: 'Keyset is not known',
-			12002: 'Keyset is inactive, cannot sign messages',
-			20001: 'Quote request is not paid',
-			20002: 'Tokens have already been issued for quote',
-			20003: 'Minting is disabled',
-			20004: 'Lightning payment failed',
-			20005: 'Quote is pending',
-			20006: 'Invoice already paid',
-			20007: 'Quote is expired',
-			20008: 'Signature for mint request invalid',
-			20009: 'Pubkey required for mint quote',
-			30001: 'Endpoint requires clear auth',
-			30002: 'Clear authentication failed',
-			31001: 'Endpoint requires blind auth',
-			31002: 'Blind authentication failed',
-			31003: 'Maximum BAT mint amount exceeded',
-			31004: 'BAT mint rate limit exceeded'
-		};
-		// Use detail if returned by the mint, otherwise use fallback messages
-		super(detail || messages[code] || 'Unknown mint operation error');
+		super(detail || 'Unknown mint operation error', 400);
 		this.code = code;
 		this.name = 'MintOperationError';
 		Object.setPrototypeOf(this, MintOperationError.prototype);

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -1,7 +1,57 @@
+/** This error is thrown when a HTTP response is not 2XX or 400. */
 export class HttpResponseError extends Error {
 	status: number;
 	constructor(message: string, status: number) {
 		super(message);
 		this.status = status;
+		this.name = 'HttpResponseError';
+		Object.setPrototypeOf(this, HttpResponseError.prototype);
+	}
+}
+
+/** This error is thrown when a network request fails. */
+export class NetworkError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'NetworkError';
+		Object.setPrototypeOf(this, NetworkError.prototype);
+	}
+}
+
+/** This error is thrown when a mint operation returns a 400. */
+export class MintOperationError extends Error {
+	code: number;
+
+	constructor(code: number, detail: string) {
+		const messages: Record<number, string> = {
+			10002: 'Blinded message of output already signed',
+			10003: 'Token could not be verified',
+			11001: 'Token is already spent',
+			11002: 'Transaction is not balanced (inputs != outputs)',
+			11005: 'Unit in request is not supported',
+			11006: 'Amount outside of limit range',
+			12001: 'Keyset is not known',
+			12002: 'Keyset is inactive, cannot sign messages',
+			20001: 'Quote request is not paid',
+			20002: 'Tokens have already been issued for quote',
+			20003: 'Minting is disabled',
+			20004: 'Lightning payment failed',
+			20005: 'Quote is pending',
+			20006: 'Invoice already paid',
+			20007: 'Quote is expired',
+			20008: 'Signature for mint request invalid',
+			20009: 'Pubkey required for mint quote',
+			30001: 'Endpoint requires clear auth',
+			30002: 'Clear authentication failed',
+			31001: 'Endpoint requires blind auth',
+			31002: 'Blind authentication failed',
+			31003: 'Maximum BAT mint amount exceeded',
+			31004: 'BAT mint rate limit exceeded'
+		};
+		// Use detail if returned by the mint, otherwise use fallback messages
+		super(detail || messages[code] || 'Unknown mint operation error');
+		this.code = code;
+		this.name = 'MintOperationError';
+		Object.setPrototypeOf(this, MintOperationError.prototype);
 	}
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,4 @@
-import { HttpResponseError } from './model/Errors';
+import { HttpResponseError, NetworkError, MintOperationError } from './model/Errors';
 
 type RequestArgs = {
 	endpoint: string;
@@ -31,13 +31,26 @@ async function _request({
 		...requestHeaders
 	};
 
-	const response = await fetch(endpoint, { body, headers, ...options });
+	let response: Response;
+	try {
+		response = await fetch(endpoint, { body, headers, ...options });
+	} catch (err) {
+		// A fetch() promise only rejects when the request fails,
+		// for example, because of a badly-formed request URL or a network error.
+		throw new NetworkError(err instanceof Error ? err.message : 'Network request failed');
+	}
 
 	if (!response.ok) {
-		// expecting: { error: '', code: 0 }
-		// or: { detail: '' } (cashuBtc via pythonApi)
-		const { error, detail } = await response.json().catch(() => ({ error: 'bad response' }));
-		throw new HttpResponseError(error || detail || 'bad response', response.status);
+		const errorData = await response.json().catch(() => ({ error: 'bad response' }));
+
+		if (response.status === 400 && 'code' in errorData && 'detail' in errorData) {
+			throw new MintOperationError(errorData.code, errorData.detail);
+		}
+
+		throw new HttpResponseError(
+			'error' in errorData ? errorData.error : errorData.detail || 'HTTP request failed',
+			response.status
+		);
 	}
 
 	try {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -14,6 +14,7 @@ import {
 	ProofState,
 	Token
 } from '../src/model/types/index.js';
+import { MintOperationError } from '../src/model/Errors.js';
 import ws from 'ws';
 import { injectWebSocketImpl } from '../src/ws.js';
 import {
@@ -249,7 +250,7 @@ describe('mint api', () => {
 		const result = await wallet
 			.receive(encoded, { privkey: bytesToHex(privKeyAlice) })
 			.catch((e) => e);
-		expect(result).toEqual(new Error('no valid signature provided for input.'));
+		expect(result).toEqual(new MintOperationError(0, 'no valid signature provided for input.'));
 
 		const proofs = await wallet.receive(encoded, { privkey: bytesToHex(privKeyBob) });
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,9 +1,10 @@
-import { beforeAll, beforeEach, test, describe, expect, afterAll, afterEach } from 'vitest';
+import { beforeAll, test, describe, expect, afterAll, afterEach } from 'vitest';
 import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { setGlobalRequestOptions } from '../src/request.js';
+import { HttpResponseError, NetworkError, MintOperationError } from '../src/model/Errors';
 
 const mintUrl = 'https://localhost:3338';
 const unit = 'sats';
@@ -46,6 +47,7 @@ describe('requests', () => {
 		// expect(request!['content-type']).toContain('application/json');
 		expect(headers!.get('accept')).toContain('application/json, text/plain, */*');
 	});
+
 	test('global custom headers can be set', async () => {
 		let headers: Headers;
 		const mint = new CashuMint(mintUrl);
@@ -69,5 +71,46 @@ describe('requests', () => {
 
 		expect(headers!).toBeDefined();
 		expect(headers!.get('x-cashu')).toContain('xyz-123-abc');
+	});
+
+	test('handles HttpResponseError on non-200 response', async () => {
+		const mint = new CashuMint(mintUrl);
+		server.use(
+			http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
+				return new HttpResponse(JSON.stringify({ error: 'Not Found' }), { status: 404 });
+			})
+		);
+
+		const wallet = new CashuWallet(mint, { unit });
+		await expect(wallet.checkMeltQuote('test')).rejects.toThrowError(HttpResponseError);
+	});
+	test('handles NetworkError on network failure', async () => {
+		const mint = new CashuMint(mintUrl);
+		server.use(
+			http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
+				// This simulates a network failure at the fetch level
+				return Response.error();
+			})
+		);
+
+		const wallet = new CashuWallet(mint, { unit });
+		await expect(wallet.checkMeltQuote('test')).rejects.toThrow(NetworkError);
+	});
+
+	test('handles MintOperationError on 400 response with code and detail', async () => {
+		const mint = new CashuMint(mintUrl);
+		server.use(
+			http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
+				return new HttpResponse(JSON.stringify({ code: 20003, detail: 'Minting is disabled' }), {
+					status: 400
+				});
+			})
+		);
+
+		const wallet = new CashuWallet(mint, { unit });
+		const promise = wallet.checkMeltQuote('test');
+		await expect(promise).rejects.toThrow(MintOperationError);
+		// assert that the error message is set correctly by the code
+		await expect(promise).rejects.toThrow('Minting is disabled');
 	});
 });


### PR DESCRIPTION
# Fixes: error handling

Error handling was not specific enough and did not even get the error `code` from a `400` response

## Description

There are a variety of errors that can occur when making a request to a mint.

- fetch fail -> instanceof NetworkError
- fetch succeeds, but status is neither 2xx nor 400 -> instanceof HttpResponseError
- fetch succeeds and status is 400 -> instanceof MintOperationError with specific Cashu Error code as defined [in the nuts](https://github.com/cashubtc/nuts/blob/main/error_codes.md)

...

## Changes

- added NetworkError and MintOperationError classes
- catch fetch error and throw NetworkError
- If fetch succeeds but `!response.ok` (ie. http error), then throw MintOperationError if applicable otherwise HttpResponseError
- Export these new error classes so they can be used to handle the specific errors

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
