### PR TITLE
Chore/drop buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 	"dependencies": {
 		"@noble/curves": "^1.9.5",
 		"@noble/hashes": "^1.5.0",
-		"@scure/bip32": "^1.5.0",
-		"buffer": "^6.0.3"
-	}
+		"@scure/bip32": "^1.5.0"
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,28 +1,27 @@
-import { Buffer } from 'buffer';
+import { Bytes } from './utils/Bytes';
 
 function encodeUint8toBase64(uint8array: Uint8Array): string {
-	return Buffer.from(uint8array).toString('base64');
+	return Bytes.toBase64(uint8array);
 }
 
 function encodeUint8toBase64Url(bytes: Uint8Array): string {
-	return Buffer.from(bytes)
-		.toString('base64')
+	return Bytes.toBase64(bytes)
 		.replace(/\+/g, '-') // Replace + with -
 		.replace(/\//g, '_') // Replace / with _
 		.replace(/=+$/, ''); // Remove padding characters
 }
 
 function encodeBase64toUint8(base64String: string): Uint8Array {
-	return Buffer.from(base64String, 'base64');
+	return Bytes.fromBase64(base64String);
 }
 
 function encodeJsonToBase64(jsonObj: unknown): string {
 	const jsonString = JSON.stringify(jsonObj);
-	return base64urlFromBase64(Buffer.from(jsonString).toString('base64'));
+	return base64urlFromBase64(Bytes.toBase64(Bytes.fromString(jsonString)));
 }
 
 function encodeBase64ToJson<T extends object>(base64String: string): T {
-	const jsonString = Buffer.from(base64urlToBase64(base64String), 'base64').toString();
+	const jsonString = Bytes.toString(Bytes.fromBase64(base64urlToBase64(base64String)));
 	const jsonObj = JSON.parse(jsonString) as T;
 	return jsonObj;
 }

--- a/src/crypto/client/NUT09.ts
+++ b/src/crypto/client/NUT09.ts
@@ -2,7 +2,7 @@ import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha2';
 import { getKeysetIdInt } from '../common/index';
 import { HDKey } from '@scure/bip32';
-import { Buffer } from 'buffer';
+import { Bytes } from '../../utils/Bytes';
 
 const STANDARD_DERIVATION_PATH = `m/129372'/0'`;
 
@@ -39,20 +39,18 @@ const derive = (
 	counter: number,
 	secretOrBlinding: DerivationType,
 ): Uint8Array => {
-	const counterBuffer = Buffer.alloc(8);
-	counterBuffer.writeBigUInt64BE(BigInt(counter));
-	let message = Buffer.concat([
-		Buffer.from('Cashu_KDF_HMAC_SHA256'),
-		Buffer.from(keysetId, 'hex'),
-		counterBuffer,
-	]);
+	let message = Bytes.concat(
+		Bytes.fromString('Cashu_KDF_HMAC_SHA256'),
+		Bytes.fromHex(keysetId),
+		Bytes.writeBigUint64BE(BigInt(counter))
+	);
 
 	switch (secretOrBlinding) {
 		case DerivationType.SECRET:
-			message = Buffer.concat([message, Buffer.from([0])]);
+			message = Bytes.concat(message, Bytes.fromHex("00"));
 			break;
 		case DerivationType.BLINDING_FACTOR:
-			message = Buffer.concat([message, Buffer.from([1])]);
+			message = Bytes.concat(message, Bytes.fromHex("01"));
 	}
 
 	// Step 2: Compute HMAC-SHA256

--- a/src/crypto/client/NUT09.ts
+++ b/src/crypto/client/NUT09.ts
@@ -1,6 +1,6 @@
 import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha2';
-import { getKeysetIdInt } from '../common/index';
+import { getKeysetIdInt } from '../common';
 import { HDKey } from '@scure/bip32';
 import { Bytes } from '../../utils/Bytes';
 
@@ -42,15 +42,15 @@ const derive = (
 	let message = Bytes.concat(
 		Bytes.fromString('Cashu_KDF_HMAC_SHA256'),
 		Bytes.fromHex(keysetId),
-		Bytes.writeBigUint64BE(BigInt(counter))
+		Bytes.writeBigUint64BE(BigInt(counter)),
 	);
 
 	switch (secretOrBlinding) {
 		case DerivationType.SECRET:
-			message = Bytes.concat(message, Bytes.fromHex("00"));
+			message = Bytes.concat(message, Bytes.fromHex('00'));
 			break;
 		case DerivationType.BLINDING_FACTOR:
-			message = Bytes.concat(message, Bytes.fromHex("01"));
+			message = Bytes.concat(message, Bytes.fromHex('01'));
 	}
 
 	// Step 2: Compute HMAC-SHA256

--- a/src/crypto/common/index.ts
+++ b/src/crypto/common/index.ts
@@ -3,7 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { bytesToNumber, encodeBase64toUint8, hexToNumber } from '../util/utils';
-import { Buffer } from 'buffer';
+import { Bytes } from '../../utils/Bytes';
 
 export type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
 	? Acc[number]
@@ -86,14 +86,14 @@ export type SigFlag = 'SIG_INPUTS' | 'SIG_ALL';
 const DOMAIN_SEPARATOR = hexToBytes('536563703235366b315f48617368546f43757276655f43617368755f');
 
 export function hashToCurve(secret: Uint8Array): ProjPointType<bigint> {
-	const msgToHash = sha256(Buffer.concat([DOMAIN_SEPARATOR, secret]));
+	const msgToHash = sha256(Bytes.concat(DOMAIN_SEPARATOR, secret));
 	const counter = new Uint32Array(1);
 	const maxIterations = 2 ** 16;
 	for (let i = 0; i < maxIterations; i++) {
 		const counterBytes = new Uint8Array(counter.buffer);
-		const hash = sha256(Buffer.concat([msgToHash, counterBytes]));
+		const hash = sha256(Bytes.concat(msgToHash, counterBytes));
 		try {
-			return pointFromHex(bytesToHex(Buffer.concat([new Uint8Array([0x02]), hash])));
+			return pointFromHex(bytesToHex(Bytes.concat(new Uint8Array([0x02]), hash)));
 		} catch {
 			counter[0]++;
 		}
@@ -158,7 +158,7 @@ export function deriveKeysetId(keys: MintKeys): string {
 		.map(([, pubKey]) => hexToBytes(pubKey))
 		.reduce((prev, curr) => mergeUInt8Arrays(prev, curr), new Uint8Array());
 	const hash = sha256(pubkeysConcat);
-	const hashHex = Buffer.from(hash).toString('hex').slice(0, 14);
+	const hashHex = Bytes.toHex(hash).slice(0, 14);
 	return KEYSET_VERSION + hashHex;
 }
 

--- a/src/crypto/common/index.ts
+++ b/src/crypto/common/index.ts
@@ -104,8 +104,7 @@ export function hashToCurve(secret: Uint8Array): ProjPointType<bigint> {
 export function hash_e(pubkeys: Array<ProjPointType<bigint>>): Uint8Array {
 	const hexStrings = pubkeys.map((p) => p.toHex(false));
 	const e_ = hexStrings.join('');
-	const e = sha256(new TextEncoder().encode(e_));
-	return e;
+	return sha256(new TextEncoder().encode(e_));
 }
 
 export function pointFromBytes(bytes: Uint8Array) {

--- a/src/crypto/util/utils.ts
+++ b/src/crypto/util/utils.ts
@@ -1,5 +1,5 @@
 import { bytesToHex } from '@noble/curves/abstract/utils';
-import { Buffer } from 'buffer';
+import { Bytes } from '../../utils/Bytes';
 
 export function bytesToNumber(bytes: Uint8Array): bigint {
 	return hexToNumber(bytesToHex(bytes));
@@ -10,5 +10,5 @@ export function hexToNumber(hex: string): bigint {
 }
 
 export function encodeBase64toUint8(base64String: string): Uint8Array {
-	return Buffer.from(base64String, 'base64');
+	return Bytes.fromBase64(base64String);
 }

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -7,7 +7,7 @@ import {
 	type PaymentRequestTransport,
 	type PaymentRequestTransportType,
 } from './types';
-import { Buffer } from 'buffer';
+import { Bytes } from '../utils/Bytes';
 
 export class PaymentRequest {
 	constructor(
@@ -61,7 +61,7 @@ export class PaymentRequest {
 	toEncodedRequest() {
 		const rawRequest: RawPaymentRequest = this.toRawRequest();
 		const data = encodeCBOR(rawRequest);
-		const encodedData = Buffer.from(data).toString('base64');
+		const encodedData = Bytes.toBase64(data);
 		return 'creq' + 'A' + encodedData;
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { verifyDLEQProof_reblind } from './crypto/client/NUT12';
-import { type DLEQ, pointFromHex } from './crypto/common/index';
+import { type DLEQ, pointFromHex } from './crypto/common';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha2';
 import {
@@ -22,7 +22,7 @@ import {
 	type V4DLEQTemplate,
 	type V4InnerToken,
 	type V4ProofTemplate,
-} from './model/types/index';
+} from './model/types';
 import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants';
 import { Bytes } from './utils/Bytes';
 
@@ -101,8 +101,7 @@ export function getKeepAmounts(
 			amountsWeWant.push(amt);
 		});
 	}
-	const sortedAmountsWeWant = amountsWeWant.sort((a, b) => a - b);
-	return sortedAmountsWeWant;
+	return amountsWeWant.sort((a, b) => a - b);
 }
 /**
  * Returns the amounts in the keyset sorted by the order specified.
@@ -386,8 +385,7 @@ export function handleTokens(token: string): Token {
 	} else if (version === 'B') {
 		const uInt8Token = encodeBase64toUint8(encodedToken);
 		const tokenData = decodeCBOR(uInt8Token) as TokenV4Template;
-		const decodedToken = tokenFromTemplate(tokenData);
-		return decodedToken;
+		return tokenFromTemplate(tokenData);
 	}
 	throw new Error('Token version is not supported');
 }
@@ -418,7 +416,7 @@ export function deriveKeysetId(
 	switch (versionByte) {
 		case 0:
 			hash = sha256(pubkeysConcat);
-			hashHex = Bytes.toHex(hash).slice(0,14);
+			hashHex = Bytes.toHex(hash).slice(0, 14);
 			return '00' + hashHex;
 		case 1:
 			if (!unit) {
@@ -647,18 +645,12 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean {
 		throw new Error(`undefined key for amount ${proof.amount}`);
 	}
 	const key = keyset.keys[proof.amount];
-	if (
-		!verifyDLEQProof_reblind(
-			new TextEncoder().encode(proof.secret),
-			dleq,
-			pointFromHex(proof.C),
-			pointFromHex(key),
-		)
-	) {
-		return false;
-	}
-
-	return true;
+	return verifyDLEQProof_reblind(
+		new TextEncoder().encode(proof.secret),
+		dleq,
+		pointFromHex(proof.C),
+		pointFromHex(key),
+	);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { verifyDLEQProof_reblind } from './crypto/client/NUT12';
 import { type DLEQ, pointFromHex } from './crypto/common/index';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
@@ -25,6 +24,7 @@ import {
 	type V4ProofTemplate,
 } from './model/types/index';
 import { TOKEN_PREFIX, TOKEN_VERSION } from './utils/Constants';
+import { Bytes } from './utils/Bytes';
 
 /**
  * Splits the amount into denominations of the provided @param keyset.
@@ -418,21 +418,21 @@ export function deriveKeysetId(
 	switch (versionByte) {
 		case 0:
 			hash = sha256(pubkeysConcat);
-			hashHex = Buffer.from(hash).toString('hex').slice(0, 14);
+			hashHex = Bytes.toHex(hash).slice(0,14);
 			return '00' + hashHex;
 		case 1:
 			if (!unit) {
 				throw new Error('Cannot compute keyset ID version 01: unit is required.');
 			}
-			pubkeysConcat = mergeUInt8Arrays(pubkeysConcat, Buffer.from('unit:' + unit));
+			pubkeysConcat = mergeUInt8Arrays(pubkeysConcat, Bytes.fromString('unit:' + unit));
 			if (expiry) {
 				pubkeysConcat = mergeUInt8Arrays(
 					pubkeysConcat,
-					Buffer.from('final_expiry:' + expiry.toString()),
+					Bytes.fromString('final_expiry:' + expiry.toString()),
 				);
 			}
 			hash = sha256(pubkeysConcat);
-			hashHex = Buffer.from(hash).toString('hex');
+			hashHex = Bytes.toHex(hash);
 			return '01' + hashHex;
 		default:
 			throw new Error(`Unrecognized keyset ID version: ${versionByte}`);

--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -1,13 +1,13 @@
 export class Bytes {
 	static fromHex(hex: string): Uint8Array {
-		hex = hex.trim()
+		hex = hex.trim();
 		if (hex.length === 0) {
 			return new Uint8Array(0);
 		}
-		if(hex.length < 2 || hex.length & 1) {
-			throw new Error("Invalid hex string: odd length.")
+		if (hex.length < 2 || hex.length & 1) {
+			throw new Error('Invalid hex string: odd length.');
 		}
-		if (hex.startsWith("0x") || hex.startsWith("0X")) {
+		if (hex.startsWith('0x') || hex.startsWith('0X')) {
 			hex = hex.slice(2);
 		}
 		const match = hex.match(/^[0-9a-fA-F]*$/);
@@ -18,20 +18,20 @@ export class Bytes {
 		if (!matches) {
 			throw new Error('Invalid hex string');
 		}
-		return new Uint8Array(matches.map(byte => parseInt(byte, 16)));
+		return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
 	}
 
 	static toHex(bytes: Uint8Array): string {
-		return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+		return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 	}
 
 	static fromString(str: string): Uint8Array {
-		str = str.trim()
+		str = str.trim();
 		return new TextEncoder().encode(str);
 	}
 
 	static toString(bytes: Uint8Array): string {
-		return new TextDecoder().decode(bytes);
+		return new TextDecoder('utf-8').decode(bytes);
 	}
 
 	static concat(...arrays: Uint8Array[]): Uint8Array {
@@ -72,11 +72,16 @@ export class Bytes {
 	}
 
 	static fromBase64(base64: string): Uint8Array {
-		base64 = base64.trim()
+		base64 = base64.trim();
 		if (typeof Buffer !== 'undefined') {
 			return new Uint8Array(Buffer.from(base64, 'base64'));
 		}
-		return new Uint8Array([...atob(base64)].map(c => c.charCodeAt(0)));
+
+		let normalizedBase64 = base64.replace(/-/g, '+').replace(/_/g, '/');
+		while (normalizedBase64.length % 4) {
+			normalizedBase64 += '=';
+		}
+		return new Uint8Array([...atob(normalizedBase64)].map((c) => c.charCodeAt(0)));
 	}
 
 	static equals(a: Uint8Array, b: Uint8Array): boolean {

--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -1,0 +1,99 @@
+export class Bytes {
+	static fromHex(hex: string): Uint8Array {
+		hex = hex.trim()
+		if (hex.length === 0) {
+			return new Uint8Array(0);
+		}
+		if(hex.length < 2 || hex.length & 1) {
+			throw new Error("Invalid hex string: odd length.")
+		}
+		if (hex.startsWith("0x") || hex.startsWith("0X")) {
+			hex = hex.slice(2);
+		}
+		const match = hex.match(/^[0-9a-fA-F]*$/);
+		if (!match) {
+			throw new Error('Invalid hex string: contains non-hex characters');
+		}
+		const matches = hex.match(/.{1,2}/g);
+		if (!matches) {
+			throw new Error('Invalid hex string');
+		}
+		return new Uint8Array(matches.map(byte => parseInt(byte, 16)));
+	}
+
+	static toHex(bytes: Uint8Array): string {
+		return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+	}
+
+	static fromString(str: string): Uint8Array {
+		str = str.trim()
+		return new TextEncoder().encode(str);
+	}
+
+	static toString(bytes: Uint8Array): string {
+		return new TextDecoder().decode(bytes);
+	}
+
+	static concat(...arrays: Uint8Array[]): Uint8Array {
+		const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+		const result = new Uint8Array(totalLength);
+		let offset = 0;
+		for (const arr of arrays) {
+			result.set(arr, offset);
+			offset += arr.length;
+		}
+		return result;
+	}
+
+	static alloc(size: number): Uint8Array {
+		return new Uint8Array(size);
+	}
+
+	static writeBigUint64BE(value: bigint): Uint8Array {
+		const buffer = new ArrayBuffer(8);
+		new DataView(buffer).setBigUint64(0, value, false);
+		return new Uint8Array(buffer);
+	}
+
+	static toBase64(bytes: Uint8Array): string {
+		if (typeof Buffer !== 'undefined') {
+			return Buffer.from(bytes).toString('base64');
+		}
+		// preventing stack overflow by chunking
+		if (bytes.length > 32768) {
+			let result = '';
+			for (let i = 0; i < bytes.length; i += 32768) {
+				const chunk = bytes.slice(i, i + 32768);
+				result += btoa(String.fromCharCode(...chunk));
+			}
+			return result;
+		}
+		return btoa(String.fromCharCode(...bytes));
+	}
+
+	static fromBase64(base64: string): Uint8Array {
+		base64 = base64.trim()
+		if (typeof Buffer !== 'undefined') {
+			return new Uint8Array(Buffer.from(base64, 'base64'));
+		}
+		return new Uint8Array([...atob(base64)].map(c => c.charCodeAt(0)));
+	}
+
+	static equals(a: Uint8Array, b: Uint8Array): boolean {
+		if (a.length !== b.length) return false;
+		let result = 0;
+		for (let i = 0; i < a.length; i++) {
+			result |= a[i] ^ b[i];
+		}
+		return result === 0;
+	}
+
+	static compare(a: Uint8Array, b: Uint8Array): number {
+		const minLength = Math.min(a.length, b.length);
+		for (let i = 0; i < minLength; i++) {
+			if (a[i] < b[i]) return -1;
+			if (a[i] > b[i]) return 1;
+		}
+		return a.length - b.length;
+	}
+}

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -1,0 +1,619 @@
+import { describe, test, expect } from 'vitest';
+import { Bytes } from '../src/utils/Bytes';
+
+describe('Bytes utility class', () => {
+	describe('fromHex', () => {
+		test('should convert valid hex string to Uint8Array', () => {
+			const hex = 'deadbeef';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle hex string with 0x prefix', () => {
+			const hex = '0xdeadbeef';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle hex string with 0X prefix', () => {
+			const hex = '0Xdeadbeef';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle uppercase hex characters', () => {
+			const hex = 'DEADBEEF';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle mixed case hex characters', () => {
+			const hex = 'DeAdBeEf';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle empty string', () => {
+			const hex = '';
+			const result = Bytes.fromHex(hex);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should handle whitespace-only string', () => {
+			const hex = '   ';
+			const result = Bytes.fromHex(hex);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should handle hex string with leading/trailing whitespace', () => {
+			const hex = '  deadbeef  ';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle single byte hex', () => {
+			const hex = 'ff';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0xff]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle zero bytes', () => {
+			const hex = '0000';
+			const result = Bytes.fromHex(hex);
+			const expected = new Uint8Array([0x00, 0x00]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should throw error for odd length hex string', () => {
+			const hex = 'deadbee';
+			expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
+		});
+
+		test('should throw error for single character', () => {
+			const hex = 'f';
+			expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
+		});
+
+		test('should throw error for non-hex characters', () => {
+			const hex = 'deadbeeg';
+			expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: contains non-hex characters');
+		});
+
+		test('should throw error for hex with special characters', () => {
+			const hex = 'dead-beef';
+			expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
+		});
+
+		test('should throw error for hex with spaces in middle', () => {
+			const hex = 'dead beef';
+			expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
+		});
+	});
+
+	describe('toHex', () => {
+		test('should convert Uint8Array to hex string', () => {
+			const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+			const result = Bytes.toHex(bytes);
+			expect(result).toBe('deadbeef');
+		});
+
+		test('should handle empty Uint8Array', () => {
+			const bytes = new Uint8Array(0);
+			const result = Bytes.toHex(bytes);
+			expect(result).toBe('');
+		});
+
+		test('should handle single byte', () => {
+			const bytes = new Uint8Array([0xff]);
+			const result = Bytes.toHex(bytes);
+			expect(result).toBe('ff');
+		});
+
+		test('should handle zero bytes', () => {
+			const bytes = new Uint8Array([0x00, 0x00]);
+			const result = Bytes.toHex(bytes);
+			expect(result).toBe('0000');
+		});
+
+		test('should pad single digit hex values', () => {
+			const bytes = new Uint8Array([0x01, 0x0a, 0x10]);
+			const result = Bytes.toHex(bytes);
+			expect(result).toBe('010a10');
+		});
+
+		test('should be consistent with fromHex', () => {
+			const originalHex = 'deadbeef01234567';
+			const bytes = Bytes.fromHex(originalHex);
+			const resultHex = Bytes.toHex(bytes);
+			expect(resultHex).toBe(originalHex);
+		});
+	});
+
+	describe('fromString', () => {
+		test('should convert string to Uint8Array', () => {
+			const str = 'hello';
+			const result = Bytes.fromString(str);
+			const expected = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle empty string', () => {
+			const str = '';
+			const result = Bytes.fromString(str);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should handle unicode characters', () => {
+			const str = '🚀';
+			const result = Bytes.fromString(str);
+			// UTF-8 encoding of rocket emoji
+			const expected = new Uint8Array([0xf0, 0x9f, 0x9a, 0x80]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle whitespace-only string by trimming to empty', () => {
+			const str = ' \t\n';
+			const result = Bytes.fromString(str);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should preserve internal whitespace', () => {
+			const str = 'hello world';
+			const result = Bytes.fromString(str);
+			const expected = new Uint8Array([
+				0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,
+			]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should trim leading/trailing whitespace', () => {
+			const str = '  hello  ';
+			const result = Bytes.fromString(str);
+			const expected = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle special characters', () => {
+			const str = 'café';
+			const result = Bytes.fromString(str);
+			// UTF-8 encoding of café
+			const expected = new Uint8Array([0x63, 0x61, 0x66, 0xc3, 0xa9]);
+			expect(result).toEqual(expected);
+		});
+	});
+
+	describe('toString', () => {
+		test('should convert Uint8Array to string', () => {
+			const bytes = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+			const result = Bytes.toString(bytes);
+			expect(result).toBe('hello');
+		});
+
+		test('should handle empty Uint8Array', () => {
+			const bytes = new Uint8Array(0);
+			const result = Bytes.toString(bytes);
+			expect(result).toBe('');
+		});
+
+		test('should handle unicode characters', () => {
+			const bytes = new Uint8Array([0xf0, 0x9f, 0x9a, 0x80]);
+			const result = Bytes.toString(bytes);
+			expect(result).toBe('🚀');
+		});
+
+		test('should handle special characters', () => {
+			const bytes = new Uint8Array([0x63, 0x61, 0x66, 0xc3, 0xa9]);
+			const result = Bytes.toString(bytes);
+			expect(result).toBe('café');
+		});
+
+		test('should be consistent with fromString', () => {
+			const originalStr = 'Hello, World! 🌍';
+			const bytes = Bytes.fromString(originalStr);
+			const resultStr = Bytes.toString(bytes);
+			expect(resultStr).toBe(originalStr);
+		});
+	});
+
+	describe('concat', () => {
+		test('should concatenate multiple Uint8Arrays', () => {
+			const arr1 = new Uint8Array([0x01, 0x02]);
+			const arr2 = new Uint8Array([0x03, 0x04]);
+			const arr3 = new Uint8Array([0x05, 0x06]);
+			const result = Bytes.concat(arr1, arr2, arr3);
+			const expected = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle empty arrays', () => {
+			const arr1 = new Uint8Array([0x01, 0x02]);
+			const arr2 = new Uint8Array(0);
+			const arr3 = new Uint8Array([0x03, 0x04]);
+			const result = Bytes.concat(arr1, arr2, arr3);
+			const expected = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle single array', () => {
+			const arr1 = new Uint8Array([0x01, 0x02, 0x03]);
+			const result = Bytes.concat(arr1);
+			expect(result).toEqual(arr1);
+		});
+
+		test('should handle no arrays', () => {
+			const result = Bytes.concat();
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should handle all empty arrays', () => {
+			const arr1 = new Uint8Array(0);
+			const arr2 = new Uint8Array(0);
+			const result = Bytes.concat(arr1, arr2);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+	});
+
+	describe('alloc', () => {
+		test('should allocate Uint8Array of specified size', () => {
+			const size = 10;
+			const result = Bytes.alloc(size);
+			expect(result).toBeInstanceOf(Uint8Array);
+			expect(result.length).toBe(size);
+			expect(result).toEqual(new Uint8Array(size));
+		});
+
+		test('should allocate zero-length array', () => {
+			const result = Bytes.alloc(0);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should initialize with zeros', () => {
+			const result = Bytes.alloc(5);
+			const expected = new Uint8Array([0, 0, 0, 0, 0]);
+			expect(result).toEqual(expected);
+		});
+	});
+
+	describe('writeBigUint64BE', () => {
+		test('should write bigint as big-endian bytes', () => {
+			const value = 0x0123456789abcdefn;
+			const result = Bytes.writeBigUint64BE(value);
+			const expected = new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle zero value', () => {
+			const value = 0n;
+			const result = Bytes.writeBigUint64BE(value);
+			const expected = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle maximum uint64 value', () => {
+			const value = 0xffffffffffffffffn;
+			const result = Bytes.writeBigUint64BE(value);
+			const expected = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle small values', () => {
+			const value = 0x42n;
+			const result = Bytes.writeBigUint64BE(value);
+			const expected = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42]);
+			expect(result).toEqual(expected);
+		});
+	});
+
+	describe('toBase64', () => {
+		test('should convert Uint8Array to base64', () => {
+			const bytes = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+			const result = Bytes.toBase64(bytes);
+			expect(result).toBe('aGVsbG8=');
+		});
+
+		test('should handle empty array', () => {
+			const bytes = new Uint8Array(0);
+			const result = Bytes.toBase64(bytes);
+			expect(result).toBe('');
+		});
+
+		test('should handle single byte', () => {
+			const bytes = new Uint8Array([0x61]);
+			const result = Bytes.toBase64(bytes);
+			expect(result).toBe('YQ==');
+		});
+
+		test('should handle binary data', () => {
+			const bytes = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+			const result = Bytes.toBase64(bytes);
+			expect(result).toBe('AAEC//79');
+		});
+
+		test('should handle large arrays (chunk processing)', () => {
+			// create array larger than 32768 to test chunking
+			const size = 40000;
+			const bytes = new Uint8Array(size);
+			for (let i = 0; i < size; i++) {
+				bytes[i] = i % 256;
+			}
+			const result = Bytes.toBase64(bytes);
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+			expect(result.length % 4).toBe(0);
+		});
+	});
+
+	describe('fromBase64', () => {
+		test('should convert base64 to Uint8Array', () => {
+			const base64 = 'aGVsbG8=';
+			const result = Bytes.fromBase64(base64);
+			const expected = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle empty string', () => {
+			const base64 = '';
+			const result = Bytes.fromBase64(base64);
+			expect(result).toEqual(new Uint8Array(0));
+		});
+
+		test('should handle whitespace', () => {
+			const base64 = '  aGVsbG8=  ';
+			const result = Bytes.fromBase64(base64);
+			const expected = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should handle binary data', () => {
+			const base64 = 'AAEC//79';
+			const result = Bytes.fromBase64(base64);
+			const expected = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+			expect(result).toEqual(expected);
+		});
+
+		test('should be consistent with toBase64', () => {
+			const originalBytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x01, 0x23, 0x45, 0x67]);
+			const base64 = Bytes.toBase64(originalBytes);
+			const resultBytes = Bytes.fromBase64(base64);
+			expect(resultBytes).toEqual(originalBytes);
+		});
+	});
+
+	describe('equals', () => {
+		test('should return true for identical arrays', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x01, 0x02, 0x03]);
+			expect(Bytes.equals(a, b)).toBe(true);
+		});
+
+		test('should return true for empty arrays', () => {
+			const a = new Uint8Array(0);
+			const b = new Uint8Array(0);
+			expect(Bytes.equals(a, b)).toBe(true);
+		});
+
+		test('should return false for different content', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x01, 0x02, 0x04]);
+			expect(Bytes.equals(a, b)).toBe(false);
+		});
+
+		test('should return false for different lengths', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x01, 0x02]);
+			expect(Bytes.equals(a, b)).toBe(false);
+		});
+
+		test('should return false for one empty array', () => {
+			const a = new Uint8Array([0x01]);
+			const b = new Uint8Array(0);
+			expect(Bytes.equals(a, b)).toBe(false);
+		});
+
+		test('should be symmetric', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x04, 0x05, 0x06]);
+			expect(Bytes.equals(a, b)).toBe(Bytes.equals(b, a));
+		});
+
+		test('should handle single byte arrays', () => {
+			const a = new Uint8Array([0xff]);
+			const b = new Uint8Array([0xff]);
+			const c = new Uint8Array([0x00]);
+			expect(Bytes.equals(a, b)).toBe(true);
+			expect(Bytes.equals(a, c)).toBe(false);
+		});
+	});
+
+	describe('compare', () => {
+		test('should return 0 for identical arrays', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x01, 0x02, 0x03]);
+			expect(Bytes.compare(a, b)).toBe(0);
+		});
+
+		test('should return 0 for empty arrays', () => {
+			const a = new Uint8Array(0);
+			const b = new Uint8Array(0);
+			expect(Bytes.compare(a, b)).toBe(0);
+		});
+
+		test('should return negative for lexicographically smaller first array', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x01, 0x02, 0x04]);
+			expect(Bytes.compare(a, b)).toBe(-1);
+		});
+
+		test('should return positive for lexicographically larger first array', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x04]);
+			const b = new Uint8Array([0x01, 0x02, 0x03]);
+			expect(Bytes.compare(a, b)).toBe(1);
+		});
+
+		test('should compare by length when one is prefix of another', () => {
+			const a = new Uint8Array([0x01, 0x02]);
+			const b = new Uint8Array([0x01, 0x02, 0x03]);
+			expect(Bytes.compare(a, b)).toBe(-1);
+			expect(Bytes.compare(b, a)).toBe(1);
+		});
+
+		test('should handle empty vs non-empty', () => {
+			const a = new Uint8Array(0);
+			const b = new Uint8Array([0x01]);
+			expect(Bytes.compare(a, b)).toBe(-1);
+			expect(Bytes.compare(b, a)).toBe(1);
+		});
+
+		test('should handle first byte difference', () => {
+			const a = new Uint8Array([0x00, 0xff, 0xff]);
+			const b = new Uint8Array([0x01, 0x00, 0x00]);
+			expect(Bytes.compare(a, b)).toBe(-1);
+		});
+
+		test('should be anti-symmetric', () => {
+			const a = new Uint8Array([0x01, 0x02, 0x03]);
+			const b = new Uint8Array([0x04, 0x05, 0x06]);
+			expect(Bytes.compare(a, b)).toBe(-Bytes.compare(b, a));
+		});
+
+		test('should be transitive', () => {
+			const a = new Uint8Array([0x01]);
+			const b = new Uint8Array([0x02]);
+			const c = new Uint8Array([0x03]);
+			expect(Bytes.compare(a, b)).toBeLessThan(0);
+			expect(Bytes.compare(b, c)).toBeLessThan(0);
+			expect(Bytes.compare(a, c)).toBeLessThan(0);
+		});
+
+		test('should handle single byte arrays', () => {
+			const a = new Uint8Array([0x42]);
+			const b = new Uint8Array([0x43]);
+			expect(Bytes.compare(a, b)).toBe(-1);
+			expect(Bytes.compare(b, a)).toBe(1);
+		});
+	});
+
+	describe('integration tests', () => {
+		test('hex roundtrip with various data', () => {
+			const testCases = ['', '00', 'ff', 'deadbeef', '0123456789abcdef', 'a0b1c2d3e4f5'];
+
+			testCases.forEach((hex) => {
+				if (hex.length > 0) {
+					const bytes = Bytes.fromHex(hex);
+					const result = Bytes.toHex(bytes);
+					expect(result).toBe(hex);
+				}
+			});
+		});
+
+		test('string roundtrip with various encodings', () => {
+			const testCases = [
+				'',
+				'hello',
+				'Hello, World!',
+				'🚀🌍💻',
+				'café naïve résumé',
+				'中文测试',
+				'Привет мир',
+				'العربية',
+			];
+
+			testCases.forEach((str) => {
+				const bytes = Bytes.fromString(str);
+				const result = Bytes.toString(bytes);
+				expect(result).toBe(str);
+			});
+		});
+
+		test('base64 roundtrip with various data', () => {
+			const testCases = [
+				new Uint8Array([]),
+				new Uint8Array([0x00]),
+				new Uint8Array([0xff]),
+				new Uint8Array([0x00, 0x01, 0x02, 0x03]),
+				new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+				new Uint8Array(Array.from({ length: 1000 }, (_, i) => i % 256)),
+			];
+
+			testCases.forEach((bytes) => {
+				const base64 = Bytes.toBase64(bytes);
+				const result = Bytes.fromBase64(base64);
+				expect(result).toEqual(bytes);
+			});
+		});
+
+		test('concat and split operations', () => {
+			const part1 = Bytes.fromString('Hello, ');
+			const part2 = Bytes.fromString('World!');
+			const part3 = Bytes.fromHex('deadbeef');
+
+			const combined = Bytes.concat(part1, part2, part3);
+
+			// verify we can extract parts
+			const extractedPart1 = combined.slice(0, part1.length);
+			const extractedPart2 = combined.slice(part1.length, part1.length + part2.length);
+			const extractedPart3 = combined.slice(part1.length + part2.length);
+
+			expect(extractedPart1).toEqual(part1);
+			expect(extractedPart2).toEqual(part2);
+			expect(extractedPart3).toEqual(part3);
+		});
+
+		test('bigint serialization consistency', () => {
+			const testValues = [
+				0n,
+				1n,
+				255n,
+				256n,
+				65535n,
+				65536n,
+				0xdeadbeefcafebaben,
+				0xffffffffffffffffn,
+			];
+
+			testValues.forEach((value) => {
+				const bytes = Bytes.writeBigUint64BE(value);
+				expect(bytes.length).toBe(8);
+
+				// verify we can read it back with DataView
+				const view = new DataView(bytes.buffer);
+				const result = view.getBigUint64(0, false); // false = big endian
+				expect(result).toBe(value);
+			});
+		});
+
+		test('comparison and equality consistency', () => {
+			const arrays = [
+				new Uint8Array([]),
+				new Uint8Array([0x00]),
+				new Uint8Array([0x01]),
+				new Uint8Array([0x00, 0x00]),
+				new Uint8Array([0x00, 0x01]),
+				new Uint8Array([0x01, 0x00]),
+				new Uint8Array([0xff, 0xff]),
+			];
+
+			for (let i = 0; i < arrays.length; i++) {
+				for (let j = 0; j < arrays.length; j++) {
+					const a = arrays[i];
+					const b = arrays[j];
+					const isEqual = Bytes.equals(a, b);
+					const comparison = Bytes.compare(a, b);
+
+					if (isEqual) {
+						expect(comparison).toBe(0);
+					} else {
+						expect(comparison).not.toBe(0);
+					}
+				}
+			}
+		});
+	});
+});

--- a/test/cbor.test.ts
+++ b/test/cbor.test.ts
@@ -1,22 +1,18 @@
-import { Buffer } from 'buffer';
 import { decodeCBOR, encodeCBOR } from '../src/cbor';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { test, describe, expect } from 'vitest';
+import { Bytes } from '../src/utils/Bytes';
 
 // Test Polyfills for Node Buffer (which is not properly polyfilled in vite browser tests)
 // Instead of Buffer.from(encoded).toString('base64url')
 function base64urlEncode(buffer: Uint8Array): string {
-	return Buffer.from(buffer)
-		.toString('base64')
-		.replace(/\+/g, '-')
-		.replace(/\//g, '_')
-		.replace(/=+$/, '');
+	return Bytes.toBase64(buffer).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 // Instead of Buffer.from(..., 'base64url')
 function base64urlDecode(str: string): Uint8Array {
 	str = str.replace(/-/g, '+').replace(/_/g, '/');
 	while (str.length % 4) str += '=';
-	return Buffer.from(str, 'base64');
+	return Bytes.fromBase64(str);
 }
 
 const tests = [

--- a/test/crypto/client/NUT09.test.ts
+++ b/test/crypto/client/NUT09.test.ts
@@ -1,13 +1,12 @@
-import { Buffer } from 'buffer';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
 import { deriveSecret } from '../../../src/crypto/client/NUT09';
+import { Bytes } from '../../../src/utils/Bytes';
 
 const seed = Uint8Array.from(
-	Buffer.from(
+	Bytes.fromHex(
 		'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
-		'hex',
 	),
 );
 
@@ -24,7 +23,7 @@ describe('testing hdkey from seed', () => {
 
 		const seed_expected =
 			'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8';
-		const seed_uint8_array_expected = Uint8Array.from(Buffer.from(seed_expected, 'hex'));
+		const seed_uint8_array_expected = Bytes.fromHex(seed_expected);
 		expect(seed).toEqual(seed_uint8_array_expected);
 	});
 });
@@ -114,7 +113,7 @@ describe('testing deterministic blindedMessage', () => {
 describe('test private key derivation from derivation path -- deprecated', () => {
 	const seed =
 		'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8';
-	const seed_uint8_array = Uint8Array.from(Buffer.from(seed, 'hex'));
+	const seed_uint8_array = Bytes.fromHex(seed);
 	const hdkey = HDKey.fromMasterSeed(seed_uint8_array);
 	const expected_privatekey = '9d32fc57e6fa2942d05ee475d28ba6a56839b8cb8a3f174b05ed0ed9d3a420f6';
 	const derivation_path = "m/129372'/0'/2004500376'/0'/0";

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { blindMessage, constructProofFromPromise, serializeProof } from '../src/crypto/client/';
 import { test, describe, expect } from 'vitest';
 import { Keys, Proof, Token } from '../src/model/types/index';


### PR DESCRIPTION
# Fixes: #357

## Description
Drop buffer dependency (cut deps by 50%)
...

## Changes

- Moved all buffer logic to Bytes class which is operating on Uint8Array. Base64 serialization is done by node:buffer in node and by [atob](https://developer.mozilla.org/en-US/docs/Web/API/Window/atob) in browser.
- Migrated all Buffer use to Bytes
- Migrated tests to Bytes
- Removed Buffer dependency
- Added tests for Bytes class

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
