### PR TITLE
Fix: Update getEncodedTokenV4 parameter format

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const meltResponse = await wallet.meltProofs(meltQuote, proofsToSend);
 ```typescript
 // we assume that `wallet` already minted `proofs`, as above
 const { keep, send } = await wallet.send(32, proofs);
-const token = getEncodedTokenV4({ token: [{ mint: mintUrl, proofs: send }] });
+const token = getEncodedTokenV4({ mint: mintUrl, proofs: send });
 console.log(token);
 
 const wallet2 = new CashuWallet(mint); // receiving wallet


### PR DESCRIPTION
The previous README.md used an incorrect parameter structure for the `getEncodedTokenV4` function, which caused it to fail.