### PR TITLE
use undefined for p2pk params on swap payload

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -943,9 +943,9 @@ class CashuWallet {
 				keepAmount,
 				keyset,
 				counter,
-				pubkey,
+				undefined,
 				outputAmounts?.keepAmounts,
-				p2pk,
+				undefined,
 				this._keepFactory
 			);
 		}


### PR DESCRIPTION
# Fixes: p2pk params broken

## Description

P2pk params are being set on the creation of the `keep` proofs, leading to unspendable proofs in the sender wallet, if a split occurs

## Changes

- changed p2pk params to undefined in `keep` output creation

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
