### PR TITLE
Add method for automated batch restoration

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -601,20 +601,39 @@ class CashuWallet {
 		};
 	}
 
-	async batchRestore(gapLimit = 300, batchSize = 100, initialCounter = 0): Promise<Array<Proof>> {
-		const recursiveRestore = async (counter: number, currentGap = 0, proofs: Array<Proof> = []) => {
+	async batchRestore(
+		gapLimit = 300,
+		batchSize = 100,
+		initialCounter = 0
+	): Promise<{ proofs: Array<Proof>; lastFoundCounter?: number }> {
+		const recursiveRestore = async (
+			counter: number,
+			currentGap = 0,
+			proofs: Array<Proof> = [],
+			lastFoundCounter = 0
+		) => {
 			if (currentGap >= gapLimit) {
-				return proofs;
+				return { proofs, lastFoundCounter };
 			}
 
-			const { proofs: batchProofs } = await this.restore(counter, batchSize);
+			const { proofs: batchProofs, lastFoundCounter: lastFound } = await this.restore(
+				counter,
+				batchSize
+			);
 			if (batchProofs.length === 0) {
-				return recursiveRestore(counter + batchSize, currentGap + batchSize, [
-					...proofs,
-					...batchProofs
-				]);
+				return recursiveRestore(
+					counter + batchSize,
+					currentGap + batchSize,
+					[...proofs, ...batchProofs],
+					lastFoundCounter
+				);
 			}
-			return recursiveRestore(counter + batchSize, 0, [...proofs, ...batchProofs]);
+			return recursiveRestore(
+				counter + batchSize,
+				0,
+				[...proofs, ...batchProofs],
+				counter + (lastFound || 0)
+			);
 		};
 
 		return recursiveRestore(initialCounter);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -601,36 +601,20 @@ class CashuWallet {
 		};
 	}
 
-	async batchRestore(
-		gapLimit = 300,
-		batchSize = 100,
-		initialCounter = 0
-	): Promise<{ proofs: Array<Proof>; lastCounter: number }> {
-		const recursiveRestore = async (
-			counter: number,
-			currentGap = 0,
-			proofs: Array<Proof> = [],
-			lastFoundCounter = 0
-		) => {
+	async batchRestore(gapLimit = 300, batchSize = 100, initialCounter = 0): Promise<Array<Proof>> {
+		const recursiveRestore = async (counter: number, currentGap = 0, proofs: Array<Proof> = []) => {
 			if (currentGap >= gapLimit) {
-				return { proofs, lastCounter: lastFoundCounter };
+				return proofs;
 			}
 
 			const { proofs: batchProofs } = await this.restore(counter, batchSize);
 			if (batchProofs.length === 0) {
-				return recursiveRestore(
-					counter + batchSize,
-					currentGap + batchSize,
-					[...proofs, ...batchProofs],
-					lastFoundCounter
-				);
+				return recursiveRestore(counter + batchSize, currentGap + batchSize, [
+					...proofs,
+					...batchProofs
+				]);
 			}
-			return recursiveRestore(
-				counter + batchSize,
-				0,
-				[...proofs, ...batchProofs],
-				lastFoundCounter + batchProofs.length
-			);
+			return recursiveRestore(counter + batchSize, 0, [...proofs, ...batchProofs]);
 		};
 
 		return recursiveRestore(initialCounter);

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -601,6 +601,28 @@ class CashuWallet {
 		};
 	}
 
+	async batchRestore(
+		counter = 0,
+		currentGap = 0,
+		accProofs: Array<Proof> = [],
+		lastFoundCounter = 0
+	): Promise<{ proofs: Array<Proof>; lastCounter: number }> {
+		if (currentGap >= 300) {
+			return { proofs: accProofs, lastCounter: lastFoundCounter };
+		}
+
+		const { proofs } = await this.restore(counter, 100);
+		if (proofs.length === 0) {
+			return this.batchRestore(
+				counter + 100,
+				currentGap + 100,
+				[...accProofs, ...proofs],
+				lastFoundCounter
+			);
+		}
+		return this.batchRestore(counter + 100, 0, [...accProofs, ...proofs], counter);
+	}
+
 	/**
 	 * Regenerates
 	 * @param start set starting point for count (first cycle for each keyset should usually be 0)

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -668,7 +668,9 @@ describe('Wallet Restore', () => {
 		await new Promise((r) => setTimeout(r, 1000));
 		const proofs = await wallet.mintProofs(70, mintQuote.quote, { counter: 5 });
 
-		const restoredProofs = await wallet.batchRestore();
+		const { proofs: restoredProofs, lastFoundCounter } = await wallet.batchRestore();
 		expect(restoredProofs).toEqual(proofs);
+		expect(sumProofs(restoredProofs)).toBe(70);
+		expect(lastFoundCounter).toBe(7);
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -668,9 +668,9 @@ describe('Wallet Restore', () => {
 		await new Promise((r) => setTimeout(r, 1000));
 		const proofs = await wallet.mintProofs(70, mintQuote.quote, { counter: 5 });
 
-		const { proofs: restoredProofs, lastFoundCounter } = await wallet.batchRestore();
+		const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore();
 		expect(restoredProofs).toEqual(proofs);
 		expect(sumProofs(restoredProofs)).toBe(70);
-		expect(lastFoundCounter).toBe(7);
+		expect(lastCounterWithSignature).toBe(7);
 	});
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -658,3 +658,17 @@ describe('Keep Vector and Reordering', () => {
 		send.forEach((p, i) => expect(p.amount).toBe(testOutputAmounts[i]));
 	});
 });
+describe('Wallet Restore', () => {
+	test('Using batch restore', async () => {
+		const seed = randomBytes(64);
+		const mint = new CashuMint(mintUrl);
+		const wallet = new CashuWallet(mint, { bip39seed: seed });
+
+		const mintQuote = await wallet.createMintQuote(70);
+		await new Promise((r) => setTimeout(r, 1000));
+		const proofs = await wallet.mintProofs(70, mintQuote.quote, { counter: 5 });
+
+		const restoredProofs = await wallet.batchRestore();
+		expect(restoredProofs).toEqual(proofs);
+	});
+});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -928,19 +928,23 @@ describe('Restoring deterministic proofs', () => {
 					start,
 					count,
 					options?
-				): Promise<{ proofs: Array<Proof>; lastFoundCounter?: number }> => {
+				): Promise<{ proofs: Array<Proof>; lastCounterWithSignature?: number }> => {
 					if (rounds === 0) {
 						rounds++;
-						return { proofs: Array(42).fill(1) as Array<Proof>, lastFoundCounter: 41 };
+						return { proofs: Array(42).fill(1) as Array<Proof>, lastCounterWithSignature: 41 };
 					}
 					rounds++;
 					return { proofs: [] };
 				}
 			);
-		const { proofs: restoredProofs, lastFoundCounter } = await wallet.batchRestore(100, 50, 0);
+		const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore(
+			100,
+			50,
+			0
+		);
 		expect(restoredProofs.length).toBe(42);
 		expect(mockRestore).toHaveBeenCalledTimes(3);
-		expect(lastFoundCounter).toBe(41);
+		expect(lastCounterWithSignature).toBe(41);
 		mockRestore.mockClear();
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -914,8 +914,7 @@ describe('Restoring deterministic proofs', () => {
 				return { proofs: [] };
 			});
 		const restoredProofs = await wallet.batchRestore();
-		expect(restoredProofs.proofs.length).toBe(21);
-		expect(restoredProofs.lastCounter).toBe(21);
+		expect(restoredProofs.length).toBe(21);
 		expect(mockRestore).toHaveBeenCalledTimes(4);
 		mockRestore.mockClear();
 	});
@@ -933,8 +932,7 @@ describe('Restoring deterministic proofs', () => {
 				return { proofs: [] };
 			});
 		const restoredProofs = await wallet.batchRestore(100, 50, 0);
-		expect(restoredProofs.proofs.length).toBe(42);
-		expect(restoredProofs.lastCounter).toBe(42);
+		expect(restoredProofs.length).toBe(42);
 		expect(mockRestore).toHaveBeenCalledTimes(3);
 		mockRestore.mockClear();
 	});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -913,7 +913,7 @@ describe('Restoring deterministic proofs', () => {
 				rounds++;
 				return { proofs: [] };
 			});
-		const restoredProofs = await wallet.batchRestore();
+		const { proofs: restoredProofs } = await wallet.batchRestore();
 		expect(restoredProofs.length).toBe(21);
 		expect(mockRestore).toHaveBeenCalledTimes(4);
 		mockRestore.mockClear();
@@ -923,17 +923,24 @@ describe('Restoring deterministic proofs', () => {
 		let rounds = 0;
 		const mockRestore = vi
 			.spyOn(wallet, 'restore')
-			.mockImplementation(async (start, count, options?): Promise<{ proofs: Array<Proof> }> => {
-				if (rounds === 0) {
+			.mockImplementation(
+				async (
+					start,
+					count,
+					options?
+				): Promise<{ proofs: Array<Proof>; lastFoundCounter?: number }> => {
+					if (rounds === 0) {
+						rounds++;
+						return { proofs: Array(42).fill(1) as Array<Proof>, lastFoundCounter: 41 };
+					}
 					rounds++;
-					return { proofs: Array(42).fill(1) as Array<Proof> };
+					return { proofs: [] };
 				}
-				rounds++;
-				return { proofs: [] };
-			});
-		const restoredProofs = await wallet.batchRestore(100, 50, 0);
+			);
+		const { proofs: restoredProofs, lastFoundCounter } = await wallet.batchRestore(100, 50, 0);
 		expect(restoredProofs.length).toBe(42);
 		expect(mockRestore).toHaveBeenCalledTimes(3);
+		expect(lastFoundCounter).toBe(41);
 		mockRestore.mockClear();
 	});
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,6 +1,6 @@
 import { setupServer } from 'msw/node';
 import { HttpResponse, http } from 'msw';
-import { beforeAll, beforeEach, afterAll, afterEach, test, describe, expect } from 'vitest';
+import { beforeAll, beforeEach, afterAll, afterEach, test, describe, expect, vi } from 'vitest';
 
 import { CashuMint } from '../src/CashuMint.js';
 import { CashuWallet } from '../src/CashuWallet.js';
@@ -896,6 +896,47 @@ describe('P2PK BlindingData', () => {
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toEqual([]);
 		});
+	});
+});
+
+describe('Restoring deterministic proofs', () => {
+	test('Batch restore', async () => {
+		const wallet = new CashuWallet(mint);
+		let rounds = 0;
+		const mockRestore = vi
+			.spyOn(wallet, 'restore')
+			.mockImplementation(async (start, count, options?): Promise<{ proofs: Array<Proof> }> => {
+				if (rounds === 0) {
+					rounds++;
+					return { proofs: Array(21).fill(1) as Array<Proof> };
+				}
+				rounds++;
+				return { proofs: [] };
+			});
+		const restoredProofs = await wallet.batchRestore();
+		expect(restoredProofs.proofs.length).toBe(21);
+		expect(restoredProofs.lastCounter).toBe(21);
+		expect(mockRestore).toHaveBeenCalledTimes(4);
+		mockRestore.mockClear();
+	});
+	test('Batch restore with custom values', async () => {
+		const wallet = new CashuWallet(mint);
+		let rounds = 0;
+		const mockRestore = vi
+			.spyOn(wallet, 'restore')
+			.mockImplementation(async (start, count, options?): Promise<{ proofs: Array<Proof> }> => {
+				if (rounds === 0) {
+					rounds++;
+					return { proofs: Array(42).fill(1) as Array<Proof> };
+				}
+				rounds++;
+				return { proofs: [] };
+			});
+		const restoredProofs = await wallet.batchRestore(100, 50, 0);
+		expect(restoredProofs.proofs.length).toBe(42);
+		expect(restoredProofs.lastCounter).toBe(42);
+		expect(mockRestore).toHaveBeenCalledTimes(3);
+		mockRestore.mockClear();
 	});
 });
 


### PR DESCRIPTION
## Description

This adds a new method to CashuWallet that automates the proofs restoration process according to the specifications recommendations.

## Changes

- Adds CashuWallet.batchRestore

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
