### PR TITLE
use lazy mint info in createLockedMintQuote

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -979,7 +979,7 @@ class CashuWallet {
 		pubkey: string,
 		description?: string,
 	): Promise<LockedMintQuoteResponse> {
-		const { supported } = (await this.getMintInfo()).isSupported(20);
+		const { supported } = (await this.lazyGetMintInfo()).isSupported(20);
 		if (!supported) {
 			throw new Error('Mint does not support NUT-20');
 		}


### PR DESCRIPTION


## Description

 I updated `createLockedMintQuote` to use lazy mint info instead of refetching every time. This matches the pattern of the rest of the methods.


## Changes

- use `getLazyMintInfo` in `createLockedMintQuote` instead of `getMintInfo`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
