### PR TITLE
Fix P2PK refund to reflect NUT-11 format

### DIFF
--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -101,7 +101,7 @@ export class OutputData implements OutputDataLike {
 			newSecret[1].tags.push(['locktime', p2pk.locktime]);
 		}
 		if (p2pk.refundKeys) {
-			newSecret[1].tags.push(['refund', p2pk.refundKeys]);
+			newSecret[1].tags.push(['refund', ...p2pk.refundKeys]);
 		}
 		const parsed = JSON.stringify(newSecret);
 		const secretBytes = new TextEncoder().encode(parsed);

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -865,7 +865,7 @@ describe('P2PK BlindingData', () => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toContainEqual(['locktime', 212]);
-			expect(s[1].tags).toContainEqual(['refund', ['iamarefund']]);
+			expect(s[1].tags).toContainEqual(['refund', 'iamarefund']);
 		});
 	});
 	test('Create BlindingData locked to pk with locktime and multiple refund keys', async () => {
@@ -882,7 +882,7 @@ describe('P2PK BlindingData', () => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toContainEqual(['locktime', 212]);
-			expect(s[1].tags).toContainEqual(['refund', ['iamarefund', 'asecondrefund']]);
+			expect(s[1].tags).toContainEqual(['refund', 'iamarefund', 'asecondrefund']);
 		});
 	});
 	test('Create BlindingData locked to pk without locktime and no refund keys', async () => {


### PR DESCRIPTION
[NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md) specifies the refund tag as follows:

`refund: <hex_str> are optional refund public keys that can exclusively spend after locktime (allows multiple entries)`

Tags are arrays with two or more strings being `["key", "value1", "value2", ...]`.

The refund format should therefore be:  `["refund", "value1", "value2", ...]`

The current format is: `["refund", ["value1", "value2", ...]]`

This PR spreads the array properly, and updates the tests, which were incorrect to spec.

