### PR TITLE
Added NUT-11 P2PK multisig support and corresponding tests

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,5 +1,5 @@
 import { serializeProof } from './crypto/client/index.js';
-import { getSignedProofs } from './crypto/client/NUT11.js';
+import { getSignedProofs, getSignatures } from './crypto/client/NUT11.js';
 import { hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
 import { CashuMint } from './CashuMint.js';
 import { MintInfo } from './model/MintInfo.js';
@@ -912,12 +912,13 @@ class CashuWallet {
 		if (privkey != undefined) {
 			proofsToSend = getSignedProofs(
 				proofsToSend.map((p: Proof) => {
+					const signatures = getSignatures(p.witness);
 					return {
 						amount: p.amount,
 						C: pointFromHex(p.C),
 						id: p.id,
 						secret: new TextEncoder().encode(p.secret),
-						witness: typeof p.witness === 'string' ? JSON.parse(p.witness) : p.witness
+						witness: { signatures: signatures }
 					};
 				}),
 				privkey
@@ -1025,12 +1026,13 @@ class CashuWallet {
 		if (privkey) {
 			proofsToSend = getSignedProofs(
 				proofsToSend.map((p: Proof) => {
+					const signatures = getSignatures(p.witness);
 					return {
 						amount: p.amount,
 						C: pointFromHex(p.C),
 						id: p.id,
 						secret: new TextEncoder().encode(p.secret),
-						witness: typeof p.witness === 'string' ? JSON.parse(p.witness) : { signatures: [] }
+						witness: { signatures: signatures }
 					};
 				}),
 				privkey

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -917,7 +917,8 @@ class CashuWallet {
 						amount: p.amount,
 						C: pointFromHex(p.C),
 						id: p.id,
-						secret: new TextEncoder().encode(p.secret)
+						secret: new TextEncoder().encode(p.secret),
+						witness: typeof p.witness === "string" ? JSON.parse(p.witness) : p.witness,
 					};
 				}),
 				privkey
@@ -960,7 +961,12 @@ class CashuWallet {
 			keep?: Array<OutputDataLike> | OutputDataFactory;
 			send?: Array<OutputDataLike> | OutputDataFactory;
 		},
-		p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> }
+		p2pk?: {
+			pubkey: string | Array<string>;
+			locktime?: number;
+			refundKeys?: Array<string>;
+			nsig?: number;
+		}
 	): SwapTransaction {
 		const totalAmount = proofsToSend.reduce((total: number, curr: Proof) => total + curr.amount, 0);
 		if (outputAmounts && outputAmounts.sendAmounts && !outputAmounts.keepAmounts) {
@@ -1023,7 +1029,8 @@ class CashuWallet {
 						amount: p.amount,
 						C: pointFromHex(p.C),
 						id: p.id,
-						secret: new TextEncoder().encode(p.secret)
+						secret: new TextEncoder().encode(p.secret),
+						witness: typeof p.witness === "string" ? JSON.parse(p.witness) : null,
 					};
 				}),
 				privkey
@@ -1236,7 +1243,12 @@ class CashuWallet {
 		counter?: number,
 		pubkey?: string,
 		outputAmounts?: Array<number>,
-		p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> },
+		p2pk?: {
+			pubkey: string | Array<string>;
+			locktime?: number;
+			refundKeys?: Array<string>;
+			nsig?: number;
+		},
 		factory?: OutputDataFactory
 	): Array<OutputDataLike> {
 		let outputData: Array<OutputDataLike>;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -918,7 +918,7 @@ class CashuWallet {
 						C: pointFromHex(p.C),
 						id: p.id,
 						secret: new TextEncoder().encode(p.secret),
-						witness: typeof p.witness === "string" ? JSON.parse(p.witness) : p.witness,
+						witness: typeof p.witness === 'string' ? JSON.parse(p.witness) : p.witness
 					};
 				}),
 				privkey
@@ -1030,7 +1030,7 @@ class CashuWallet {
 						C: pointFromHex(p.C),
 						id: p.id,
 						secret: new TextEncoder().encode(p.secret),
-						witness: typeof p.witness === "string" ? JSON.parse(p.witness) : null,
+						witness: typeof p.witness === 'string' ? JSON.parse(p.witness) : null
 					};
 				}),
 				privkey

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,5 +1,5 @@
 import { serializeProof } from './crypto/client/index.js';
