### PR TITLE
Revert change to mint/melt quote public API 

### DIFF
--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -13,10 +13,10 @@ import type {
 	MintQuotePayload,
 	MintPayload,
 	MintResponse,
+	MintQuoteResponse,
 	PostRestorePayload,
 	MeltQuotePayload,
-	MeltQuoteResponse,
-	PartialMintQuoteResponse
+	MeltQuoteResponse
 } from './model/types/index.js';
 import { MeltQuoteState } from './model/types/index.js';
 import request, { setRequestLogger } from './request';
@@ -155,13 +155,11 @@ class CashuMint {
 		customRequest?: typeof request,
 		blindAuthToken?: string,
 		logger?: Logger
-	): Promise<PartialMintQuoteResponse> {
+	): Promise<MintQuoteResponse> {
 		const mintLogger = logger ?? NULL_LOGGER;
 		const requestInstance = customRequest || request;
 		const headers: Record<string, string> = blindAuthToken ? { 'Blind-auth': blindAuthToken } : {};
-		const response = await requestInstance<
-			PartialMintQuoteResponse & MintQuoteResponsePaidDeprecated
-		>({
+		const response = await requestInstance<MintQuoteResponse & MintQuoteResponsePaidDeprecated>({
 			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11'),
 			method: 'POST',
 			requestBody: mintQuotePayload,
@@ -175,7 +173,7 @@ class CashuMint {
 	 * @param mintQuotePayload Payload for creating a new mint quote
 	 * @returns the mint will create and return a new mint quote containing a payment request for the specified amount and unit
 	 */
-	async createMintQuote(mintQuotePayload: MintQuotePayload): Promise<PartialMintQuoteResponse> {
+	async createMintQuote(mintQuotePayload: MintQuotePayload): Promise<MintQuoteResponse> {
 		const blindAuthToken = await this.handleBlindAuth('/v1/mint/quote/bolt11');
 		return CashuMint.createMintQuote(
 			this._mintUrl,
@@ -198,13 +196,11 @@ class CashuMint {
 		customRequest?: typeof request,
 		blindAuthToken?: string,
 		logger?: Logger
-	): Promise<PartialMintQuoteResponse> {
+	): Promise<MintQuoteResponse> {
 		const mintLogger = logger ?? NULL_LOGGER;
 		const requestInstance = customRequest || request;
 		const headers: Record<string, string> = blindAuthToken ? { 'Blind-auth': blindAuthToken } : {};
-		const response = await requestInstance<
-			PartialMintQuoteResponse & MintQuoteResponsePaidDeprecated
-		>({
+		const response = await requestInstance<MintQuoteResponse & MintQuoteResponsePaidDeprecated>({
 			endpoint: joinUrls(mintUrl, '/v1/mint/quote/bolt11', quote),
 			method: 'GET',
 			headers
@@ -218,7 +214,7 @@ class CashuMint {
 	 * @param quote Quote ID
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async checkMintQuote(quote: string): Promise<PartialMintQuoteResponse> {
+	async checkMintQuote(quote: string): Promise<MintQuoteResponse> {
 		const blindAuthToken = await this.handleBlindAuth(`/v1/mint/quote/bolt11/${quote}`);
 		return CashuMint.checkMintQuote(this._mintUrl, quote, this._customRequest, blindAuthToken);
 	}

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -16,8 +16,7 @@ import type {
 	PostRestorePayload,
 	MeltQuotePayload,
 	MeltQuoteResponse,
-	PartialMintQuoteResponse,
-	PartialMeltQuoteResponse
+	PartialMintQuoteResponse
 } from './model/types/index.js';
 import { MeltQuoteState } from './model/types/index.js';
 import request, { setRequestLogger } from './request';
@@ -274,13 +273,11 @@ class CashuMint {
 		customRequest?: typeof request,
 		blindAuthToken?: string,
 		logger?: Logger
-	): Promise<PartialMeltQuoteResponse> {
+	): Promise<MeltQuoteResponse> {
 		const mintLogger = logger ?? NULL_LOGGER;
 		const requestInstance = customRequest || request;
 		const headers: Record<string, string> = blindAuthToken ? { 'Blind-auth': blindAuthToken } : {};
-		const response = await requestInstance<
-			PartialMeltQuoteResponse & MeltQuoteResponsePaidDeprecated
-		>({
+		const response = await requestInstance<MeltQuoteResponse & MeltQuoteResponsePaidDeprecated>({
 			endpoint: joinUrls(mintUrl, '/v1/melt/quote/bolt11'),
 			method: 'POST',
 			requestBody: meltQuotePayload,
@@ -304,7 +301,7 @@ class CashuMint {
 	 * @param MeltQuotePayload
 	 * @returns
 	 */
-	async createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<PartialMeltQuoteResponse> {
+	async createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<MeltQuoteResponse> {
 		const blindAuthToken = await this.handleBlindAuth('/v1/melt/quote/bolt11');
 		return CashuMint.createMeltQuote(
 			this._mintUrl,
@@ -326,7 +323,7 @@ class CashuMint {
 		customRequest?: typeof request,
 		blindAuthToken?: string,
 		logger?: Logger
-	): Promise<PartialMeltQuoteResponse> {
+	): Promise<MeltQuoteResponse> {
 		const mintLogger = logger ?? NULL_LOGGER;
 		const requestInstance = customRequest || request;
 		const headers: Record<string, string> = blindAuthToken ? { 'Blind-auth': blindAuthToken } : {};
@@ -356,7 +353,7 @@ class CashuMint {
 	 * @param quote Quote ID
 	 * @returns
 	 */
-	async checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse> {
+	async checkMeltQuote(quote: string): Promise<MeltQuoteResponse> {
 		const blindAuthToken = await this.handleBlindAuth(`/v1/melt/quote/bolt11/${quote}`);
 		return CashuMint.checkMeltQuote(this._mintUrl, quote, this._customRequest, blindAuthToken);
 	}
@@ -374,7 +371,7 @@ class CashuMint {
 		customRequest?: typeof request,
 		blindAuthToken?: string,
 		logger?: Logger
-	): Promise<PartialMeltQuoteResponse> {
+	): Promise<MeltQuoteResponse> {
 		const mintLogger = logger ?? NULL_LOGGER;
 		const requestInstance = customRequest || request;
 		const headers: Record<string, string> = blindAuthToken ? { 'Blind-auth': blindAuthToken } : {};
@@ -402,7 +399,7 @@ class CashuMint {
 	 * @param meltPayload
 	 * @returns
 	 */
-	async melt(meltPayload: MeltPayload): Promise<PartialMeltQuoteResponse> {
+	async melt(meltPayload: MeltPayload): Promise<MeltQuoteResponse> {
 		const blindAuthToken = await this.handleBlindAuth('/v1/melt/bolt11');
 		return CashuMint.melt(this._mintUrl, meltPayload, this._customRequest, blindAuthToken);
 	}

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -32,7 +32,7 @@ import type {
 	MeltQuoteOptions,
 	SwapTransaction,
 	LockedMintQuoteResponse,
-	PartialMintQuoteResponse
+	FullMintQuoteResponse
 } from './model/types/index.js';
 import { MintQuoteState, MeltQuoteState } from './model/types/index.js';
 import { SubscriptionCanceller } from './model/types/wallet/websocket.js';
@@ -666,7 +666,7 @@ class CashuWallet {
 	 * @param pubkey optional public key to lock the quote to
 	 * @returns the mint will return a mint quote with a Lightning invoice for minting tokens of the specified amount and unit
 	 */
-	async createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse> {
+	async createMintQuote(amount: number, description?: string): Promise<FullMintQuoteResponse> {
 		const mintQuotePayload: MintQuotePayload = {
 			unit: this._unit,
 			amount: amount,
@@ -688,7 +688,7 @@ class CashuWallet {
 		amount: number,
 		pubkey: string,
 		description?: string
-	): Promise<LockedMintQuoteResponse> {
+	): Promise<LockedMintQuoteResponse & { amount: number; unit: string }> {
 		const { supported } = (await this.getMintInfo()).isSupported(20);
 		if (!supported) {
 			throw new Error('Mint does not support NUT-20');
@@ -713,11 +713,11 @@ class CashuWallet {
 	 * @param quote Quote ID
 	 * @returns the mint will create and return a Lightning invoice for the specified amount
 	 */
-	async checkMintQuote(quote: MintQuoteResponse): Promise<MintQuoteResponse>;
-	async checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
+	async checkMintQuote(quote: MintQuoteResponse): Promise<FullMintQuoteResponse>;
+	async checkMintQuote(quote: string): Promise<MintQuoteResponse>;
 	async checkMintQuote(
 		quote: string | MintQuoteResponse
-	): Promise<MintQuoteResponse | PartialMintQuoteResponse> {
+	): Promise<MintQuoteResponse | FullMintQuoteResponse> {
 		const quoteId = typeof quote === 'string' ? quote : quote.quote;
 		const baseRes = await this.mint.checkMintQuote(quoteId);
 		if (typeof quote === 'string') {

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -20,6 +20,7 @@ import type {
 	MeltProofsResponse,
 	MeltQuotePayload,
 	MeltQuoteResponse,
+	FullMeltQuoteResponse,
 	MintKeys,
 	MintKeyset,
 	MintPayload,
@@ -31,8 +32,7 @@ import type {
 	MeltQuoteOptions,
 	SwapTransaction,
 	LockedMintQuoteResponse,
-	PartialMintQuoteResponse,
-	PartialMeltQuoteResponse
+	PartialMintQuoteResponse
 } from './model/types/index.js';
 import { MintQuoteState, MeltQuoteState } from './model/types/index.js';
 import { SubscriptionCanceller } from './model/types/wallet/websocket.js';
@@ -811,7 +811,7 @@ class CashuWallet {
 	 * @param invoice LN invoice that needs to get a fee estimate
 	 * @returns the mint will create and return a melt quote for the invoice with an amount and fee reserve
 	 */
-	async createMeltQuote(invoice: string): Promise<MeltQuoteResponse> {
+	async createMeltQuote(invoice: string): Promise<FullMeltQuoteResponse> {
 		const meltQuotePayload: MeltQuotePayload = {
 			unit: this._unit,
 			request: invoice
@@ -833,7 +833,7 @@ class CashuWallet {
 	async createMultiPathMeltQuote(
 		invoice: string,
 		millisatPartialAmount: number
-	): Promise<MeltQuoteResponse> {
+	): Promise<FullMeltQuoteResponse> {
 		const { supported, params } = (await this.lazyGetMintInfo()).isSupported(15);
 		if (!supported) {
 			throw new Error('Mint does not support NUT-15');
@@ -861,11 +861,11 @@ class CashuWallet {
 	 * @param quote ID of the melt quote
 	 * @returns the mint will return an existing melt quote
 	 */
-	async checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
-	async checkMeltQuote(quote: MeltQuoteResponse): Promise<MeltQuoteResponse>;
+	async checkMeltQuote(quote: string): Promise<MeltQuoteResponse>;
+	async checkMeltQuote(quote: FullMeltQuoteResponse): Promise<FullMeltQuoteResponse>;
 	async checkMeltQuote(
 		quote: string | MeltQuoteResponse
-	): Promise<MeltQuoteResponse | PartialMeltQuoteResponse> {
+	): Promise<MeltQuoteResponse | FullMeltQuoteResponse> {
 		const quoteId = typeof quote === 'string' ? quote : quote.quote;
 		const meltQuote = await this.mint.checkMeltQuote(quoteId);
 		if (typeof quote === 'string') {

--- a/src/legacy/nut-04.ts
+++ b/src/legacy/nut-04.ts
@@ -1,4 +1,4 @@
-import type { PartialMintQuoteResponse } from '../model/types/index.js';
+import type { MintQuoteResponse } from '../model/types/index.js';
 import { MintQuoteState } from '../model/types/index.js';
 import type { Logger } from '../logger';
 
@@ -7,9 +7,9 @@ export type MintQuoteResponsePaidDeprecated = {
 };
 
 export function handleMintQuoteResponseDeprecated(
-	response: PartialMintQuoteResponse & MintQuoteResponsePaidDeprecated,
+	response: MintQuoteResponse & MintQuoteResponsePaidDeprecated,
 	logger: Logger
-): PartialMintQuoteResponse {
+): MintQuoteResponse {
 	// if the response MeltQuoteResponse has a "paid" flag, we monkey patch it to the state enum
 	if (!response.state) {
 		logger.warn(

--- a/src/legacy/nut-05.ts
+++ b/src/legacy/nut-05.ts
@@ -1,4 +1,4 @@
-import type { PartialMeltQuoteResponse } from '../model/types/index.js';
+import type { MeltQuoteResponse } from '../model/types/index.js';
 import { MeltQuoteState } from '../model/types/index.js';
 import type { Logger } from '../logger';
 
@@ -7,9 +7,9 @@ export type MeltQuoteResponsePaidDeprecated = {
 };
 
 export function handleMeltQuoteResponseDeprecated(
-	response: PartialMeltQuoteResponse & MeltQuoteResponsePaidDeprecated,
+	response: MeltQuoteResponse & MeltQuoteResponsePaidDeprecated,
 	logger: Logger
-): PartialMeltQuoteResponse {
+): MeltQuoteResponse {
 	// if the response MeltQuoteResponse has a "paid" flag, we monkey patch it to the state enum
 	if (!response.state) {
 		logger.warn(

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -121,7 +121,7 @@ export type GetInfoResponse = {
 /**
  * Response from the mint after requesting a melt quote
  */
-export type PartialMeltQuoteResponse = {
+export type MeltQuoteResponse = {
 	/**
 	 * Quote ID
 	 */
@@ -160,7 +160,7 @@ export type PartialMeltQuoteResponse = {
 	unit?: string;
 } & ApiError;
 
-export type MeltQuoteResponse = PartialMeltQuoteResponse & { request: string; unit: string };
+export type FullMeltQuoteResponse = MeltQuoteResponse & { request: string; unit: string };
 
 export const MeltQuoteState = {
 	UNPAID: 'UNPAID',

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -184,7 +184,7 @@ export type MintQuoteState = (typeof MintQuoteState)[keyof typeof MintQuoteState
 /**
  * Response from the mint after requesting a mint
  */
-export type PartialMintQuoteResponse = {
+export type MintQuoteResponse = {
 	/**
 	 * Payment request
 	 */
@@ -215,7 +215,7 @@ export type PartialMintQuoteResponse = {
 	amount?: number;
 } & ApiError;
 
-export type MintQuoteResponse = PartialMintQuoteResponse & { amount: number; unit: string };
+export type FullMintQuoteResponse = MintQuoteResponse & { amount: number; unit: string };
 
 export type LockedMintQuoteResponse = MintQuoteResponse & { pubkey: string };
 


### PR DESCRIPTION
# Fixes: https://github.com/cashubtc/cashu-ts/issues/323

## Description

In the latest release we introduces a change to the mint and melt operations that broke the public API. This change reverts that, while keeping the same functionality. It does this by making sure the old type definition is the same again, and introducing a narrower type that can be assigned without any issues.

```ts

const mintQuote = await wallet.createMintQuote(21); // <- Returns FullMintQuoteResponse
const mintQuote2: MintQuoteReponse = await wallet.createMintQuote(21); // This also works, as FullMintQuoteReponse is narrower

mintQuote.amount // <- this is still "number" not "number | undefined"
```

## Changes

- Revert change to `MintQuoteReponse` and `MeltQuoteReponse`
- Add new `FullMintQuoteReponse` and `FullMeltQuoteReponse` types, that represent responses without optional keys.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
- [x] run `npm run api:update`
