### PR TITLE
Don't throw when unsubscribe is attempted on non open socket

### DIFF
--- a/src/WSConnection.ts
+++ b/src/WSConnection.ts
@@ -83,6 +83,9 @@ export class WSConnection {
 	sendRequest(method: 'unsubscribe', params: { subId: string }): void;
 	sendRequest(method: 'subscribe' | 'unsubscribe', params: Partial<JsonRpcReqParams>) {
 		if (this.ws?.readyState !== 1) {
+			if (method === 'unsubscribe') {
+				return;
+			}
 			throw new Error('Socket not open...');
 		}
 		const id = this.rpcId;


### PR DESCRIPTION
# Fixes: https://github.com/cashubtc/cashu-ts/issues/305

## Description

When socket is not open attempt to unsubscribe should be a noop instead of throwing error. Socket state can be one of the following non-open states:
- connecting - no point in unsubscribing if connection wasn't even established
- closing -  no point in unsubscribing if connection is about to be closed
- closed - no point in unsubscribing if connection is already closed

## Changes

Return without doing anything instead of throwing an error in the sendRequest method.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
