### PR TITLE
implement onchain (NUT-26)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -85,19 +85,27 @@ export class CashuMint {
     checkMeltQuote(quote: string): Promise<PartialMeltQuoteResponse>;
     static checkMeltQuoteBolt12(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<Bolt12MeltQuoteResponse>;
     checkMeltQuoteBolt12(quote: string): Promise<Bolt12MeltQuoteResponse>;
+    static checkMeltQuoteOnchain(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<OnchainMeltQuoteResponse>;
+    checkMeltQuoteOnchain(quote: string): Promise<OnchainMeltQuoteResponse>;
     static checkMintQuote(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string, logger?: Logger): Promise<PartialMintQuoteResponse>;
     checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
     static checkMintQuoteBolt12(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<Bolt12MintQuoteResponse>;
     checkMintQuoteBolt12(quote: string): Promise<Bolt12MintQuoteResponse>;
+    static checkMintQuoteOnchain(mintUrl: string, quote: string, customRequest?: typeof request, blindAuthToken?: string): Promise<OnchainMintQuoteResponse>;
+    checkMintQuoteOnchain(quote: string): Promise<OnchainMintQuoteResponse>;
     connectWebSocket(): Promise<void>;
     static createMeltQuote(mintUrl: string, meltQuotePayload: MeltQuotePayload, customRequest?: typeof request, blindAuthToken?: string, logger?: Logger): Promise<PartialMeltQuoteResponse>;
     createMeltQuote(meltQuotePayload: MeltQuotePayload): Promise<PartialMeltQuoteResponse>;
     static createMeltQuoteBolt12(mintUrl: string, meltQuotePayload: MeltQuotePayload, customRequest?: typeof request, blindAuthToken?: string): Promise<Bolt12MeltQuoteResponse>;
     createMeltQuoteBolt12(meltQuotePayload: MeltQuotePayload): Promise<Bolt12MeltQuoteResponse>;
+    static createMeltQuoteOnchain(mintUrl: string, meltQuotePayload: OnchainMeltQuoteRequest, customRequest?: typeof request, blindAuthToken?: string): Promise<OnchainMeltQuoteResponse>;
+    createMeltQuoteOnchain(meltQuotePayload: OnchainMeltQuoteRequest): Promise<OnchainMeltQuoteResponse>;
     static createMintQuote(mintUrl: string, mintQuotePayload: MintQuotePayload, customRequest?: typeof request, blindAuthToken?: string, logger?: Logger): Promise<PartialMintQuoteResponse>;
     createMintQuote(mintQuotePayload: MintQuotePayload): Promise<PartialMintQuoteResponse>;
     static createMintQuoteBolt12(mintUrl: string, mintQuotePayload: Bolt12MintQuotePayload, customRequest?: typeof request, blindAuthToken?: string): Promise<Bolt12MintQuoteResponse>;
     createMintQuoteBolt12(mintQuotePayload: Bolt12MintQuotePayload): Promise<Bolt12MintQuoteResponse>;
+    static createMintQuoteOnchain(mintUrl: string, mintQuotePayload: OnchainMintQuoteRequest, customRequest?: typeof request, blindAuthToken?: string): Promise<OnchainMintQuoteResponse>;
+    createMintQuoteOnchain(mintQuotePayload: OnchainMintQuoteRequest): Promise<OnchainMintQuoteResponse>;
     disconnectWebSocket(): void;
     static getInfo(mintUrl: string, customRequest?: typeof request, logger?: Logger): Promise<GetInfoResponse>;
     getInfo(): Promise<GetInfoResponse>;
@@ -115,10 +123,14 @@ export class CashuMint {
     melt(meltPayload: MeltPayload): Promise<PartialMeltQuoteResponse>;
     static meltBolt12(mintUrl: string, meltPayload: MeltPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<Bolt12MeltQuoteResponse>;
     meltBolt12(meltPayload: MeltPayload): Promise<Bolt12MeltQuoteResponse>;
+    static meltOnchain(mintUrl: string, meltPayload: MeltPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<OnchainMeltQuoteResponse>;
+    meltOnchain(meltPayload: MeltPayload): Promise<OnchainMeltQuoteResponse>;
     static mint(mintUrl: string, mintPayload: MintPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<MintResponse>;
     mint(mintPayload: MintPayload): Promise<MintResponse>;
     static mintBolt12(mintUrl: string, mintPayload: MintPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<MintResponse>;
     mintBolt12(mintPayload: MintPayload): Promise<MintResponse>;
+    static mintOnchain(mintUrl: string, mintPayload: MintPayload, customRequest?: typeof request, blindAuthToken?: string): Promise<MintResponse>;
+    mintOnchain(mintPayload: MintPayload): Promise<MintResponse>;
     // (undocumented)
     get mintUrl(): string;
     // (undocumented)
@@ -156,19 +168,23 @@ export class CashuWallet {
     checkMeltQuote(quote: MeltQuoteResponse): Promise<MeltQuoteResponse>;
     // (undocumented)
     checkMeltQuoteBolt12(quote: string): Promise<Bolt12MeltQuoteResponse>;
+    checkMeltQuoteOnchain(quote: string): Promise<OnchainMeltQuoteResponse>;
     checkMintQuote(quote: MintQuoteResponse): Promise<MintQuoteResponse>;
     // (undocumented)
     checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
     checkMintQuoteBolt12(quote: string): Promise<Bolt12MintQuoteResponse>;
+    checkMintQuoteOnchain(quote: string): Promise<OnchainMintQuoteResponse>;
     checkProofsStates(proofs: Proof[]): Promise<ProofState[]>;
     createLockedMintQuote(amount: number, pubkey: string, description?: string): Promise<LockedMintQuoteResponse>;
     createMeltQuote(invoice: string): Promise<MeltQuoteResponse>;
     createMeltQuoteBolt12(offer: string, amountMsat?: number): Promise<Bolt12MeltQuoteResponse>;
+    createMeltQuoteOnchain(address: string, amount: number): Promise<OnchainMeltQuoteResponse>;
     createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse>;
     createMintQuoteBolt12(pubkey: string, options?: {
         amount?: number;
         description?: string;
     }): Promise<Bolt12MintQuoteResponse>;
+    createMintQuoteOnchain(pubkey: string): Promise<OnchainMintQuoteResponse>;
     createMultiPathMeltQuote(invoice: string, millisatPartialAmount: number): Promise<MeltQuoteResponse>;
     getActiveKeyset(keysets: MintKeyset[]): MintKeyset;
     getAllKeys(): Promise<MintKeys[]>;
@@ -186,11 +202,9 @@ export class CashuWallet {
     get keysets(): MintKeyset[];
     lazyGetMintInfo(): Promise<MintInfo>;
     loadMint(): Promise<void>;
-    meltProofs(meltQuote: MeltQuoteResponse, proofsToSend: Proof[], options?: MeltProofOptions): Promise<MeltProofsResponse>;
-    meltProofsBolt12(meltQuote: Bolt12MeltQuoteResponse, proofsToSend: Proof[], options?: MeltProofOptions): Promise<{
-        quote: Bolt12MeltQuoteResponse;
-        change: Proof[];
-    }>;
+    meltProofs(meltQuote: MeltQuoteResponse, proofsToSend: Proof[], options?: MeltProofOptions): Promise<MeltProofsResponse<MeltQuoteResponse>>;
+    meltProofsBolt12(meltQuote: Bolt12MeltQuoteResponse, proofsToSend: Proof[], options?: MeltProofOptions): Promise<MeltProofsResponse<Bolt12MeltQuoteResponse>>;
+    meltProofsOnchain(meltQuote: OnchainMeltQuoteResponse, proofsToSend: Proof[], options?: MeltProofOptions): Promise<MeltProofsResponse<OnchainMeltQuoteResponse>>;
     // (undocumented)
     mint: CashuMint;
     // (undocumented)
@@ -201,6 +215,7 @@ export class CashuWallet {
     // (undocumented)
     mintProofs(amount: number, quote: string, options?: MintProofOptions): Promise<Proof[]>;
     mintProofsBolt12(amount: number, quote: Bolt12MintQuoteResponse, privateKey: string, options?: MintProofOptions): Promise<Proof[]>;
+    mintProofsOnchain(amount: number, quote: OnchainMintQuoteResponse, privateKey: string, options?: MintProofOptions): Promise<Proof[]>;
     onMeltQuotePaid(quoteId: string, callback: (payload: MeltQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
     onMeltQuoteUpdates(quoteIds: string[], callback: (payload: MeltQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
     onMintQuotePaid(quoteId: string, callback: (payload: MintQuoteResponse) => void, errorCallback: (e: Error) => void): Promise<SubscriptionCanceller>;
@@ -476,8 +491,8 @@ export type MeltProofOptions = {
 };
 
 // @public
-export type MeltProofsResponse = {
-    quote: MeltQuoteResponse;
+export type MeltProofsResponse<T = MeltQuoteResponse | OnchainMeltQuoteResponse> = {
+    quote: T;
     change: Proof[];
 };
 
@@ -623,6 +638,46 @@ export type NUT10Option = {
     kind: string;
     data: string;
     tags: string[][];
+};
+
+// @public
+export type OnchainMeltQuoteRequest = {
+    request: string;
+    unit: string;
+    amount: number;
+};
+
+// @public
+export type OnchainMeltQuoteResponse = {
+    quote: string;
+    amount: number;
+    request: string;
+    unit: string;
+    fee_reserve: number;
+    state: MeltQuoteState;
+    expiry: number;
+    transaction_id?: string;
+    change?: SerializedBlindedSignature[];
+};
+
+// @public
+export type OnchainMintQuoteRequest = {
+    unit: string;
+    pubkey: string;
+};
+
+// @public
+export type OnchainMintQuoteResponse = {
+    quote: string;
+    request: string;
+    amount: number | null;
+    unit: string;
+    expiry: number | null;
+    pubkey: string;
+    amount_paid: number;
+    amount_issued: number;
+    amount_unconfirmed: number;
+    next_confirmation_height: number | null;
 };
 
 // @public (undocumented)
@@ -833,12 +888,6 @@ export type ReceiveOptions = {
 };
 
 // @public
-export type ReceiveResponse = {
-    token: Token;
-    tokensWithErrors: Token | undefined;
-};
-
-// @public
 export type ReceiveTokenEntryResponse = {
     proofs: Proof[];
 };
@@ -920,6 +969,8 @@ export type SwapMethod = {
     max_amount: number;
     options?: {
         description?: boolean;
+        amountless?: boolean;
+        confirmations?: number;
     };
 };
 

--- a/examples/onchain_example.ts
+++ b/examples/onchain_example.ts
@@ -1,0 +1,179 @@
+import { CashuMint } from '../src/CashuMint';
+import { CashuWallet } from '../src/CashuWallet';
+import { MintQuoteState, Proof, OnchainMintQuoteResponse } from '../src/model/types/index';
+import { sumProofs } from '../src/utils';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { bytesToHex, randomBytes } from '@noble/hashes/utils';
+
+// Configuration
+const MINT_URL = 'http://localhost:8085';
+const INITIAL_MINT_AMOUNT = 5000;
+
+const privateKey = randomBytes(32);
+const pubkey = secp256k1.getPublicKey(privateKey, true);
+
+const runOnchainWalletExample = async () => {
+	try {
+		console.log('🚀 Onchain Wallet Example');
+		console.log('=========================\n');
+
+		// Initialize mint and wallet
+		const mint = new CashuMint(MINT_URL);
+		const wallet = new CashuWallet(mint);
+		await wallet.loadMint();
+
+		// Mint initial proofs via BOLT11 for demonstration purposes
+		let proofs = await mintInitialProofs(wallet);
+
+		// Create onchain mint quote to get a Bitcoin address
+		console.log('📋 Creating onchain mint quote (generates Bitcoin address)');
+		const onchainMintQuote = await wallet.createMintQuoteOnchain(bytesToHex(pubkey));
+		console.log(`✅ Bitcoin address generated: ${onchainMintQuote.request}\n`);
+
+		// Demonstrate onchain melt (sending Bitcoin onchain) using existing proofs
+		console.log('🔥 Demonstrating onchain melt (sending Bitcoin onchain)...');
+		proofs = await demonstrateOnchainMelt(wallet, proofs, onchainMintQuote.request);
+
+		// Check for onchain payments to the generated address
+		console.log('\n💰 Checking for onchain payments to the generated address...');
+		console.log('(In real usage, you would send Bitcoin to the address above)');
+		const updatedQuote = await checkForOnchainPayments(wallet, onchainMintQuote);
+
+		if (updatedQuote.amount_paid > 0) {
+			const newProofs = await mintFromOnchainQuote(wallet, updatedQuote);
+			proofs.push(...newProofs);
+			console.log(`💰 Updated balance: ${sumProofs(proofs)} sats\n`);
+		} else {
+			console.log('💭 No onchain payments received\n');
+		}
+
+		// Final summary
+		console.log('🎯 Summary');
+		console.log('==========');
+		console.log(`💰 Final balance: ${sumProofs(proofs)} sats`);
+		console.log(`✅ Onchain example completed!`);
+	} catch (error) {
+		console.error('❌ Error:', error);
+	}
+};
+
+runOnchainWalletExample();
+
+// Helper functions
+
+/**
+ * Waits for a BOLT11 mint quote to be paid and then mints proofs.
+ */
+const waitForMintQuote = async (wallet: CashuWallet, quoteId: string): Promise<Proof[]> => {
+	while (true) {
+		const quote = await wallet.checkMintQuote(quoteId);
+
+		if (quote.state === MintQuoteState.PAID) {
+			return await wallet.mintProofs(INITIAL_MINT_AMOUNT, quoteId);
+		} else if (quote.state === MintQuoteState.ISSUED) {
+			throw new Error('Quote has already been issued');
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+};
+
+/**
+ * Mints initial proofs via BOLT11 Lightning invoice for demonstration purposes.
+ */
+const mintInitialProofs = async (wallet: CashuWallet): Promise<Proof[]> => {
+	console.log(`💰 Minting ${INITIAL_MINT_AMOUNT} sats via BOLT11 Lightning invoice...`);
+
+	const bolt11Quote = await wallet.createMintQuote(INITIAL_MINT_AMOUNT);
+	console.log(`Pay this invoice: ${bolt11Quote.request}`);
+
+	const proofs = await waitForMintQuote(wallet, bolt11Quote.quote);
+	console.log(`✅ Minted ${sumProofs(proofs)} sats\n`);
+
+	return proofs;
+};
+
+/**
+ * Checks for onchain Bitcoin payments to the generated address.
+ */
+const checkForOnchainPayments = async (
+	wallet: CashuWallet,
+	quote: OnchainMintQuoteResponse,
+): Promise<OnchainMintQuoteResponse> => {
+	console.log('🔍 Checking for onchain payments...');
+
+	// In a real scenario, you might poll this multiple times until payment is received
+	const updatedQuote = await wallet.checkMintQuoteOnchain(quote.quote);
+
+	console.log(`📊 Payment status:`);
+	console.log(`   - Amount paid: ${updatedQuote.amount_paid} sats`);
+	console.log(`   - Amount issued: ${updatedQuote.amount_issued} sats`);
+	console.log(`   - Amount unconfirmed: ${updatedQuote.amount_unconfirmed} sats`);
+
+	return updatedQuote;
+};
+
+/**
+ * Mints proofs from received onchain Bitcoin payments.
+ */
+const mintFromOnchainQuote = async (
+	wallet: CashuWallet,
+	quote: OnchainMintQuoteResponse,
+): Promise<Proof[]> => {
+	const availableToMint = quote.amount_paid - quote.amount_issued;
+
+	if (availableToMint <= 0) {
+		console.log('💭 No new payments available to mint');
+		return [];
+	}
+
+	console.log(`💎 Minting ${availableToMint} sats from onchain payment`);
+	const proofs = await wallet.mintProofsOnchain(availableToMint, quote, bytesToHex(privateKey));
+
+	console.log(`✅ Minted ${proofs.length} proofs totaling ${sumProofs(proofs)} sats`);
+	return proofs;
+};
+
+/**
+ * Demonstrates onchain melting (sending Bitcoin onchain) using existing proofs.
+ */
+const demonstrateOnchainMelt = async (
+	wallet: CashuWallet,
+	proofs: Proof[],
+	bitcoinAddress: string,
+): Promise<Proof[]> => {
+	// Use 80% of balance for melting, keeping some for demonstration
+	const meltAmount = Math.floor(sumProofs(proofs) * 0.8);
+
+	try {
+		// Create onchain melt quote
+		const meltQuote = await wallet.createMeltQuoteOnchain(bitcoinAddress, meltAmount);
+		const totalNeeded = meltQuote.amount + meltQuote.fee_reserve;
+
+		console.log(`📤 Onchain melt quote created:`);
+		console.log(`   - Destination: ${meltQuote.request}`);
+		console.log(`   - Amount: ${meltQuote.amount} sats`);
+		console.log(`   - Fee reserve: ${meltQuote.fee_reserve} sats`);
+		console.log(`   - Total needed: ${totalNeeded} sats`);
+
+		if (sumProofs(proofs) < totalNeeded) {
+			console.log(`❌ Insufficient balance: need ${totalNeeded}, have ${sumProofs(proofs)}`);
+			return proofs;
+		}
+
+		// Send the onchain payment
+		const { keep, send } = await wallet.send(totalNeeded, proofs, { includeFees: true });
+		const { change } = await wallet.meltProofsOnchain(meltQuote, send);
+
+		console.log(`✅ Bitcoin sent onchain successfully!`);
+		console.log(`   - Sent: ${sumProofs(send)} sats`);
+		console.log(`   - Change: ${sumProofs(change)} sats`);
+		console.log(`   - Remaining: ${sumProofs([...keep, ...change])} sats`);
+
+		// Return the updated proofs (keep + change)
+		return [...keep, ...change];
+	} catch (error) {
+		console.error(`❌ Onchain melt failed:`, error);
+		return proofs; // Return original proofs if melt failed
+	}
+};

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -139,4 +139,14 @@ export class MintInfo {
 			(method) => method.method === 'bolt12' && method.options?.description === true,
 		);
 	}
+
+	get minimumOnchainConfirmations() {
+		const onchain = this.isSupported(4);
+
+		if (onchain.disabled) {
+			throw new Error('Onchain minting is not supported by this mint');
+		}
+
+		return onchain.params.find((p) => p.method === 'onchain')?.options?.confirmations || 0;
+	}
 }

--- a/src/model/types/mint/responses.ts
+++ b/src/model/types/mint/responses.ts
@@ -167,6 +167,49 @@ export type MeltQuoteResponse = PartialMeltQuoteResponse & { request: string; un
  */
 export type Bolt12MeltQuoteResponse = MeltQuoteResponse;
 
+/**
+ * Response from the mint after requesting an on-chain melt quote. Contains payment details and
+ * state for sending Bitcoin to on-chain addresses.
+ */
+export type OnchainMeltQuoteResponse = {
+	/**
+	 * Quote identifier.
+	 */
+	quote: string;
+	/**
+	 * The amount that needs to be provided.
+	 */
+	amount: number;
+	/**
+	 * Payment request.
+	 */
+	request: string;
+	/**
+	 * Unit of the quote.
+	 */
+	unit: string;
+	/**
+	 * The fee reserve that is required.
+	 */
+	fee_reserve: number;
+	/**
+	 * Quote state.
+	 */
+	state: MeltQuoteState;
+	/**
+	 * Unix timestamp when the quote expires.
+	 */
+	expiry: number;
+	/**
+	 * Onchain transaction ID.
+	 */
+	transaction_id?: string;
+	/**
+	 * Change from overpaid fees.
+	 */
+	change?: SerializedBlindedSignature[];
+};
+
 export const MeltQuoteState = {
 	UNPAID: 'UNPAID',
 	PENDING: 'PENDING',
@@ -265,6 +308,55 @@ export type Bolt12MintQuoteResponse = {
 };
 
 /**
+ * Response from the mint after requesting an on-chain mint quote. Contains a Bitcoin address and
+ * tracks payment/issuance amounts for on-chain Bitcoin transactions.
+ */
+export type OnchainMintQuoteResponse = {
+	/**
+	 * Quote identifier.
+	 */
+	quote: string;
+	/**
+	 * Bitcoin address that can be paid to mint tokens.
+	 */
+	request: string;
+	/**
+	 * Requested amount. This is null for on-chain quotes as amount is determined by payment.
+	 */
+	amount: number | null;
+	/**
+	 * Unit of the amount (e.g., 'sat' for satoshis).
+	 */
+	unit: string;
+	/**
+	 * Unix timestamp when quote expires.
+	 */
+	expiry: number | null;
+	/**
+	 * Public key that locked this quote.
+	 */
+	pubkey: string;
+	/**
+	 * The amount that has been paid to the mint via the Bitcoin address. The difference between this
+	 * and `amount_issued` can be minted.
+	 */
+	amount_paid: number;
+	/**
+	 * The amount of ecash that has been issued for the given mint quote.
+	 */
+	amount_issued: number;
+	/**
+	 * The amount of Bitcoin that has been received but not yet confirmed on-chain.
+	 */
+	amount_unconfirmed: number;
+	/**
+	 * The next block height at which confirmations will be checked. Null if no confirmations are
+	 * pending.
+	 */
+	next_confirmation_height: number | null;
+};
+
+/**
  * Response from the mint after requesting a mint.
  */
 export type MintResponse = {
@@ -319,8 +411,22 @@ export type SwapMethod = {
 	unit: string;
 	min_amount: number;
 	max_amount: number;
+	/**
+	 * Method specific options.
+	 */
 	options?: {
+		/**
+		 * Whether a bolt11 or bolt12 offer can be created with a description when minting.
+		 */
 		description?: boolean;
+		/**
+		 * Whether the mint can pay amountless bolt11 invoices.
+		 */
+		amountless?: boolean;
+		/**
+		 * The number of blocks required for on-chain payments to be considered confirmed.
+		 */
+		confirmations?: number;
 	};
 };
 

--- a/src/model/types/wallet/payloads.ts
+++ b/src/model/types/wallet/payloads.ts
@@ -43,6 +43,24 @@ export type MeltQuotePayload = {
 export type Bolt12MeltQuotePayload = MeltQuotePayload;
 
 /**
+ * Request for an on-chain melt quote. Used for sending Bitcoin to an on-chain address.
+ */
+export type OnchainMeltQuoteRequest = {
+	/**
+	 * Bitcoin address to send to (destination address).
+	 */
+	request: string;
+	/**
+	 * Unit to be melted (e.g., 'sat' for satoshis).
+	 */
+	unit: string;
+	/**
+	 * Amount in satoshis to send to the Bitcoin address.
+	 */
+	amount: number;
+};
+
+/**
  * Melt quote specific options.
  */
 export type MeltQuoteOptions = {
@@ -111,6 +129,20 @@ export type Bolt12MintQuotePayload = Omit<MintQuotePayload, 'amount'> & {
 	 * Optional amount for the offer. If not specified, then the offer must have an amount.
 	 */
 	amount?: number;
+	/**
+	 * Public key required to lock the quote.
+	 */
+	pubkey: string;
+};
+
+/**
+ * Request for an on-chain mint quote. Used for minting tokens via Bitcoin on-chain payments.
+ */
+export type OnchainMintQuoteRequest = {
+	/**
+	 * Unit of the quote.
+	 */
+	unit: string;
 	/**
 	 * Public key required to lock the quote.
 	 */

--- a/src/model/types/wallet/responses.ts
+++ b/src/model/types/wallet/responses.ts
@@ -1,34 +1,19 @@
-import { type MeltQuoteResponse } from '../mint';
-import { type Proof, type Token } from './index';
+import { type MeltQuoteResponse, type OnchainMeltQuoteResponse } from '../mint';
+import { type Proof } from './index';
 
 /**
  * Response after paying a Lightning invoice.
  */
-export type MeltProofsResponse = {
+export type MeltProofsResponse<T = MeltQuoteResponse | OnchainMeltQuoteResponse> = {
 	/**
 	 * If false, the proofs have not been invalidated and the payment can be tried later again with
 	 * the same proofs.
 	 */
-	quote: MeltQuoteResponse;
+	quote: T;
 	/**
 	 * Return/Change from overpaid fees. This happens due to Lighting fee estimation being inaccurate.
 	 */
 	change: Proof[];
-};
-
-/**
- * Response when receiving a complete token.
- */
-export type ReceiveResponse = {
-	/**
-	 * Successfully received Cashu Token.
-	 */
-	token: Token;
-	/**
-	 * TokenEntries that had errors. No error will be thrown, but clients can choose to handle tokens
-	 * with errors accordingly.
-	 */
-	tokensWithErrors: Token | undefined;
 };
 
 /**

--- a/test/onchain.test.ts
+++ b/test/onchain.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CashuMint } from '../src/CashuMint';
+import { CashuWallet } from '../src/CashuWallet';
+
+type ReqArgs = {
+	endpoint: string;
+	method?: string;
+	requestBody?: any;
+	headers?: Record<string, string>;
+};
+
+const makeRequestSpy = <T>(payload: T) => {
+	const calls: ReqArgs[] = [];
+	const req = async (options: ReqArgs) => {
+		calls.push({
+			endpoint: options.endpoint,
+			method: options.method,
+			requestBody: options.requestBody,
+			headers: options.headers,
+		});
+		return payload as any;
+	};
+	return { req, calls };
+};
+
+const MINT_URL = 'https://mint.example';
+
+describe('CashuMint (Onchain) – static methods via customRequest', () => {
+	it('createMintQuoteOnchain posts to /v1/mint/quote/onchain with payload incl. pubkey', async () => {
+		const response = {
+			quote: 'q123',
+			request: 'bc1qexample123...',
+			amount: null,
+			unit: 'sat',
+			expiry: 123456,
+			pubkey: '02abcd',
+			amount_paid: 0,
+			amount_issued: 0,
+			amount_unconfirmed: 0,
+		};
+		const { req, calls } = makeRequestSpy(response);
+
+		const payload = { unit: 'sat', pubkey: '02abcd' };
+		const res = await CashuMint.createMintQuoteOnchain(MINT_URL, payload, req as any);
+
+		expect(res).toEqual(response);
+		expect(calls).toHaveLength(1);
+
+		const c = calls[0];
+		expect(c.endpoint).toMatch(/^https:\/\/mint\.example\/v1\/mint\/quote\/onchain$/);
+		expect(c.method?.toUpperCase()).toBe('POST');
+		expect(c.requestBody).toEqual(payload);
+	});
+
+	it('checkMintQuoteOnchain requests /v1/mint/quote/onchain/{quote}', async () => {
+		const response = {
+			quote: 'q123',
+			request: 'bc1qexample123...',
+			amount: null,
+			unit: 'sat',
+			expiry: 123456,
+			pubkey: '02abcd',
+			amount_paid: 5000,
+			amount_issued: 0,
+			amount_unconfirmed: 0,
+			state: 'PAID',
+		};
+		const { req, calls } = makeRequestSpy(response);
+
+		const res = await CashuMint.checkMintQuoteOnchain(MINT_URL, 'q123', req as any);
+
+		expect(res).toEqual(response);
+		expect(calls).toHaveLength(1);
+		const c = calls[0];
+		expect(c.endpoint).toMatch(/^https:\/\/mint\.example\/v1\/mint\/quote\/onchain\/q123$/);
+	});
+
+	it('mintOnchain posts to /v1/mint/onchain', async () => {
+		const response = { signatures: [{ C_: '...', e: '...' }] };
+		const { req, calls } = makeRequestSpy(response);
+
+		const mintPayload = { quote: 'q123', outputs: [{ amount: 42, id: 'ks1', B_: '...' }] };
+		const res = await CashuMint.mintOnchain(MINT_URL, mintPayload as any, req as any);
+
+		expect(res).toEqual(response);
+		const c = calls[0];
+		expect(c.endpoint).toMatch(/^https:\/\/mint\.example\/v1\/mint\/onchain$/);
+		expect(c.method?.toUpperCase()).toBe('POST');
+		expect(c.requestBody).toEqual(mintPayload);
+	});
+
+	it('createMeltQuoteOnchain posts to /v1/melt/quote/onchain', async () => {
+		const response = {
+			quote: 'm123',
+			amount: 100,
+			fee_reserve: 3,
+			request: 'bc1qexample123...',
+			unit: 'sat',
+		};
+		const { req, calls } = makeRequestSpy(response);
+
+		const meltQuotePayload = { request: 'bc1qexample123...', unit: 'sat', amount: 100 };
+		const res = await CashuMint.createMeltQuoteOnchain(
+			MINT_URL,
+			meltQuotePayload as any,
+			req as any,
+		);
+
+		expect(res).toEqual(response);
+		const c = calls[0];
+		expect(c.endpoint).toMatch(/^https:\/\/mint\.example\/v1\/melt\/quote\/onchain$/);
+		expect(c.method?.toUpperCase()).toBe('POST');
+		expect(c.requestBody).toEqual(meltQuotePayload);
+	});
+
+	it('checkMeltQuoteOnchain requests /v1/melt/quote/onchain/{quote}', async () => {
+		const response = {
+			quote: 'm123',
+			amount: 100,
+			fee_reserve: 3,
+			request: 'bc1qexample123...',
+			unit: 'sat',
+			state: 'UNPAID',
+		};
+		const { req, calls } = makeRequestSpy(response);
+
+		const res = await CashuMint.checkMeltQuoteOnchain(MINT_URL, 'm123', req as any);
+
+		expect(res).toEqual(response);
+		const c = calls[0];
+		expect(c.endpoint).toMatch(/^https:\/\/mint\.example\/v1\/melt\/quote\/onchain\/m123$/);
+	});
+
+	it('meltOnchain posts to /v1/melt/onchain', async () => {
+		const response = {
+			quote: 'm123',
+			amount: 100,
+			change: [],
+			txid: 'abcd1234...',
+		};
+		const { req, calls } = makeRequestSpy(response);
+
+		const meltPayload = { quote: 'm123', inputs: [], outputs: [] };
+		const res = await CashuMint.meltOnchain(MINT_URL, meltPayload as any, req as any);
+
+		expect(res).toEqual(response);
+		const c = calls[0];
+		expect(c.endpoint).toMatch(/^https:\/\/mint\.example\/v1\/melt\/onchain$/);
+		expect(c.method?.toUpperCase()).toBe('POST');
+		expect(c.requestBody).toEqual(meltPayload);
+	});
+});
+
+describe('CashuMint (Onchain) – instance methods delegate to static', () => {
+	it('instance.createMintQuoteOnchain delegates to static and returns response', async () => {
+		const response = {
+			quote: 'q1',
+			request: 'bc1qexample123...',
+			amount: null,
+			unit: 'sat',
+			pubkey: '02abcd',
+			amount_paid: 0,
+			amount_issued: 0,
+			amount_unconfirmed: 0,
+		};
+		const { req } = makeRequestSpy(response);
+
+		const mint = new CashuMint(MINT_URL);
+
+		const spy = vi.spyOn(CashuMint, 'createMintQuoteOnchain').mockResolvedValue(response as any);
+
+		const res = await mint.createMintQuoteOnchain({
+			unit: 'sat',
+			pubkey: '02abcd',
+		} as any);
+		expect(res).toEqual(response);
+		expect(spy).toHaveBeenCalledWith(
+			MINT_URL,
+			{ unit: 'sat', pubkey: '02abcd' },
+			undefined,
+			undefined,
+		);
+	});
+
+	it('instance methods for melt/mint/check variants call their static counterparts', async () => {
+		const mint = new CashuMint(MINT_URL);
+
+		const responses = {
+			createMeltQuoteOnchain: {
+				quote: 'm1',
+				amount: 100,
+				fee_reserve: 2,
+				request: 'bc1qexample123...',
+				unit: 'sat',
+			},
+			checkMintQuoteOnchain: {
+				quote: 'q1',
+				state: 'PAID',
+				amount_paid: 5000,
+				amount_issued: 0,
+				amount_unconfirmed: 0,
+			},
+			checkMeltQuoteOnchain: { quote: 'm1', state: 'UNPAID' },
+			mintOnchain: { signatures: [] },
+			meltOnchain: { quote: 'm1', change: [], txid: 'abcd1234...' },
+		};
+
+		const s1 = vi
+			.spyOn(CashuMint, 'createMeltQuoteOnchain')
+			.mockResolvedValue(responses.createMeltQuoteOnchain as any);
+		const s2 = vi
+			.spyOn(CashuMint, 'checkMintQuoteOnchain')
+			.mockResolvedValue(responses.checkMintQuoteOnchain as any);
+		const s3 = vi
+			.spyOn(CashuMint, 'checkMeltQuoteOnchain')
+			.mockResolvedValue(responses.checkMeltQuoteOnchain as any);
+		const s4 = vi.spyOn(CashuMint, 'mintOnchain').mockResolvedValue(responses.mintOnchain as any);
+		const s5 = vi.spyOn(CashuMint, 'meltOnchain').mockResolvedValue(responses.meltOnchain as any);
+
+		expect(
+			await mint.createMeltQuoteOnchain({
+				request: 'bc1qexample123...',
+				unit: 'sat',
+				amount: 100,
+			} as any),
+		).toEqual(responses.createMeltQuoteOnchain);
+		expect(await mint.checkMintQuoteOnchain('q1')).toEqual(responses.checkMintQuoteOnchain);
+		expect(await mint.checkMeltQuoteOnchain('m1')).toEqual(responses.checkMeltQuoteOnchain);
+		expect(await mint.mintOnchain({ quote: 'q1', outputs: [] } as any)).toEqual(
+			responses.mintOnchain,
+		);
+		expect(await mint.meltOnchain({ quote: 'm1', inputs: [], outputs: [] } as any)).toEqual(
+			responses.meltOnchain,
+		);
+
+		expect(s1).toHaveBeenCalledWith(
+			MINT_URL,
+			{ request: 'bc1qexample123...', unit: 'sat', amount: 100 },
+			undefined,
+			undefined,
+		);
+		expect(s2).toHaveBeenCalledWith(MINT_URL, 'q1', undefined, undefined);
+		expect(s3).toHaveBeenCalledWith(MINT_URL, 'm1', undefined, undefined);
+		expect(s4).toHaveBeenCalledWith(MINT_URL, { quote: 'q1', outputs: [] }, undefined, undefined);
+		expect(s5).toHaveBeenCalledWith(
+			MINT_URL,
+			{ quote: 'm1', inputs: [], outputs: [] },
+			undefined,
+			undefined,
+		);
+	});
+});
+
+describe('CashuWallet (Onchain) – wrappers', () => {
+	it('wallet.createMintQuoteOnchain delegates to mint', async () => {
+		const mockMint = {
+			createMintQuoteOnchain: vi.fn(),
+		};
+		const wallet = new CashuWallet(mockMint as any);
+
+		const response = {
+			quote: 'q1',
+			request: 'bc1qexample123...',
+			amount: null,
+			unit: 'sat',
+			pubkey: '02abcd',
+			amount_paid: 0,
+			amount_issued: 0,
+			amount_unconfirmed: 0,
+		};
+		mockMint.createMintQuoteOnchain.mockResolvedValue(response);
+
+		const res = await wallet.createMintQuoteOnchain('02abcd');
+		expect(res).toEqual(response);
+		expect(mockMint.createMintQuoteOnchain).toHaveBeenCalledWith({
+			unit: 'sat',
+			pubkey: '02abcd',
+		});
+	});
+
+	it('wallet.checkMintQuoteOnchain delegates to mint', async () => {
+		const mockMint = {
+			checkMintQuoteOnchain: vi.fn(),
+		};
+		const wallet = new CashuWallet(mockMint as any);
+
+		const response = {
+			quote: 'q1',
+			state: 'PAID',
+			amount_paid: 5000,
+			amount_issued: 0,
+			amount_unconfirmed: 0,
+		};
+		mockMint.checkMintQuoteOnchain.mockResolvedValue(response);
+
+		const res = await wallet.checkMintQuoteOnchain('q1');
+		expect(res).toEqual(response);
+		expect(mockMint.checkMintQuoteOnchain).toHaveBeenCalledWith('q1');
+	});
+
+	it('wallet.createMeltQuoteOnchain delegates to mint', async () => {
+		const mockMint = {
+			createMeltQuoteOnchain: vi.fn(),
+		};
+		const wallet = new CashuWallet(mockMint as any);
+
+		const response = {
+			quote: 'm1',
+			request: 'bc1qexample123...',
+			amount: 100,
+			fee_reserve: 2,
+			unit: 'sat',
+		};
+		mockMint.createMeltQuoteOnchain.mockResolvedValue(response);
+
+		const res = await wallet.createMeltQuoteOnchain('bc1qexample123...', 100);
+		expect(res).toEqual(response);
+		expect(mockMint.createMeltQuoteOnchain).toHaveBeenCalledWith({
+			request: 'bc1qexample123...',
+			unit: 'sat',
+			amount: 100,
+		});
+	});
+
+	it('wallet.checkMeltQuoteOnchain delegates to mint', async () => {
+		const mockMint = {
+			checkMeltQuoteOnchain: vi.fn(),
+		};
+		const wallet = new CashuWallet(mockMint as any);
+
+		const response = {
+			quote: 'm1',
+			state: 'UNPAID',
+			amount: 100,
+			fee_reserve: 2,
+		};
+		mockMint.checkMeltQuoteOnchain.mockResolvedValue(response);
+
+		const res = await wallet.checkMeltQuoteOnchain('m1');
+		expect(res).toEqual(response);
+		expect(mockMint.checkMeltQuoteOnchain).toHaveBeenCalledWith('m1');
+	});
+
+	it('wallet.meltProofsOnchain delegates and returns {quote, change}', async () => {
+		const mockMint = {
+			meltOnchain: vi.fn(),
+		};
+		const mockKeys = { 1: 'pubkey1', 2: 'pubkey2' };
+		const wallet = new CashuWallet(mockMint as any);
+
+		// Mock the getKeys method
+		vi.spyOn(wallet as any, 'getKeys').mockResolvedValue(mockKeys);
+		// Mock the createBlankOutputs method
+		vi.spyOn(wallet as any, 'createBlankOutputs').mockReturnValue([]);
+
+		const meltResponse = {
+			quote: 'm1',
+			amount: 100,
+			change: [],
+			txid: 'abcd1234...',
+		};
+		mockMint.meltOnchain.mockResolvedValue(meltResponse);
+
+		const meltQuote = {
+			quote: 'm1',
+			amount: 100,
+			unit: 'sat',
+			request: 'bc1qexample123...',
+		};
+		const res = await wallet.meltProofsOnchain(meltQuote as any, [] as any, {});
+
+		expect(res.quote.quote).toEqual('m1');
+		expect(mockMint.meltOnchain).toHaveBeenCalled();
+	});
+
+	it('wallet.mintProofsOnchain requires privateKey and delegates to mint.mintOnchain', async () => {
+		const mockMint = {
+			mintOnchain: vi.fn(),
+		};
+		const mockKeys = {
+			1: '02f970b6ee058705c0dddc4313721cffb7efd3d142d96ea8e01d31c2b2ff09f181',
+			2: '03361cd8bd1329fea797a6add1cf1990ffcf2270ceb9fc81eeee0e8e9c1bd0cdf5',
+			4: '03361cd8bd1329fea797a6add1cf1990ffcf2270ceb9fc81eeee0e8e9c1bd0cdf5',
+			8: '03361cd8bd1329fea797a6add1cf1990ffcf2270ceb9fc81eeee0e8e9c1bd0cdf5',
+			16: '03361cd8bd1329fea797a6add1cf1990ffcf2270ceb9fc81eeee0e8e9c1bd0cdf5',
+		};
+		const wallet = new CashuWallet(mockMint as any);
+
+		// Mock the getKeys method
+		vi.spyOn(wallet as any, 'getKeys').mockResolvedValue(mockKeys);
+
+		// Mock createOutputData instead of createBlankOutputs
+		vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
+			{
+				blindedMessage: { amount: 16, B_: 'B1' },
+				toProof: () => ({ amount: 16, secret: 'secret1', C: 'C1' }),
+			},
+			{
+				blindedMessage: { amount: 4, B_: 'B2' },
+				toProof: () => ({ amount: 4, secret: 'secret2', C: 'C2' }),
+			},
+			{
+				blindedMessage: { amount: 1, B_: 'B3' },
+				toProof: () => ({ amount: 1, secret: 'secret3', C: 'C3' }),
+			},
+		]);
+
+		const mintResponse = {
+			signatures: [
+				{ C_: 'sig1', e: 'e1' },
+				{ C_: 'sig2', e: 'e2' },
+				{ C_: 'sig3', e: 'e3' },
+			],
+		};
+		mockMint.mintOnchain.mockResolvedValue(mintResponse);
+
+		// Test missing privateKey
+		await expect(
+			wallet.mintProofsOnchain(21, { quote: 'q1' } as any, undefined as any),
+		).rejects.toBeTruthy();
+
+		// Test successful path with privateKey (valid secp256k1 private key)
+		const privateKey = '0000000000000000000000000000000000000000000000000000000000000001';
+		const proofs = await wallet.mintProofsOnchain(
+			21,
+			{ quote: 'q1', request: 'bc1qexample123...' } as any,
+			privateKey,
+		);
+		expect(proofs).toHaveLength(3);
+		expect(mockMint.mintOnchain).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Description

Implements onchain as defined by [NUT-26](https://github.com/cashubtc/nuts/pull/283) (PR open)

## Changes

- added onchain wallet and mint methods

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run lint` --> no warnings or errors
- [ ] run `npm run format`
- [ ] run `npm run api:check` --> run `npm run api:update` for changes to the API
