### PR TITLE
Patch restore blank amounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cashu/cashu-ts",
-			"version": "2.2.0",
+			"version": "2.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"@cashu/crypto": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "cashu library for communicating with a cashu mint",
 	"type": "module",
 	"main": "lib/cashu-ts.cjs.js",

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -603,7 +603,7 @@ class CashuWallet {
 			throw new Error('CashuWallet must be initialized with a seed to use restore');
 		}
 		// create blank amounts for unknown restore amounts
-		const amounts = Array(count).fill(0);
+		const amounts = Array(count).fill(1);
 		const outputData = OutputData.createDeterministicData(
 			amounts.length,
 			this._seed,


### PR DESCRIPTION
# Fixes: #252 

## Description

Restore would not work if keyset doesn't include blank output amount

## Changes

- change blank output to `1` instead of `0`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
