### PR TITLE
Ensure active keyset chosen has the wallet unit

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -192,7 +192,7 @@ class CashuWallet {
 	 * @returns active keyset
 	 */
 	getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset {
-		let activeKeysets = keysets.filter((k: MintKeyset) => k.active);
+		let activeKeysets = keysets.filter((k: MintKeyset) => k.active && k.unit === this._unit);
 
 		// we only consider keyset IDs that start with "00"
 		activeKeysets = activeKeysets.filter((k: MintKeyset) => k.id.startsWith('00'));


### PR DESCRIPTION
## Description

This makes CashuWallet more robust by avoiding the need for apps to filter persisted keysets by unit before instantiating a CashuWallet instance.

This makes the persistence of mint keys/keysets and instantiation simpler, and prevents input/output keyset unit mismatch MintOperation errors if the app does not properly filter keysets when loading them.

## Changes

- Adds a unit filter to `getActiveKeyset()`.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
