### PR TITLE
remove dleqValid from proof and expose verification api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
 	deriveKeysetId,
 	decodePaymentRequest,
 	getDecodedTokenBinary,
-	getEncodedTokenBinary
+	getEncodedTokenBinary,
+	hasValidDleq
 } from './utils.js';
 
 export * from './model/types/index.js';
@@ -27,7 +28,8 @@ export {
 	deriveKeysetId,
 	setGlobalRequestOptions,
 	getDecodedTokenBinary,
-	getEncodedTokenBinary
+	getEncodedTokenBinary,
+	hasValidDleq
 };
 
 export { injectWebSocketImpl } from './ws.js';

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -64,9 +64,6 @@ export class OutputData implements OutputDataLike {
 		const serializedProof = {
 			...serializeProof(proof),
 			...(dleq && {
-				dleqValid: verifyDLEQProof_reblind(this.secret, dleq, proof.C, A)
-			}),
-			...(dleq && {
 				dleq: {
 					s: bytesToHex(dleq.s),
 					e: bytesToHex(dleq.e),

--- a/src/model/types/wallet/index.ts
+++ b/src/model/types/wallet/index.ts
@@ -29,10 +29,6 @@ export type Proof = {
 	 * DLEQ proof
 	 */
 	dleq?: SerializedDLEQ;
-	/**
-	 * Is the associated DLEQ proof valid?
-	 */
-	dleqValid?: boolean;
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -478,11 +478,10 @@ export class MessageQueue {
  * Removes all traces of DLEQs from a list of proofs
  * @param proofs The list of proofs that dleq should be stripped from
  */
-export function stripDleq(proofs: Array<Proof>): Array<Omit<Proof, 'dleq' | 'dleqValid'>> {
+export function stripDleq(proofs: Array<Proof>): Array<Omit<Proof, 'dleq'>> {
 	return proofs.map((p) => {
 		const newP = { ...p };
 		delete newP['dleq'];
-		delete newP['dleqValid'];
 		return newP;
 	});
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -411,7 +411,6 @@ describe('dleq', () => {
 			expect(p.dleq).toHaveProperty('s');
 			expect(p.dleq).toHaveProperty('e');
 			expect(p.dleq).toHaveProperty('r');
-			expect(p).toHaveProperty('dleqValid', true);
 		});
 	});
 	test('send and receive token with dleq', async () => {


### PR DESCRIPTION
# Fixes: DLEQ validity should not be stored on proof

## Description

The `dleqValid` flag on the proof doesn't make sense, since it has to be verified by the receiver independently. So IMO the better approach is to just encode the dleq params, and instead expose the verification API so that the receiver can verify the proofs on receive

## Changes

- remove dleqValid field from proof
- expose API

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
