### PR TITLE
[FEAT] GCS Filter Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cashu/cashu-ts",
-			"version": "2.5.0",
+			"version": "2.5.1",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/curves": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cashu/cashu-ts",
-			"version": "2.5.1",
+			"version": "2.5.2",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/curves": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "cashu library for communicating with a cashu mint",
 	"type": "module",
 	"main": "lib/cashu-ts.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cashu/cashu-ts",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "cashu library for communicating with a cashu mint",
 	"type": "module",
 	"main": "lib/cashu-ts.cjs.js",

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -529,7 +529,12 @@ class CashuMint {
 		return data;
 	}
 
-	async getSpentFilter(keysetId: string): Promise<GetFilterResponse	> {
+	/**
+	 * Gets the GCS spent ecash filter for the specific keyset id
+	 * @param keysetId the keyset ID
+	 * @returns response containing the compressed set and its parameters
+	 */
+	async getSpentFilter(keysetId: string): Promise<GetFilterResponse> {
 		return CashuMint.getSpentFilter(this._mintUrl, keysetId, this._customRequest)
 	}
 

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -17,7 +17,8 @@ import type {
 	MeltQuotePayload,
 	MeltQuoteResponse,
 	PartialMintQuoteResponse,
-	PartialMeltQuoteResponse
+	PartialMeltQuoteResponse,
+	GetFilterResponse
 } from './model/types/index.js';
 import { MeltQuoteState } from './model/types/index.js';
 import request from './request.js';
@@ -508,6 +509,28 @@ class CashuMint {
 		outputs: Array<SerializedBlindedMessage>;
 	}): Promise<PostRestoreResponse> {
 		return CashuMint.restore(this._mintUrl, restorePayload, this._customRequest);
+	}
+
+	public static async getSpentFilter(
+		mintUrl: string,
+		keysetId: string,
+		customRequest?: typeof request
+	): Promise<GetFilterResponse> {
+		const requestInstance = customRequest || request;
+		const data = await requestInstance<GetFilterResponse>({
+			endpoint: joinUrls(mintUrl, `/v1/filter/spent/${keysetId}`),
+			method: 'GET',
+		});
+
+		if (!isObj(data) || !data?.content) {
+			throw new Error('bad response');
+		}
+
+		return data;
+	}
+
+	async getSpentFilter(keysetId: string): Promise<GetFilterResponse	> {
+		return CashuMint.getSpentFilter(this._mintUrl, keysetId, this._customRequest)
 	}
 
 	/**

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,6 +1,6 @@
 import { serializeProof } from './crypto/client/index.js';
 import { getSignedProofs } from './crypto/client/NUT11.js';
-import { BlindSignature, hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
+import { hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
 import { CashuMint } from './CashuMint.js';
 import { MintInfo } from './model/MintInfo.js';
 import {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,6 +1,6 @@
 import { serializeProof } from './crypto/client/index.js';
 import { getSignedProofs } from './crypto/client/NUT11.js';
-import { hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
+import { BlindSignature, hashToCurve, pointFromHex, type Proof as NUT11Proof } from './crypto/common/index.js';
 import { CashuMint } from './CashuMint.js';
 import { MintInfo } from './model/MintInfo.js';
 import {
@@ -1213,6 +1213,15 @@ class CashuWallet {
 		return () => {
 			this.mint.webSocketConnection?.cancelSubscription(subId, callback);
 		};
+	}
+
+	/**
+	 * Get the spent ecash filter for a specific keyset
+	 * @param The keyset ID
+	 * @returns `GetFilterResponse`
+	 */
+	async getSpentFilter(keysetId: string) {
+		return this.mint.getSpentFilter(keysetId);
 	}
 
 	/**

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -309,3 +309,14 @@ export type WebSocketSupport = {
 export type BlindAuthMintResponse = {
 	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
+
+/**
+ * Response to a get spent filter request
+ */
+export type GetFilterResponse = {
+	n: number,
+	p?: number,
+	m?: number,
+	content: string,
+	timestamp: number,
+} & ApiError;


### PR DESCRIPTION
## Description

Add support for getting spent ecash filters

## Changes

- `CashuMint.getSpentFilter(keysetId: str)`
- `CashuWallet.getSpentFilter(keysetId: str)`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
