### PR TITLE
Wallet Keyset Unit-Filtering on Instantiation 

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -125,7 +125,7 @@ class CashuWallet {
 		if (options?.keysets) {
 			const filteredKeysets = options.keysets.filter((k) => k.unit === this._unit);
 			if (filteredKeysets.length === 0) {
-				throw new Error(`None of the specified keyset is suitable for unit ${this._unit}`)
+				throw new Error(`None of the specified keyset is suitable for unit ${this._unit}`);
 			}
 			this._keysets = filteredKeysets;
 		}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -122,7 +122,7 @@ class CashuWallet {
 		}
 		if (keys) keys.forEach((key: MintKeys) => this._keys.set(key.id, key));
 		if (options?.unit) this._unit = options?.unit;
-		if (options?.keysets) this._keysets = options.keysets;
+		if (options?.keysets) this._keysets = options.keysets.filter((k) => k.unit === this._unit);
 		if (options?.mintInfo) this._mintInfo = new MintInfo(options.mintInfo);
 		if (options?.denominationTarget) {
 			this._denominationTarget = options.denominationTarget;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -122,7 +122,13 @@ class CashuWallet {
 		}
 		if (keys) keys.forEach((key: MintKeys) => this._keys.set(key.id, key));
 		if (options?.unit) this._unit = options?.unit;
-		if (options?.keysets) this._keysets = options.keysets.filter((k) => k.unit === this._unit);
+		if (options?.keysets) {
+			const filteredKeysets = options.keysets.filter((k) => k.unit === this._unit);
+			if (filteredKeysets.length === 0) {
+				throw new Error(`None of the specified keyset is suitable for unit ${this._unit}`)
+			}
+			this._keysets = filteredKeysets;
+		}
 		if (options?.mintInfo) this._mintInfo = new MintInfo(options.mintInfo);
 		if (options?.denominationTarget) {
 			this._denominationTarget = options.denominationTarget;

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -918,7 +918,7 @@ describe('CashuWallet instantiation properties', () => {
 		] as MintKeyset[];
 		
 		const satWallet = new CashuWallet(mint, {
-			unit: 'sat',
+			//unit: 'sat',
 			keysets,
 		});
 		const usdWallet = new CashuWallet(mint, {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -8,6 +8,7 @@ import {
 	CheckStateEnum,
 	MeltQuoteResponse,
 	MeltQuoteState,
+	MintKeyset,
 	MintQuoteResponse,
 	MintQuoteState,
 	Proof
@@ -896,6 +897,39 @@ describe('P2PK BlindingData', () => {
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toEqual([]);
 		});
+	});
+});
+
+describe('CashuWallet instantiation properties', () => {
+	test('Test constructor\'s unit-filtering of keysets', () => {
+		const keysets = [
+			{
+				"id": "00ed0ddf25402eae",
+				"unit": "usd",
+				"active": true,
+				"input_fee_ppk": 0
+			},
+			{
+				"id": "00bedc9ddf986021",
+				"unit": "sat",
+				"active": true,
+				"input_fee_ppk": 0	
+			}
+		] as MintKeyset[];
+		
+		const satWallet = new CashuWallet(mint, {
+			unit: 'sat',
+			keysets,
+		});
+		const usdWallet = new CashuWallet(mint, {
+			unit: 'usd',
+			keysets,
+		});
+
+		expect((satWallet as any)._keysets).toHaveLength(1);
+		expect((satWallet as any)._keysets[0].unit).toEqual("sat");
+		expect((usdWallet as any)._keysets).toHaveLength(1);
+		expect((usdWallet as any)._keysets[0].unit).toEqual("usd");
 	});
 });
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -901,35 +901,35 @@ describe('P2PK BlindingData', () => {
 });
 
 describe('CashuWallet instantiation properties', () => {
-	test('Test constructor\'s unit-filtering of keysets', () => {
+	test("Test constructor's unit-filtering of keysets", () => {
 		const keysets = [
 			{
-				"id": "00ed0ddf25402eae",
-				"unit": "usd",
-				"active": true,
-				"input_fee_ppk": 0
+				id: '00ed0ddf25402eae',
+				unit: 'usd',
+				active: true,
+				input_fee_ppk: 0
 			},
 			{
-				"id": "00bedc9ddf986021",
-				"unit": "sat",
-				"active": true,
-				"input_fee_ppk": 0	
+				id: '00bedc9ddf986021',
+				unit: 'sat',
+				active: true,
+				input_fee_ppk: 0
 			}
 		] as MintKeyset[];
-		
+
 		const satWallet = new CashuWallet(mint, {
 			//unit: 'sat',
-			keysets,
+			keysets
 		});
 		const usdWallet = new CashuWallet(mint, {
 			unit: 'usd',
-			keysets,
+			keysets
 		});
 
 		expect((satWallet as any)._keysets).toHaveLength(1);
-		expect((satWallet as any)._keysets[0].unit).toEqual("sat");
+		expect((satWallet as any)._keysets[0].unit).toEqual('sat');
 		expect((usdWallet as any)._keysets).toHaveLength(1);
-		expect((usdWallet as any)._keysets[0].unit).toEqual("usd");
+		expect((usdWallet as any)._keysets[0].unit).toEqual('usd');
 	});
 });
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -936,9 +936,7 @@ describe('CashuWallet instantiation properties', () => {
 				unit: 'msat',
 				keysets
 			});
-		})
-		.toThrowError("None of the specified keyset is suitable for unit msat");
-
+		}).toThrowError('None of the specified keyset is suitable for unit msat');
 	});
 });
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -930,6 +930,15 @@ describe('CashuWallet instantiation properties', () => {
 		expect((satWallet as any)._keysets[0].unit).toEqual('sat');
 		expect((usdWallet as any)._keysets).toHaveLength(1);
 		expect((usdWallet as any)._keysets[0].unit).toEqual('usd');
+
+		expect(() => {
+			const _ = new CashuWallet(mint, {
+				unit: 'msat',
+				keysets
+			});
+		})
+		.toThrowError("None of the specified keyset is suitable for unit msat");
+
 	});
 });
 


### PR DESCRIPTION
# Fixes: #276

## Changes

- `CashuWallet` does unit-based filtering of the passed keysets, if any. Throws an error if it can't find a single keyset for the specified unit (or the default unit, in case not specified).
- Unit test

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
