### PR TITLE
Move to extensionless imports

### DIFF
--- a/examples/simpleWallet_example.ts
+++ b/examples/simpleWallet_example.ts
@@ -1,5 +1,5 @@
-import { CashuMint } from '../src/CashuMint.js';
-import { CashuWallet } from '../src/CashuWallet.js';
+import { CashuMint } from '../src/CashuMint';
+import { CashuWallet } from '../src/CashuWallet';
 
 import dns from 'node:dns';
 import {
@@ -9,8 +9,8 @@ import {
 	MintQuoteState,
 	Proof,
 	Token
-} from '../src/model/types/index.js';
-import { getEncodedTokenV4, sumProofs } from '../src/utils.js';
+} from '../src/model/types/index';
+import { getEncodedTokenV4, sumProofs } from '../src/utils';
 dns.setDefaultResultOrder('ipv4first');
 
 const externalInvoice =

--- a/src/CashuMint.ts
+++ b/src/CashuMint.ts
@@ -1,4 +1,4 @@
-import { ConnectionManager, WSConnection } from './WSConnection.js';
+import { ConnectionManager, WSConnection } from './WSConnection';
 import type {
 	CheckStatePayload,
 	CheckStateResponse,
@@ -18,20 +18,20 @@ import type {
 	MeltQuoteResponse,
 	PartialMintQuoteResponse,
 	PartialMeltQuoteResponse
-} from './model/types/index.js';
-import { MeltQuoteState } from './model/types/index.js';
+} from './model/types/index';
+import { MeltQuoteState } from './model/types/index';
 import request, { setRequestLogger } from './request';
