### PR TITLE
chore:add support for amountless in mintinfo and createMeltQuote

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -662,11 +662,26 @@ class CashuWallet {
 	 * @param invoice LN invoice that needs to get a fee estimate
 	 * @returns the mint will create and return a melt quote for the invoice with an amount and fee reserve
 	 */
-	async createMeltQuote(invoice: string): Promise<MeltQuoteResponse> {
+	async createMeltQuote(invoice: string, amount?: number): Promise<MeltQuoteResponse> {
 		const meltQuotePayload: MeltQuotePayload = {
 			unit: this._unit,
 			request: invoice
 		};
+
+		if(this._mintInfo?.amountless){
+			const meltQuotePayload: MeltQuotePayload = {
+  		unit: this._unit,
+			request: invoice,
+			options: {
+				amountless: {
+					amount_msat: amount ?? 0,
+				},
+			},
+		};
+		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
+		return meltQuote;
+		
+	}
 		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
 		return meltQuote;
 	}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -668,20 +668,19 @@ class CashuWallet {
 			request: invoice
 		};
 
-		if(this._mintInfo?.amountless){
+		if (this._mintInfo?.amountless) {
 			const meltQuotePayload: MeltQuotePayload = {
-  		unit: this._unit,
-			request: invoice,
-			options: {
-				amountless: {
-					amount_msat: amount ?? 0,
-				},
-			},
-		};
-		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
-		return meltQuote;
-		
-	}
+				unit: this._unit,
+				request: invoice,
+				options: {
+					amountless: {
+						amount_msat: amount ?? 0
+					}
+				}
+			};
+			const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
+			return meltQuote;
+		}
 		const meltQuote = await this.mint.createMeltQuote(meltQuotePayload);
 		return meltQuote;
 	}

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -94,4 +94,7 @@ export class MintInfo {
 	get motd() {
 		return this._mintInfo.motd;
 	}
+	get amountless() {
+		return this._mintInfo.amountless;
+	}
 }

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -105,6 +105,7 @@ export type GetInfoResponse = {
 		};
 	};
 	motd?: string;
+	amountless?: boolean;
 };
 
 /**

--- a/src/model/types/wallet/payloads.ts
+++ b/src/model/types/wallet/payloads.ts
@@ -48,7 +48,24 @@ export type MeltQuotePayload = {
 	 * Request to be melted to
 	 */
 	request: string;
+
+	options?: MeltQuotePayloadAmountLess;
 };
+
+/**
+ * Payload for a melt quote with an optional amountless option.
+ */
+export type MeltQuotePayloadAmountLess = {
+	/**
+   * Optional property for specifying an amountless option.
+   */
+	amountless?: {
+		/**
+     * The amount in milli-satoshis.
+     */
+		amount_msat: number
+	}
+}
 
 /**
  * Payload that needs to be sent to the mint when requesting a mint

--- a/src/model/types/wallet/payloads.ts
+++ b/src/model/types/wallet/payloads.ts
@@ -57,15 +57,15 @@ export type MeltQuotePayload = {
  */
 export type MeltQuotePayloadAmountLess = {
 	/**
-   * Optional property for specifying an amountless option.
-   */
+	 * Optional property for specifying an amountless option.
+	 */
 	amountless?: {
 		/**
-     * The amount in milli-satoshis.
-     */
-		amount_msat: number
-	}
-}
+		 * The amount in milli-satoshis.
+		 */
+		amount_msat: number;
+	};
+};
 
 /**
  * Payload that needs to be sent to the mint when requesting a mint


### PR DESCRIPTION
# Fixes: #225 

## Description
PR base on [https://github.com/cashubtc/nuts/pull/173](https://github.com/cashubtc/nuts/pull/173) for handling amountless when melting quote

## Changes

- add check if mint support amountless 
- add options field for handling amountless in `MeltQuotePayload`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
