### PR TITLE
change checkProofsStates type to only require secrets

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -165,7 +165,7 @@ export class CashuWallet {
     // (undocumented)
     checkMintQuote(quote: string): Promise<PartialMintQuoteResponse>;
     checkMintQuoteBolt12(quote: string): Promise<Bolt12MintQuoteResponse>;
-    checkProofsStates(proofs: Proof[]): Promise<ProofState[]>;
+    checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]>;
     createLockedMintQuote(amount: number, pubkey: string, description?: string): Promise<LockedMintQuoteResponse>;
     createMeltQuote(invoice: string): Promise<MeltQuoteResponse>;
     createMeltQuoteBolt12(offer: string, amountMsat?: number): Promise<Bolt12MeltQuoteResponse>;

--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1380,9 +1380,11 @@ class CashuWallet {
 	 * @param proofs (only the `secret` field is required)
 	 * @returns
 	 */
-	async checkProofsStates(proofs: Proof[]): Promise<ProofState[]> {
+	async checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]> {
 		const enc = new TextEncoder();
-		const Ys = proofs.map((p: Proof) => hashToCurve(enc.encode(p.secret)).toHex(true));
+		const Ys = proofs.map((p: Pick<Proof, 'secret'>) =>
+			hashToCurve(enc.encode(p.secret)).toHex(true),
+		);
 		// TODO: Replace this with a value from the info endpoint of the mint eventually
 		const BATCH_SIZE = 100;
 		const states: ProofState[] = [];


### PR DESCRIPTION
# Fixes: 
`checkProofsStates` says it only requires `secret`s, but the type says otherwise.
## Description
This is a non-breaking change that allows users to only pass the secret to `checkProofsStates` instead of a whole proof
...

## Changes

- ...
- ...

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
