### PR TITLE
Fix websocket cancellation bug

### DIFF
--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -114,6 +114,9 @@ export class WSConnection {
 	}
 
 	private removeListener(subId: string, callback: (payload: any) => any) {
+		if (!this.subListeners[subId]) {
+			return;
+		}
 		if (this.subListeners[subId].length === 1) {
 			delete this.subListeners[subId];
 			return;
@@ -191,6 +194,7 @@ export class WSConnection {
 	}
 
 	cancelSubscription(subId: string, callback: (payload: any) => any) {
+		this.removeRpcListener(subId);
 		this.removeListener(subId, callback);
 		this.rpcId++;
 		this.sendRequest('unsubscribe', { subId });


### PR DESCRIPTION
# Fixes: https://github.com/cashubtc/cashu-ts/issues/301

## Description

The socket cancellation now check the sub listener exists and also calls removeRpcListener so that when subscribe command's response is received from the mint it will just be ignored.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
