### PR TITLE
De-duplicate deriveKeysetId Functions refactor: 

### DIFF
--- a/src/crypto/common/index.ts
+++ b/src/crypto/common/index.ts
@@ -147,25 +147,4 @@ export function deserializeMintKeys(serializedMintKeys: SerializedMintKeys): Min
 	return mintKeys;
 }
 
-export function deriveKeysetId(keys: MintKeys): string {
-	const KEYSET_VERSION = '00';
-	const mapBigInt = (k: [string, string]): [bigint, string] => {
-		return [BigInt(k[0]), k[1]];
-	};
-	const pubkeysConcat = Object.entries(serializeMintKeys(keys))
-		.map(mapBigInt)
-		.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
-		.map(([, pubKey]) => hexToBytes(pubKey))
-		.reduce((prev, curr) => mergeUInt8Arrays(prev, curr), new Uint8Array());
-	const hash = sha256(pubkeysConcat);
-	const hashHex = Buffer.from(hash).toString('hex').slice(0, 14);
-	return KEYSET_VERSION + hashHex;
-}
-
-function mergeUInt8Arrays(a1: Uint8Array, a2: Uint8Array): Uint8Array {
-	// sum of individual array lengths
-	const mergedArray = new Uint8Array(a1.length + a2.length);
-	mergedArray.set(a1);
-	mergedArray.set(a2, a1.length);
-	return mergedArray;
-}
+export { deriveKeysetId, mergeUInt8Arrays } from '../../utils';

--- a/src/crypto/mint/index.ts
+++ b/src/crypto/mint/index.ts
@@ -10,6 +10,7 @@ import {
 	createRandomPrivateKey,
 	deriveKeysetId,
 	hashToCurve,
+	serializeMintKeys,
 } from '../common/index';
 import { HDKey } from '@scure/bip32';
 
@@ -63,7 +64,7 @@ export function createNewMintKeys(pow2height: IntRange<0, 65>, seed?: Uint8Array
 		pubKeys[index] = getPubKeyFromPrivKey(privKeys[index]);
 		counter++;
 	}
-	const keysetId = deriveKeysetId(pubKeys);
+	const keysetId = deriveKeysetId(serializeMintKeys(pubKeys));
 	return { pubKeys, privKeys, keysetId };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -572,7 +572,7 @@ export function stripDleq(proofs: Proof[]): Array<Omit<Proof, 'dleq'>> {
  * @throws Error if the keyset ID version is unrecognized.
  */
 export function verifyKeysetId(keys: MintKeys): boolean {
-	const versionByte = hexToBytes(keys.id)[0];
+	const versionByte = hexToBytes(keys.id)[0] as 0 | 1 | undefined;
 	return deriveKeysetId(keys.keys, keys.unit, keys.final_expiry, versionByte) === keys.id;
 }
 

--- a/test/crypto/common/common.test.ts
+++ b/test/crypto/common/common.test.ts
@@ -65,10 +65,8 @@ describe('serialize mint keys', () => {
 
 describe('test keyset derivation', () => {
 	test('derive', () => {
-		const keys: SerializedMintKeys = PUBKEYS;
-		const deserializedKeys = deserializeMintKeys(keys);
-		const keysetId = deriveKeysetId(deserializedKeys);
-		console.log(keysetId);
+		const deserializedKeys = deserializeMintKeys(PUBKEYS);
+		const keysetId = deriveKeysetId(serializeMintKeys(deserializedKeys));
 		expect(keysetId).toBe('009a1f293253e41e');
 	});
 });


### PR DESCRIPTION
# Fixes: #348 

## Description
De-duplicate deriveKeysetId function and mergeUInt8Arrays helper functions found simultaneously in utils.ts and common/index.ts

## Changes

- Remove crypto/common implementations
- Re-export v2-aware utils versions
- Update all references and usage including test cases

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
