### PR TITLE
Keyset ID verification

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -8,102 +8,195 @@ import { MintContactInfo as MintContactInfo_2 } from './types';
 
 // @public
 export type ApiError = {
-    error?: string;
-    code?: number;
-    detail?: string;
+    	error?: string;
+    	code?: number;
+    	detail?: string;
 };
 
 // @public
 export type BlindAuthMintPayload = {
-    outputs: Array<SerializedBlindedMessage>;
+    	outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public
 export type BlindAuthMintResponse = {
-    signatures: Array<SerializedBlindedSignature>;
+    	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 // @public
 export class CashuAuthMint {
-    // Warning: (ae-forgotten-export) The symbol "request" needs to be exported by the entry point index.d.ts
+    	// Warning: (ae-forgotten-export) The symbol "request" needs to be exported by the entry point index.d.ts
     constructor(_mintUrl: string, _customRequest?: typeof request | undefined);
-    static getKeys(mintUrl: string, keysetId?: string, customRequest?: typeof request): Promise<MintActiveKeys>;
-    getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
-    static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
-    getKeySets(): Promise<MintAllKeysets>;
-    static mint(mintUrl: string, mintPayload: BlindAuthMintPayload, clearAuthToken: string, customRequest?: typeof request): Promise<BlindAuthMintResponse>;
-    mint(mintPayload: BlindAuthMintPayload, clearAuthToken: string): Promise<BlindAuthMintResponse>;
-    // (undocumented)
+    	static getKeys(
+    		mintUrl: string,
+    		keysetId?: string,
+    		customRequest?: typeof request
+    	): Promise<MintActiveKeys>;
+    	getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
+    	static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
+    	getKeySets(): Promise<MintAllKeysets>;
+    	static mint(
+    		mintUrl: string,
+    		mintPayload: BlindAuthMintPayload,
+    		clearAuthToken: string,
+    		customRequest?: typeof request
+    	): Promise<BlindAuthMintResponse>;
+    	mint(mintPayload: BlindAuthMintPayload, clearAuthToken: string): Promise<BlindAuthMintResponse>;
+    	// (undocumented)
     get mintUrl(): string;
 }
 
 // @public
 export class CashuAuthWallet {
-    constructor(mint: CashuAuthMint, options?: {
-        keys?: Array<MintKeys> | MintKeys;
-        keysets?: Array<MintKeyset>;
-    });
-    getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
-    getAllKeys(): Promise<Array<MintKeys>>;
-    getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
-    getKeySets(): Promise<Array<MintKeyset>>;
-    // (undocumented)
+    	constructor(
+    		mint: CashuAuthMint,
+    		options?: {
+        			keys?: Array<MintKeys> | MintKeys;
+        			keysets?: Array<MintKeyset>;
+        		}
+    	);
+    	getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
+    	getAllKeys(): Promise<Array<MintKeys>>;
+    	getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
+    	getKeySets(): Promise<Array<MintKeyset>>;
+    	// (undocumented)
     get keys(): Map<string, MintKeys>;
-    // (undocumented)
+    	// (undocumented)
     get keysetId(): string;
-    set keysetId(keysetId: string);
-    // (undocumented)
+    	set keysetId(keysetId: string);
+    	// (undocumented)
     get keysets(): Array<MintKeyset>;
-    loadMint(): Promise<void>;
-    // (undocumented)
+    	loadMint(): Promise<void>;
+    	// (undocumented)
     mint: CashuAuthMint;
-    mintProofs(amount: number, clearAuthToken: string, options?: {
-        keysetId?: string;
-    }): Promise<Array<Proof>>;
+    	mintProofs(
+    		amount: number,
+    		clearAuthToken: string,
+    		options?: {
+        			keysetId?: string;
+        		}
+    	): Promise<Array<Proof>>;
 }
 
 // @public
 export class CashuMint {
-    constructor(_mintUrl: string, _customRequest?: typeof request | undefined, authTokenGetter?: () => Promise<string>);
-    static check(mintUrl: string, checkPayload: CheckStatePayload, customRequest?: typeof request): Promise<CheckStateResponse>;
-    check(checkPayload: CheckStatePayload): Promise<CheckStateResponse>;
-    static checkMeltQuote(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMeltQuoteResponse>;
-    checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
-    static checkMintQuote(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMintQuoteResponse>;
-    checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
-    connectWebSocket(): Promise<void>;
-    static createMeltQuote(mintUrl: string, meltQuotePayload: MeltQuotePayload, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMeltQuoteResponse>;
-    createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<PartialMeltQuoteResponse>;
-    static createMintQuote(mintUrl: string, mintQuotePayload: MintQuotePayload, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMintQuoteResponse>;
-    createMintQuote(mintQuotePayload: MintQuotePayload): Promise<PartialMintQuoteResponse>;
-    disconnectWebSocket(): void;
-    static getInfo(mintUrl: string, customRequest?: typeof request): Promise<GetInfoResponse>;
-    getInfo(): Promise<GetInfoResponse>;
-    static getKeys(mintUrl: string, keysetId?: string, customRequest?: typeof request): Promise<MintActiveKeys>;
-    getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
-    static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
-    getKeySets(): Promise<MintAllKeysets>;
-    // Warning: (ae-forgotten-export) The symbol "MintInfo" needs to be exported by the entry point index.d.ts
+    	constructor(
+    		_mintUrl: string,
+    		_customRequest?: typeof request | undefined,
+    		authTokenGetter?: () => Promise<string>,
+    		options?: {
+        			logger?: Logger;
+        		}
+    	);
+    	static check(
+    		mintUrl: string,
+    		checkPayload: CheckStatePayload,
+    		customRequest?: typeof request
+    	): Promise<CheckStateResponse>;
+    	check(checkPayload: CheckStatePayload): Promise<CheckStateResponse>;
+    	static checkMeltQuote(
+    		mintUrl: string,
+    		quote: string,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string,
+    		logger?: Logger
+    	): Promise<PartialMeltQuoteResponse>;
+    	checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
+    	static checkMintQuote(
+    		mintUrl: string,
+    		quote: string,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string,
+    		logger?: Logger
+    	): Promise<PartialMintQuoteResponse>;
+    	checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
+    	connectWebSocket(): Promise<void>;
+    	static createMeltQuote(
+    		mintUrl: string,
+    		meltQuotePayload: MeltQuotePayload,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string,
+    		logger?: Logger
+    	): Promise<PartialMeltQuoteResponse>;
+    	createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<PartialMeltQuoteResponse>;
+    	static createMintQuote(
+    		mintUrl: string,
+    		mintQuotePayload: MintQuotePayload,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string,
+    		logger?: Logger
+    	): Promise<PartialMintQuoteResponse>;
+    	createMintQuote(mintQuotePayload: MintQuotePayload): Promise<PartialMintQuoteResponse>;
+    	disconnectWebSocket(): void;
+    	static getInfo(
+    		mintUrl: string,
+    		customRequest?: typeof request,
+    		logger?: Logger
+    	): Promise<GetInfoResponse>;
+    	getInfo(): Promise<GetInfoResponse>;
+    	// (undocumented)
+    static getIssuedFilter(
+    		mintUrl: string,
+    		keysetId: string,
+    		customRequest?: typeof request
+    	): Promise<GetFilterResponse>;
+    	getIssuedFilter(keysetId: string): Promise<GetFilterResponse>;
+    	static getKeys(
+    		mintUrl: string,
+    		keysetId?: string,
+    		customRequest?: typeof request
+    	): Promise<MintActiveKeys>;
+    	getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
+    	static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
+    	getKeySets(): Promise<MintAllKeysets>;
+    	// Warning: (ae-forgotten-export) The symbol "MintInfo" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     getLazyMintInfo(): Promise<MintInfo>;
-    // (undocumented)
+    	// (undocumented)
+    static getSpentFilter(
+    		mintUrl: string,
+    		keysetId: string,
+    		customRequest?: typeof request
+    	): Promise<GetFilterResponse>;
+    	getSpentFilter(keysetId: string): Promise<GetFilterResponse>;
+    	// (undocumented)
     handleBlindAuth(path: string): Promise<string | undefined>;
-    static melt(mintUrl: string, meltPayload: MeltPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMeltQuoteResponse>;
-    melt(meltPayload: MeltPayload): Promise<PartialMeltQuoteResponse>;
-    static mint(mintUrl: string, mintPayload: MintPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<MintResponse>;
-    mint(mintPayload: MintPayload): Promise<MintResponse>;
-    // (undocumented)
+    	static melt(
+    		mintUrl: string,
+    		meltPayload: MeltPayload,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string,
+    		logger?: Logger
+    	): Promise<PartialMeltQuoteResponse>;
+    	melt(meltPayload: MeltPayload): Promise<PartialMeltQuoteResponse>;
+    	static mint(
+    		mintUrl: string,
+    		mintPayload: MintPayload,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string
+    	): Promise<MintResponse>;
+    	mint(mintPayload: MintPayload): Promise<MintResponse>;
+    	// (undocumented)
     get mintUrl(): string;
-    // (undocumented)
-    static restore(mintUrl: string, restorePayload: PostRestorePayload, customRequest?: typeof request): Promise<PostRestoreResponse>;
-    // (undocumented)
+    	// (undocumented)
+    static restore(
+    		mintUrl: string,
+    		restorePayload: PostRestorePayload,
+    		customRequest?: typeof request
+    	): Promise<PostRestoreResponse>;
+    	// (undocumented)
     restore(restorePayload: {
-        outputs: Array<SerializedBlindedMessage>;
-    }): Promise<PostRestoreResponse>;
-    static swap(mintUrl: string, swapPayload: SwapPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<SwapResponse>;
-    swap(swapPayload: SwapPayload): Promise<SwapResponse>;
-    // Warning: (ae-forgotten-export) The symbol "WSConnection" needs to be exported by the entry point index.d.ts
+        		outputs: Array<SerializedBlindedMessage>;
+        	}): Promise<PostRestoreResponse>;
+    	static swap(
+    		mintUrl: string,
+    		swapPayload: SwapPayload,
+    		customRequest?: typeof request,
+    		blindAuthToken?: string
+    	): Promise<SwapResponse>;
+    	swap(swapPayload: SwapPayload): Promise<SwapResponse>;
+    	// Warning: (ae-forgotten-export) The symbol "WSConnection" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     get webSocketConnection(): WSConnection | undefined;
@@ -111,82 +204,140 @@ export class CashuMint {
 
 // @public
 export class CashuWallet {
-    constructor(mint: CashuMint, options?: {
-        unit?: string;
-        keys?: Array<MintKeys> | MintKeys;
-        keysets?: Array<MintKeyset>;
-        mintInfo?: GetInfoResponse;
-        bip39seed?: Uint8Array;
-        denominationTarget?: number;
-        keepFactory?: OutputDataFactory;
-    });
-    batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{
-        proofs: Array<Proof>;
-        lastCounterWithSignature?: number;
-    }>;
-    checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
-    // (undocumented)
+    	constructor(
+    		mint: CashuMint,
+    		options?: {
+        			unit?: string;
+        			keys?: Array<MintKeys> | MintKeys;
+        			keysets?: Array<MintKeyset>;
+        			mintInfo?: GetInfoResponse;
+        			bip39seed?: Uint8Array;
+        			denominationTarget?: number;
+        			keepFactory?: OutputDataFactory;
+        			logger?: Logger;
+        		}
+    	);
+    	batchRestore(
+    		gapLimit?: number,
+    		batchSize?: number,
+    		counter?: number,
+    		keysetId?: string
+    	): Promise<{
+        		proofs: Array<Proof>;
+        		lastCounterWithSignature?: number;
+        	}>;
+    	checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
+    	// (undocumented)
     checkMeltQuote(quote: MeltQuoteResponse): Promise<MeltQuoteResponse>;
-    checkMintQuote(quote: MintQuoteResponse): Promise<MintQuoteResponse>;
-    // (undocumented)
+    	checkMintQuote(quote: MintQuoteResponse): Promise<MintQuoteResponse>;
+    	// (undocumented)
     checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
-    checkProofsStates(proofs: Array<Proof>): Promise<Array<ProofState>>;
-    createLockedMintQuote(amount: number, pubkey: string, description?: string): Promise<LockedMintQuoteResponse>;
-    createMeltQuote(invoice: string): Promise<MeltQuoteResponse>;
-    createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse>;
-    createMultiPathMeltQuote(invoice: string, millisatPartialAmount: number): Promise<MeltQuoteResponse>;
-    getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
-    getAllKeys(): Promise<Array<MintKeys>>;
-    getFeesForKeyset(nInputs: number, keysetId: string): number;
-    getFeesForProofs(proofs: Array<Proof>): number;
-    getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
-    getKeySets(): Promise<Array<MintKeyset>>;
-    getMintInfo(): Promise<MintInfo>;
-    // (undocumented)
+    	checkProofsStates(proofs: Array<Proof>): Promise<Array<ProofState>>;
+    	checkProofStateWithFilter(proofs: Array<Proof>, keysetId?: string): Promise<Array<ProofState>>;
+    	createLockedMintQuote(
+    		amount: number,
+    		pubkey: string,
+    		description?: string
+    	): Promise<LockedMintQuoteResponse>;
+    	createMeltQuote(invoice: string): Promise<MeltQuoteResponse>;
+    	createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse>;
+    	createMultiPathMeltQuote(
+    		invoice: string,
+    		millisatPartialAmount: number
+    	): Promise<MeltQuoteResponse>;
+    	getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
+    	getAllKeys(): Promise<Array<MintKeys>>;
+    	getFeesForKeyset(nInputs: number, keysetId: string): number;
+    	getFeesForProofs(proofs: Array<Proof>): number;
+    	getIssuedFilter(keysetId: string): Promise<GCSFilter>;
+    	getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
+    	getKeySets(): Promise<Array<MintKeyset>>;
+    	getMintInfo(): Promise<MintInfo>;
+    	// Warning: (ae-forgotten-export) The symbol "GCSFilter" needs to be exported by the entry point index.d.ts
+    getSpentFilter(keysetId: string): Promise<GCSFilter>;
+    	// (undocumented)
     get keys(): Map<string, MintKeys>;
-    // (undocumented)
+    	// (undocumented)
     get keysetId(): string;
-    set keysetId(keysetId: string);
-    // (undocumented)
+    	set keysetId(keysetId: string);
+    	// (undocumented)
     get keysets(): Array<MintKeyset>;
-    lazyGetMintInfo(): Promise<MintInfo>;
-    loadMint(): Promise<void>;
-    meltProofs(meltQuote: MeltQuoteResponse, proofsToSend: Array<Proof>, options?: MeltProofOptions): Promise<MeltProofsResponse>;
-    // (undocumented)
+    	lazyGetMintInfo(): Promise<MintInfo>;
+    	loadMint(): Promise<void>;
+    	meltProofs(
+    		meltQuote: MeltQuoteResponse,
+    		proofsToSend: Array<Proof>,
+    		options?: MeltProofOptions
+    	): Promise<MeltProofsResponse>;
+    	// (undocumented)
     mint: CashuMint;
-    // (undocumented)
+    	// (undocumented)
     get mintInfo(): MintInfo;
-    mintProofs(amount: number, quote: MintQuoteResponse, options: MintProofOptions & {
-        privateKey: string;
-    }): Promise<Array<Proof>>;
-    // (undocumented)
+    	mintProofs(
+    		amount: number,
+    		quote: MintQuoteResponse,
+    		options: MintProofOptions & {
+        			privateKey: string;
+        		}
+    	): Promise<Array<Proof>>;
+    	// (undocumented)
     mintProofs(amount: number, quote: string, options?: MintProofOptions): Promise<Array<Proof>>;
-    onMeltQuotePaid(quoteId: string, callback: (payload: MeltQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
-    onMeltQuoteUpdates(quoteIds: Array<string>, callback: (payload: MeltQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
-    onMintQuotePaid(quoteId: string, callback: (payload: MintQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
-    // Warning: (ae-forgotten-export) The symbol "SubscriptionCanceller" needs to be exported by the entry point index.d.ts
-    onMintQuoteUpdates(quoteIds: Array<string>, callback: (payload: MintQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
-    onProofStateUpdates(proofs: Array<Proof>, callback: (payload: ProofState & {
-        proof: Proof;
-    }) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
-    receive(token: string | Token, options?: ReceiveOptions): Promise<Array<Proof>>;
-    restore(start: number, count: number, options?: RestoreOptions): Promise<{
-        proofs: Array<Proof>;
-        lastCounterWithSignature?: number;
-    }>;
-    // (undocumented)
-    selectProofsToSend(proofs: Array<Proof>, amountToSend: number, includeFees?: boolean): SendResponse;
-    send(amount: number, proofs: Array<Proof>, options?: SendOptions): Promise<SendResponse>;
-    swap(amount: number, proofs: Array<Proof>, options?: SwapOptions): Promise<SendResponse>;
-    // (undocumented)
+    	onMeltQuotePaid(
+    		quoteId: string,
+    		callback: (payload: MeltQuoteResponse) => void,
+    		errorCallback: (e: Error) => void
+    	): Promise<SubscriptionCanceller>;
+    	onMeltQuoteUpdates(
+    		quoteIds: Array<string>,
+    		callback: (payload: MeltQuoteResponse) => void,
+    		errorCallback: (e: Error) => void
+    	): Promise<SubscriptionCanceller>;
+    	onMintQuotePaid(
+    		quoteId: string,
+    		callback: (payload: MintQuoteResponse) => void,
+    		errorCallback: (e: Error) => void
+    	): Promise<SubscriptionCanceller>;
+    	// Warning: (ae-forgotten-export) The symbol "SubscriptionCanceller" needs to be exported by the entry point index.d.ts
+    onMintQuoteUpdates(
+    		quoteIds: Array<string>,
+    		callback: (payload: MintQuoteResponse) => void,
+    		errorCallback: (e: Error) => void
+    	): Promise<SubscriptionCanceller>;
+    	onProofStateUpdates(
+    		proofs: Array<Proof>,
+    		callback: (
+    			payload: ProofState & {
+        				proof: Proof;
+        			}
+    		) => void,
+    		errorCallback: (e: Error) => void
+    	): Promise<SubscriptionCanceller>;
+    	receive(token: string | Token, options?: ReceiveOptions): Promise<Array<Proof>>;
+    	restore(
+    		start: number,
+    		count: number,
+    		options?: RestoreOptions
+    	): Promise<{
+        		proofs: Array<Proof>;
+        		lastCounterWithSignature?: number;
+        	}>;
+    	// (undocumented)
+    selectProofsToSend(
+    		proofs: Array<Proof>,
+    		amountToSend: number,
+    		includeFees?: boolean
+    	): SendResponse;
+    	send(amount: number, proofs: Array<Proof>, options?: SendOptions): Promise<SendResponse>;
+    	swap(amount: number, proofs: Array<Proof>, options?: SwapOptions): Promise<SendResponse>;
+    	// (undocumented)
     get unit(): string;
-}
+    	}
 
 // @public
 export const CheckStateEnum: {
-    readonly UNSPENT: "UNSPENT";
-    readonly PENDING: "PENDING";
-    readonly SPENT: "SPENT";
+    	readonly UNSPENT: 'UNSPENT';
+    	readonly PENDING: 'PENDING';
+    	readonly SPENT: 'SPENT';
 };
 
 // @public (undocumented)
@@ -194,29 +345,54 @@ export type CheckStateEnum = (typeof CheckStateEnum)[keyof typeof CheckStateEnum
 
 // @public
 export type CheckStatePayload = {
-    Ys: Array<string>;
+    	Ys: Array<string>;
 };
 
 // @public
 export type CheckStateResponse = {
-    states: Array<ProofState>;
+    	states: Array<ProofState>;
 } & ApiError;
+
+// @public
+export class ConsoleLogger implements Logger {
+    	constructor(minLevel?: LogLevel);
+    	// (undocumented)
+    debug(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    error(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    fatal(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    info(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    log(level: LogLevel, message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    static readonly SEVERITY: Record<LogLevel, number>;
+    	// (undocumented)
+    trace(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    warn(message: string, context?: Record<string, any>): void;
+}
 
 // @public (undocumented)
 export function decodePaymentRequest(paymentRequest: string): PaymentRequest_2;
 
 // @public
 export type DeprecatedToken = {
-    token: Array<TokenEntry>;
-    memo?: string;
-    unit?: string;
+    	token: Array<TokenEntry>;
+    	memo?: string;
+    	unit?: string;
 };
 
 // @public
 export function deriveKeysetId(keys: Keys): string;
 
 // @public (undocumented)
-export function getBlindedAuthToken(amount: number, url: string, clearAuthToken: string): Promise<string[]>;
+export function getBlindedAuthToken(
+	amount: number,
+	url: string,
+	clearAuthToken: string
+): Promise<string[]>;
 
 // @public
 export function getDecodedToken(token: string): Token;
@@ -228,73 +404,89 @@ export function getDecodedTokenBinary(bytes: Uint8Array): Token;
 export function getEncodedAuthToken(proof: Proof): string;
 
 // @public
-export function getEncodedToken(token: Token, opts?: {
-    version: 3 | 4;
-}): string;
+export function getEncodedToken(
+	token: Token,
+	opts?: {
+    		version?: 3 | 4;
+    		removeDleq?: boolean;
+    	}
+): string;
 
 // @public (undocumented)
 export function getEncodedTokenBinary(token: Token): Uint8Array;
 
 // @public (undocumented)
-export function getEncodedTokenV4(token: Token): string;
+export function getEncodedTokenV4(token: Token, removeDleq?: boolean): string;
+
+// @public
+export type GetFilterResponse = {
+    	n: number;
+    	p?: number;
+    	m?: number;
+    	content: string;
+    	timestamp: number;
+} & ApiError;
 
 // @public
 export type GetInfoResponse = {
-    name: string;
-    pubkey: string;
-    version: string;
-    description?: string;
-    description_long?: string;
-    icon_url?: string;
-    contact: Array<MintContactInfo>;
-    nuts: {
-        '4': {
-            methods: Array<SwapMethod>;
-            disabled: boolean;
-        };
-        '5': {
-            methods: Array<SwapMethod>;
-            disabled: boolean;
-        };
-        '7'?: {
-            supported: boolean;
-        };
-        '8'?: {
-            supported: boolean;
-        };
-        '9'?: {
-            supported: boolean;
-        };
-        '10'?: {
-            supported: boolean;
-        };
-        '11'?: {
-            supported: boolean;
-        };
-        '12'?: {
-            supported: boolean;
-        };
-        '14'?: {
-            supported: boolean;
-        };
-        '15'?: {
-            methods: Array<MPPMethod>;
-        };
-        '17'?: {
-            supported: Array<WebSocketSupport>;
-        };
-        '20'?: {
-            supported: boolean;
-        };
-        '22'?: {
-            bat_max_mint: number;
-            protected_endpoints: Array<{
-                method: 'GET' | 'POST';
-                path: string;
-            }>;
-        };
-    };
-    motd?: string;
+    	name: string;
+    	pubkey: string;
+    	version: string;
+    	description?: string;
+    	description_long?: string;
+    	icon_url?: string;
+    	contact: Array<MintContactInfo>;
+    	nuts: {
+        		'4': {
+            			methods: Array<SwapMethod>;
+            			disabled: boolean;
+            		};
+        		'5': {
+            			methods: Array<SwapMethod>;
+            			disabled: boolean;
+            		};
+        		'7'?: {
+            			supported: boolean;
+            		};
+        		'8'?: {
+            			supported: boolean;
+            		};
+        		'9'?: {
+            			supported: boolean;
+            		};
+        		'10'?: {
+            			supported: boolean;
+            		};
+        		'11'?: {
+            			supported: boolean;
+            		};
+        		'12'?: {
+            			supported: boolean;
+            		};
+        		'14'?: {
+            			supported: boolean;
+            		};
+        		'15'?: {
+            			methods: Array<MPPMethod>;
+            		};
+        		'17'?: {
+            			supported: Array<WebSocketSupport>;
+            		};
+        		'20'?: {
+            			supported: boolean;
+            		};
+        		'22'?: {
+            			bat_max_mint: number;
+            			protected_endpoints: Array<{
+                				method: 'GET' | 'POST';
+                				path: string;
+                			}>;
+            		};
+        		'25'?: {
+            			supported: boolean;
+            		};
+        	};
+    	motd?: string;
 };
 
 // @public
@@ -302,14 +494,14 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean;
 
 // @public
 export type HTLCWitness = {
-    preimage: string;
-    signatures?: Array<string>;
+    	preimage: string;
+    	signatures?: Array<string>;
 };
 
 // @public
 export class HttpResponseError extends Error {
-    constructor(message: string, status: number);
-    // (undocumented)
+    	constructor(message: string, status: number);
+    	// (undocumented)
     status: number;
 }
 
@@ -318,20 +510,20 @@ export function injectWebSocketImpl(ws: any): void;
 
 // @public (undocumented)
 export type InvoiceData = {
-    paymentRequest: string;
-    amountInSats?: number;
-    amountInMSats?: number;
-    timestamp?: number;
-    paymentHash?: string;
-    memo?: string;
-    expiry?: number;
+    	paymentRequest: string;
+    	amountInSats?: number;
+    	amountInMSats?: number;
+    	timestamp?: number;
+    	paymentHash?: string;
+    	memo?: string;
+    	expiry?: number;
 };
 
 // @public (undocumented)
 export type JsonRpcErrorObject = {
-    code: number;
-    message: string;
-    data?: any;
+    	code: number;
+    	message: string;
+    	data?: any;
 };
 
 // Warning: (ae-forgotten-export) The symbol "JsonRpcRequest" needs to be exported by the entry point index.d.ts
@@ -343,77 +535,108 @@ export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcSucce
 
 // @public (undocumented)
 export type JsonRpcNotification = {
-    jsonrpc: '2.0';
-    method: string;
-    params?: JsonRpcParams;
+    	jsonrpc: '2.0';
+    	method: string;
+    	params?: JsonRpcParams;
 };
 
 // @public (undocumented)
 export type JsonRpcReqParams = {
-    kind: RpcSubKinds;
-    filters: Array<string>;
-    subId: string;
+    	kind: RpcSubKinds;
+    	filters: Array<string>;
+    	subId: string;
 };
 
 // @public
 export type Keys = {
-    [amount: number]: string;
+    	[amount: number]: string;
 };
 
 // @public (undocumented)
 export type LockedMintQuote = {
-    id: string;
-    privkey: string;
+    	id: string;
+    	privkey: string;
 };
 
 // @public (undocumented)
 export type LockedMintQuoteResponse = MintQuoteResponse & {
-    pubkey: string;
+    	pubkey: string;
+};
+
+// @public (undocumented)
+export interface Logger {
+    	// (undocumented)
+    debug(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    error(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    fatal(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    info(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    log(level: LogLevel, message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    trace(message: string, context?: Record<string, any>): void;
+    	// (undocumented)
+    warn(message: string, context?: Record<string, any>): void;
+}
+
+// @public
+export const LogLevel: {
+    	readonly FATAL: 'FATAL';
+    	readonly ERROR: 'ERROR';
+    	readonly WARN: 'WARN';
+    	readonly INFO: 'INFO';
+    	readonly DEBUG: 'DEBUG';
+    	readonly TRACE: 'TRACE';
 };
 
 // @public
+export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
+
+// @public
 export type MeltPayload = {
-    quote: string;
-    inputs: Array<Proof>;
-    outputs: Array<SerializedBlindedMessage>;
+    	quote: string;
+    	inputs: Array<Proof>;
+    	outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public (undocumented)
 export type MeltProofOptions = {
-    keysetId?: string;
-    counter?: number;
-    privkey?: string;
+    	keysetId?: string;
+    	counter?: number;
+    	privkey?: string;
 };
 
 // @public
 export type MeltProofsResponse = {
-    quote: MeltQuoteResponse;
-    change: Array<Proof>;
+    	quote: MeltQuoteResponse;
+    	change: Array<Proof>;
 };
 
 // @public
 export type MeltQuoteOptions = {
-    mpp: MPPOption;
+    	mpp: MPPOption;
 };
 
 // @public
 export type MeltQuotePayload = {
-    unit: string;
-    request: string;
-    options?: MeltQuoteOptions;
+    	unit: string;
+    	request: string;
+    	options?: MeltQuoteOptions;
 };
 
 // @public (undocumented)
 export type MeltQuoteResponse = PartialMeltQuoteResponse & {
-    request: string;
-    unit: string;
+    	request: string;
+    	unit: string;
 };
 
 // @public (undocumented)
 export const MeltQuoteState: {
-    readonly UNPAID: "UNPAID";
-    readonly PENDING: "PENDING";
-    readonly PAID: "PAID";
+    	readonly UNPAID: 'UNPAID';
+    	readonly PENDING: 'PENDING';
+    	readonly PAID: 'PAID';
 };
 
 // @public (undocumented)
@@ -421,83 +644,85 @@ export type MeltQuoteState = (typeof MeltQuoteState)[keyof typeof MeltQuoteState
 
 // @public
 export type MintActiveKeys = {
-    keysets: Array<MintKeys>;
+    	keysets: Array<MintKeys>;
 };
 
 // @public
 export type MintAllKeysets = {
-    keysets: Array<MintKeyset>;
+    	keysets: Array<MintKeyset>;
 };
 
 // @public (undocumented)
 export type MintContactInfo = {
-    method: string;
-    info: string;
+    	method: string;
+    	info: string;
 };
 
 // @public
 export type MintKeys = {
-    id: string;
-    unit: string;
-    keys: Keys;
+    	id: string;
+    	unit: string;
+    	keys: Keys;
 };
 
 // @public
 export type MintKeyset = {
-    id: string;
-    unit: string;
-    active: boolean;
-    input_fee_ppk?: number;
+    	id: string;
+    	unit: string;
+    	active: boolean;
+    	input_fee_ppk?: number;
 };
 
 // @public
 export class MintOperationError extends HttpResponseError {
-    constructor(code: number, detail: string);
-    // (undocumented)
+    	constructor(code: number, detail: string);
+    	// (undocumented)
     code: number;
 }
 
 // @public
 export type MintPayload = {
-    quote: string;
-    outputs: Array<SerializedBlindedMessage>;
-    signature?: string;
+    	quote: string;
+    	outputs: Array<SerializedBlindedMessage>;
+    	signature?: string;
 };
 
 // @public (undocumented)
 export type MintProofOptions = {
-    keysetId?: string;
-    outputAmounts?: OutputAmounts;
-    proofsWeHave?: Array<Proof>;
-    counter?: number;
-    pubkey?: string;
-    outputData?: Array<OutputDataLike> | OutputDataFactory;
-    p2pk?: {
-        pubkey: string;
-        locktime?: number;
-        refundKeys?: Array<string>;
-    };
+    	keysetId?: string;
+    	outputAmounts?: OutputAmounts;
+    	proofsWeHave?: Array<Proof>;
+    	counter?: number;
+    	pubkey?: string;
+    	outputData?: Array<OutputDataLike> | OutputDataFactory;
+    	p2pk?: {
+        		pubkey: string | Array<string>;
+        		locktime?: number;
+        		refundKeys?: Array<string>;
+        		requiredSignatures?: number;
+        		requiredRefundSignatures?: number;
+        	};
 };
 
 // @public
 export type MintQuotePayload = {
-    unit: string;
-    amount: number;
-    description?: string;
-    pubkey?: string;
+    	unit: string;
+    	amount: number;
+    	description?: string;
+    	pubkey?: string;
 };
 
 // @public (undocumented)
 export type MintQuoteResponse = PartialMintQuoteResponse & {
-    amount: number;
-    unit: string;
+    	amount: number;
+    	unit: string;
 };
 
 // @public (undocumented)
 export const MintQuoteState: {
-    readonly UNPAID: "UNPAID";
-    readonly PAID: "PAID";
-    readonly ISSUED: "ISSUED";
+    	readonly UNPAID: 'UNPAID';
+    	readonly PAID: 'PAID';
+    	readonly ISSUED: 'ISSUED';
 };
 
 // @public (undocumented)
@@ -505,247 +730,288 @@ export type MintQuoteState = (typeof MintQuoteState)[keyof typeof MintQuoteState
 
 // @public
 export type MintResponse = {
-    signatures: Array<SerializedBlindedSignature>;
+    	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 // @public
 export type MPPMethod = {
-    method: string;
-    unit: string;
+    	method: string;
+    	unit: string;
 };
 
 // @public
 export type MPPOption = {
-    amount: number;
+    	amount: number;
 };
 
 // @public
 export class NetworkError extends Error {
-    constructor(message: string);
+    	constructor(message: string);
 }
 
 // @public
 export type NUT10Option = {
-    kind: string;
-    data: string;
-    tags: Array<Array<string>>;
+    	kind: string;
+    	data: string;
+    	tags: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export type OutputAmounts = {
-    sendAmounts: Array<number>;
-    keepAmounts?: Array<number>;
+    	sendAmounts: Array<number>;
+    	keepAmounts?: Array<number>;
 };
 
 // @public (undocumented)
 export class OutputData implements OutputDataLike {
-    constructor(blindedMessage: SerializedBlindedMessage, blidingFactor: bigint, secret: Uint8Array);
-    // (undocumented)
+    	constructor(blindedMessage: SerializedBlindedMessage, blidingFactor: bigint, secret: Uint8Array);
+    	// (undocumented)
     blindedMessage: SerializedBlindedMessage;
-    // (undocumented)
+    	// (undocumented)
     blindingFactor: bigint;
-    // (undocumented)
-    static createDeterministicData(amount: number, seed: Uint8Array, counter: number, keyset: MintKeys, customSplit?: Array<number>): Array<OutputData>;
-    // (undocumented)
-    static createP2PKData(p2pk: {
-        pubkey: string;
-        locktime?: number;
-        refundKeys?: Array<string>;
-    }, amount: number, keyset: MintKeys, customSplit?: Array<number>): OutputData[];
-    // (undocumented)
-    static createRandomData(amount: number, keyset: MintKeys, customSplit?: Array<number>): OutputData[];
-    // (undocumented)
-    static createSingleDeterministicData(amount: number, seed: Uint8Array, counter: number, keysetId: string): OutputData;
-    // (undocumented)
-    static createSingleP2PKData(p2pk: {
-        pubkey: string;
-        locktime?: number;
-        refundKeys?: Array<string>;
-    }, amount: number, keysetId: string): OutputData;
-    // (undocumented)
+    	// (undocumented)
+    static createDeterministicData(
+    		amount: number,
+    		seed: Uint8Array,
+    		counter: number,
+    		keyset: MintKeys,
+    		customSplit?: Array<number>
+    	): Array<OutputData>;
+    	// (undocumented)
+    static createP2PKData(
+    		p2pk: {
+        			pubkey: string | Array<string>;
+        			locktime?: number;
+        			refundKeys?: Array<string>;
+        			requiredSignatures?: number;
+        			requiredRefundSignatures?: number;
+        		},
+    		amount: number,
+    		keyset: MintKeys,
+    		customSplit?: Array<number>
+    	): OutputData[];
+    	// (undocumented)
+    static createRandomData(
+    		amount: number,
+    		keyset: MintKeys,
+    		customSplit?: Array<number>
+    	): OutputData[];
+    	// (undocumented)
+    static createSingleDeterministicData(
+    		amount: number,
+    		seed: Uint8Array,
+    		counter: number,
+    		keysetId: string
+    	): OutputData;
+    	// (undocumented)
+    static createSingleP2PKData(
+    		p2pk: {
+        			pubkey: string | Array<string>;
+        			locktime?: number;
+        			refundKeys?: Array<string>;
+        			requiredSignatures?: number;
+        			requiredRefundSignatures?: number;
+        		},
+    		amount: number,
+    		keysetId: string
+    	): OutputData;
+    	// (undocumented)
     static createSingleRandomData(amount: number, keysetId: string): OutputData;
-    // (undocumented)
+    	// (undocumented)
     secret: Uint8Array;
-    // (undocumented)
+    	// (undocumented)
     toProof(sig: SerializedBlindedSignature, keyset: MintKeys): Proof;
 }
 
 // @public
 export type P2PKWitness = {
-    signatures?: Array<string>;
+    	signatures?: Array<string>;
 };
 
 // @public
 export type PartialMeltQuoteResponse = {
-    quote: string;
-    amount: number;
-    fee_reserve: number;
-    state: MeltQuoteState;
-    expiry: number;
-    payment_preimage: string | null;
-    change?: Array<SerializedBlindedSignature>;
-    request?: string;
-    unit?: string;
+    	quote: string;
+    	amount: number;
+    	fee_reserve: number;
+    	state: MeltQuoteState;
+    	expiry: number;
+    	payment_preimage: string | null;
+    	change?: Array<SerializedBlindedSignature>;
+    	request?: string;
+    	unit?: string;
 } & ApiError;
 
 // @public
 export type PartialMintQuoteResponse = {
-    request: string;
-    quote: string;
-    state: MintQuoteState;
-    expiry: number;
-    pubkey?: string;
-    unit?: string;
-    amount?: number;
+    	request: string;
+    	quote: string;
+    	state: MintQuoteState;
+    	expiry: number;
+    	pubkey?: string;
+    	unit?: string;
+    	amount?: number;
 } & ApiError;
 
 // @public
 export type PaymentPayload = {
-    pr: string;
-    proofs: Array<Proof>;
+    	pr: string;
+    	proofs: Array<Proof>;
 };
 
 // @public (undocumented)
 class PaymentRequest_2 {
-    constructor(transport?: Array<PaymentRequestTransport> | undefined, id?: string | undefined, amount?: number | undefined, unit?: string | undefined, mints?: Array<string> | undefined, description?: string | undefined, singleUse?: boolean, nut10?: NUT10Option | undefined);
-    // (undocumented)
+    	constructor(
+    		transport?: Array<PaymentRequestTransport> | undefined,
+    		id?: string | undefined,
+    		amount?: number | undefined,
+    		unit?: string | undefined,
+    		mints?: Array<string> | undefined,
+    		description?: string | undefined,
+    		singleUse?: boolean,
+    		nut10?: NUT10Option | undefined
+    	);
+    	// (undocumented)
     amount?: number | undefined;
-    // (undocumented)
+    	// (undocumented)
     description?: string | undefined;
-    // (undocumented)
+    	// (undocumented)
     static fromEncodedRequest(encodedRequest: string): PaymentRequest_2;
-    // (undocumented)
+    	// (undocumented)
     static fromRawRequest(rawPaymentRequest: RawPaymentRequest): PaymentRequest_2;
-    // (undocumented)
+    	// (undocumented)
     getTransport(type: PaymentRequestTransportType): PaymentRequestTransport | undefined;
-    // (undocumented)
+    	// (undocumented)
     id?: string | undefined;
-    // (undocumented)
+    	// (undocumented)
     mints?: Array<string> | undefined;
-    // (undocumented)
+    	// (undocumented)
     nut10?: NUT10Option | undefined;
-    // (undocumented)
+    	// (undocumented)
     singleUse: boolean;
-    // (undocumented)
+    	// (undocumented)
     toEncodedRequest(): string;
-    // (undocumented)
+    	// (undocumented)
     toRawRequest(): RawPaymentRequest;
-    // (undocumented)
+    	// (undocumented)
     transport?: Array<PaymentRequestTransport> | undefined;
-    // (undocumented)
+    	// (undocumented)
     unit?: string | undefined;
 }
 export { PaymentRequest_2 as PaymentRequest }
 
 // @public (undocumented)
 export type PaymentRequestPayload = {
-    id?: string;
-    memo?: string;
-    unit: string;
-    mint: string;
-    proofs: Array<Proof>;
+    	id?: string;
+    	memo?: string;
+    	unit: string;
+    	mint: string;
+    	proofs: Array<Proof>;
 };
 
 // @public (undocumented)
 export type PaymentRequestTransport = {
-    type: PaymentRequestTransportType;
-    target: string;
-    tags?: Array<Array<string>>;
+    	type: PaymentRequestTransportType;
+    	target: string;
+    	tags?: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export enum PaymentRequestTransportType {
-    // (undocumented)
-    NOSTR = "nostr",
-    // (undocumented)
-    POST = "post"
+    	// (undocumented)
+    NOSTR = 'nostr',
+    	// (undocumented)
+    POST = 'post'
 }
 
 // @public
 export type PostRestorePayload = {
-    outputs: Array<SerializedBlindedMessage>;
+    	outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public
 export type PostRestoreResponse = {
-    outputs: Array<SerializedBlindedMessage>;
-    signatures: Array<SerializedBlindedSignature>;
+    	outputs: Array<SerializedBlindedMessage>;
+    	signatures: Array<SerializedBlindedSignature>;
 };
 
 // @public
 export type Proof = {
-    id: string;
-    amount: number;
-    secret: string;
-    C: string;
-    dleq?: SerializedDLEQ;
-    witness?: string | P2PKWitness | HTLCWitness;
+    	id: string;
+    	amount: number;
+    	secret: string;
+    	C: string;
+    	dleq?: SerializedDLEQ;
+    	witness?: string | P2PKWitness | HTLCWitness;
 };
 
 // @public
 export type ProofState = {
-    Y: string;
-    state: CheckStateEnum;
-    witness: string | null;
+    	Y: string;
+    	state: CheckStateEnum;
+    	witness: string | null;
 };
 
 // @public (undocumented)
 export type RawNUT10Option = {
-    k: string;
-    d: string;
-    t: Array<Array<string>>;
+    	k: string;
+    	d: string;
+    	t: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export type RawPaymentRequest = {
-    i?: string;
-    a?: number;
-    u?: string;
-    s?: boolean;
-    m?: Array<string>;
-    d?: string;
-    t?: Array<RawTransport>;
-    nut10?: RawNUT10Option;
+    	i?: string;
+    	a?: number;
+    	u?: string;
+    	s?: boolean;
+    	m?: Array<string>;
+    	d?: string;
+    	t?: Array<RawTransport>;
+    	nut10?: RawNUT10Option;
 };
 
 // @public (undocumented)
 export type RawTransport = {
-    t: PaymentRequestTransportType;
-    a: string;
-    g?: Array<Array<string>>;
+    	t: PaymentRequestTransportType;
+    	a: string;
+    	g?: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export type ReceiveOptions = {
-    keysetId?: string;
-    outputAmounts?: OutputAmounts;
-    proofsWeHave?: Array<Proof>;
-    counter?: number;
-    pubkey?: string;
-    privkey?: string;
-    requireDleq?: boolean;
-    outputData?: Array<OutputDataLike> | OutputDataFactory;
-    p2pk?: {
-        pubkey: string;
-        locktime?: number;
-        refundKeys?: Array<string>;
-    };
+    	keysetId?: string;
+    	outputAmounts?: OutputAmounts;
+    	proofsWeHave?: Array<Proof>;
+    	counter?: number;
+    	pubkey?: string;
+    	privkey?: string;
+    	requireDleq?: boolean;
+    	outputData?: Array<OutputDataLike> | OutputDataFactory;
+    	p2pk?: {
+        		pubkey: string | Array<string>;
+        		locktime?: number;
+        		refundKeys?: Array<string>;
+        		requiredSignatures?: number;
+        		requiredRefundSignatures?: number;
+        	};
 };
 
 // @public
 export type ReceiveResponse = {
-    token: Token;
-    tokensWithErrors: Token | undefined;
+    	token: Token;
+    	tokensWithErrors: Token | undefined;
 };
 
 // @public
 export type ReceiveTokenEntryResponse = {
-    proofs: Array<Proof>;
+    	proofs: Array<Proof>;
 };
 
 // @public (undocumented)
 export type RestoreOptions = {
-    keysetId?: string;
+    	keysetId?: string;
+    	issuedFilter?: GCSFilter;
+    	spentFilter?: GCSFilter;
 };
 
 // @public (undocumented)
@@ -753,56 +1019,58 @@ export type RpcSubId = string | number | null;
 
 // @public (undocumented)
 export type SendOptions = {
-    outputAmounts?: OutputAmounts;
-    proofsWeHave?: Array<Proof>;
-    counter?: number;
-    pubkey?: string;
-    privkey?: string;
-    keysetId?: string;
-    offline?: boolean;
-    includeFees?: boolean;
-    includeDleq?: boolean;
-    outputData?: {
-        send?: Array<OutputDataLike> | OutputDataFactory;
-        keep?: Array<OutputDataLike> | OutputDataFactory;
-    };
-    p2pk?: {
-        pubkey: string;
-        locktime?: number;
-        refundKeys?: Array<string>;
-    };
+    	outputAmounts?: OutputAmounts;
+    	proofsWeHave?: Array<Proof>;
+    	counter?: number;
+    	pubkey?: string;
+    	privkey?: string;
+    	keysetId?: string;
+    	offline?: boolean;
+    	includeFees?: boolean;
+    	includeDleq?: boolean;
+    	outputData?: {
+        		send?: Array<OutputDataLike> | OutputDataFactory;
+        		keep?: Array<OutputDataLike> | OutputDataFactory;
+        	};
+    	p2pk?: {
+        		pubkey: string | Array<string>;
+        		locktime?: number;
+        		refundKeys?: Array<string>;
+        		requiredSignatures?: number;
+        		requiredRefundSignatures?: number;
+        	};
 };
 
 // @public
 export type SendResponse = {
-    keep: Array<Proof>;
-    send: Array<Proof>;
-    serialized?: Array<{
-        proof: Proof;
-        keep: boolean;
-    }>;
+    	keep: Array<Proof>;
+    	send: Array<Proof>;
+    	serialized?: Array<{
+        		proof: Proof;
+        		keep: boolean;
+        	}>;
 };
 
 // @public
 export type SerializedBlindedMessage = {
-    amount: number;
-    B_: string;
-    id: string;
+    	amount: number;
+    	B_: string;
+    	id: string;
 };
 
 // @public
 export type SerializedBlindedSignature = {
-    id: string;
-    amount: number;
-    C_: string;
-    dleq?: SerializedDLEQ;
+    	id: string;
+    	amount: number;
+    	C_: string;
+    	dleq?: SerializedDLEQ;
 };
 
 // @public (undocumented)
 export type SerializedDLEQ = {
-    s: string;
-    e: string;
-    r?: string;
+    	s: string;
+    	e: string;
+    	r?: string;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RequestOptions" needs to be exported by the entry point index.d.ts
@@ -812,112 +1080,114 @@ export function setGlobalRequestOptions(options: Partial<RequestOptions>): void;
 
 // @public
 export type SwapMethod = {
-    method: string;
-    unit: string;
-    min_amount: number;
-    max_amount: number;
+    	method: string;
+    	unit: string;
+    	min_amount: number;
+    	max_amount: number;
 };
 
 // @public (undocumented)
 export type SwapOptions = {
-    outputAmounts?: OutputAmounts;
-    proofsWeHave?: Array<Proof>;
-    counter?: number;
-    pubkey?: string;
-    privkey?: string;
-    keysetId?: string;
-    includeFees?: boolean;
-    outputData?: {
-        send?: Array<OutputDataLike> | OutputDataFactory;
-        keep?: Array<OutputDataLike> | OutputDataFactory;
-    };
-    p2pk?: {
-        pubkey: string;
-        locktime?: number;
-        refundKeys?: Array<string>;
-    };
+    	outputAmounts?: OutputAmounts;
+    	proofsWeHave?: Array<Proof>;
+    	counter?: number;
+    	pubkey?: string;
+    	privkey?: string;
+    	keysetId?: string;
+    	includeFees?: boolean;
+    	outputData?: {
+        		send?: Array<OutputDataLike> | OutputDataFactory;
+        		keep?: Array<OutputDataLike> | OutputDataFactory;
+        	};
+    	p2pk?: {
+        		pubkey: string | Array<string>;
+        		locktime?: number;
+        		refundKeys?: Array<string>;
+        		requiredSignatures?: number;
+        		requiredRefundSignatures?: number;
+        	};
 };
 
 // @public
 export type SwapPayload = {
-    inputs: Array<Proof>;
-    outputs: Array<SerializedBlindedMessage>;
+    	inputs: Array<Proof>;
+    	outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public
 export type SwapResponse = {
-    signatures: Array<SerializedBlindedSignature>;
+    	signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 // @public
 export type SwapTransaction = {
-    payload: SwapPayload;
-    outputData: Array<OutputData>;
-    keepVector: Array<boolean>;
-    sortedIndices: Array<number>;
+    	payload: SwapPayload;
+    	outputData: Array<OutputData>;
+    	keepVector: Array<boolean>;
+    	sortedIndices: Array<number>;
 };
 
 // @public
 export type Token = {
-    mint: string;
-    proofs: Array<Proof>;
-    memo?: string;
-    unit?: string;
+    	mint: string;
+    	proofs: Array<Proof>;
+    	memo?: string;
+    	unit?: string;
 };
 
 // @public @deprecated (undocumented)
 export type TokenV2 = {
-    proofs: Array<Proof>;
-    mints: Array<{
-        url: string;
-        ids: Array<string>;
-    }>;
+    	proofs: Array<Proof>;
+    	mints: Array<{
+        		url: string;
+        		ids: Array<string>;
+        	}>;
 };
 
 // @public
 export type TokenV4Template = {
-    t: Array<V4InnerToken>;
-    d: string;
-    m: string;
-    u: string;
+    	t: Array<V4InnerToken>;
+    	d: string;
+    	m: string;
+    	u: string;
 };
 
 // @public (undocumented)
 export type V4DLEQTemplate = {
-    e: Uint8Array;
-    s: Uint8Array;
-    r: Uint8Array;
+    	e: Uint8Array;
+    	s: Uint8Array;
+    	r: Uint8Array;
 };
 
 // @public
 export type V4InnerToken = {
-    i: Uint8Array;
-    p: Array<V4ProofTemplate>;
+    	i: Uint8Array;
+    	p: Array<V4ProofTemplate>;
 };
 
 // @public
 export type V4ProofTemplate = {
-    a: number;
-    s: string;
-    c: Uint8Array;
-    d?: V4DLEQTemplate;
-    w?: string;
+    	a: number;
+    	s: string;
+    	c: Uint8Array;
+    	d?: V4DLEQTemplate;
+    	w?: string;
 };
 
 // @public
 export type WebSocketSupport = {
-    method: string;
-    unit: string;
-    commands: Array<string>;
+    	method: string;
+    	unit: string;
+    	commands: Array<string>;
 };
 
 // Warnings were encountered during analysis:
 //
-// lib/types/CashuWallet.d.ts:38:9 - (ae-forgotten-export) The symbol "OutputDataFactory" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:117:5 - (ae-forgotten-export) The symbol "OutputDataLike" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:148:5 - (ae-forgotten-export) The symbol "RpcSubKinds" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:176:5 - (ae-forgotten-export) The symbol "JsonRpcParams" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/wallet/tokens.d.ts:103:5 - (ae-forgotten-export) The symbol "TokenEntry" needs to be exported by the entry point index.d.ts
+// lib/types/CashuWallet.d.ts:63:4 - (ae-forgotten-export) The symbol "OutputDataFactory" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/index.d.ts:134:2 - (ae-forgotten-export) The symbol "OutputDataLike" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/index.d.ts:167:2 - (ae-forgotten-export) The symbol "RpcSubKinds" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/index.d.ts:195:2 - (ae-forgotten-export) The symbol "JsonRpcParams" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/wallet/tokens.d.ts:103:2 - (ae-forgotten-export) The symbol "TokenEntry" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -8,195 +8,102 @@ import { MintContactInfo as MintContactInfo_2 } from './types';
 
 // @public
 export type ApiError = {
-    	error?: string;
-    	code?: number;
-    	detail?: string;
+    error?: string;
+    code?: number;
+    detail?: string;
 };
 
 // @public
 export type BlindAuthMintPayload = {
-    	outputs: Array<SerializedBlindedMessage>;
+    outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public
 export type BlindAuthMintResponse = {
-    	signatures: Array<SerializedBlindedSignature>;
+    signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 // @public
 export class CashuAuthMint {
-    	// Warning: (ae-forgotten-export) The symbol "request" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "request" needs to be exported by the entry point index.d.ts
     constructor(_mintUrl: string, _customRequest?: typeof request | undefined);
-    	static getKeys(
-    		mintUrl: string,
-    		keysetId?: string,
-    		customRequest?: typeof request
-    	): Promise<MintActiveKeys>;
-    	getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
-    	static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
-    	getKeySets(): Promise<MintAllKeysets>;
-    	static mint(
-    		mintUrl: string,
-    		mintPayload: BlindAuthMintPayload,
-    		clearAuthToken: string,
-    		customRequest?: typeof request
-    	): Promise<BlindAuthMintResponse>;
-    	mint(mintPayload: BlindAuthMintPayload, clearAuthToken: string): Promise<BlindAuthMintResponse>;
-    	// (undocumented)
+    static getKeys(mintUrl: string, keysetId?: string, customRequest?: typeof request): Promise<MintActiveKeys>;
+    getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
+    static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
+    getKeySets(): Promise<MintAllKeysets>;
+    static mint(mintUrl: string, mintPayload: BlindAuthMintPayload, clearAuthToken: string, customRequest?: typeof request): Promise<BlindAuthMintResponse>;
+    mint(mintPayload: BlindAuthMintPayload, clearAuthToken: string): Promise<BlindAuthMintResponse>;
+    // (undocumented)
     get mintUrl(): string;
 }
 
 // @public
 export class CashuAuthWallet {
-    	constructor(
-    		mint: CashuAuthMint,
-    		options?: {
-        			keys?: Array<MintKeys> | MintKeys;
-        			keysets?: Array<MintKeyset>;
-        		}
-    	);
-    	getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
-    	getAllKeys(): Promise<Array<MintKeys>>;
-    	getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
-    	getKeySets(): Promise<Array<MintKeyset>>;
-    	// (undocumented)
+    constructor(mint: CashuAuthMint, options?: {
+        keys?: Array<MintKeys> | MintKeys;
+        keysets?: Array<MintKeyset>;
+    });
+    getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
+    getAllKeys(): Promise<Array<MintKeys>>;
+    getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
+    getKeySets(): Promise<Array<MintKeyset>>;
+    // (undocumented)
     get keys(): Map<string, MintKeys>;
-    	// (undocumented)
+    // (undocumented)
     get keysetId(): string;
-    	set keysetId(keysetId: string);
-    	// (undocumented)
+    set keysetId(keysetId: string);
+    // (undocumented)
     get keysets(): Array<MintKeyset>;
-    	loadMint(): Promise<void>;
-    	// (undocumented)
+    loadMint(): Promise<void>;
+    // (undocumented)
     mint: CashuAuthMint;
-    	mintProofs(
-    		amount: number,
-    		clearAuthToken: string,
-    		options?: {
-        			keysetId?: string;
-        		}
-    	): Promise<Array<Proof>>;
+    mintProofs(amount: number, clearAuthToken: string, options?: {
+        keysetId?: string;
+    }): Promise<Array<Proof>>;
 }
 
 // @public
 export class CashuMint {
-    	constructor(
-    		_mintUrl: string,
-    		_customRequest?: typeof request | undefined,
-    		authTokenGetter?: () => Promise<string>,
-    		options?: {
-        			logger?: Logger;
-        		}
-    	);
-    	static check(
-    		mintUrl: string,
-    		checkPayload: CheckStatePayload,
-    		customRequest?: typeof request
-    	): Promise<CheckStateResponse>;
-    	check(checkPayload: CheckStatePayload): Promise<CheckStateResponse>;
-    	static checkMeltQuote(
-    		mintUrl: string,
-    		quote: string,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string,
-    		logger?: Logger
-    	): Promise<PartialMeltQuoteResponse>;
-    	checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
-    	static checkMintQuote(
-    		mintUrl: string,
-    		quote: string,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string,
-    		logger?: Logger
-    	): Promise<PartialMintQuoteResponse>;
-    	checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
-    	connectWebSocket(): Promise<void>;
-    	static createMeltQuote(
-    		mintUrl: string,
-    		meltQuotePayload: MeltQuotePayload,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string,
-    		logger?: Logger
-    	): Promise<PartialMeltQuoteResponse>;
-    	createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<PartialMeltQuoteResponse>;
-    	static createMintQuote(
-    		mintUrl: string,
-    		mintQuotePayload: MintQuotePayload,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string,
-    		logger?: Logger
-    	): Promise<PartialMintQuoteResponse>;
-    	createMintQuote(mintQuotePayload: MintQuotePayload): Promise<PartialMintQuoteResponse>;
-    	disconnectWebSocket(): void;
-    	static getInfo(
-    		mintUrl: string,
-    		customRequest?: typeof request,
-    		logger?: Logger
-    	): Promise<GetInfoResponse>;
-    	getInfo(): Promise<GetInfoResponse>;
-    	// (undocumented)
-    static getIssuedFilter(
-    		mintUrl: string,
-    		keysetId: string,
-    		customRequest?: typeof request
-    	): Promise<GetFilterResponse>;
-    	getIssuedFilter(keysetId: string): Promise<GetFilterResponse>;
-    	static getKeys(
-    		mintUrl: string,
-    		keysetId?: string,
-    		customRequest?: typeof request
-    	): Promise<MintActiveKeys>;
-    	getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
-    	static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
-    	getKeySets(): Promise<MintAllKeysets>;
-    	// Warning: (ae-forgotten-export) The symbol "MintInfo" needs to be exported by the entry point index.d.ts
+    constructor(_mintUrl: string, _customRequest?: typeof request | undefined, authTokenGetter?: () => Promise<string>);
+    static check(mintUrl: string, checkPayload: CheckStatePayload, customRequest?: typeof request): Promise<CheckStateResponse>;
+    check(checkPayload: CheckStatePayload): Promise<CheckStateResponse>;
+    static checkMeltQuote(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMeltQuoteResponse>;
+    checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
+    static checkMintQuote(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMintQuoteResponse>;
+    checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
+    connectWebSocket(): Promise<void>;
+    static createMeltQuote(mintUrl: string, meltQuotePayload: MeltQuotePayload, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMeltQuoteResponse>;
+    createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<PartialMeltQuoteResponse>;
+    static createMintQuote(mintUrl: string, mintQuotePayload: MintQuotePayload, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMintQuoteResponse>;
+    createMintQuote(mintQuotePayload: MintQuotePayload): Promise<PartialMintQuoteResponse>;
+    disconnectWebSocket(): void;
+    static getInfo(mintUrl: string, customRequest?: typeof request): Promise<GetInfoResponse>;
+    getInfo(): Promise<GetInfoResponse>;
+    static getKeys(mintUrl: string, keysetId?: string, customRequest?: typeof request): Promise<MintActiveKeys>;
+    getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
+    static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
+    getKeySets(): Promise<MintAllKeysets>;
+    // Warning: (ae-forgotten-export) The symbol "MintInfo" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     getLazyMintInfo(): Promise<MintInfo>;
-    	// (undocumented)
-    static getSpentFilter(
-    		mintUrl: string,
-    		keysetId: string,
-    		customRequest?: typeof request
-    	): Promise<GetFilterResponse>;
-    	getSpentFilter(keysetId: string): Promise<GetFilterResponse>;
-    	// (undocumented)
+    // (undocumented)
     handleBlindAuth(path: string): Promise<string | undefined>;
-    	static melt(
-    		mintUrl: string,
-    		meltPayload: MeltPayload,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string,
-    		logger?: Logger
-    	): Promise<PartialMeltQuoteResponse>;
-    	melt(meltPayload: MeltPayload): Promise<PartialMeltQuoteResponse>;
-    	static mint(
-    		mintUrl: string,
-    		mintPayload: MintPayload,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string
-    	): Promise<MintResponse>;
-    	mint(mintPayload: MintPayload): Promise<MintResponse>;
-    	// (undocumented)
+    static melt(mintUrl: string, meltPayload: MeltPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<PartialMeltQuoteResponse>;
+    melt(meltPayload: MeltPayload): Promise<PartialMeltQuoteResponse>;
+    static mint(mintUrl: string, mintPayload: MintPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<MintResponse>;
+    mint(mintPayload: MintPayload): Promise<MintResponse>;
+    // (undocumented)
     get mintUrl(): string;
-    	// (undocumented)
-    static restore(
-    		mintUrl: string,
-    		restorePayload: PostRestorePayload,
-    		customRequest?: typeof request
-    	): Promise<PostRestoreResponse>;
-    	// (undocumented)
+    // (undocumented)
+    static restore(mintUrl: string, restorePayload: PostRestorePayload, customRequest?: typeof request): Promise<PostRestoreResponse>;
+    // (undocumented)
     restore(restorePayload: {
-        		outputs: Array<SerializedBlindedMessage>;
-        	}): Promise<PostRestoreResponse>;
-    	static swap(
-    		mintUrl: string,
-    		swapPayload: SwapPayload,
-    		customRequest?: typeof request,
-    		blindAuthToken?: string
-    	): Promise<SwapResponse>;
-    	swap(swapPayload: SwapPayload): Promise<SwapResponse>;
-    	// Warning: (ae-forgotten-export) The symbol "WSConnection" needs to be exported by the entry point index.d.ts
+        outputs: Array<SerializedBlindedMessage>;
+    }): Promise<PostRestoreResponse>;
+    static swap(mintUrl: string, swapPayload: SwapPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<SwapResponse>;
+    swap(swapPayload: SwapPayload): Promise<SwapResponse>;
+    // Warning: (ae-forgotten-export) The symbol "WSConnection" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     get webSocketConnection(): WSConnection | undefined;
@@ -204,140 +111,82 @@ export class CashuMint {
 
 // @public
 export class CashuWallet {
-    	constructor(
-    		mint: CashuMint,
-    		options?: {
-        			unit?: string;
-        			keys?: Array<MintKeys> | MintKeys;
-        			keysets?: Array<MintKeyset>;
-        			mintInfo?: GetInfoResponse;
-        			bip39seed?: Uint8Array;
-        			denominationTarget?: number;
-        			keepFactory?: OutputDataFactory;
-        			logger?: Logger;
-        		}
-    	);
-    	batchRestore(
-    		gapLimit?: number,
-    		batchSize?: number,
-    		counter?: number,
-    		keysetId?: string
-    	): Promise<{
-        		proofs: Array<Proof>;
-        		lastCounterWithSignature?: number;
-        	}>;
-    	checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
-    	// (undocumented)
+    constructor(mint: CashuMint, options?: {
+        unit?: string;
+        keys?: Array<MintKeys> | MintKeys;
+        keysets?: Array<MintKeyset>;
+        mintInfo?: GetInfoResponse;
+        bip39seed?: Uint8Array;
+        denominationTarget?: number;
+        keepFactory?: OutputDataFactory;
+    });
+    batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{
+        proofs: Array<Proof>;
+        lastCounterWithSignature?: number;
+    }>;
+    checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
+    // (undocumented)
     checkMeltQuote(quote: MeltQuoteResponse): Promise<MeltQuoteResponse>;
-    	checkMintQuote(quote: MintQuoteResponse): Promise<MintQuoteResponse>;
-    	// (undocumented)
+    checkMintQuote(quote: MintQuoteResponse): Promise<MintQuoteResponse>;
+    // (undocumented)
     checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
-    	checkProofsStates(proofs: Array<Proof>): Promise<Array<ProofState>>;
-    	checkProofStateWithFilter(proofs: Array<Proof>, keysetId?: string): Promise<Array<ProofState>>;
-    	createLockedMintQuote(
-    		amount: number,
-    		pubkey: string,
-    		description?: string
-    	): Promise<LockedMintQuoteResponse>;
-    	createMeltQuote(invoice: string): Promise<MeltQuoteResponse>;
-    	createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse>;
-    	createMultiPathMeltQuote(
-    		invoice: string,
-    		millisatPartialAmount: number
-    	): Promise<MeltQuoteResponse>;
-    	getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
-    	getAllKeys(): Promise<Array<MintKeys>>;
-    	getFeesForKeyset(nInputs: number, keysetId: string): number;
-    	getFeesForProofs(proofs: Array<Proof>): number;
-    	getIssuedFilter(keysetId: string): Promise<GCSFilter>;
-    	getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
-    	getKeySets(): Promise<Array<MintKeyset>>;
-    	getMintInfo(): Promise<MintInfo>;
-    	// Warning: (ae-forgotten-export) The symbol "GCSFilter" needs to be exported by the entry point index.d.ts
-    getSpentFilter(keysetId: string): Promise<GCSFilter>;
-    	// (undocumented)
+    checkProofsStates(proofs: Array<Proof>): Promise<Array<ProofState>>;
+    createLockedMintQuote(amount: number, pubkey: string, description?: string): Promise<LockedMintQuoteResponse>;
+    createMeltQuote(invoice: string): Promise<MeltQuoteResponse>;
+    createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse>;
+    createMultiPathMeltQuote(invoice: string, millisatPartialAmount: number): Promise<MeltQuoteResponse>;
+    getActiveKeyset(keysets: Array<MintKeyset>): MintKeyset;
+    getAllKeys(): Promise<Array<MintKeys>>;
+    getFeesForKeyset(nInputs: number, keysetId: string): number;
+    getFeesForProofs(proofs: Array<Proof>): number;
+    getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
+    getKeySets(): Promise<Array<MintKeyset>>;
+    getMintInfo(): Promise<MintInfo>;
+    // (undocumented)
     get keys(): Map<string, MintKeys>;
-    	// (undocumented)
+    // (undocumented)
     get keysetId(): string;
-    	set keysetId(keysetId: string);
-    	// (undocumented)
+    set keysetId(keysetId: string);
+    // (undocumented)
     get keysets(): Array<MintKeyset>;
-    	lazyGetMintInfo(): Promise<MintInfo>;
-    	loadMint(): Promise<void>;
-    	meltProofs(
-    		meltQuote: MeltQuoteResponse,
-    		proofsToSend: Array<Proof>,
-    		options?: MeltProofOptions
-    	): Promise<MeltProofsResponse>;
-    	// (undocumented)
+    lazyGetMintInfo(): Promise<MintInfo>;
+    loadMint(): Promise<void>;
+    meltProofs(meltQuote: MeltQuoteResponse, proofsToSend: Array<Proof>, options?: MeltProofOptions): Promise<MeltProofsResponse>;
+    // (undocumented)
     mint: CashuMint;
-    	// (undocumented)
+    // (undocumented)
     get mintInfo(): MintInfo;
-    	mintProofs(
-    		amount: number,
-    		quote: MintQuoteResponse,
-    		options: MintProofOptions & {
-        			privateKey: string;
-        		}
-    	): Promise<Array<Proof>>;
-    	// (undocumented)
+    mintProofs(amount: number, quote: MintQuoteResponse, options: MintProofOptions & {
+        privateKey: string;
+    }): Promise<Array<Proof>>;
+    // (undocumented)
     mintProofs(amount: number, quote: string, options?: MintProofOptions): Promise<Array<Proof>>;
-    	onMeltQuotePaid(
-    		quoteId: string,
-    		callback: (payload: MeltQuoteResponse) => void,
-    		errorCallback: (e: Error) => void
-    	): Promise<SubscriptionCanceller>;
-    	onMeltQuoteUpdates(
-    		quoteIds: Array<string>,
-    		callback: (payload: MeltQuoteResponse) => void,
-    		errorCallback: (e: Error) => void
-    	): Promise<SubscriptionCanceller>;
-    	onMintQuotePaid(
-    		quoteId: string,
-    		callback: (payload: MintQuoteResponse) => void,
-    		errorCallback: (e: Error) => void
-    	): Promise<SubscriptionCanceller>;
-    	// Warning: (ae-forgotten-export) The symbol "SubscriptionCanceller" needs to be exported by the entry point index.d.ts
-    onMintQuoteUpdates(
-    		quoteIds: Array<string>,
-    		callback: (payload: MintQuoteResponse) => void,
-    		errorCallback: (e: Error) => void
-    	): Promise<SubscriptionCanceller>;
-    	onProofStateUpdates(
-    		proofs: Array<Proof>,
-    		callback: (
-    			payload: ProofState & {
-        				proof: Proof;
-        			}
-    		) => void,
-    		errorCallback: (e: Error) => void
-    	): Promise<SubscriptionCanceller>;
-    	receive(token: string | Token, options?: ReceiveOptions): Promise<Array<Proof>>;
-    	restore(
-    		start: number,
-    		count: number,
-    		options?: RestoreOptions
-    	): Promise<{
-        		proofs: Array<Proof>;
-        		lastCounterWithSignature?: number;
-        	}>;
-    	// (undocumented)
-    selectProofsToSend(
-    		proofs: Array<Proof>,
-    		amountToSend: number,
-    		includeFees?: boolean
-    	): SendResponse;
-    	send(amount: number, proofs: Array<Proof>, options?: SendOptions): Promise<SendResponse>;
-    	swap(amount: number, proofs: Array<Proof>, options?: SwapOptions): Promise<SendResponse>;
-    	// (undocumented)
+    onMeltQuotePaid(quoteId: string, callback: (payload: MeltQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
+    onMeltQuoteUpdates(quoteIds: Array<string>, callback: (payload: MeltQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
+    onMintQuotePaid(quoteId: string, callback: (payload: MintQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
+    // Warning: (ae-forgotten-export) The symbol "SubscriptionCanceller" needs to be exported by the entry point index.d.ts
+    onMintQuoteUpdates(quoteIds: Array<string>, callback: (payload: MintQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
+    onProofStateUpdates(proofs: Array<Proof>, callback: (payload: ProofState & {
+        proof: Proof;
+    }) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
+    receive(token: string | Token, options?: ReceiveOptions): Promise<Array<Proof>>;
+    restore(start: number, count: number, options?: RestoreOptions): Promise<{
+        proofs: Array<Proof>;
+        lastCounterWithSignature?: number;
+    }>;
+    // (undocumented)
+    selectProofsToSend(proofs: Array<Proof>, amountToSend: number, includeFees?: boolean): SendResponse;
+    send(amount: number, proofs: Array<Proof>, options?: SendOptions): Promise<SendResponse>;
+    swap(amount: number, proofs: Array<Proof>, options?: SwapOptions): Promise<SendResponse>;
+    // (undocumented)
     get unit(): string;
-    	}
+}
 
 // @public
 export const CheckStateEnum: {
-    	readonly UNSPENT: 'UNSPENT';
-    	readonly PENDING: 'PENDING';
-    	readonly SPENT: 'SPENT';
+    readonly UNSPENT: "UNSPENT";
+    readonly PENDING: "PENDING";
+    readonly SPENT: "SPENT";
 };
 
 // @public (undocumented)
@@ -345,54 +194,29 @@ export type CheckStateEnum = (typeof CheckStateEnum)[keyof typeof CheckStateEnum
 
 // @public
 export type CheckStatePayload = {
-    	Ys: Array<string>;
+    Ys: Array<string>;
 };
 
 // @public
 export type CheckStateResponse = {
-    	states: Array<ProofState>;
+    states: Array<ProofState>;
 } & ApiError;
-
-// @public
-export class ConsoleLogger implements Logger {
-    	constructor(minLevel?: LogLevel);
-    	// (undocumented)
-    debug(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    error(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    fatal(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    info(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    log(level: LogLevel, message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    static readonly SEVERITY: Record<LogLevel, number>;
-    	// (undocumented)
-    trace(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    warn(message: string, context?: Record<string, any>): void;
-}
 
 // @public (undocumented)
 export function decodePaymentRequest(paymentRequest: string): PaymentRequest_2;
 
 // @public
 export type DeprecatedToken = {
-    	token: Array<TokenEntry>;
-    	memo?: string;
-    	unit?: string;
+    token: Array<TokenEntry>;
+    memo?: string;
+    unit?: string;
 };
 
 // @public
 export function deriveKeysetId(keys: Keys): string;
 
 // @public (undocumented)
-export function getBlindedAuthToken(
-	amount: number,
-	url: string,
-	clearAuthToken: string
-): Promise<string[]>;
+export function getBlindedAuthToken(amount: number, url: string, clearAuthToken: string): Promise<string[]>;
 
 // @public
 export function getDecodedToken(token: string): Token;
@@ -404,89 +228,73 @@ export function getDecodedTokenBinary(bytes: Uint8Array): Token;
 export function getEncodedAuthToken(proof: Proof): string;
 
 // @public
-export function getEncodedToken(
-	token: Token,
-	opts?: {
-    		version?: 3 | 4;
-    		removeDleq?: boolean;
-    	}
-): string;
+export function getEncodedToken(token: Token, opts?: {
+    version: 3 | 4;
+}): string;
 
 // @public (undocumented)
 export function getEncodedTokenBinary(token: Token): Uint8Array;
 
 // @public (undocumented)
-export function getEncodedTokenV4(token: Token, removeDleq?: boolean): string;
-
-// @public
-export type GetFilterResponse = {
-    	n: number;
-    	p?: number;
-    	m?: number;
-    	content: string;
-    	timestamp: number;
-} & ApiError;
+export function getEncodedTokenV4(token: Token): string;
 
 // @public
 export type GetInfoResponse = {
-    	name: string;
-    	pubkey: string;
-    	version: string;
-    	description?: string;
-    	description_long?: string;
-    	icon_url?: string;
-    	contact: Array<MintContactInfo>;
-    	nuts: {
-        		'4': {
-            			methods: Array<SwapMethod>;
-            			disabled: boolean;
-            		};
-        		'5': {
-            			methods: Array<SwapMethod>;
-            			disabled: boolean;
-            		};
-        		'7'?: {
-            			supported: boolean;
-            		};
-        		'8'?: {
-            			supported: boolean;
-            		};
-        		'9'?: {
-            			supported: boolean;
-            		};
-        		'10'?: {
-            			supported: boolean;
-            		};
-        		'11'?: {
-            			supported: boolean;
-            		};
-        		'12'?: {
-            			supported: boolean;
-            		};
-        		'14'?: {
-            			supported: boolean;
-            		};
-        		'15'?: {
-            			methods: Array<MPPMethod>;
-            		};
-        		'17'?: {
-            			supported: Array<WebSocketSupport>;
-            		};
-        		'20'?: {
-            			supported: boolean;
-            		};
-        		'22'?: {
-            			bat_max_mint: number;
-            			protected_endpoints: Array<{
-                				method: 'GET' | 'POST';
-                				path: string;
-                			}>;
-            		};
-        		'25'?: {
-            			supported: boolean;
-            		};
-        	};
-    	motd?: string;
+    name: string;
+    pubkey: string;
+    version: string;
+    description?: string;
+    description_long?: string;
+    icon_url?: string;
+    contact: Array<MintContactInfo>;
+    nuts: {
+        '4': {
+            methods: Array<SwapMethod>;
+            disabled: boolean;
+        };
+        '5': {
+            methods: Array<SwapMethod>;
+            disabled: boolean;
+        };
+        '7'?: {
+            supported: boolean;
+        };
+        '8'?: {
+            supported: boolean;
+        };
+        '9'?: {
+            supported: boolean;
+        };
+        '10'?: {
+            supported: boolean;
+        };
+        '11'?: {
+            supported: boolean;
+        };
+        '12'?: {
+            supported: boolean;
+        };
+        '14'?: {
+            supported: boolean;
+        };
+        '15'?: {
+            methods: Array<MPPMethod>;
+        };
+        '17'?: {
+            supported: Array<WebSocketSupport>;
+        };
+        '20'?: {
+            supported: boolean;
+        };
+        '22'?: {
+            bat_max_mint: number;
+            protected_endpoints: Array<{
+                method: 'GET' | 'POST';
+                path: string;
+            }>;
+        };
+    };
+    motd?: string;
 };
 
 // @public
@@ -494,14 +302,14 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean;
 
 // @public
 export type HTLCWitness = {
-    	preimage: string;
-    	signatures?: Array<string>;
+    preimage: string;
+    signatures?: Array<string>;
 };
 
 // @public
 export class HttpResponseError extends Error {
-    	constructor(message: string, status: number);
-    	// (undocumented)
+    constructor(message: string, status: number);
+    // (undocumented)
     status: number;
 }
 
@@ -510,20 +318,20 @@ export function injectWebSocketImpl(ws: any): void;
 
 // @public (undocumented)
 export type InvoiceData = {
-    	paymentRequest: string;
-    	amountInSats?: number;
-    	amountInMSats?: number;
-    	timestamp?: number;
-    	paymentHash?: string;
-    	memo?: string;
-    	expiry?: number;
+    paymentRequest: string;
+    amountInSats?: number;
+    amountInMSats?: number;
+    timestamp?: number;
+    paymentHash?: string;
+    memo?: string;
+    expiry?: number;
 };
 
 // @public (undocumented)
 export type JsonRpcErrorObject = {
-    	code: number;
-    	message: string;
-    	data?: any;
+    code: number;
+    message: string;
+    data?: any;
 };
 
 // Warning: (ae-forgotten-export) The symbol "JsonRpcRequest" needs to be exported by the entry point index.d.ts
@@ -535,108 +343,77 @@ export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcSucce
 
 // @public (undocumented)
 export type JsonRpcNotification = {
-    	jsonrpc: '2.0';
-    	method: string;
-    	params?: JsonRpcParams;
+    jsonrpc: '2.0';
+    method: string;
+    params?: JsonRpcParams;
 };
 
 // @public (undocumented)
 export type JsonRpcReqParams = {
-    	kind: RpcSubKinds;
-    	filters: Array<string>;
-    	subId: string;
+    kind: RpcSubKinds;
+    filters: Array<string>;
+    subId: string;
 };
 
 // @public
 export type Keys = {
-    	[amount: number]: string;
+    [amount: number]: string;
 };
 
 // @public (undocumented)
 export type LockedMintQuote = {
-    	id: string;
-    	privkey: string;
+    id: string;
+    privkey: string;
 };
 
 // @public (undocumented)
 export type LockedMintQuoteResponse = MintQuoteResponse & {
-    	pubkey: string;
+    pubkey: string;
 };
-
-// @public (undocumented)
-export interface Logger {
-    	// (undocumented)
-    debug(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    error(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    fatal(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    info(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    log(level: LogLevel, message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    trace(message: string, context?: Record<string, any>): void;
-    	// (undocumented)
-    warn(message: string, context?: Record<string, any>): void;
-}
-
-// @public
-export const LogLevel: {
-    	readonly FATAL: 'FATAL';
-    	readonly ERROR: 'ERROR';
-    	readonly WARN: 'WARN';
-    	readonly INFO: 'INFO';
-    	readonly DEBUG: 'DEBUG';
-    	readonly TRACE: 'TRACE';
-};
-
-// @public
-export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 
 // @public
 export type MeltPayload = {
-    	quote: string;
-    	inputs: Array<Proof>;
-    	outputs: Array<SerializedBlindedMessage>;
+    quote: string;
+    inputs: Array<Proof>;
+    outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public (undocumented)
 export type MeltProofOptions = {
-    	keysetId?: string;
-    	counter?: number;
-    	privkey?: string;
+    keysetId?: string;
+    counter?: number;
+    privkey?: string;
 };
 
 // @public
 export type MeltProofsResponse = {
-    	quote: MeltQuoteResponse;
-    	change: Array<Proof>;
+    quote: MeltQuoteResponse;
+    change: Array<Proof>;
 };
 
 // @public
 export type MeltQuoteOptions = {
-    	mpp: MPPOption;
+    mpp: MPPOption;
 };
 
 // @public
 export type MeltQuotePayload = {
-    	unit: string;
-    	request: string;
-    	options?: MeltQuoteOptions;
+    unit: string;
+    request: string;
+    options?: MeltQuoteOptions;
 };
 
 // @public (undocumented)
 export type MeltQuoteResponse = PartialMeltQuoteResponse & {
-    	request: string;
-    	unit: string;
+    request: string;
+    unit: string;
 };
 
 // @public (undocumented)
 export const MeltQuoteState: {
-    	readonly UNPAID: 'UNPAID';
-    	readonly PENDING: 'PENDING';
-    	readonly PAID: 'PAID';
+    readonly UNPAID: "UNPAID";
+    readonly PENDING: "PENDING";
+    readonly PAID: "PAID";
 };
 
 // @public (undocumented)
@@ -644,85 +421,83 @@ export type MeltQuoteState = (typeof MeltQuoteState)[keyof typeof MeltQuoteState
 
 // @public
 export type MintActiveKeys = {
-    	keysets: Array<MintKeys>;
+    keysets: Array<MintKeys>;
 };
 
 // @public
 export type MintAllKeysets = {
-    	keysets: Array<MintKeyset>;
+    keysets: Array<MintKeyset>;
 };
 
 // @public (undocumented)
 export type MintContactInfo = {
-    	method: string;
-    	info: string;
+    method: string;
+    info: string;
 };
 
 // @public
 export type MintKeys = {
-    	id: string;
-    	unit: string;
-    	keys: Keys;
+    id: string;
+    unit: string;
+    keys: Keys;
 };
 
 // @public
 export type MintKeyset = {
-    	id: string;
-    	unit: string;
-    	active: boolean;
-    	input_fee_ppk?: number;
+    id: string;
+    unit: string;
+    active: boolean;
+    input_fee_ppk?: number;
 };
 
 // @public
 export class MintOperationError extends HttpResponseError {
-    	constructor(code: number, detail: string);
-    	// (undocumented)
+    constructor(code: number, detail: string);
+    // (undocumented)
     code: number;
 }
 
 // @public
 export type MintPayload = {
-    	quote: string;
-    	outputs: Array<SerializedBlindedMessage>;
-    	signature?: string;
+    quote: string;
+    outputs: Array<SerializedBlindedMessage>;
+    signature?: string;
 };
 
 // @public (undocumented)
 export type MintProofOptions = {
-    	keysetId?: string;
-    	outputAmounts?: OutputAmounts;
-    	proofsWeHave?: Array<Proof>;
-    	counter?: number;
-    	pubkey?: string;
-    	outputData?: Array<OutputDataLike> | OutputDataFactory;
-    	p2pk?: {
-        		pubkey: string | Array<string>;
-        		locktime?: number;
-        		refundKeys?: Array<string>;
-        		requiredSignatures?: number;
-        		requiredRefundSignatures?: number;
-        	};
+    keysetId?: string;
+    outputAmounts?: OutputAmounts;
+    proofsWeHave?: Array<Proof>;
+    counter?: number;
+    pubkey?: string;
+    outputData?: Array<OutputDataLike> | OutputDataFactory;
+    p2pk?: {
+        pubkey: string;
+        locktime?: number;
+        refundKeys?: Array<string>;
+    };
 };
 
 // @public
 export type MintQuotePayload = {
-    	unit: string;
-    	amount: number;
-    	description?: string;
-    	pubkey?: string;
+    unit: string;
+    amount: number;
+    description?: string;
+    pubkey?: string;
 };
 
 // @public (undocumented)
 export type MintQuoteResponse = PartialMintQuoteResponse & {
-    	amount: number;
-    	unit: string;
+    amount: number;
+    unit: string;
 };
 
 // @public (undocumented)
 export const MintQuoteState: {
-    	readonly UNPAID: 'UNPAID';
-    	readonly PAID: 'PAID';
-    	readonly ISSUED: 'ISSUED';
+    readonly UNPAID: "UNPAID";
+    readonly PAID: "PAID";
+    readonly ISSUED: "ISSUED";
 };
 
 // @public (undocumented)
@@ -730,288 +505,247 @@ export type MintQuoteState = (typeof MintQuoteState)[keyof typeof MintQuoteState
 
 // @public
 export type MintResponse = {
-    	signatures: Array<SerializedBlindedSignature>;
+    signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 // @public
 export type MPPMethod = {
-    	method: string;
-    	unit: string;
+    method: string;
+    unit: string;
 };
 
 // @public
 export type MPPOption = {
-    	amount: number;
+    amount: number;
 };
 
 // @public
 export class NetworkError extends Error {
-    	constructor(message: string);
+    constructor(message: string);
 }
 
 // @public
 export type NUT10Option = {
-    	kind: string;
-    	data: string;
-    	tags: Array<Array<string>>;
+    kind: string;
+    data: string;
+    tags: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export type OutputAmounts = {
-    	sendAmounts: Array<number>;
-    	keepAmounts?: Array<number>;
+    sendAmounts: Array<number>;
+    keepAmounts?: Array<number>;
 };
 
 // @public (undocumented)
 export class OutputData implements OutputDataLike {
-    	constructor(blindedMessage: SerializedBlindedMessage, blidingFactor: bigint, secret: Uint8Array);
-    	// (undocumented)
+    constructor(blindedMessage: SerializedBlindedMessage, blidingFactor: bigint, secret: Uint8Array);
+    // (undocumented)
     blindedMessage: SerializedBlindedMessage;
-    	// (undocumented)
+    // (undocumented)
     blindingFactor: bigint;
-    	// (undocumented)
-    static createDeterministicData(
-    		amount: number,
-    		seed: Uint8Array,
-    		counter: number,
-    		keyset: MintKeys,
-    		customSplit?: Array<number>
-    	): Array<OutputData>;
-    	// (undocumented)
-    static createP2PKData(
-    		p2pk: {
-        			pubkey: string | Array<string>;
-        			locktime?: number;
-        			refundKeys?: Array<string>;
-        			requiredSignatures?: number;
-        			requiredRefundSignatures?: number;
-        		},
-    		amount: number,
-    		keyset: MintKeys,
-    		customSplit?: Array<number>
-    	): OutputData[];
-    	// (undocumented)
-    static createRandomData(
-    		amount: number,
-    		keyset: MintKeys,
-    		customSplit?: Array<number>
-    	): OutputData[];
-    	// (undocumented)
-    static createSingleDeterministicData(
-    		amount: number,
-    		seed: Uint8Array,
-    		counter: number,
-    		keysetId: string
-    	): OutputData;
-    	// (undocumented)
-    static createSingleP2PKData(
-    		p2pk: {
-        			pubkey: string | Array<string>;
-        			locktime?: number;
-        			refundKeys?: Array<string>;
-        			requiredSignatures?: number;
-        			requiredRefundSignatures?: number;
-        		},
-    		amount: number,
-    		keysetId: string
-    	): OutputData;
-    	// (undocumented)
+    // (undocumented)
+    static createDeterministicData(amount: number, seed: Uint8Array, counter: number, keyset: MintKeys, customSplit?: Array<number>): Array<OutputData>;
+    // (undocumented)
+    static createP2PKData(p2pk: {
+        pubkey: string;
+        locktime?: number;
+        refundKeys?: Array<string>;
+    }, amount: number, keyset: MintKeys, customSplit?: Array<number>): OutputData[];
+    // (undocumented)
+    static createRandomData(amount: number, keyset: MintKeys, customSplit?: Array<number>): OutputData[];
+    // (undocumented)
+    static createSingleDeterministicData(amount: number, seed: Uint8Array, counter: number, keysetId: string): OutputData;
+    // (undocumented)
+    static createSingleP2PKData(p2pk: {
+        pubkey: string;
+        locktime?: number;
+        refundKeys?: Array<string>;
+    }, amount: number, keysetId: string): OutputData;
+    // (undocumented)
     static createSingleRandomData(amount: number, keysetId: string): OutputData;
-    	// (undocumented)
+    // (undocumented)
     secret: Uint8Array;
-    	// (undocumented)
+    // (undocumented)
     toProof(sig: SerializedBlindedSignature, keyset: MintKeys): Proof;
 }
 
 // @public
 export type P2PKWitness = {
-    	signatures?: Array<string>;
+    signatures?: Array<string>;
 };
 
 // @public
 export type PartialMeltQuoteResponse = {
-    	quote: string;
-    	amount: number;
-    	fee_reserve: number;
-    	state: MeltQuoteState;
-    	expiry: number;
-    	payment_preimage: string | null;
-    	change?: Array<SerializedBlindedSignature>;
-    	request?: string;
-    	unit?: string;
+    quote: string;
+    amount: number;
+    fee_reserve: number;
+    state: MeltQuoteState;
+    expiry: number;
+    payment_preimage: string | null;
+    change?: Array<SerializedBlindedSignature>;
+    request?: string;
+    unit?: string;
 } & ApiError;
 
 // @public
 export type PartialMintQuoteResponse = {
-    	request: string;
-    	quote: string;
-    	state: MintQuoteState;
-    	expiry: number;
-    	pubkey?: string;
-    	unit?: string;
-    	amount?: number;
+    request: string;
+    quote: string;
+    state: MintQuoteState;
+    expiry: number;
+    pubkey?: string;
+    unit?: string;
+    amount?: number;
 } & ApiError;
 
 // @public
 export type PaymentPayload = {
-    	pr: string;
-    	proofs: Array<Proof>;
+    pr: string;
+    proofs: Array<Proof>;
 };
 
 // @public (undocumented)
 class PaymentRequest_2 {
-    	constructor(
-    		transport?: Array<PaymentRequestTransport> | undefined,
-    		id?: string | undefined,
-    		amount?: number | undefined,
-    		unit?: string | undefined,
-    		mints?: Array<string> | undefined,
-    		description?: string | undefined,
-    		singleUse?: boolean,
-    		nut10?: NUT10Option | undefined
-    	);
-    	// (undocumented)
+    constructor(transport?: Array<PaymentRequestTransport> | undefined, id?: string | undefined, amount?: number | undefined, unit?: string | undefined, mints?: Array<string> | undefined, description?: string | undefined, singleUse?: boolean, nut10?: NUT10Option | undefined);
+    // (undocumented)
     amount?: number | undefined;
-    	// (undocumented)
+    // (undocumented)
     description?: string | undefined;
-    	// (undocumented)
+    // (undocumented)
     static fromEncodedRequest(encodedRequest: string): PaymentRequest_2;
-    	// (undocumented)
+    // (undocumented)
     static fromRawRequest(rawPaymentRequest: RawPaymentRequest): PaymentRequest_2;
-    	// (undocumented)
+    // (undocumented)
     getTransport(type: PaymentRequestTransportType): PaymentRequestTransport | undefined;
-    	// (undocumented)
+    // (undocumented)
     id?: string | undefined;
-    	// (undocumented)
+    // (undocumented)
     mints?: Array<string> | undefined;
-    	// (undocumented)
+    // (undocumented)
     nut10?: NUT10Option | undefined;
-    	// (undocumented)
+    // (undocumented)
     singleUse: boolean;
-    	// (undocumented)
+    // (undocumented)
     toEncodedRequest(): string;
-    	// (undocumented)
+    // (undocumented)
     toRawRequest(): RawPaymentRequest;
-    	// (undocumented)
+    // (undocumented)
     transport?: Array<PaymentRequestTransport> | undefined;
-    	// (undocumented)
+    // (undocumented)
     unit?: string | undefined;
 }
 export { PaymentRequest_2 as PaymentRequest }
 
 // @public (undocumented)
 export type PaymentRequestPayload = {
-    	id?: string;
-    	memo?: string;
-    	unit: string;
-    	mint: string;
-    	proofs: Array<Proof>;
+    id?: string;
+    memo?: string;
+    unit: string;
+    mint: string;
+    proofs: Array<Proof>;
 };
 
 // @public (undocumented)
 export type PaymentRequestTransport = {
-    	type: PaymentRequestTransportType;
-    	target: string;
-    	tags?: Array<Array<string>>;
+    type: PaymentRequestTransportType;
+    target: string;
+    tags?: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export enum PaymentRequestTransportType {
-    	// (undocumented)
-    NOSTR = 'nostr',
-    	// (undocumented)
-    POST = 'post'
+    // (undocumented)
+    NOSTR = "nostr",
+    // (undocumented)
+    POST = "post"
 }
 
 // @public
 export type PostRestorePayload = {
-    	outputs: Array<SerializedBlindedMessage>;
+    outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public
 export type PostRestoreResponse = {
-    	outputs: Array<SerializedBlindedMessage>;
-    	signatures: Array<SerializedBlindedSignature>;
+    outputs: Array<SerializedBlindedMessage>;
+    signatures: Array<SerializedBlindedSignature>;
 };
 
 // @public
 export type Proof = {
-    	id: string;
-    	amount: number;
-    	secret: string;
-    	C: string;
-    	dleq?: SerializedDLEQ;
-    	witness?: string | P2PKWitness | HTLCWitness;
+    id: string;
+    amount: number;
+    secret: string;
+    C: string;
+    dleq?: SerializedDLEQ;
+    witness?: string | P2PKWitness | HTLCWitness;
 };
 
 // @public
 export type ProofState = {
-    	Y: string;
-    	state: CheckStateEnum;
-    	witness: string | null;
+    Y: string;
+    state: CheckStateEnum;
+    witness: string | null;
 };
 
 // @public (undocumented)
 export type RawNUT10Option = {
-    	k: string;
-    	d: string;
-    	t: Array<Array<string>>;
+    k: string;
+    d: string;
+    t: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export type RawPaymentRequest = {
-    	i?: string;
-    	a?: number;
-    	u?: string;
-    	s?: boolean;
-    	m?: Array<string>;
-    	d?: string;
-    	t?: Array<RawTransport>;
-    	nut10?: RawNUT10Option;
+    i?: string;
+    a?: number;
+    u?: string;
+    s?: boolean;
+    m?: Array<string>;
+    d?: string;
+    t?: Array<RawTransport>;
+    nut10?: RawNUT10Option;
 };
 
 // @public (undocumented)
 export type RawTransport = {
-    	t: PaymentRequestTransportType;
-    	a: string;
-    	g?: Array<Array<string>>;
+    t: PaymentRequestTransportType;
+    a: string;
+    g?: Array<Array<string>>;
 };
 
 // @public (undocumented)
 export type ReceiveOptions = {
-    	keysetId?: string;
-    	outputAmounts?: OutputAmounts;
-    	proofsWeHave?: Array<Proof>;
-    	counter?: number;
-    	pubkey?: string;
-    	privkey?: string;
-    	requireDleq?: boolean;
-    	outputData?: Array<OutputDataLike> | OutputDataFactory;
-    	p2pk?: {
-        		pubkey: string | Array<string>;
-        		locktime?: number;
-        		refundKeys?: Array<string>;
-        		requiredSignatures?: number;
-        		requiredRefundSignatures?: number;
-        	};
+    keysetId?: string;
+    outputAmounts?: OutputAmounts;
+    proofsWeHave?: Array<Proof>;
+    counter?: number;
+    pubkey?: string;
+    privkey?: string;
+    requireDleq?: boolean;
+    outputData?: Array<OutputDataLike> | OutputDataFactory;
+    p2pk?: {
+        pubkey: string;
+        locktime?: number;
+        refundKeys?: Array<string>;
+    };
 };
 
 // @public
 export type ReceiveResponse = {
-    	token: Token;
-    	tokensWithErrors: Token | undefined;
+    token: Token;
+    tokensWithErrors: Token | undefined;
 };
 
 // @public
 export type ReceiveTokenEntryResponse = {
-    	proofs: Array<Proof>;
+    proofs: Array<Proof>;
 };
 
 // @public (undocumented)
 export type RestoreOptions = {
-    	keysetId?: string;
-    	issuedFilter?: GCSFilter;
-    	spentFilter?: GCSFilter;
+    keysetId?: string;
 };
 
 // @public (undocumented)
@@ -1019,58 +753,56 @@ export type RpcSubId = string | number | null;
 
 // @public (undocumented)
 export type SendOptions = {
-    	outputAmounts?: OutputAmounts;
-    	proofsWeHave?: Array<Proof>;
-    	counter?: number;
-    	pubkey?: string;
-    	privkey?: string;
-    	keysetId?: string;
-    	offline?: boolean;
-    	includeFees?: boolean;
-    	includeDleq?: boolean;
-    	outputData?: {
-        		send?: Array<OutputDataLike> | OutputDataFactory;
-        		keep?: Array<OutputDataLike> | OutputDataFactory;
-        	};
-    	p2pk?: {
-        		pubkey: string | Array<string>;
-        		locktime?: number;
-        		refundKeys?: Array<string>;
-        		requiredSignatures?: number;
-        		requiredRefundSignatures?: number;
-        	};
+    outputAmounts?: OutputAmounts;
+    proofsWeHave?: Array<Proof>;
+    counter?: number;
+    pubkey?: string;
+    privkey?: string;
+    keysetId?: string;
+    offline?: boolean;
+    includeFees?: boolean;
+    includeDleq?: boolean;
+    outputData?: {
+        send?: Array<OutputDataLike> | OutputDataFactory;
+        keep?: Array<OutputDataLike> | OutputDataFactory;
+    };
+    p2pk?: {
+        pubkey: string;
+        locktime?: number;
+        refundKeys?: Array<string>;
+    };
 };
 
 // @public
 export type SendResponse = {
-    	keep: Array<Proof>;
-    	send: Array<Proof>;
-    	serialized?: Array<{
-        		proof: Proof;
-        		keep: boolean;
-        	}>;
+    keep: Array<Proof>;
+    send: Array<Proof>;
+    serialized?: Array<{
+        proof: Proof;
+        keep: boolean;
+    }>;
 };
 
 // @public
 export type SerializedBlindedMessage = {
-    	amount: number;
-    	B_: string;
-    	id: string;
+    amount: number;
+    B_: string;
+    id: string;
 };
 
 // @public
 export type SerializedBlindedSignature = {
-    	id: string;
-    	amount: number;
-    	C_: string;
-    	dleq?: SerializedDLEQ;
+    id: string;
+    amount: number;
+    C_: string;
+    dleq?: SerializedDLEQ;
 };
 
 // @public (undocumented)
 export type SerializedDLEQ = {
-    	s: string;
-    	e: string;
-    	r?: string;
+    s: string;
+    e: string;
+    r?: string;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RequestOptions" needs to be exported by the entry point index.d.ts
@@ -1080,114 +812,112 @@ export function setGlobalRequestOptions(options: Partial<RequestOptions>): void;
 
 // @public
 export type SwapMethod = {
-    	method: string;
-    	unit: string;
-    	min_amount: number;
-    	max_amount: number;
+    method: string;
+    unit: string;
+    min_amount: number;
+    max_amount: number;
 };
 
 // @public (undocumented)
 export type SwapOptions = {
-    	outputAmounts?: OutputAmounts;
-    	proofsWeHave?: Array<Proof>;
-    	counter?: number;
-    	pubkey?: string;
-    	privkey?: string;
-    	keysetId?: string;
-    	includeFees?: boolean;
-    	outputData?: {
-        		send?: Array<OutputDataLike> | OutputDataFactory;
-        		keep?: Array<OutputDataLike> | OutputDataFactory;
-        	};
-    	p2pk?: {
-        		pubkey: string | Array<string>;
-        		locktime?: number;
-        		refundKeys?: Array<string>;
-        		requiredSignatures?: number;
-        		requiredRefundSignatures?: number;
-        	};
+    outputAmounts?: OutputAmounts;
+    proofsWeHave?: Array<Proof>;
+    counter?: number;
+    pubkey?: string;
+    privkey?: string;
+    keysetId?: string;
+    includeFees?: boolean;
+    outputData?: {
+        send?: Array<OutputDataLike> | OutputDataFactory;
+        keep?: Array<OutputDataLike> | OutputDataFactory;
+    };
+    p2pk?: {
+        pubkey: string;
+        locktime?: number;
+        refundKeys?: Array<string>;
+    };
 };
 
 // @public
 export type SwapPayload = {
-    	inputs: Array<Proof>;
-    	outputs: Array<SerializedBlindedMessage>;
+    inputs: Array<Proof>;
+    outputs: Array<SerializedBlindedMessage>;
 };
 
 // @public
 export type SwapResponse = {
-    	signatures: Array<SerializedBlindedSignature>;
+    signatures: Array<SerializedBlindedSignature>;
 } & ApiError;
 
 // @public
 export type SwapTransaction = {
-    	payload: SwapPayload;
-    	outputData: Array<OutputData>;
-    	keepVector: Array<boolean>;
-    	sortedIndices: Array<number>;
+    payload: SwapPayload;
+    outputData: Array<OutputData>;
+    keepVector: Array<boolean>;
+    sortedIndices: Array<number>;
 };
 
 // @public
 export type Token = {
-    	mint: string;
-    	proofs: Array<Proof>;
-    	memo?: string;
-    	unit?: string;
+    mint: string;
+    proofs: Array<Proof>;
+    memo?: string;
+    unit?: string;
 };
 
 // @public @deprecated (undocumented)
 export type TokenV2 = {
-    	proofs: Array<Proof>;
-    	mints: Array<{
-        		url: string;
-        		ids: Array<string>;
-        	}>;
+    proofs: Array<Proof>;
+    mints: Array<{
+        url: string;
+        ids: Array<string>;
+    }>;
 };
 
 // @public
 export type TokenV4Template = {
-    	t: Array<V4InnerToken>;
-    	d: string;
-    	m: string;
-    	u: string;
+    t: Array<V4InnerToken>;
+    d: string;
+    m: string;
+    u: string;
 };
 
 // @public (undocumented)
 export type V4DLEQTemplate = {
-    	e: Uint8Array;
-    	s: Uint8Array;
-    	r: Uint8Array;
+    e: Uint8Array;
+    s: Uint8Array;
+    r: Uint8Array;
 };
 
 // @public
 export type V4InnerToken = {
-    	i: Uint8Array;
-    	p: Array<V4ProofTemplate>;
+    i: Uint8Array;
+    p: Array<V4ProofTemplate>;
 };
 
 // @public
 export type V4ProofTemplate = {
-    	a: number;
-    	s: string;
-    	c: Uint8Array;
-    	d?: V4DLEQTemplate;
-    	w?: string;
+    a: number;
+    s: string;
+    c: Uint8Array;
+    d?: V4DLEQTemplate;
+    w?: string;
 };
 
 // @public
 export type WebSocketSupport = {
-    	method: string;
-    	unit: string;
-    	commands: Array<string>;
+    method: string;
+    unit: string;
+    commands: Array<string>;
 };
 
 // Warnings were encountered during analysis:
 //
-// lib/types/CashuWallet.d.ts:63:4 - (ae-forgotten-export) The symbol "OutputDataFactory" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:134:2 - (ae-forgotten-export) The symbol "OutputDataLike" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:167:2 - (ae-forgotten-export) The symbol "RpcSubKinds" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:195:2 - (ae-forgotten-export) The symbol "JsonRpcParams" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/wallet/tokens.d.ts:103:2 - (ae-forgotten-export) The symbol "TokenEntry" needs to be exported by the entry point index.d.ts
+// lib/types/CashuWallet.d.ts:38:9 - (ae-forgotten-export) The symbol "OutputDataFactory" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/index.d.ts:117:5 - (ae-forgotten-export) The symbol "OutputDataLike" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/index.d.ts:148:5 - (ae-forgotten-export) The symbol "RpcSubKinds" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/index.d.ts:176:5 - (ae-forgotten-export) The symbol "JsonRpcParams" needs to be exported by the entry point index.d.ts
+// lib/types/model/types/wallet/tokens.d.ts:103:5 - (ae-forgotten-export) The symbol "TokenEntry" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -42,7 +42,8 @@ import {
 	hasValidDleq,
 	splitAmount,
 	stripDleq,
-	sumProofs
+	sumProofs,
+	verifyKeysetId
 } from './utils.js';
 import { signMintQuote } from './crypto/client/NUT20.js';
 import {
@@ -223,6 +224,11 @@ class CashuWallet {
 	 */
 	async getAllKeys(): Promise<Array<MintKeys>> {
 		const keysets = await this.mint.getKeys();
+		keysets.keysets.forEach((k) => {
+			if (!verifyKeysetId(k)) {
+				throw new Error(`Couldn't verify keyset ID ${k.id}`);
+			}
+		});
 		this._keys = new Map(keysets.keysets.map((k: MintKeys) => [k.id, k]));
 		this.keysetId = this.getActiveKeyset(this._keysets).id;
 		return keysets.keysets;
@@ -258,6 +264,9 @@ class CashuWallet {
 		// make sure we have keys for this id
 		if (!this._keys.get(keysetId)) {
 			const keys = await this.mint.getKeys(keysetId);
+			if (!verifyKeysetId(keys.keysets[0])) {
+				throw new Error(`Couldn't verify keyset ID ${keys.keysets[0].id}`);
+			}
 			this._keys.set(keysetId, keys.keysets[0]);
 		}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -348,6 +348,16 @@ export function handleTokens(token: string): Token {
 	}
 	throw new Error('Token version is not supported');
 }
+
+/**
+ * Recomputes the ID for the provided keyset and verifies it matches the ID provided by the Mint
+ * @param keys the keyset to be verified
+ * @returns true if the verification succeeded, false otherwise.
+ */
+export function verifyKeysetId(keys: MintKeys): boolean {
+	return deriveKeysetId(keys.keys) === keys.id;
+}
+
 /**
  * Returns the keyset id of a set of keys
  * @param keys keys object to derive keyset id from

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -25,7 +25,7 @@ injectWebSocketImpl(WebSocket);
 const dummyKeysResp = {
 	keysets: [
 		{
-			id: '009a1f293253e41e',
+			id: '00bd033559de27d0',
 			unit: 'sat',
 			keys: {
 				1: '02f970b6ee058705c0dddc4313721cffb7efd3d142d96ea8e01d31c2b2ff09f181',
@@ -37,7 +37,7 @@ const dummyKeysResp = {
 const dummyKeysetResp = {
 	keysets: [
 		{
-			id: '009a1f293253e41e',
+			id: '00bd033559de27d0',
 			unit: 'sat',
 			active: true,
 			input_fee_ppk: 0
@@ -62,7 +62,7 @@ beforeEach(() => {
 		})
 	);
 	server.use(
-		http.get(mintUrl + '/v1/keys/009a1f293253e41e', () => {
+		http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => {
 			return HttpResponse.json(dummyKeysResp);
 		})
 	);
@@ -174,14 +174,14 @@ describe('test fees', () => {
 
 describe('receive', () => {
 	const tokenInput =
-		'cashuAeyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IjAwOWExZjI5MzI1M2U0MWUiLCJhbW91bnQiOjEsInNlY3JldCI6IjAxZjkxMDZkMTVjMDFiOTQwYzk4ZWE3ZTk2OGEwNmUzYWY2OTYxOGVkYjhiZThlNTFiNTEyZDA4ZTkwNzkyMTYiLCJDIjoiMDJmODVkZDg0YjBmODQxODQzNjZjYjY5MTQ2MTA2YWY3YzBmMjZmMmVlMGFkMjg3YTNlNWZhODUyNTI4YmIyOWRmIn1dLCJtaW50IjoiaHR0cDovL2xvY2FsaG9zdDozMzM4In1dfQ=';
+		'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwYmQwMzM1NTlkZTI3ZDAiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICIwMWY5MTA2ZDE1YzAxYjk0MGM5OGVhN2U5NjhhMDZlM2FmNjk2MThlZGI4YmU4ZTUxYjUxMmQwOGU5MDc5MjE2IiwgIkMiOiAiMDJmODVkZDg0YjBmODQxODQzNjZjYjY5MTQ2MTA2YWY3YzBmMjZmMmVlMGFkMjg3YTNlNWZhODUyNTI4YmIyOWRmIn1dLCAibWludCI6ICJodHRwOi8vbG9jYWxob3N0OjMzMzgifV19=';
 	test('test receive encoded token', async () => {
 		server.use(
 			http.post(mintUrl + '/v1/swap', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -194,7 +194,7 @@ describe('receive', () => {
 		const proofs = await wallet.receive(tokenInput);
 
 		expect(proofs).toHaveLength(1);
-		expect(proofs).toMatchObject([{ amount: 1, id: '009a1f293253e41e' }]);
+		expect(proofs).toMatchObject([{ amount: 1, id: '00bd033559de27d0' }]);
 		expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
 	});
@@ -230,17 +230,17 @@ describe('receive', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -251,7 +251,7 @@ describe('receive', () => {
 
 		const wallet = new CashuWallet(mint, { unit });
 		const token3sat =
-			'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDA5YTFmMjkzMjUzZTQxZSIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0=';
+			'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFt7ImlkIjogIjAwYmQwMzM1NTlkZTI3ZDAiLCAiYW1vdW50IjogMSwgInNlY3JldCI6ICJlN2MxYjc2ZDFiMzFlMmJjYTJiMjI5ZDE2MGJkZjYwNDZmMzNiYzQ1NzAyMjIzMDRiNjUxMTBkOTI2ZjdhZjg5IiwgIkMiOiAiMDM4OWNkOWY0Zjk4OGUzODBhNzk4OWQ0ZDQ4OGE3YzkxYzUyNzdmYjkzMDQ3ZTdhMmNjMWVkOGUzMzk2Yjg1NGZmIn0sIHsiaWQiOiAiMDBiZDAzMzU1OWRlMjdkMCIsICJhbW91bnQiOiAyLCAic2VjcmV0IjogImRlNTVjMTVmYWVmZGVkN2Y5Yzk5OWMzZDRjNjJmODFiMGM2ZmUyMWE3NTJmZGVmZjZiMDg0Y2YyZGYyZjVjZjMiLCAiQyI6ICIwMmRlNDBjNTlkOTAzODNiODg1M2NjZjNhNGIyMDg2NGFjODNiYTc1OGZjZTNkOTU5ZGJiODkzNjEwMDJlOGNlNDcifV0sICJtaW50IjogImh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCJ9XX0=';
 
 		const proofs = await wallet.receive(token3sat, {
 			outputAmounts: { keepAmounts: [], sendAmounts: [1, 1, 1] }
@@ -259,9 +259,9 @@ describe('receive', () => {
 
 		expect(proofs).toHaveLength(3);
 		expect(proofs).toMatchObject([
-			{ amount: 1, id: '009a1f293253e41e' },
-			{ amount: 1, id: '009a1f293253e41e' },
-			{ amount: 1, id: '009a1f293253e41e' }
+			{ amount: 1, id: '00bd033559de27d0' },
+			{ amount: 1, id: '00bd033559de27d0' },
+			{ amount: 1, id: '00bd033559de27d0' }
 		]);
 		expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
@@ -295,7 +295,7 @@ describe('receive', () => {
 describe('checkProofsStates', () => {
 	const proofs = [
 		{
-			id: '009a1f293253e41e',
+			id: '00bd033559de27d0',
 			amount: 1,
 			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -332,7 +332,7 @@ describe('requestTokens', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625'
 						}
@@ -345,7 +345,7 @@ describe('requestTokens', () => {
 		const proofs = await wallet.mintProofs(1, '');
 
 		expect(proofs).toHaveLength(1);
-		expect(proofs[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(proofs[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
 	});
@@ -366,7 +366,7 @@ describe('requestTokens', () => {
 describe('send', () => {
 	const proofs = [
 		{
-			id: '009a1f293253e41e',
+			id: '00bd033559de27d0',
 			amount: 1,
 			secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 			C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -378,7 +378,7 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -392,7 +392,7 @@ describe('send', () => {
 
 		expect(result.keep).toHaveLength(0);
 		expect(result.send).toHaveLength(1);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 	});
@@ -403,12 +403,12 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -420,7 +420,7 @@ describe('send', () => {
 
 		const result = await wallet.send(1, [
 			{
-				id: '009a1f293253e41e',
+				id: '00bd033559de27d0',
 				amount: 2,
 				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -428,11 +428,11 @@ describe('send', () => {
 		]);
 
 		expect(result.send).toHaveLength(1);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.keep).toHaveLength(1);
-		expect(result.keep[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.keep[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.keep[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.keep[0].secret)).toBe(true);
 	});
@@ -442,12 +442,12 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -461,7 +461,7 @@ describe('send', () => {
 			1,
 			[
 				{
-					id: '009a1f293253e41e',
+					id: '00bd033559de27d0',
 					amount: 2,
 					secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 					C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -480,12 +480,12 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -497,7 +497,7 @@ describe('send', () => {
 
 		const overpayProofs = [
 			{
-				id: '009a1f293253e41e',
+				id: '00bd033559de27d0',
 				amount: 2,
 				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -506,11 +506,11 @@ describe('send', () => {
 		const result = await wallet.send(1, overpayProofs);
 
 		expect(result.send).toHaveLength(1);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.keep).toHaveLength(1);
-		expect(result.keep[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.keep[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.keep[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.keep[0].secret)).toBe(true);
 	});
@@ -520,22 +520,22 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -547,13 +547,13 @@ describe('send', () => {
 
 		const overpayProofs = [
 			{
-				id: '009a1f293253e41e',
+				id: '00bd033559de27d0',
 				amount: 2,
 				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			},
 			{
-				id: '009a1f293253e41e',
+				id: '00bd033559de27d0',
 				amount: 2,
 				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -566,10 +566,10 @@ describe('send', () => {
 		});
 
 		expect(result.send).toHaveLength(4);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
-		expect(result.send[1]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
-		expect(result.send[2]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
-		expect(result.send[3]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
+		expect(result.send[1]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
+		expect(result.send[2]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
+		expect(result.send[3]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.keep).toHaveLength(0);
@@ -581,22 +581,22 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						},
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -608,13 +608,13 @@ describe('send', () => {
 
 		const overpayProofs = [
 			{
-				id: '009a1f293253e41e',
+				id: '00bd033559de27d0',
 				amount: 2,
 				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
 			},
 			{
-				id: '009a1f293253e41e',
+				id: '00bd033559de27d0',
 				amount: 2,
 				secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 				C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -626,13 +626,13 @@ describe('send', () => {
 		});
 
 		expect(result.send).toHaveLength(3);
-		expect(result.send[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
-		expect(result.send[1]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
-		expect(result.send[2]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.send[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
+		expect(result.send[1]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
+		expect(result.send[2]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 		expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
 		expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
 		expect(result.keep).toHaveLength(1);
-		expect(result.keep[0]).toMatchObject({ amount: 1, id: '009a1f293253e41e' });
+		expect(result.keep[0]).toMatchObject({ amount: 1, id: '00bd033559de27d0' });
 	});
 
 	test('test send not enough funds', async () => {
@@ -641,7 +641,7 @@ describe('send', () => {
 				return HttpResponse.json({
 					signatures: [
 						{
-							id: '009a1f293253e41e',
+							id: '00bd033559de27d0',
 							amount: 1,
 							C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422'
 						}
@@ -666,7 +666,7 @@ describe('send', () => {
 		const result = await wallet
 			.send(1, [
 				{
-					id: '009a1f293253e41e',
+					id: '00bd033559de27d0',
 					amount: 2,
 					secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 					C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -687,7 +687,7 @@ describe('deterministic', () => {
 				1,
 				[
 					{
-						id: '009a1f293253e41e',
+						id: '00bd033559de27d0',
 						amount: 2,
 						secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
 						C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'
@@ -701,18 +701,18 @@ describe('deterministic', () => {
 	test.each([
 		[
 			0,
-			'485875df74771877439ac06339e284c3acfcd9be7abf3bc20b516faeadfe77ae',
-			'ad00d431add9c673e843d4c2bf9a778a5f402b985b8da2d5550bf39cda41d679'
+			'8e0ad268631046765b570f85fe0951710c6e0e13c81b3df50ddfee21d235d132',
+			'f63e13f15cfebe03e798acf3f738802c6da03bceb16e762b8169f8107316c0de'
 		],
 		[
 			1,
-			'8f2b39e8e594a4056eb1e6dbb4b0c38ef13b1b2c751f64f810ec04ee35b77270',
-			'967d5232515e10b81ff226ecf5a9e2e2aff92d66ebc3edf0987eb56357fd6248'
+			'0b59dbc968effd7f5ab4649c0d91ab160cbd58e3aa3490d060701f44dd62e52c',
+			'c3db201daaaa59771c7e176ff761f44f37adde86a1e56cbc50627d24d1143f5a'
 		],
 		[
 			2,
-			'bc628c79accd2364fd31511216a0fab62afd4a18ff77a20deded7b858c9860c8',
-			'b20f47bb6ae083659f3aa986bfa0435c55c6d93f687d51a01f26862d9b9a4899'
+			'c756ae91cf316eaa4b845edcca35f04ee9d1732c10e7205b0ef30123bcbbc1b8',
+			'6d1e1424bc2c84df6a5ee6295683e152e002891c3c142513eee41d8f3307e8f0'
 		]
 	])('deterministic OutputData: counter %i -> secret: %s, r: %s', async (counter, secret, r) => {
 		const hexSeed =
@@ -725,7 +725,7 @@ describe('deterministic', () => {
 			0,
 			hexToBytes(hexSeed),
 			counter,
-			'009a1f293253e41e'
+			'00bd033559de27d0'
 		);
 		expect(decoder.decode(data.secret)).toBe(secret);
 		expect(data.blindingFactor).toBe(numberR);


### PR DESCRIPTION
# Fixes: Not verifying keyset IDs

## Description

Adds a verification check when fetching keys from the Mint. Fails when any of the keyset ID provided by the Mint doesn't pass validation.

## Changes

- added `verifyKeysetId`.
- `getKeys()` and `getAllKeys()` use `verifyKeysetId` to perfom validation.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
- [x] run `npm run api:update` 
