### PR TITLE
Make sure to always stringify URL object for WebSockets

### DIFF
--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -51,7 +51,7 @@ export class WSConnection {
 		if (!this.connectionPromise) {
 			this.connectionPromise = new Promise((res: OnOpenSuccess, rej: OnOpenError) => {
 				try {
-					this.ws = new this._WS(this.url);
+					this.ws = new this._WS(this.url.toString());
 				} catch (err) {
 					rej(err);
 					return;


### PR DESCRIPTION
# Fixes: #294 

## Description

This small change makes sure to always stringify the WS URL before passing it to the `_WS` constructor. This ensures compatibility with implementations of `WebSocket` that do not handle `URL` objects.

## Changes

- Pass a strigified version of URL to WebSocket constructor

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
