### PR TITLE
Generic description check for bolt11 & bolt12

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -956,6 +956,14 @@ class CashuWallet {
 	 *   specified amount and unit.
 	 */
 	async createMintQuote(amount: number, description?: string): Promise<MintQuoteResponse> {
+		// Check if mint supports description for bolt11
+		if (description) {
+			const mintInfo = await this.lazyGetMintInfo();
+			if (!mintInfo.supportsDescription('bolt11')) {
+				throw new Error('Mint does not support description for bolt11');
+			}
+		}
+
 		const mintQuotePayload: MintQuotePayload = {
 			unit: this._unit,
 			amount: amount,
@@ -1018,7 +1026,7 @@ class CashuWallet {
 	): Promise<Bolt12MintQuoteResponse> {
 		// Check if mint supports description for bolt12
 		const mintInfo = await this.lazyGetMintInfo();
-		if (options?.description && !mintInfo.supportsBolt12Description) {
+		if (options?.description && !mintInfo.supportsDescription('bolt12')) {
 			throw new Error('Mint does not support description for bolt12');
 		}
 

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -130,13 +130,15 @@ export class MintInfo {
 	}
 
 	/**
-	 * Checks if the mint supports creating BOLT12 offers with a description.
+	 * Checks if the mint supports creating invoices/offers with a description
+	 * for the specified payment method.
 	 *
-	 * @returns True if the mint supports offers with a description, false otherwise.
+	 * @param method - The payment method to check ('bolt11' or 'bolt12')
+	 * @returns True if the mint supports description for the method, false otherwise.
 	 */
-	get supportsBolt12Description() {
+	supportsDescription(method: 'bolt11' | 'bolt12'): boolean {
 		return this._mintInfo.nuts[4]?.methods.some(
-			(method) => method.method === 'bolt12' && method.options?.description === true,
-		);
+			(met) => met.method === method && met.options?.description === true,
+		) ?? false;
 	}
 }

--- a/test/wallet.node.test.ts
+++ b/test/wallet.node.test.ts
@@ -156,6 +156,43 @@ describe('test info', () => {
 			{ method: 'nostr', info: 'npub1337' },
 		]);
 	});
+	test('supportsDescription and createMintQuote description check', async () => {
+		//behaviour with original mintInfoResp
+		server.use(
+			http.get(mintUrl + '/v1/info', () => {
+				return HttpResponse.json(mintInfoResp);
+			}),
+		);
+		const wallet = new CashuWallet(mint, { unit });
+		const info = await wallet.getMintInfo();
+
+		// mintInfoResp advertises description=true only for usd/eur; sat lacks it
+		expect(info.supportsDescription('bolt11')).toBe(false);
+		expect(info.supportsDescription('bolt12')).toBe(false);
+
+		//bolt11 description not supported
+		const noDescResp = JSON.parse(JSON.stringify(mintInfoResp));
+		const bolt11Method = noDescResp.nuts[4].methods.find((x: any) => x.method === 'bolt11');
+		if (bolt11Method) (bolt11Method.options ??= {}).description = false;
+
+		server.use(
+			http.get(mintUrl + '/v1/info', () => {
+				return HttpResponse.json(noDescResp);
+			}),
+		);
+
+		await expect(wallet.createMintQuote(1000, 'should fail')).rejects.toThrow(
+			/Mint does not support description for bolt11/,
+		);
+
+		//no description provided
+		server.use(
+			http.post(mintUrl + '/v1/mint/quote/bolt11', () => {
+				return HttpResponse.json({ quote: 'ok-quote', request: 'lnbc...' });
+			}),
+		);
+		await expect(wallet.createMintQuote(1000)).resolves.toHaveProperty('quote', 'ok-quote');
+	});
 });
 
 describe('test fees', () => {


### PR DESCRIPTION
# Fixes: #350 

## Description
Implements NUT-23: generic per-method description support and adds the missing guard to `createMintQuote`.

## Changes

- Refactor `MintInfo.supportsBolt12Description` → `supportsDescription(method: 'bolt11' | 'bolt12')`
- Add identical description-guard to `createMintQuote` (bolt11)
- Add integration test in `wallet.node.test.ts`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [ ] run `npm run api:check` --> run `npm run api:update` for changes to the API
