### PR TITLE
Fixes compile error in deriveKeysetId

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -273,7 +273,7 @@ export type DeprecatedToken = {
 };
 
 // @public
-export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versionByte?: 0 | 1): string;
+export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versionByte?: number): string;
 
 export { getBlindedAuthToken }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -400,7 +400,7 @@ export function handleTokens(token: string): Token {
  * @param expiry (optional) expiry of the keyset.
  * @param versionByte (optional) version of the keyset ID. Default is 0.
  * @returns Keyset id of the keys.
- * @throws if keyset versionByte is not valid
+ * @throws If keyset versionByte is not valid.
  */
 export function deriveKeysetId(
 	keys: Keys,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -400,6 +400,7 @@ export function handleTokens(token: string): Token {
  * @param expiry (optional) expiry of the keyset.
  * @param versionByte (optional) version of the keyset ID. Default is 0.
  * @returns Keyset id of the keys.
+ * @throws if keyset versionByte is not valid
  */
 export function deriveKeysetId(
 	keys: Keys,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -399,17 +399,19 @@ export function handleTokens(token: string): Token {
  * @param unit (optional) the unit of the keyset.
  * @param expiry (optional) expiry of the keyset.
  * @param versionByte (optional) version of the keyset ID. Default is 0.
- * @returns
+ * @returns Keyset id of the keys.
  */
-export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versionByte?: 0 | 1) {
+export function deriveKeysetId(
+	keys: Keys,
+	unit?: string,
+	expiry?: number,
+	versionByte: number = 0,
+) {
 	let pubkeysConcat = Object.entries(keys)
 		.sort((a: [string, string], b: [string, string]) => +a[0] - +b[0])
 		.map(([, pubKey]: [unknown, string]) => hexToBytes(pubKey))
 		.reduce((prev: Uint8Array, curr: Uint8Array) => mergeUInt8Arrays(prev, curr), new Uint8Array());
 
-	if (!versionByte) {
-		versionByte = 0;
-	}
 	let hash;
 	let hashHex;
 	switch (versionByte) {
@@ -419,7 +421,7 @@ export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versi
 			return '00' + hashHex;
 		case 1:
 			if (!unit) {
-				throw new Error("Couldn't compute ID version 2: no unit was given.");
+				throw new Error('Cannot compute keyset ID version 01: unit is required.');
 			}
 			pubkeysConcat = mergeUInt8Arrays(pubkeysConcat, Buffer.from('unit:' + unit));
 			if (expiry) {
@@ -431,6 +433,8 @@ export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versi
 			hash = sha256(pubkeysConcat);
 			hashHex = Buffer.from(hash).toString('hex');
 			return '01' + hashHex;
+		default:
+			throw new Error(`Unrecognized keyset ID version: ${versionByte}`);
 	}
 }
 


### PR DESCRIPTION
## Description

deriveKeysetId was causing a compile error due to a number assignment mismatch. This fixes.

## Changes

- Allow number type for `versionByte`, default to 0
- throw if `versionByte` is not recognised 

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