-import { isObj, joinUrls, sanitizeUrl } from './utils.js';
+import { isObj, joinUrls, sanitizeUrl } from './utils';
 import {
 	MeltQuoteResponsePaidDeprecated,
 	handleMeltQuoteResponseDeprecated
-} from './legacy/nut-05.js';
+} from './legacy/nut-05';
 import {
 	MintQuoteResponsePaidDeprecated,
 	handleMintQuoteResponseDeprecated
-} from './legacy/nut-04.js';
-import { handleMintInfoContactFieldDeprecated } from './legacy/nut-06.js';
-import { MintInfo } from './model/MintInfo.js';
+} from './legacy/nut-04';
+import { handleMintInfoContactFieldDeprecated } from './legacy/nut-06';
+import { MintInfo } from './model/MintInfo';
 import { type Logger, NULL_LOGGER } from './logger';
 /**
  * Class represents Cashu Mint API. This class contains Lower level functions that are implemented by CashuWallet.

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1,8 +1,8 @@
-import { serializeProof } from './crypto/client/index.js';
-import { signP2PKProofs, getP2PKWitnessSignatures } from './crypto/client/NUT11.js';
-import { hashToCurve, pointFromHex } from './crypto/common/index.js';
-import { CashuMint } from './CashuMint.js';
-import { MintInfo } from './model/MintInfo.js';
+import { serializeProof } from './crypto/client/index';
+import { signP2PKProofs, getP2PKWitnessSignatures } from './crypto/client/NUT11';
+import { hashToCurve, pointFromHex } from './crypto/common/index';
+import { CashuMint } from './CashuMint';
+import { MintInfo } from './model/MintInfo';
 import { type Logger, NULL_LOGGER, measureTime } from './logger';
 import type {
 	GetInfoResponse,
@@ -33,9 +33,9 @@ import type {
 	LockedMintQuoteResponse,
 	PartialMintQuoteResponse,
 	PartialMeltQuoteResponse
-} from './model/types/index.js';
-import { MintQuoteState, MeltQuoteState } from './model/types/index.js';
-import { SubscriptionCanceller } from './model/types/wallet/websocket.js';
+} from './model/types/index';
+import { MintQuoteState, MeltQuoteState } from './model/types/index';
+import { SubscriptionCanceller } from './model/types/wallet/websocket';
 import {
 	getDecodedToken,
 	getKeepAmounts,
@@ -43,14 +43,14 @@ import {
 	splitAmount,
 	stripDleq,
 	sumProofs
-} from './utils.js';
-import { signMintQuote } from './crypto/client/NUT20.js';
+} from './utils';
+import { signMintQuote } from './crypto/client/NUT20';
 import {
 	OutputData,
 	OutputDataFactory,
 	OutputDataLike,
 	isOutputDataFactory
-} from './model/OutputData.js';
+} from './model/OutputData';
 
 /**
  * The default number of proofs per denomination to keep in a wallet.

--- a/src/crypto/client/NUT09.ts
+++ b/src/crypto/client/NUT09.ts
@@ -1,5 +1,5 @@
 import { HDKey } from '@scure/bip32';
-import { getKeysetIdInt } from '../common/index.js';
+import { getKeysetIdInt } from '../common/index';
 
 const STANDARD_DERIVATION_PATH = `m/129372'/0'`;
 

--- a/src/crypto/client/NUT11.ts
+++ b/src/crypto/client/NUT11.ts
@@ -2,10 +2,10 @@ import { PrivKey, bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1';
 import { randomBytes } from '@noble/hashes/utils';
-import { parseP2PKSecret } from '../common/NUT11.js';
-import { Secret } from '../common/index.js';
-import { type P2PKWitness, type Proof } from '../../model/types/index.js';
-import { BlindedMessage } from './index.js';
+import { parseP2PKSecret } from '../common/NUT11';
+import { Secret } from '../common/index';
+import { type P2PKWitness, type Proof } from '../../model/types/index';
+import { BlindedMessage } from './index';
 
 export const createP2PKsecret = (pubkey: string): string => {
 	const newSecret: Secret = [

--- a/src/crypto/client/NUT12.ts
+++ b/src/crypto/client/NUT12.ts
@@ -1,8 +1,8 @@
-import { DLEQ, hash_e, hashToCurve } from '../common/index.js';
+import { DLEQ, hash_e, hashToCurve } from '../common/index';
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { bytesToNumber } from '../util/utils.js';
+import { bytesToNumber } from '../util/utils';
 
 function arraysEqual(arr1: any, arr2: any) {
 	if (arr1.length !== arr2.length) return false;

--- a/src/crypto/client/index.ts
+++ b/src/crypto/client/index.ts
@@ -1,17 +1,17 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { randomBytes } from '@noble/hashes/utils';
-import { bytesToNumber } from '../util/utils.js';
+import { bytesToNumber } from '../util/utils';
 import type {
 	BlindSignature,
 	Proof,
 	SerializedBlindedMessage,
 	SerializedProof
-} from '../common/index.js';
-import { hashToCurve, pointFromHex } from '../common/index.js';
+} from '../common/index';
+import { hashToCurve, pointFromHex } from '../common/index';
 import { Witness } from '../common/index';
 import { PrivKey } from '@noble/curves/abstract/utils';
-import { getSignedOutput } from './NUT11.js';
+import { getSignedOutput } from './NUT11';
 
 export type BlindedMessage = {
 	B_: ProjPointType<bigint>;

--- a/src/crypto/common/NUT11.ts
+++ b/src/crypto/common/NUT11.ts
@@ -1,4 +1,4 @@
-import { Secret } from './index.js';
+import { Secret } from './index';
 
 export const parseP2PKSecret = (secret: string | Uint8Array): Secret => {
 	try {

--- a/src/crypto/common/index.ts
+++ b/src/crypto/common/index.ts
@@ -2,7 +2,7 @@ import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
-import { bytesToNumber, encodeBase64toUint8, hexToNumber } from '../util/utils.js';
+import { bytesToNumber, encodeBase64toUint8, hexToNumber } from '../util/utils';
 import { Buffer } from 'buffer';
 
 export type Enumerate<N extends number, Acc extends Array<number> = []> = Acc['length'] extends N

--- a/src/crypto/mint/NUT11.ts
+++ b/src/crypto/mint/NUT11.ts
@@ -1,14 +1,14 @@
 import { schnorr } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import { parseP2PKSecret } from '../common/NUT11.js';
+import { parseP2PKSecret } from '../common/NUT11';
 import {
 	getP2PKExpectedKWitnessPubkeys,
 	getP2PKWitnessSignatures,
 	getP2PKNSigs,
 	verifyP2PKSecretSignature
-} from '../client/NUT11.js';
-import { type Proof } from '../../model/types/index.js';
-import { BlindedMessage } from '../client/index.js';
+} from '../client/NUT11';
+import { type Proof } from '../../model/types/index';
+import { BlindedMessage } from '../client/index';
 
 export const verifyP2PKSig = (proof: Proof): boolean => {
 	if (!proof.witness) {

--- a/src/crypto/mint/NUT12.ts
+++ b/src/crypto/mint/NUT12.ts
@@ -1,8 +1,8 @@
-import { hash_e, createRandomPrivateKey, DLEQ } from '../common/index.js';
+import { hash_e, createRandomPrivateKey, DLEQ } from '../common/index';
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { bytesToHex, numberToBytesBE } from '@noble/curves/abstract/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { bytesToNumber, hexToNumber } from '../util/utils.js';
+import { bytesToNumber, hexToNumber } from '../util/utils';
 
 /**
  * !!! WARNING !!! Not recommended for production use, due to non-constant time operations

--- a/src/crypto/mint/index.ts
+++ b/src/crypto/mint/index.ts
@@ -1,8 +1,8 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { bytesToNumber } from '../util/utils.js';
-import { BlindSignature, IntRange, Keyset, MintKeys, Proof } from '../common/index.js';
-import { createRandomPrivateKey, deriveKeysetId, hashToCurve } from '../common/index.js';
+import { bytesToNumber } from '../util/utils';
+import { BlindSignature, IntRange, Keyset, MintKeys, Proof } from '../common/index';
+import { createRandomPrivateKey, deriveKeysetId, hashToCurve } from '../common/index';
 import { HDKey } from '@scure/bip32';
 
 const DERIVATION_PATH = "m/0'/0'/0'";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { CashuMint } from './CashuMint.js';
-import { CashuWallet } from './CashuWallet.js';
-import { OutputData } from './model/OutputData.js';
-import { PaymentRequest } from './model/PaymentRequest.js';
-import { setGlobalRequestOptions } from './request.js';
+import { CashuMint } from './CashuMint';
+import { CashuWallet } from './CashuWallet';
+import { OutputData } from './model/OutputData';
+import { PaymentRequest } from './model/PaymentRequest';
+import { setGlobalRequestOptions } from './request';
 import { LogLevel, ConsoleLogger, type Logger } from './logger';
 import {
 	getEncodedToken,
@@ -13,10 +13,10 @@ import {
 	getDecodedTokenBinary,
 	getEncodedTokenBinary,
 	hasValidDleq
-} from './utils.js';
+} from './utils';
 import { CashuAuthMint, CashuAuthWallet, getBlindedAuthToken, getEncodedAuthToken } from './auth';
 
-export * from './model/types/index.js';
+export * from './model/types/index';
 
 export {
 	CashuMint,
@@ -41,6 +41,6 @@ export {
 	type Logger
 };
 
-export { injectWebSocketImpl } from './ws.js';
+export { injectWebSocketImpl } from './ws';
 
-export { MintOperationError, NetworkError, HttpResponseError } from './model/Errors.js';
+export { MintOperationError, NetworkError, HttpResponseError } from './model/Errors';

--- a/src/legacy/nut-04.ts
+++ b/src/legacy/nut-04.ts
@@ -1,5 +1,5 @@
-import type { PartialMintQuoteResponse } from '../model/types/index.js';
-import { MintQuoteState } from '../model/types/index.js';
+import type { PartialMintQuoteResponse } from '../model/types/index';
+import { MintQuoteState } from '../model/types/index';
 import type { Logger } from '../logger';
 
 export type MintQuoteResponsePaidDeprecated = {

--- a/src/legacy/nut-05.ts
+++ b/src/legacy/nut-05.ts
@@ -1,5 +1,5 @@
-import type { PartialMeltQuoteResponse } from '../model/types/index.js';
-import { MeltQuoteState } from '../model/types/index.js';
+import type { PartialMeltQuoteResponse } from '../model/types/index';
+import { MeltQuoteState } from '../model/types/index';
 import type { Logger } from '../logger';
 
 export type MeltQuoteResponsePaidDeprecated = {

--- a/src/legacy/nut-06.ts
+++ b/src/legacy/nut-06.ts
@@ -1,4 +1,4 @@
-import type { MintContactInfo, GetInfoResponse } from '../model/types/index.js';
+import type { MintContactInfo, GetInfoResponse } from '../model/types/index';
 import type { Logger } from '../logger';
 
 export function handleMintInfoContactFieldDeprecated(data: GetInfoResponse, logger: Logger) {

--- a/src/model/BlindedMessage.ts
+++ b/src/model/BlindedMessage.ts
@@ -1,4 +1,4 @@
-import { SerializedBlindedMessage } from './types/index.js';
+import { SerializedBlindedMessage } from './types/index';
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
 
 class BlindedMessage {

--- a/src/model/BlindedSignature.ts
+++ b/src/model/BlindedSignature.ts
@@ -1,8 +1,8 @@
 import { ProjPointType } from '@noble/curves/abstract/weierstrass';
-import { SerializedBlindedSignature } from './types/index.js';
-import { DLEQ } from '../crypto/common/index.js';
+import { SerializedBlindedSignature } from './types/index';
+import { DLEQ } from '../crypto/common/index';
 import { bytesToHex } from '@noble/hashes/utils';
-import { numberToHexPadded64 } from '../utils.js';
+import { numberToHexPadded64 } from '../utils';
 
 class BlindedSignature {
 	id: string;

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -8,9 +8,9 @@ import {
 import { blindMessage, constructProofFromPromise, serializeProof } from '../crypto/client/index';
 import { BlindedMessage } from './BlindedMessage';
 import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
-import { DLEQ, pointFromHex } from '../crypto/common/index.js';
+import { DLEQ, pointFromHex } from '../crypto/common/index';
 import { bytesToNumber, numberToHexPadded64, splitAmount } from '../utils';
-import { deriveBlindingFactor, deriveSecret } from '../crypto/client/NUT09.js';
+import { deriveBlindingFactor, deriveSecret } from '../crypto/client/NUT09';
 
 export interface OutputDataLike {
 	blindedMessage: SerializedBlindedMessage;

--- a/src/model/Split.ts
+++ b/src/model/Split.ts
@@ -1,5 +1,5 @@
-import { BlindedMessage } from './BlindedMessage.js';
-import { Proof } from './types/index.js';
+import { BlindedMessage } from './BlindedMessage';
+import { Proof } from './types/index';
 
 class Split {
 	proofs: Array<Proof>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { verifyDLEQProof_reblind } from './crypto/client/NUT12.js';
-import { DLEQ, pointFromHex } from './crypto/common/index.js';
+import { verifyDLEQProof_reblind } from './crypto/client/NUT12';
+import { DLEQ, pointFromHex } from './crypto/common/index';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import {
@@ -7,9 +7,9 @@ import {
 	encodeBase64toUint8,
 	encodeJsonToBase64,
 	encodeUint8toBase64Url
-} from './base64.js';
-import { decodeCBOR, encodeCBOR } from './cbor.js';
-import { PaymentRequest } from './model/PaymentRequest.js';
+} from './base64';
+import { decodeCBOR, encodeCBOR } from './cbor';
+import { PaymentRequest } from './model/PaymentRequest';
 import {
 	DeprecatedToken,
 	Keys,
@@ -21,8 +21,8 @@ import {
 	V4DLEQTemplate,
 	V4InnerToken,
 	V4ProofTemplate
-} from './model/types/index.js';
-import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants.js';
+} from './model/types/index';
+import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants';
 
 /**
  * Splits the amount into denominations of the provided @param keyset

--- a/test/base64.test.ts
+++ b/test/base64.test.ts
@@ -3,7 +3,7 @@ import {
 	encodeBase64toUint8,
 	encodeJsonToBase64,
 	encodeUint8toBase64
-} from '../src/base64.js';
+} from '../src/base64';
 import { test, describe, expect } from 'vitest';
 describe('testing uint8 encoding', () => {
 	test('uint8 to base64', async () => {

--- a/test/crypto/client/NUT09.test.ts
+++ b/test/crypto/client/NUT09.test.ts
@@ -1,7 +1,7 @@
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
-import { deriveSecret } from '../../../src/crypto/client/NUT09.js';
+import { deriveSecret } from '../../../src/crypto/client/NUT09';
 
 const seed = Uint8Array.from(
 	Buffer.from(

--- a/test/crypto/client/NUT11.test.ts
+++ b/test/crypto/client/NUT11.test.ts
@@ -12,8 +12,8 @@ import {
 	getP2PKSigFlag,
 	getP2PKWitnessSignatures
 } from '../../../src/crypto/client/NUT11';
-import { Secret } from '../../../src/crypto/common/index.js';
-import { P2PKWitness } from '../../../src/model/types/index.js';
+import { Secret } from '../../../src/crypto/common/index';
+import { P2PKWitness } from '../../../src/model/types/index';
 import { pointFromHex, Proof } from '../../../src/crypto/common';
 import { verifyP2PKSig, verifyP2PKSigOutput } from '../../../src/crypto/mint/NUT11';
 import { getPubKeyFromPrivKey } from '../../../src/crypto/mint';

--- a/test/crypto/common/NUT12.test.ts
+++ b/test/crypto/common/NUT12.test.ts
@@ -1,14 +1,14 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { bytesToHex } from '@noble/hashes/utils';
 import { describe, expect, test } from 'vitest';
-import { hash_e, pointFromBytes, pointFromHex } from '../../../src/crypto/common/index.js';
+import { hash_e, pointFromBytes, pointFromHex } from '../../../src/crypto/common/index';
 import {
 	constructProofFromPromise,
 	createRandomBlindedMessage
-} from '../../../src/crypto/client/index.js';
-import { createBlindSignature } from '../../../src/crypto/mint/index.js';
-import { createDLEQProof } from '../../../src/crypto/mint/NUT12.js';
-import { verifyDLEQProof, verifyDLEQProof_reblind } from '../../../src/crypto/client/NUT12.js';
+} from '../../../src/crypto/client/index';
+import { createBlindSignature } from '../../../src/crypto/mint/index';
+import { createDLEQProof } from '../../../src/crypto/mint/NUT12';
+import { verifyDLEQProof, verifyDLEQProof_reblind } from '../../../src/crypto/client/NUT12';
 
 describe('test hash_e', () => {
 	test('test hash_e function', async () => {

--- a/test/crypto/mint/NUT11.test.ts
+++ b/test/crypto/mint/NUT11.test.ts
@@ -1,6 +1,6 @@
 import { bytesToHex, randomBytes } from '@noble/hashes/utils';
 import { Proof, pointFromHex } from '../../../src/crypto/common';
-import { verifyP2PKSig } from '../../../src/crypto/mint/NUT11.js';
+import { verifyP2PKSig } from '../../../src/crypto/mint/NUT11';
 import { describe, expect, test } from 'vitest';
 describe('test p2pk verify', () => {
 	test('test no witness', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,5 +1,5 @@
-import { CashuMint } from '../src/CashuMint.js';
-import { CashuWallet } from '../src/CashuWallet.js';
+import { CashuMint } from '../src/CashuMint';
+import { CashuWallet } from '../src/CashuWallet';
 
 import dns from 'node:dns';
 import { test, describe, expect } from 'vitest';
@@ -13,10 +13,10 @@ import {
 	Proof,
 	ProofState,
 	Token
-} from '../src/model/types/index.js';
-import { MintOperationError } from '../src/model/Errors.js';
+} from '../src/model/types/index';
+import { MintOperationError } from '../src/model/Errors';
 import ws from 'ws';
-import { injectWebSocketImpl } from '../src/ws.js';
+import { injectWebSocketImpl } from '../src/ws';
 import {
 	getDecodedToken,
 	getEncodedToken,
@@ -25,8 +25,8 @@ import {
 	numberToHexPadded64,
 	splitAmount,
 	sumProofs
-} from '../src/utils.js';
-import { OutputData, OutputDataFactory } from '../src/model/OutputData.js';
+} from '../src/utils';
+import { OutputData, OutputDataFactory } from '../src/model/OutputData';
 import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils';
 dns.setDefaultResultOrder('ipv4first');
 

--- a/test/paymentRequests.test.ts
+++ b/test/paymentRequests.test.ts
@@ -5,7 +5,7 @@ import {
 	PaymentRequestTransport,
 	PaymentRequestTransportType,
 	NUT10Option
-} from '../src/index.js';
+} from '../src/index';
 
 describe('payment requests', () => {
 	test('encode payment requests', async () => {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,9 +1,9 @@
 import { beforeAll, test, describe, expect, afterAll, afterEach } from 'vitest';
-import { CashuMint } from '../src/CashuMint.js';
-import { CashuWallet } from '../src/CashuWallet.js';
+import { CashuMint } from '../src/CashuMint';
+import { CashuWallet } from '../src/CashuWallet';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
-import { setGlobalRequestOptions } from '../src/request.js';
+import { setGlobalRequestOptions } from '../src/request';
 import { HttpResponseError, NetworkError, MintOperationError } from '../src/model/Errors';
 
 const mintUrl = 'https://localhost:3338';

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,10 +1,10 @@
 import { blindMessage, constructProofFromPromise, serializeProof } from '../src/crypto/client/';
 import { test, describe, expect } from 'vitest';
-import { Keys, Proof, Token } from '../src/model/types/index.js';
-import * as utils from '../src/utils.js';
-import { PUBKEYS } from './consts.js';
+import { Keys, Proof, Token } from '../src/model/types/index';
+import * as utils from '../src/utils';
+import { PUBKEYS } from './consts';
 import { createDLEQProof } from '../src/crypto/mint/NUT12';
-import { hasValidDleq, hexToNumber, numberToHexPadded64 } from '../src/utils.js';
+import { hasValidDleq, hexToNumber, numberToHexPadded64 } from '../src/utils';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { createBlindSignature, getPubKeyFromPrivKey } from '../src/crypto/mint';
 import { pointFromBytes } from '../src/crypto/common';

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -2,8 +2,8 @@ import { setupServer } from 'msw/node';
 import { HttpResponse, http } from 'msw';
 import { beforeAll, beforeEach, afterAll, afterEach, test, describe, expect, vi } from 'vitest';
 
-import { CashuMint } from '../src/CashuMint.js';
-import { CashuWallet } from '../src/CashuWallet.js';
+import { CashuMint } from '../src/CashuMint';
+import { CashuWallet } from '../src/CashuWallet';
 import {
 	CheckStateEnum,
 	MeltQuoteResponse,
@@ -11,12 +11,12 @@ import {
 	MintQuoteResponse,
 	MintQuoteState,
 	Proof
-} from '../src/model/types/index.js';
-import { bytesToNumber, getDecodedToken, sumProofs } from '../src/utils.js';
+} from '../src/model/types/index';
+import { bytesToNumber, getDecodedToken, sumProofs } from '../src/utils';
 import { Server, WebSocket } from 'mock-socket';
-import { injectWebSocketImpl } from '../src/ws.js';
-import { MintInfo } from '../src/model/MintInfo.js';
-import { OutputData } from '../src/model/OutputData.js';
+import { injectWebSocketImpl } from '../src/ws';
+import { MintInfo } from '../src/model/MintInfo';
+import { OutputData } from '../src/model/OutputData';
 import { hexToBytes } from '@noble/curves/abstract/utils';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils';
 


### PR DESCRIPTION
# Fixes: #332 

## Description

This PR removes the `.js` extensions from all import statements across the library
e.g., changing `import { foo } from './bar.js';` to `import { foo } from './bar';`.

This creates cleaner and more idiomatic code: Extensionless imports align with standard TypeScript conventions and reduce visual clutter, making the codebase easier to read and maintain.

It also improves compatibility with bundlers like Vite, that handle module resolution automatically, eliminating the need for explicit extensions and avoiding potential resolution errors.

No functional changes; all tests pass.

...

## Changes

- removes all `.js` extensions from imports

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