-import { getSignedProofs, getSignatures } from './crypto/client/NUT11.js';
+import { getSignedProofs, getP2PKWitnessSignatures } from './crypto/client/NUT11.js';
 import { hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
 import { CashuMint } from './CashuMint.js';
 import { MintInfo } from './model/MintInfo.js';
@@ -912,7 +912,7 @@ class CashuWallet {
 		if (privkey != undefined) {
 			proofsToSend = getSignedProofs(
 				proofsToSend.map((p: Proof) => {
-					const signatures = getSignatures(p.witness);
+					const signatures = getP2PKWitnessSignatures(p.witness);
 					return {
 						amount: p.amount,
 						C: pointFromHex(p.C),
@@ -1026,7 +1026,7 @@ class CashuWallet {
 		if (privkey) {
 			proofsToSend = getSignedProofs(
 				proofsToSend.map((p: Proof) => {
-					const signatures = getSignatures(p.witness);
+					const signatures = getP2PKWitnessSignatures(p.witness);
 					return {
 						amount: p.amount,
 						C: pointFromHex(p.C),

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1029,7 +1029,7 @@ class CashuWallet {
 						C: pointFromHex(p.C),
 						id: p.id,
 						secret: new TextEncoder().encode(p.secret),
-						witness: typeof p.witness === 'string' ? JSON.parse(p.witness) : null
+						witness: typeof p.witness === 'string' ? JSON.parse(p.witness) : { signatures: [] }
 					};
 				}),
 				privkey

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -32,7 +32,6 @@ import {
 	MeltQuoteOptions,
 	SwapTransaction,
 	LockedMintQuoteResponse,
-	MintQuote,
 	PartialMintQuoteResponse,
 	PartialMeltQuoteResponse
 } from './model/types/index.js';

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -965,6 +965,7 @@ class CashuWallet {
 			locktime?: number;
 			refundKeys?: Array<string>;
 			nsig?: number;
+			rsig?: number;
 		}
 	): SwapTransaction {
 		const totalAmount = proofsToSend.reduce((total: number, curr: Proof) => total + curr.amount, 0);
@@ -1247,6 +1248,7 @@ class CashuWallet {
 			locktime?: number;
 			refundKeys?: Array<string>;
 			nsig?: number;
+			rsig?: number;
 		},
 		factory?: OutputDataFactory
 	): Array<OutputDataLike> {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,6 +1,6 @@
 import { serializeProof } from './crypto/client/index.js';
-import { getSignedProofs, getP2PKWitnessSignatures } from './crypto/client/NUT11.js';
-import { hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
+import { signP2PKProofs, getP2PKWitnessSignatures } from './crypto/client/NUT11.js';
+import { hashToCurve, pointFromHex } from './crypto/common/index.js';
 import { CashuMint } from './CashuMint.js';
 import { MintInfo } from './model/MintInfo.js';
 import {
@@ -910,19 +910,9 @@ class CashuWallet {
 			this._keepFactory
 		);
 		if (privkey != undefined) {
-			proofsToSend = getSignedProofs(
-				proofsToSend.map((p: Proof) => {
-					const signatures = getP2PKWitnessSignatures(p.witness);
-					return {
-						amount: p.amount,
-						C: pointFromHex(p.C),
-						id: p.id,
-						secret: new TextEncoder().encode(p.secret),
-						witness: { signatures: signatures }
-					};
-				}),
-				privkey
-			).map((p: NUT11Proof) => serializeProof(p));
+			proofsToSend = signP2PKProofs(proofsToSend, privkey).map((p: Proof) => {
+				return { ...p, witness: JSON.stringify(p.witness) };
+			});
 		}
 
 		proofsToSend = stripDleq(proofsToSend);
@@ -1024,19 +1014,9 @@ class CashuWallet {
 		}
 
 		if (privkey) {
-			proofsToSend = getSignedProofs(
-				proofsToSend.map((p: Proof) => {
-					const signatures = getP2PKWitnessSignatures(p.witness);
-					return {
-						amount: p.amount,
-						C: pointFromHex(p.C),
-						id: p.id,
-						secret: new TextEncoder().encode(p.secret),
-						witness: { signatures: signatures }
-					};
-				}),
-				privkey
-			).map((p: NUT11Proof) => serializeProof(p));
+			proofsToSend = signP2PKProofs(proofsToSend, privkey).map((p: Proof) => {
+				return { ...p, witness: JSON.stringify(p.witness) };
+			});
 		}
 
 		proofsToSend = stripDleq(proofsToSend);

--- a/src/crypto/client/NUT11.ts
+++ b/src/crypto/client/NUT11.ts
@@ -68,15 +68,11 @@ export function getP2PKExpectedKWitnessPubkeys(secret: Secret): Array<string> {
 		const n_sigsTag = tags && tags.find((tag) => tag[0] === 'n_sigs');
 		const n_sigs = n_sigsTag && n_sigsTag.length > 1 ? parseInt(n_sigsTag[1], 10) : null;
 		if (locktime > now) {
-			// NB: Am interpretting NUT-11 as intending the pubkeys tag is only used
-			// if n_sigs is a positive integer. Otherwise we can just return
-			// [data, ...pubkeys] when locktime > now
-			if (n_sigs && n_sigs >= 1) {
-				const pubkeysTag = tags && tags.find((tag) => tag[0] === 'pubkeys');
-				const pubkeys = pubkeysTag && pubkeysTag.length > 1 ? pubkeysTag.slice(1) : [];
-				return [data, ...pubkeys];
-			}
-			return [data];
+			// Am interpretting NUT-11 as intending pubkeys to be usable for a
+			// 1-of-m multisig if provided, even if n_sigs is not
+			const pubkeysTag = tags && tags.find((tag) => tag[0] === 'pubkeys');
+			const pubkeys = pubkeysTag && pubkeysTag.length > 1 ? pubkeysTag.slice(1) : [];
+			return [data, ...pubkeys];
 		}
 		const refundTag = tags && tags.find((tag) => tag[0] === 'refund');
 		const refundKeys = refundTag && refundTag.length > 1 ? refundTag.slice(1) : [];

--- a/src/crypto/client/NUT11.ts
+++ b/src/crypto/client/NUT11.ts
@@ -147,7 +147,9 @@ export function getP2PKSigFlag(secret: Secret): string {
  * Gets witness signatures as an array
  * @type {array} of signatures
  */
-export const getSignatures = (witness: string | P2PKWitness | undefined): Array<string> => {
+export const getP2PKWitnessSignatures = (
+	witness: string | P2PKWitness | undefined
+): Array<string> => {
 	if (!witness) return [];
 	if (typeof witness === 'string') {
 		try {
@@ -203,7 +205,7 @@ export const getSignedProof = (proof: Proof, privateKey: string): Proof => {
 		return proof; // nothing to sign
 	}
 	// Check if this pubkey has already signed
-	const signatures = getSignatures(proof.witness);
+	const signatures = getP2PKWitnessSignatures(proof.witness);
 	const alreadySigned = signatures.some((sig) => {
 		try {
 			return verifyP2PKSecretSignature(sig, proof.secret, pubkey);

--- a/src/crypto/client/NUT11.ts
+++ b/src/crypto/client/NUT11.ts
@@ -1,9 +1,10 @@
 import { PrivKey, bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
-import { schnorr } from '@noble/curves/secp256k1';
+import { schnorr, secp256k1 } from '@noble/curves/secp256k1';
 import { randomBytes } from '@noble/hashes/utils';
 import { parseSecret } from '../common/NUT11.js';
 import { Proof, Secret } from '../common/index.js';
+import { type P2PKWitness } from '../../model/types/index.js';
 import { BlindedMessage } from './index.js';
 
 export const createP2PKsecret = (pubkey: string): Uint8Array => {
@@ -18,7 +19,7 @@ export const createP2PKsecret = (pubkey: string): Uint8Array => {
 	return new TextEncoder().encode(parsed);
 };
 
-export const signP2PKsecret = (secret: Uint8Array, privateKey: PrivKey) => {
+export const signP2PKsecret = (secret: Uint8Array, privateKey: PrivKey): Uint8Array => {
 	const msghash = sha256(new TextDecoder().decode(secret));
 	const sig = schnorr.sign(msghash, privateKey);
 	return sig;
@@ -30,66 +31,194 @@ export const signBlindedMessage = (B_: string, privateKey: PrivKey): Uint8Array 
 	return sig;
 };
 
-export const getP2PExpectedKWitnessPubkeys = (secret: Secret): Array<string> => {
+/**
+ * Verifies a Schnorr signature on a P2PK secret.
+ * @param signature - The Schnorr signature (hex-encoded).
+ * @param secret - The Secret to verify.
+ * @param pubkey - The Cashu P2PK public key (hex-encoded, starting with 02 or 03).
+ * @returns {boolean} True if the signature is valid, false otherwise.
+ */
+export const verifyP2PKSecretSignature = (
+	signature: string,
+	secret: Uint8Array,
+	pubkey: string
+): boolean => {
 	try {
-		const now = Math.floor(Date.now() / 1000); // unix TS
+		const msghash = sha256(new TextDecoder().decode(secret));
+		const pubkeyX = pubkey.slice(2);
+		if (schnorr.verify(signature, msghash, hexToBytes(pubkeyX))) {
+			return true;
+		}
+	} catch (e) {
+		console.error('verifyP2PKsecret error:', e);
+	}
+	return false; // no bueno
+};
+
+/**
+ * Returns the expected witness public keys from a NUT-11 P2PK secret
+ * @param secret - The NUT-11 P2PK secret.
+ * @returns {array} with the public keys or empty array
+ */
+export function getP2PKExpectedKWitnessPubkeys(secret: Secret): Array<string> {
+	try {
+		const now = Math.floor(Date.now() / 1000);
 		const { data, tags } = secret[1];
-		const locktimeTag = tags && tags.find((tag) => tag[0] === 'locktime');
-		const locktime = locktimeTag ? parseInt(locktimeTag[1], 10) : Infinity; // Permanent lock if not set
-		const refundTag = tags && tags.find((tag) => tag[0] === 'refund');
-		const refundKeys = refundTag && refundTag.length > 1 ? refundTag.slice(1) : [];
-		const pubkeysTag = tags && tags.find((tag) => tag[0] === 'pubkeys');
-		const pubkeys = pubkeysTag && pubkeysTag.length > 1 ? pubkeysTag.slice(1) : [];
+		const locktime = getP2PKLocktime(secret);
 		const n_sigsTag = tags && tags.find((tag) => tag[0] === 'n_sigs');
-		const n_sigs = n_sigsTag ? parseInt(n_sigsTag[1], 10) : undefined;
-		// If locktime is in the future, return 'data'+'pubkeys' if multisig ('n_sigs')
-		// otherwise return the main locking key ('data')
+		const n_sigs = n_sigsTag && n_sigsTag.length > 1 ? parseInt(n_sigsTag[1], 10) : null;
 		if (locktime > now) {
+			// NB: Am interpretting NUT-11 as intending the pubkeys tag is only used
+			// if n_sigs is a positive integer. Otherwise we can just return
+			// [data, ...pubkeys] when locktime > now
 			if (n_sigs && n_sigs >= 1) {
+				const pubkeysTag = tags && tags.find((tag) => tag[0] === 'pubkeys');
+				const pubkeys = pubkeysTag && pubkeysTag.length > 1 ? pubkeysTag.slice(1) : [];
 				return [data, ...pubkeys];
 			}
-			return [data]; // as array
+			return [data];
 		}
-		// If locktime expired, return 'refund' keys
+		const refundTag = tags && tags.find((tag) => tag[0] === 'refund');
+		const refundKeys = refundTag && refundTag.length > 1 ? refundTag.slice(1) : [];
 		if (refundKeys) {
 			return refundKeys;
 		}
 	} catch {}
-	return []; // Token is not locked / secret is malformed
+	return []; // Unlocked or expired with no refund keys
+}
+
+/**
+ * Returns the locktime from a NUT-11 P2PK secret or Infinity if no locktime
+ * @param secret - The NUT-11 P2PK secret.
+ * @returns {number} The locktime unix timestamp or Infinity (permanent lock)
+ */
+export function getP2PKLocktime(secret: Secret): number {
+	// Validate secret format
+	if (secret[0] !== 'P2PK') {
+		throw new Error('Invalid P2PK secret: must start with "P2PK"');
+	}
+	const { tags } = secret[1];
+	const locktimeTag = tags && tags.find((tag) => tag[0] === 'locktime');
+	return locktimeTag && locktimeTag.length > 1 ? parseInt(locktimeTag[1], 10) : Infinity; // Permanent lock if not set
+}
+
+/**
+ * Returns the number of signatures required from a NUT-11 P2PK secret
+ * @param secret - The NUT-11 P2PK secret.
+ * @returns {number} The number of signatories (n_sigs / n_sigs_refund) or 0 if secret is unlocked
+ */
+export function getP2PKNSigs(secret: Secret): number {
+	// Validate secret format
+	if (secret[0] !== 'P2PK') {
+		throw new Error('Invalid P2PK secret: must start with "P2PK"');
+	}
+	const now = Math.floor(Date.now() / 1000);
+	const witness = getP2PKExpectedKWitnessPubkeys(secret);
+	const locktime = getP2PKLocktime(secret);
+	const { tags } = secret[1];
+	// Check lock multisig
+	const n_sigsTag = tags && tags.find((tag) => tag[0] === 'n_sigs');
+	const n_sigs = n_sigsTag && n_sigsTag.length > 1 ? parseInt(n_sigsTag[1], 10) : 1; // Default: 1
+	if (locktime > now) {
+		return n_sigs; // locked
+	}
+	// Check refund multisig
+	const n_sigs_refundTag = tags && tags.find((tag) => tag[0] === 'n_sigs_refund');
+	const n_sigs_refund =
+		n_sigs_refundTag && n_sigs_refundTag.length > 1 ? parseInt(n_sigs_refundTag[1], 10) : 1; // Default: 1
+	return witness.length > 0 ? n_sigs_refund : 0; // unlocked if no witnesses needed
+}
+
+/**
+ * Returns the sigflag from a NUT-11 P2PK secret
+ * @param secret - The NUT-11 P2PK secret.
+ * @returns {string} The sigflag or 'SIG_INPUTS' (default)
+ */
+export function getP2PKSigFlag(secret: Secret): string {
+	// Validate secret format
+	if (secret[0] !== 'P2PK') {
+		throw new Error('Invalid P2PK secret: must start with "P2PK"');
+	}
+	const { tags } = secret[1];
+	const sigFlagTag = tags && tags.find((tag) => tag[0] === 'sigflag');
+	return sigFlagTag && sigFlagTag.length > 1 ? sigFlagTag[1] : 'SIG_INPUTS';
+}
+
+/**
+ * Gets witness signatures as an array
+ * @type {array} of signatures
+ */
+export const getSignatures = (witness: string | P2PKWitness | undefined): Array<string> => {
+	if (!witness) return [];
+	if (typeof witness === 'string') {
+		try {
+			return JSON.parse(witness).signatures || [];
+		} catch (e) {
+			console.error('Failed to parse witness string:', e);
+			return [];
+		}
+	}
+	return witness.signatures || [];
 };
 
+/**
+ * Signs proofs with provided private key(s) if required
+ * NB: Will only sign if the proof requires a signature from the key
+ * @param proofs - An array of proofs to sign
+ * @param privateKey - a single private key, or array of private keys
+ */
 export const getSignedProofs = (
 	proofs: Array<Proof>,
 	privateKey: string | Array<string>
 ): Array<Proof> => {
-	// Normalize keypairs
-	const keypairs: Array<{ priv: string; pub: string }> = [];
-	if (Array.isArray(privateKey)) {
-		for (const priv of privateKey) {
-			keypairs.push({ priv, pub: bytesToHex(schnorr.getPublicKey(priv)) });
-		}
-	} else {
-		keypairs.push({ priv: privateKey, pub: bytesToHex(schnorr.getPublicKey(privateKey)) });
-	}
+	const privateKeys: Array<string> = Array.isArray(privateKey) ? privateKey : [privateKey];
 	return proofs.map((proof) => {
 		try {
-			const parsed: Secret = parseSecret(proof.secret);
-			if (parsed[0] !== 'P2PK') {
-				throw new Error('unknown secret type');
-			}
-			// Sign proof for every required witness we have pk for
-			const witnesses = getP2PExpectedKWitnessPubkeys(parsed);
 			let signedProof = proof;
-			for (const { priv, pub } of keypairs) {
-				if (witnesses.includes(pub)) {
-					signedProof = getSignedProof(signedProof, hexToBytes(priv));
-				}
+			for (const priv of privateKeys) {
+				signedProof = getSignedProof(signedProof, priv);
 			}
 			return signedProof;
 		} catch {
 			return proof;
 		}
 	});
+};
+
+/**
+ * Signs a single proof with the provided private key if required
+ * NB: Will only sign if the proof requires a signature from the key
+ * @param proof - A proof to sign
+ * @param privateKey - a single private key
+ */
+export const getSignedProof = (proof: Proof, privateKey: string): Proof => {
+	// Check secret is P2PK
+	const parsed: Secret = parseSecret(proof.secret);
+	if (parsed[0] !== 'P2PK') {
+		throw new Error('not a P2PK secret');
+	}
+	// Check this pubkey is required to sign
+	const pubkey = bytesToHex(secp256k1.getPublicKey(privateKey)); // for Cashu
+	const witnesses = getP2PKExpectedKWitnessPubkeys(parsed);
+	if (!witnesses.length || !witnesses.includes(pubkey)) {
+		return proof; // nothing to sign
+	}
+	// Check if this pubkey has already signed
+	const signatures = getSignatures(proof.witness);
+	const alreadySigned = signatures.some((sig) => {
+		try {
+			return verifyP2PKSecretSignature(sig, proof.secret, pubkey);
+		} catch {
+			return false; // Invalid signature, treat as not signed
+		}
+	});
+	if (alreadySigned) {
+		return proof; // Skip signing if pubkey has a valid signature
+	}
+	// Add new signature
+	const signature = signP2PKsecret(proof.secret, privateKey);
+	signatures.push(bytesToHex(signature));
+	return { ...proof, witness: { signatures } };
 };
 
 export const getSignedOutput = (output: BlindedMessage, privateKey: PrivKey): BlindedMessage => {
@@ -104,14 +233,4 @@ export const getSignedOutputs = (
 	privateKey: string
 ): Array<BlindedMessage> => {
 	return outputs.map((o) => getSignedOutput(o, privateKey));
-};
-
-export const getSignedProof = (proof: Proof, privateKey: PrivKey): Proof => {
-	const signature = bytesToHex(signP2PKsecret(proof.secret, privateKey));
-	if (!proof.witness) {
-		proof.witness = { signatures: [signature] };
-	} else {
-		proof.witness.signatures = [...(proof.witness.signatures || []), signature];
-	}
-	return proof;
 };

--- a/src/crypto/client/NUT11.ts
+++ b/src/crypto/client/NUT11.ts
@@ -2,12 +2,12 @@ import { PrivKey, bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1';
 import { randomBytes } from '@noble/hashes/utils';
-import { parseSecret } from '../common/NUT11.js';
-import { Proof, Secret } from '../common/index.js';
-import { type P2PKWitness } from '../../model/types/index.js';
+import { parseP2PKSecret } from '../common/NUT11.js';
+import { Secret } from '../common/index.js';
+import { type P2PKWitness, type Proof } from '../../model/types/index.js';
 import { BlindedMessage } from './index.js';
 
-export const createP2PKsecret = (pubkey: string): Uint8Array => {
+export const createP2PKsecret = (pubkey: string): string => {
 	const newSecret: Secret = [
 		'P2PK',
 		{
@@ -15,37 +15,37 @@ export const createP2PKsecret = (pubkey: string): Uint8Array => {
 			data: pubkey
 		}
 	];
-	const parsed = JSON.stringify(newSecret);
-	return new TextEncoder().encode(parsed);
+	return JSON.stringify(newSecret);
 };
 
-export const signP2PKsecret = (secret: Uint8Array, privateKey: PrivKey): Uint8Array => {
-	const msghash = sha256(new TextDecoder().decode(secret));
+export const signP2PKSecret = (secret: string, privateKey: PrivKey): string => {
+	const msghash = sha256(secret);
 	const sig = schnorr.sign(msghash, privateKey);
-	return sig;
+	return bytesToHex(sig);
 };
 
-export const signBlindedMessage = (B_: string, privateKey: PrivKey): Uint8Array => {
+export const signBlindedMessage = (B_: string, privateKey: PrivKey): string => {
 	const msgHash = sha256(B_);
 	const sig = schnorr.sign(msgHash, privateKey);
-	return sig;
+	return bytesToHex(sig);
 };
 
 /**
  * Verifies a Schnorr signature on a P2PK secret.
  * @param signature - The Schnorr signature (hex-encoded).
  * @param secret - The Secret to verify.
- * @param pubkey - The Cashu P2PK public key (hex-encoded, starting with 02 or 03).
+ * @param pubkey - The Cashu P2PK public key (hex-encoded, X-only or with 02/03 prefix).
  * @returns {boolean} True if the signature is valid, false otherwise.
  */
 export const verifyP2PKSecretSignature = (
 	signature: string,
-	secret: Uint8Array,
+	secret: string,
 	pubkey: string
 ): boolean => {
 	try {
-		const msghash = sha256(new TextDecoder().decode(secret));
-		const pubkeyX = pubkey.slice(2);
+		const msghash = sha256(secret);
+		// Use X-only pubkey: strip 02/03 prefix if pubkey is 66 hex chars (33 bytes)
+		const pubkeyX = pubkey.length === 66 ? pubkey.slice(2) : pubkey;
 		if (schnorr.verify(signature, msghash, hexToBytes(pubkeyX))) {
 			return true;
 		}
@@ -56,13 +56,36 @@ export const verifyP2PKSecretSignature = (
 };
 
 /**
+ * Verifies a pubkey has signed a P2PK Proof.
+ * @param pubkey - The Cashu P2PK public key (hex-encoded, X-only or with 02/03 prefix).
+ * @param proof - A Cashu proof
+ * @returns {boolean} True if one of the signatures is theirs, false otherwise
+ */
+export const hasP2PKSignedProof = (pubkey: string, proof: Proof): boolean => {
+	if (!proof.witness) {
+		return false;
+	}
+	const signatures = getP2PKWitnessSignatures(proof.witness);
+	// See if any of the signatures belong to this pubkey.
+	// We need to do this as Schnorr signatures are non-deterministic.
+	return signatures.some((sig) => {
+		try {
+			return verifyP2PKSecretSignature(sig, proof.secret, pubkey);
+		} catch {
+			return false; // Invalid signature, treat as not signed
+		}
+	});
+};
+
+/**
  * Returns the expected witness public keys from a NUT-11 P2PK secret
- * @param secret - The NUT-11 P2PK secret.
+ * @param secretStr - The NUT-11 P2PK secret.
  * @returns {array} with the public keys or empty array
  */
-export function getP2PKExpectedKWitnessPubkeys(secret: Secret): Array<string> {
+export function getP2PKExpectedKWitnessPubkeys(secretStr: string | Secret): Array<string> {
 	try {
-		// Validate secret format
+		// Validate secret
+		const secret: Secret = typeof secretStr === 'string' ? parseP2PKSecret(secretStr) : secretStr;
 		if (secret[0] !== 'P2PK') {
 			throw new Error('Invalid P2PK secret: must start with "P2PK"');
 		}
@@ -87,11 +110,12 @@ export function getP2PKExpectedKWitnessPubkeys(secret: Secret): Array<string> {
 
 /**
  * Returns the locktime from a NUT-11 P2PK secret or Infinity if no locktime
- * @param secret - The NUT-11 P2PK secret.
+ * @param secretStr - The NUT-11 P2PK secret.
  * @returns {number} The locktime unix timestamp or Infinity (permanent lock)
  */
-export function getP2PKLocktime(secret: Secret): number {
-	// Validate secret format
+export function getP2PKLocktime(secretStr: string | Secret): number {
+	// Validate secret
+	const secret: Secret = typeof secretStr === 'string' ? parseP2PKSecret(secretStr) : secretStr;
 	if (secret[0] !== 'P2PK') {
 		throw new Error('Invalid P2PK secret: must start with "P2PK"');
 	}
@@ -102,11 +126,12 @@ export function getP2PKLocktime(secret: Secret): number {
 
 /**
  * Returns the number of signatures required from a NUT-11 P2PK secret
- * @param secret - The NUT-11 P2PK secret.
+ * @param secretStr - The NUT-11 P2PK secret.
  * @returns {number} The number of signatories (n_sigs / n_sigs_refund) or 0 if secret is unlocked
  */
-export function getP2PKNSigs(secret: Secret): number {
-	// Validate secret format
+export function getP2PKNSigs(secretStr: string | Secret): number {
+	// Validate secret
+	const secret: Secret = typeof secretStr === 'string' ? parseP2PKSecret(secretStr) : secretStr;
 	if (secret[0] !== 'P2PK') {
 		throw new Error('Invalid P2PK secret: must start with "P2PK"');
 	}
@@ -130,11 +155,12 @@ export function getP2PKNSigs(secret: Secret): number {
 
 /**
  * Returns the sigflag from a NUT-11 P2PK secret
- * @param secret - The NUT-11 P2PK secret.
+ * @param secretStr - The NUT-11 P2PK secret.
  * @returns {string} The sigflag or 'SIG_INPUTS' (default)
  */
-export function getP2PKSigFlag(secret: Secret): string {
-	// Validate secret format
+export function getP2PKSigFlag(secretStr: string | Secret): string {
+	// Validate secret
+	const secret: Secret = typeof secretStr === 'string' ? parseP2PKSecret(secretStr) : secretStr;
 	if (secret[0] !== 'P2PK') {
 		throw new Error('Invalid P2PK secret: must start with "P2PK"');
 	}
@@ -168,7 +194,7 @@ export const getP2PKWitnessSignatures = (
  * @param proofs - An array of proofs to sign
  * @param privateKey - a single private key, or array of private keys
  */
-export const getSignedProofs = (
+export const signP2PKProofs = (
 	proofs: Array<Proof>,
 	privateKey: string | Array<string>
 ): Array<Proof> => {
@@ -177,7 +203,7 @@ export const getSignedProofs = (
 		try {
 			let signedProof = proof;
 			for (const priv of privateKeys) {
-				signedProof = getSignedProof(signedProof, priv);
+				signedProof = signP2PKProof(signedProof, priv);
 			}
 			return signedProof;
 		} catch {
@@ -192,19 +218,22 @@ export const getSignedProofs = (
  * @param proof - A proof to sign
  * @param privateKey - a single private key
  */
-export const getSignedProof = (proof: Proof, privateKey: string): Proof => {
+export const signP2PKProof = (proof: Proof, privateKey: string): Proof => {
 	// Check secret is P2PK
-	const parsed: Secret = parseSecret(proof.secret);
+	const parsed: Secret = parseP2PKSecret(proof.secret);
 	if (parsed[0] !== 'P2PK') {
 		throw new Error('not a P2PK secret');
 	}
-	// Check this pubkey is required to sign
-	const pubkey = bytesToHex(secp256k1.getPublicKey(privateKey)); // for Cashu
+	// Check if the private key is required to sign by checking its
+	// X-only pubkey (no 02/03 prefix) against the expected witness pubkeys
+	// NB: Nostr pubkeys prepend 02 by convention, ignoring actual Y-parity
+	const pubkey = bytesToHex(schnorr.getPublicKey(privateKey)); // x-only
 	const witnesses = getP2PKExpectedKWitnessPubkeys(parsed);
-	if (!witnesses.length || !witnesses.includes(pubkey)) {
+	if (!witnesses.length || !witnesses.some((w) => w.includes(pubkey))) {
+		console.warn(`Signature not required from [02|03]${pubkey}`);
 		return proof; // nothing to sign
 	}
-	// Check if this pubkey has already signed
+	// Check if the public key has already signed
 	const signatures = getP2PKWitnessSignatures(proof.witness);
 	const alreadySigned = signatures.some((sig) => {
 		try {
@@ -214,18 +243,19 @@ export const getSignedProof = (proof: Proof, privateKey: string): Proof => {
 		}
 	});
 	if (alreadySigned) {
+		console.warn(`Proof already signed by [02|03]${pubkey}`);
 		return proof; // Skip signing if pubkey has a valid signature
 	}
 	// Add new signature
-	const signature = signP2PKsecret(proof.secret, privateKey);
-	signatures.push(bytesToHex(signature));
+	const signature = signP2PKSecret(proof.secret, privateKey);
+	signatures.push(signature);
 	return { ...proof, witness: { signatures } };
 };
 
 export const getSignedOutput = (output: BlindedMessage, privateKey: PrivKey): BlindedMessage => {
 	const B_ = output.B_.toHex(true);
 	const signature = signBlindedMessage(B_, privateKey);
-	output.witness = { signatures: [bytesToHex(signature)] };
+	output.witness = { signatures: [signature] };
 	return output;
 };
 

--- a/src/crypto/common/NUT11.ts
+++ b/src/crypto/common/NUT11.ts
@@ -1,6 +1,6 @@
 import { Secret } from './index.js';
 
-export const parseSecret = (secret: string | Uint8Array): Secret => {
+export const parseP2PKSecret = (secret: string | Uint8Array): Secret => {
 	try {
 		if (secret instanceof Uint8Array) {
 			secret = new TextDecoder().decode(secret);

--- a/src/crypto/common/index.ts
+++ b/src/crypto/common/index.ts
@@ -5,7 +5,7 @@ import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { bytesToNumber, encodeBase64toUint8, hexToNumber } from '../util/utils.js';
 import { Buffer } from 'buffer/';
 
-export type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
+export type Enumerate<N extends number, Acc extends Array<number> = []> = Acc['length'] extends N
 	? Acc[number]
 	: Enumerate<N, [...Acc, Acc['length']]>;
 

--- a/src/crypto/mint/NUT11.ts
+++ b/src/crypto/mint/NUT11.ts
@@ -1,20 +1,20 @@
 import { schnorr } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import { parseSecret } from '../common/NUT11.js';
+import { parseP2PKSecret } from '../common/NUT11.js';
 import {
 	getP2PKExpectedKWitnessPubkeys,
 	getP2PKWitnessSignatures,
 	getP2PKNSigs,
 	verifyP2PKSecretSignature
 } from '../client/NUT11.js';
-import { Proof } from '../common/index.js';
+import { type Proof } from '../../model/types/index.js';
 import { BlindedMessage } from '../client/index.js';
 
 export const verifyP2PKSig = (proof: Proof): boolean => {
 	if (!proof.witness) {
 		throw new Error('could not verify signature, no witness provided');
 	}
-	const parsedSecret = parseSecret(proof.secret);
+	const parsedSecret = parseP2PKSecret(proof.secret);
 	const witnesses = getP2PKExpectedKWitnessPubkeys(parsedSecret);
 	if (!witnesses.length) {
 		throw new Error('no signatures required, proof is unlocked');

--- a/src/crypto/mint/NUT11.ts
+++ b/src/crypto/mint/NUT11.ts
@@ -3,7 +3,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { parseSecret } from '../common/NUT11.js';
 import {
 	getP2PKExpectedKWitnessPubkeys,
-	getSignatures,
+	getP2PKWitnessSignatures,
 	getP2PKNSigs,
 	verifyP2PKSecretSignature
 } from '../client/NUT11.js';
@@ -21,7 +21,7 @@ export const verifyP2PKSig = (proof: Proof): boolean => {
 	}
 	let signatories = 0;
 	const requiredSigs = getP2PKNSigs(parsedSecret);
-	const signatures = getSignatures(proof.witness);
+	const signatures = getP2PKWitnessSignatures(proof.witness);
 	// Loop through witnesses to see if any of the signatures belong to them.
 	// We need to do this as Schnorr signatures are non-deterministic, so we
 	// count the number of valid witnesses, not the number of valid signatures

--- a/src/crypto/mint/NUT11.ts
+++ b/src/crypto/mint/NUT11.ts
@@ -1,52 +1,55 @@
 import { schnorr } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { parseSecret } from '../common/NUT11.js';
+import {
+	getP2PKExpectedKWitnessPubkeys,
+	getSignatures,
+	getP2PKNSigs,
+	verifyP2PKSecretSignature
+} from '../client/NUT11.js';
 import { Proof } from '../common/index.js';
 import { BlindedMessage } from '../client/index.js';
 
-export const verifyP2PKSig = (proof: Proof) => {
+export const verifyP2PKSig = (proof: Proof): boolean => {
 	if (!proof.witness) {
 		throw new Error('could not verify signature, no witness provided');
 	}
 	const parsedSecret = parseSecret(proof.secret);
-
-	// const tags = {} as Tags
-	// parsedSecret[1].tags.forEach((e: string[]) => {tags[e[0]]=e.shift()})
-	// if (tags.locktime) {
-	//     const locktime = parseInt(tags.locktime[1])
-
-	//     let isUnlocked = false
-	//     if (Math.floor(Date.now() / 1000)>=locktime) {
-	//         isUnlocked = true
-	//     }
-	// }
-	// if (tags.sigflag as SigFlag) {
-	//     if (tags.sigflag[0]==='SIG_INPUT') {
-
-	//     }
-	//     else if(tags.sigflag[0]==='SIG_ALL') {
-
-	//     }
-	//     else {
-	//         throw new Error("Unknown sigflag");
-	//     }
-	// }
-	// if (tags.n_sigs) {
-	//     if (tags.pubkeys) {
-
-	//     }
-	// }
-
-	return schnorr.verify(
-		proof.witness.signatures[0],
-		sha256(new TextDecoder().decode(proof.secret)),
-		parsedSecret[1].data
-	);
+	const witnesses = getP2PKExpectedKWitnessPubkeys(parsedSecret);
+	if (!witnesses.length) {
+		throw new Error('no signatures required, proof is unlocked');
+	}
+	let signatories = 0;
+	const requiredSigs = getP2PKNSigs(parsedSecret);
+	const signatures = getSignatures(proof.witness);
+	// Loop through witnesses to see if any of the signatures belong to them.
+	// We need to do this as Schnorr signatures are non-deterministic, so we
+	// count the number of valid witnesses, not the number of valid signatures
+	for (const pubkey of witnesses) {
+		const hasSigned = signatures.some((sig) => {
+			try {
+				return verifyP2PKSecretSignature(sig, proof.secret, pubkey);
+			} catch {
+				return false; // Invalid signature, treat as not signed
+			}
+		});
+		if (hasSigned) {
+			signatories++;
+		}
+	}
+	if (signatories >= requiredSigs) {
+		return true;
+	}
+	return false;
 };
 
 export const verifyP2PKSigOutput = (output: BlindedMessage, publicKey: string): boolean => {
 	if (!output.witness) {
 		throw new Error('could not verify signature, no witness provided');
 	}
-	return schnorr.verify(output.witness.signatures[0], sha256(output.B_.toHex(true)), publicKey);
+	return schnorr.verify(
+		output.witness.signatures[0],
+		sha256(output.B_.toHex(true)),
+		publicKey.slice(2)
+	);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,16 @@ import {
 	hasValidDleq
 } from './utils.js';
 import { CashuAuthMint, CashuAuthWallet, getBlindedAuthToken, getEncodedAuthToken } from './auth';
+import {
+	signP2PKProofs,
+	hasP2PKSignedProof,
+	getP2PKExpectedKWitnessPubkeys,
+	getP2PKLocktime,
+	getP2PKNSigs,
+	getP2PKSigFlag,
+	getP2PKWitnessSignatures
+} from './crypto/client/NUT11.js';
+import { parseP2PKSecret } from './crypto/common/NUT11.js';
 
 export * from './model/types/index.js';
 
@@ -34,7 +44,15 @@ export {
 	setGlobalRequestOptions,
 	getDecodedTokenBinary,
 	getEncodedTokenBinary,
-	hasValidDleq
+	hasValidDleq,
+	getP2PKExpectedKWitnessPubkeys,
+	getP2PKLocktime,
+	getP2PKNSigs,
+	getP2PKSigFlag,
+	getP2PKWitnessSignatures,
+	parseP2PKSecret,
+	signP2PKProofs,
+	hasP2PKSignedProof
 };
 
 export { injectWebSocketImpl } from './ws.js';

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -113,20 +113,20 @@ export class OutputData implements OutputDataLike {
 			}
 		];
 		if (p2pk.locktime) {
-			newSecret[1].tags.push(['locktime', p2pk.locktime]);
+			newSecret[1].tags.push(['locktime', String(p2pk.locktime)]); // NUT-10 string
 		}
 		if (pubkeys.length > 1) {
 			newSecret[1].tags.push(['pubkeys', ...pubkeys.slice(1)]); // Additional keys
 			if (n_sigs > 1) {
 				// 1 is the default, so we can save space if not multisig
-				newSecret[1].tags.push(['n_sigs', n_sigs]);
+				newSecret[1].tags.push(['n_sigs', String(n_sigs)]); // NUT-10 string
 			}
 		}
 		if (p2pk.refundKeys) {
 			newSecret[1].tags.push(['refund', ...p2pk.refundKeys]);
 			if (n_sigs_refund > 1) {
 				// 1 is the default, so we can save space if not multisig
-				newSecret[1].tags.push(['n_sigs_refund', n_sigs_refund]);
+				newSecret[1].tags.push(['n_sigs_refund', String(n_sigs_refund)]); // NUT-10 string
 			}
 		}
 		const parsed = JSON.stringify(newSecret);

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -75,6 +75,7 @@ export class OutputData implements OutputDataLike {
 			locktime?: number;
 			refundKeys?: Array<string>;
 			nsig?: number;
+			rsig?: number;
 		},
 		amount: number,
 		keyset: MintKeys,
@@ -90,13 +91,19 @@ export class OutputData implements OutputDataLike {
 			locktime?: number;
 			refundKeys?: Array<string>;
 			nsig?: number;
+			rsig?: number;
 		},
 		amount: number,
 		keysetId: string
 	) {
-		// Standardize pubkey (backwards compat) and clamp n_sigs between 1 and total pubkeys
+		// Standardize pubkey (backwards compat), clamp n_sigs between 1 and total pubkeys
+		// clamp n_sigs_refund between 1 and total refundKeys, and create secret
 		const pubkeys: Array<string> = Array.isArray(p2pk.pubkey) ? p2pk.pubkey : [p2pk.pubkey];
 		const n_sigs: number = Math.max(1, Math.min(p2pk.nsig || 1, pubkeys.length));
+		const n_sigs_refund: number = Math.max(
+			1,
+			Math.min(p2pk.rsig || 1, p2pk.refundKeys ? p2pk.refundKeys.length : 1)
+		);
 		const newSecret: [string, { nonce: string; data: string; tags: Array<any> }] = [
 			'P2PK',
 			{
@@ -109,12 +116,18 @@ export class OutputData implements OutputDataLike {
 			newSecret[1].tags.push(['locktime', p2pk.locktime]);
 		}
 		if (pubkeys.length > 1) {
-			// Mint will consider additional pubkeys if n_sigs tag is 1 or higher
 			newSecret[1].tags.push(['pubkeys', ...pubkeys.slice(1)]); // Additional keys
-			newSecret[1].tags.push(['n_sigs', n_sigs]);
+			if (n_sigs > 1) {
+				// 1 is the default, so we can save space if not multisig
+				newSecret[1].tags.push(['n_sigs', n_sigs]);
+			}
 		}
 		if (p2pk.refundKeys) {
 			newSecret[1].tags.push(['refund', ...p2pk.refundKeys]);
+			if (n_sigs_refund > 1) {
+				// 1 is the default, so we can save space if not multisig
+				newSecret[1].tags.push(['n_sigs_refund', n_sigs_refund]);
+			}
 		}
 		const parsed = JSON.stringify(newSecret);
 		const secretBytes = new TextEncoder().encode(parsed);

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -33,7 +33,12 @@ export type ReceiveOptions = {
 	privkey?: string;
 	requireDleq?: boolean;
 	outputData?: Array<OutputDataLike> | OutputDataFactory;
-	p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> };
+	p2pk?: {
+		pubkey: string | Array<string>;
+		locktime?: number;
+		refundKeys?: Array<string>;
+		nsig?: number;
+	};
 };
 
 /**
@@ -62,7 +67,12 @@ export type SendOptions = {
 		send?: Array<OutputDataLike> | OutputDataFactory;
 		keep?: Array<OutputDataLike> | OutputDataFactory;
 	};
-	p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> };
+	p2pk?: {
+		pubkey: string | Array<string>;
+		locktime?: number;
+		refundKeys?: Array<string>;
+		nsig?: number;
+	};
 };
 
 /**
@@ -89,7 +99,12 @@ export type SwapOptions = {
 		send?: Array<OutputDataLike> | OutputDataFactory;
 		keep?: Array<OutputDataLike> | OutputDataFactory;
 	};
-	p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> };
+	p2pk?: {
+		pubkey: string | Array<string>;
+		locktime?: number;
+		refundKeys?: Array<string>;
+		nsig?: number;
+	};
 };
 
 export type RestoreOptions = {
@@ -111,7 +126,12 @@ export type MintProofOptions = {
 	counter?: number;
 	pubkey?: string;
 	outputData?: Array<OutputDataLike> | OutputDataFactory;
-	p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> };
+	p2pk?: {
+		pubkey: string | Array<string>;
+		locktime?: number;
+		refundKeys?: Array<string>;
+		nsig?: number;
+	};
 };
 
 /**

--- a/src/model/types/index.ts
+++ b/src/model/types/index.ts
@@ -38,6 +38,7 @@ export type ReceiveOptions = {
 		locktime?: number;
 		refundKeys?: Array<string>;
 		nsig?: number;
+		rsig?: number;
 	};
 };
 
@@ -72,6 +73,7 @@ export type SendOptions = {
 		locktime?: number;
 		refundKeys?: Array<string>;
 		nsig?: number;
+		rsig?: number;
 	};
 };
 
@@ -104,6 +106,7 @@ export type SwapOptions = {
 		locktime?: number;
 		refundKeys?: Array<string>;
 		nsig?: number;
+		rsig?: number;
 	};
 };
 
@@ -131,6 +134,7 @@ export type MintProofOptions = {
 		locktime?: number;
 		refundKeys?: Array<string>;
 		nsig?: number;
+		rsig?: number;
 	};
 };
 

--- a/test/crypto/client/NUT11.test.ts
+++ b/test/crypto/client/NUT11.test.ts
@@ -12,7 +12,7 @@ import {
 	getP2PKLocktime,
 	getP2PKNSigs,
 	getP2PKSigFlag,
-	getSignatures
+	getP2PKWitnessSignatures
 } from '../../../src/crypto/client/NUT11';
 import { Secret } from '../../../src/crypto/common/index.js';
 import { P2PKWitness } from '../../../src/model/types/index.js';
@@ -350,17 +350,17 @@ describe('test getSignedProof', () => {
 	});
 });
 
-describe('test getSignatures', () => {
+describe('test getP2PKWitnessSignatures', () => {
 	test('undefined witness', async () => {
 		const witness = undefined;
-		const result = getSignatures(witness);
+		const result = getP2PKWitnessSignatures(witness);
 		expect(result).toStrictEqual([]);
 	});
 	test('malformed witness', async () => {
 		// Spy on console.error and mock its implementation to do nothing
 		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		const witness = 'malformed';
-		const result = getSignatures(witness);
+		const result = getP2PKWitnessSignatures(witness);
 		expect(result).toStrictEqual([]);
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
 			'Failed to parse witness string:',
@@ -370,7 +370,7 @@ describe('test getSignatures', () => {
 	test('string witness', async () => {
 		const witness =
 			'{"signatures":["60f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383"]}';
-		const result = getSignatures(witness);
+		const result = getP2PKWitnessSignatures(witness);
 		expect(result).toStrictEqual([
 			'60f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383'
 		]);
@@ -382,7 +382,7 @@ describe('test getSignatures', () => {
 				'70f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383'
 			]
 		};
-		const result = getSignatures(witness);
+		const result = getP2PKWitnessSignatures(witness);
 		expect(result).toStrictEqual([
 			'60f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383',
 			'70f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383'

--- a/test/crypto/client/NUT11.test.ts
+++ b/test/crypto/client/NUT11.test.ts
@@ -1,12 +1,8 @@
 import { schnorr } from '@noble/curves/secp256k1';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { describe, expect, test, vi } from 'vitest';
-import {
-	createP2PKsecret,
-	getSignedProof,
-	getSignedProofs
-} from '../../../src/crypto/client/NUT11';
-import { parseSecret } from '../../../src/crypto/common/NUT11';
+import { createP2PKsecret, signP2PKProof, signP2PKProofs } from '../../../src/crypto/client/NUT11';
+import { parseP2PKSecret } from '../../../src/crypto/common/NUT11';
 import {
 	getP2PKExpectedKWitnessPubkeys,
 	getP2PKLocktime,
@@ -26,7 +22,7 @@ const PUBKEY = bytesToHex(getPubKeyFromPrivKey(PRIVKEY));
 describe('test create p2pk secret', () => {
 	test('create from key', async () => {
 		const secret = createP2PKsecret(PUBKEY);
-		const decodedSecret = parseSecret(secret);
+		const decodedSecret = parseP2PKSecret(secret);
 
 		expect(decodedSecret[0]).toBe('P2PK');
 		// console.log(JSON.stringify(decodedSecret))
@@ -41,7 +37,7 @@ describe('test create p2pk secret', () => {
 			id: '00000000000',
 			secret: new TextEncoder().encode(secretStr)
 		};
-		const signedProof = getSignedProof(proof, PRIVKEY);
+		const signedProof = signP2PKProof(proof, PRIVKEY);
 		const verify = verifyP2PKSig(signedProof);
 		expect(verify).toBe(true);
 	});
@@ -64,7 +60,7 @@ describe('test create p2pk secret', () => {
 
 		const proofs = [proof1, proof2];
 
-		const signedProofs = getSignedProofs(proofs, bytesToHex(PRIVKEY));
+		const signedProofs = signP2PKProofs(proofs, bytesToHex(PRIVKEY));
 		const verify0 = verifyP2PKSig(signedProofs[0]);
 		const verify1 = verifyP2PKSig(signedProofs[1]);
 		expect(verify0).toBe(true);
@@ -93,7 +89,7 @@ describe('test create p2pk secret', () => {
 
 		const proofs = [proof1, proof2];
 
-		const signedProofs = getSignedProofs(proofs, [bytesToHex(PRIVKEY), bytesToHex(PRIVKEY2)]);
+		const signedProofs = signP2PKProofs(proofs, [bytesToHex(PRIVKEY), bytesToHex(PRIVKEY2)]);
 		const verify0 = verifyP2PKSig(signedProofs[0]);
 		const verify1 = verifyP2PKSig(signedProofs[1]);
 		expect(verify0).toBe(true);
@@ -122,7 +118,7 @@ describe('test create p2pk secret', () => {
 
 		const proofs = [proof1, proof2];
 
-		const signedProofs = getSignedProofs(proofs, [bytesToHex(PRIVKEY), bytesToHex(PRIVKEY2)]);
+		const signedProofs = signP2PKProofs(proofs, [bytesToHex(PRIVKEY), bytesToHex(PRIVKEY2)]);
 		const verify0 = verifyP2PKSig(signedProofs[0]);
 		const verify1 = verifyP2PKSig(signedProofs[1]);
 		expect(verify0).toBe(true);
@@ -139,35 +135,39 @@ describe('test create p2pk secret', () => {
 describe('test getP2PKNSigs', () => {
 	test('non-p2pk secret', async () => {
 		const secretStr = `["BAD",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		expect(() => getP2PKNSigs(parsed)).toThrow('Invalid P2PK secret: must start with "P2PK"');
+		expect(() => getP2PKNSigs(secretStr)).toThrow('Invalid P2PK secret: must start with "P2PK"');
 	});
 	test('permanent lock, unspecified n_sigs', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKNSigs(parsed);
 		expect(result).toBe(1); // 1 is default
+		expect(getP2PKNSigs(secretStr)).toBe(1); // 1 is default
 	});
 	test('permanent lock, 2 n_sigs', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["n_sigs","2"],["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKNSigs(parsed);
 		expect(result).toBe(2);
+		expect(getP2PKNSigs(secretStr)).toBe(2);
 	});
 	test('expired lock, 2 n_sigs, no refund keys', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["n_sigs","2"],["locktime","212"],["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKNSigs(parsed);
 		expect(result).toBe(0);
+		expect(getP2PKNSigs(secretStr)).toBe(0);
 	});
 	test('expired lock, 2 n_sigs, 2 refund keys, unspecified n_sigs_refund', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
@@ -176,9 +176,10 @@ describe('test getP2PKNSigs', () => {
 		const PUBKEY3 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY3));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["n_sigs","2"],["locktime","212"],["pubkeys","${PUBKEY2}"],["refund","${PUBKEY2}","${PUBKEY3}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKNSigs(parsed);
 		expect(result).toBe(1);
+		expect(getP2PKNSigs(secretStr)).toBe(1);
 	});
 	test('expired lock, 1 n_sigs, 2 refund keys, 2 n_sigs_refund', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
@@ -187,103 +188,115 @@ describe('test getP2PKNSigs', () => {
 		const PUBKEY3 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY3));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["n_sigs","1"],["n_sigs_refund","2"],["locktime","212"],["pubkeys","${PUBKEY2}"],["refund","${PUBKEY2}","${PUBKEY3}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKNSigs(parsed);
 		expect(result).toBe(2);
+		expect(getP2PKNSigs(secretStr)).toBe(2);
 	});
 });
 
 describe('test getP2PKSigFlag', () => {
 	test('non-p2pk secret', async () => {
 		const secretStr = `["BAD",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		expect(() => getP2PKSigFlag(parsed)).toThrow('Invalid P2PK secret: must start with "P2PK"');
+		expect(() => getP2PKSigFlag(secretStr)).toThrow('Invalid P2PK secret: must start with "P2PK"');
 	});
 	test('unspecified sigflag', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKSigFlag(parsed);
 		expect(result).toBe('SIG_INPUTS'); // default
+		expect(getP2PKSigFlag(secretStr)).toBe('SIG_INPUTS'); // default
 	});
 	test('SIG_INPUTS sigflag', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["sigflag","SIG_INPUTS"],["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKSigFlag(parsed);
 		expect(result).toBe('SIG_INPUTS'); // default
+		expect(getP2PKSigFlag(secretStr)).toBe('SIG_INPUTS'); // default
 	});
 	test('SIG_ALL sigflag', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["sigflag","SIG_ALL"],["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKSigFlag(parsed);
-		expect(result).toBe('SIG_ALL'); // default
+		expect(result).toBe('SIG_ALL');
+		expect(getP2PKSigFlag(secretStr)).toBe('SIG_ALL');
 	});
 });
 
 describe('test getP2PKLocktime', () => {
 	test('non-p2pk secret', async () => {
 		const secretStr = `["BAD",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		expect(() => getP2PKLocktime(parsed)).toThrow('Invalid P2PK secret: must start with "P2PK"');
+		expect(() => getP2PKLocktime(secretStr)).toThrow('Invalid P2PK secret: must start with "P2PK"');
 	});
 	test('unspecified locktime', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKLocktime(parsed);
 		expect(result).toBe(Infinity); // default
+		expect(getP2PKLocktime(secretStr)).toBe(Infinity); // default
 	});
 	test('specified locktime', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["locktime","212"],["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKLocktime(parsed);
-		expect(result).toBe(212); // default
+		expect(result).toBe(212);
+		expect(getP2PKLocktime(secretStr)).toBe(212);
 	});
 });
 
 describe('test getP2PKExpectedKWitnessPubkeys', () => {
 	test('non-p2pk secret', async () => {
 		const secretStr = `["BAD",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKExpectedKWitnessPubkeys(parsed);
 		expect(result).toEqual([]);
+		expect(getP2PKExpectedKWitnessPubkeys(secretStr)).toEqual([]);
 	});
 	test('permanent lock, 1 pubkey', async () => {
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKExpectedKWitnessPubkeys(parsed);
 		expect(result).toStrictEqual([PUBKEY]);
+		expect(getP2PKExpectedKWitnessPubkeys(secretStr)).toEqual([PUBKEY]);
 	});
 	test('permanent lock, 2 pubkeys', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKExpectedKWitnessPubkeys(parsed);
 		expect(result).toStrictEqual([PUBKEY, PUBKEY2]);
+		expect(getP2PKExpectedKWitnessPubkeys(secretStr)).toEqual([PUBKEY, PUBKEY2]);
 	});
 	test('expired lock, 2 pubkeys, no refund keys', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
 		const PUBKEY2 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["n_sigs","2"],["locktime","212"],["pubkeys","${PUBKEY2}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKExpectedKWitnessPubkeys(parsed);
 		expect(result).toStrictEqual([]);
+		expect(getP2PKExpectedKWitnessPubkeys(secretStr)).toEqual([]);
 	});
 	test('expired lock, 2 pubkeys, 2 refund keys', async () => {
 		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
@@ -292,13 +305,14 @@ describe('test getP2PKExpectedKWitnessPubkeys', () => {
 		const PUBKEY3 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY3));
 
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}","tags":[["n_sigs","2"],["locktime","212"],["pubkeys","${PUBKEY2}"],["refund","${PUBKEY2}","${PUBKEY3}"]]}]`;
-		const parsed: Secret = parseSecret(secretStr);
+		const parsed: Secret = parseP2PKSecret(secretStr);
 		const result = getP2PKExpectedKWitnessPubkeys(parsed);
 		expect(result).toStrictEqual([PUBKEY2, PUBKEY3]);
+		expect(getP2PKExpectedKWitnessPubkeys(secretStr)).toEqual([PUBKEY2, PUBKEY3]);
 	});
 });
 
-describe('test getSignedProof', () => {
+describe('test signP2PKProof', () => {
 	test('non-p2pk secret', async () => {
 		const secretStr = `["BAD",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
 		const proof: Proof = {
@@ -307,7 +321,7 @@ describe('test getSignedProof', () => {
 			id: '00000000000',
 			secret: new TextEncoder().encode(secretStr)
 		};
-		expect(() => getSignedProof(proof, PRIVKEY).toThrow('not a P2PK secret'));
+		expect(() => signP2PKProof(proof, PRIVKEY).toThrow('not a P2PK secret'));
 	});
 	test('can only sign and verify once', async () => {
 		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
@@ -320,12 +334,12 @@ describe('test getSignedProof', () => {
 				'{"signatures":["60f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383"]}'
 		};
 		// first signing
-		const signedProof = getSignedProof(proof, PRIVKEY);
+		const signedProof = signP2PKProof(proof, PRIVKEY);
 		const verify = verifyP2PKSig(signedProof);
 		expect(verify).toBe(true);
 		expect(signedProof.witness.signatures).toHaveLength(2);
 		// try signing again
-		const signedProof2 = getSignedProof(signedProof, PRIVKEY);
+		const signedProof2 = signP2PKProof(signedProof, PRIVKEY);
 		const verify2 = verifyP2PKSig(signedProof2);
 		expect(verify2).toBe(true);
 		expect(signedProof2.witness.signatures).toHaveLength(2);
@@ -343,10 +357,29 @@ describe('test getSignedProof', () => {
 			witness:
 				'{"signatures":["60f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383"]}'
 		};
-		const signedProof = getSignedProof(proof, PRIVKEY2);
+		const signedProof = signP2PKProof(proof, PRIVKEY2);
 		const verify = verifyP2PKSig(signedProof);
 		expect(verify).toBe(false);
 		expect(signedProof).toBe(proof); // unchanged
+	});
+	test('sign with 02-prepended Nostr key', async () => {
+		const PRIVKEY2 = '622320785910d6aac0d5406ce1b6ef1640ab97c2acdea6a246eb6859decd6230'; // produces an Odd Y-parity pubkey
+		const PUBKEY2 = '02' + bytesToHex(schnorr.getPublicKey(PRIVKEY2)); // Prepended x-only pubkey
+		const PUBKEY3 = bytesToHex(getPubKeyFromPrivKey(PRIVKEY2)); // full 33-byte pubkey
+		expect(PUBKEY3).toMatch(/^03/); // Verify it really is an odd Y-parity key
+		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY2}"}]`;
+		const proof: Proof = {
+			amount: 1,
+			C: pointFromHex('034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'),
+			id: '00000000000',
+			secret: new TextEncoder().encode(secretStr),
+			witness:
+				'{"signatures":["60f3c9b766770b46caac1d27e1ae6b77c8866ebaeba0b9489fe6a15a837eaa6fcd6eaa825499c72ac342983983fd3ba3a8a41f56677cc99ffd73da68b59e1383"]}'
+		};
+		const signedProof = signP2PKProof(proof, PRIVKEY2);
+		const verify = verifyP2PKSig(signedProof);
+		expect(verify).toBe(true);
+		expect(signedProof.witness.signatures).toHaveLength(2);
 	});
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -250,7 +250,7 @@ describe('mint api', () => {
 		const result = await wallet
 			.receive(encoded, { privkey: bytesToHex(privKeyAlice) })
 			.catch((e) => e);
-		expect(result).toEqual(new MintOperationError(0, 'no valid signature provided for input.'));
+		expect(result).toEqual(new MintOperationError(0, 'no signatures in proof.'));
 
 		const proofs = await wallet.receive(encoded, { privkey: bytesToHex(privKeyBob) });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -250,7 +250,7 @@ describe('mint api', () => {
 		const result = await wallet
 			.receive(encoded, { privkey: bytesToHex(privKeyAlice) })
 			.catch((e) => e);
-		expect(result).toEqual(new MintOperationError(0, 'no signatures in proof.'));
+		expect(result).toEqual(new MintOperationError(0, 'Witness is missing for p2pk signature'));
 
 		const proofs = await wallet.receive(encoded, { privkey: bytesToHex(privKeyBob) });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -386,7 +386,7 @@ describe('mint api', () => {
 		const wallet = new CashuWallet(mint);
 
 		const privkey = 'd56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac';
-		const pubkey = '02' + bytesToHex(schnorr.getPublicKey(hexToBytes(privkey)));
+		const pubkey = bytesToHex(secp256k1.getPublicKey(hexToBytes(privkey)));
 
 		const quote = await wallet.createLockedMintQuote(63, pubkey);
 		const proofs = await wallet.mintProofs(63, quote, { privateKey: privkey });
@@ -510,9 +510,9 @@ describe('dleq', () => {
 });
 describe('Custom Outputs', () => {
 	const sk = randomBytes(32);
-	const pk = schnorr.getPublicKey(sk);
+	const pk = secp256k1.getPublicKey(sk);
 	const hexSk = bytesToHex(sk);
-	const hexPk = '02' + bytesToHex(pk);
+	const hexPk = bytesToHex(pk);
 	const invoice =
 		'lnbc10n1pn449a7pp5eh3jn9p8hlcq0c0ppcfem2hg9ehptqr9hjk5gst6c0c9qfmrrvgsdq4gdshx6r4ypqkgerjv4ehxcqzpuxqr8pqsp539s9559pdth06j37kexk9zq2pusl4yvy97ruf36jqgyskawlls3s9p4gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqysgqy00qa3xgn03jtwrtpu93rqrp806czmpftj8g97cm0r3d2x4rsvlhp5vzgjyzzazl9xf4gpgd35gmys998tlfu8j5zrk7sf3n2nh3t3gpyul75t';
 	test('Default keepFactory', async () => {

--- a/test/quoteSignature.test.ts
+++ b/test/quoteSignature.test.ts
@@ -2,7 +2,7 @@ import { test, describe, expect } from 'vitest';
 import { MintPayload } from '../src/model/types/wallet/payloads';
 import { signMintQuote, verifyMintQuoteSignature } from '../src/crypto/client/NUT20';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-import { schnorr } from '@noble/curves/secp256k1';
+import { schnorr, secp256k1 } from '@noble/curves/secp256k1';
 
 describe('mint quote signatures', () => {
 	test('valid signature verification', () => {
@@ -116,7 +116,7 @@ describe('mint quote signatures', () => {
 		} as MintPayload;
 		const quote = mintRequest.quote;
 		const privkey = 'd56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac';
-		const pubkey = '02' + bytesToHex(schnorr.getPublicKey(hexToBytes(privkey)));
+		const pubkey = bytesToHex(secp256k1.getPublicKey(hexToBytes(privkey)));
 		const blindedMessages = mintRequest.outputs;
 		const signature = signMintQuote(privkey, quote, blindedMessages);
 		expect(verifyMintQuoteSignature(pubkey, quote, blindedMessages, signature)).toBe(true);

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -864,7 +864,7 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund']);
 		});
 	});
@@ -881,7 +881,7 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund', 'asecondrefund']);
 		});
 	});
@@ -923,7 +923,7 @@ describe('P2PK BlindingData', () => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toContainEqual(['pubkeys', 'asecondpk', 'athirdpk']);
-			expect(s[1].tags).not.toContainEqual(['n_sigs', 1]);
+			expect(s[1].tags).not.toContainEqual(['n_sigs', '1']);
 		});
 	});
 	test('Create BlindingData locked to multiple pks with 2-of-3 nsig', async () => {
@@ -940,7 +940,7 @@ describe('P2PK BlindingData', () => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toContainEqual(['pubkeys', 'asecondpk', 'athirdpk']);
-			expect(s[1].tags).toContainEqual(['n_sigs', 2]);
+			expect(s[1].tags).toContainEqual(['n_sigs', '2']);
 		});
 	});
 	test('Create BlindingData locked to multiple pks with out of range nsig', async () => {
@@ -957,7 +957,7 @@ describe('P2PK BlindingData', () => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
 			expect(s[1].tags).toContainEqual(['pubkeys', 'asecondpk', 'athirdpk']);
-			expect(s[1].tags).toContainEqual(['n_sigs', 3]);
+			expect(s[1].tags).toContainEqual(['n_sigs', '3']);
 		});
 	});
 	test('Create BlindingData locked to single refund key with default rsig', async () => {
@@ -973,9 +973,9 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund']);
-			expect(s[1].tags).not.toContainEqual(['n_sigs_refund', 1]); // 1 is default
+			expect(s[1].tags).not.toContainEqual(['n_sigs_refund', '1']); // 1 is default
 		});
 	});
 	test('Create BlindingData locked to multiple refund keys with no rsig', async () => {
@@ -991,9 +991,9 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund', 'asecondrefund']);
-			expect(s[1].tags).not.toContainEqual(['n_sigs_refund', 1]); // 1 is default
+			expect(s[1].tags).not.toContainEqual(['n_sigs_refund', '1']); // 1 is default
 		});
 	});
 	test('Create BlindingData locked to multiple refund keys with 2-of-3 rsig', async () => {
@@ -1014,9 +1014,9 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund', 'asecondrefund', 'athirdrefund']);
-			expect(s[1].tags).toContainEqual(['n_sigs_refund', 2]);
+			expect(s[1].tags).toContainEqual(['n_sigs_refund', '2']);
 		});
 	});
 	test('Create BlindingData locked to multiple refund keys with out of range rsig', async () => {
@@ -1037,9 +1037,9 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund', 'asecondrefund', 'athirdrefund']);
-			expect(s[1].tags).toContainEqual(['n_sigs_refund', 3]);
+			expect(s[1].tags).toContainEqual(['n_sigs_refund', '3']);
 		});
 	});
 	test('Create BlindingData locked to multiple refund keys with expired multisig', async () => {
@@ -1061,11 +1061,11 @@ describe('P2PK BlindingData', () => {
 		allSecrets.forEach((s) => {
 			expect(s[0] === 'P2PK');
 			expect(s[1].data).toBe('thisisatest');
-			expect(s[1].tags).toContainEqual(['locktime', 212]);
+			expect(s[1].tags).toContainEqual(['locktime', '212']);
 			expect(s[1].tags).toContainEqual(['pubkeys', 'asecondpk', 'athirdpk']);
 			expect(s[1].tags).toContainEqual(['refund', 'iamarefund', 'asecondrefund']);
-			expect(s[1].tags).toContainEqual(['n_sigs', 2]);
-			expect(s[1].tags).not.toContainEqual(['n_sigs_refund', 1]); // 1 is default
+			expect(s[1].tags).toContainEqual(['n_sigs', '2']);
+			expect(s[1].tags).not.toContainEqual(['n_sigs_refund', '1']); // 1 is default
 		});
 	});
 });


### PR DESCRIPTION
Adds [NUT-11 P2PK multisig support](https://github.com/cashubtc/nuts/blob/main/11.md) and corresponding tests.

This PR is backwards compatible, is formatted and passes unit tests.

## Changes

- Updates the p2pk type signature from:

`p2pk?: { pubkey: string; locktime?: number; refundKeys?: Array<string> }`

to support multisig tags in a backwards compatible way:

```
p2pk?: {
    pubkey: string | Array<string>;
    locktime?: number;
    refundKeys?: Array<string>;
    nsig?: number;
    rsig?: number;
}
```

- Implements multisig handling in `createSingleP2PKData()`, also in a backwards compatible way.

- Added unit tests to confirm functionality works as per NUT-11 spec

- Adds utility functions for P2PK handling

- Exposes P2PK utility functions to public API

- Harmonizes NUT-11 crypto module client side to use the main cashu-ts Proof type definition 

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`

## Post PR Tasks

- The change in p2pk type signature should be noted in documentation.