### PR TITLE
Support for proof witness field in token serialization

### DIFF
--- a/src/model/types/wallet/index.ts
+++ b/src/model/types/wallet/index.ts
@@ -29,6 +29,34 @@ export type Proof = {
 	 * DLEQ proof
 	 */
 	dleq?: SerializedDLEQ;
+	/**
+	 * The witness for this proof.
+	 */
+	witness?: string | P2PKWitness | HTLCWitness;
+};
+
+/**
+ * P2PK witness
+ */
+export type P2PKWitness = {
+	/**
+	 * An array of signatures in hex format
+	 */
+	signatures?: Array<string>;
+};
+
+/**
+ * HTLC witness
+ */
+export type HTLCWitness = {
+	/**
+	 * preimage
+	 */
+	preimage: string;
+	/**
+	 * An array of signatures in hex format
+	 */
+	signatures?: Array<string>;
 };
 
 /**

--- a/src/model/types/wallet/tokens.ts
+++ b/src/model/types/wallet/tokens.ts
@@ -57,6 +57,10 @@ export type V4ProofTemplate = {
 	 * DLEQ
 	 */
 	d?: V4DLEQTemplate;
+	/**
+	 * Witness
+	 */
+	w?: string;
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -256,6 +256,9 @@ function templateFromToken(token: Token): TokenV4Template {
 								s: hexToBytes(p.dleq.s),
 								r: hexToBytes(p.dleq.r ?? '00')
 							} as V4DLEQTemplate
+						}),
+						...(p.witness && {
+							w: JSON.stringify(p.witness)
 						})
 					})
 				)
@@ -283,6 +286,9 @@ function tokenFromTemplate(template: TokenV4Template): Token {
 						s: bytesToHex(p.d.s),
 						e: bytesToHex(p.d.e)
 					} as SerializedDLEQ
+				}),
+				...(p.w && {
+					witness: p.w
 				})
 			});
 		})


### PR DESCRIPTION
## Description

Proof.witness field was getting dropped during serialization by getEncodedTokenV4

## Changes

`witness` field added to types `Proof`, `w` added to type `V4ProofTemplate` and serialization/deserialization logic added to `tokenTemplate` and `tokenFromTemplate`.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
