### PR TITLE
V2 fix d.ts post-processing

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -4,30 +4,6 @@
 
 ```ts
 
-import { CashuAuthMint } from './auth.js';
-import { CashuAuthWallet } from './auth.js';
-import { getBlindedAuthToken } from './auth.js';
-import { getEncodedAuthToken } from './auth.js';
-import { GetInfoResponse as GetInfoResponse_2 } from './types.js';
-import { JsonRpcReqParams as JsonRpcReqParams_2 } from './model/types.js';
-import { Keys as Keys_2 } from './model/types.js';
-import { MintContactInfo as MintContactInfo_2 } from './types';
-import { MintKeys as MintKeys_2 } from './types.js';
-import { MintKeys as MintKeys_3 } from './model/types.js';
-import { MintKeyset as MintKeyset_2 } from './model/types.js';
-import { MPPMethod as MPPMethod_2 } from './types.js';
-import { NUT10Option as NUT10Option_2 } from './types.js';
-import { PaymentRequestTransport as PaymentRequestTransport_2 } from './types.js';
-import { PaymentRequestTransportType as PaymentRequestTransportType_2 } from './types.js';
-import { Proof as Proof_2 } from './types.js';
-import { Proof as Proof_3 } from './model/types.js';
-import { RawPaymentRequest as RawPaymentRequest_2 } from './types.js';
-import { SerializedBlindedMessage as SerializedBlindedMessage_2 } from './types.js';
-import { SerializedBlindedSignature as SerializedBlindedSignature_2 } from './types.js';
-import { SwapMethod as SwapMethod_2 } from './types.js';
-import { Token as Token_2 } from './model/types.js';
-import { WebSocketSupport as WebSocketSupport_2 } from './types.js';
-
 // @public
 export type AmountlessOption = {
     amount_msat: number;
@@ -74,13 +50,47 @@ export type Bolt12MintQuoteResponse = {
     amount_issued: number;
 };
 
-export { CashuAuthMint }
+// @public
+export class CashuAuthMint {
+    // Warning: (ae-forgotten-export) The symbol "request" needs to be exported by the entry point index.d.ts
+    constructor(_mintUrl: string, _customRequest?: typeof request | undefined);
+    static getKeys(mintUrl: string, keysetId?: string, customRequest?: typeof request): Promise<MintActiveKeys>;
+    getKeys(keysetId?: string, mintUrl?: string): Promise<MintActiveKeys>;
+    static getKeySets(mintUrl: string, customRequest?: typeof request): Promise<MintAllKeysets>;
+    getKeySets(): Promise<MintAllKeysets>;
+    static mint(mintUrl: string, mintPayload: BlindAuthMintPayload, clearAuthToken: string, customRequest?: typeof request): Promise<BlindAuthMintResponse>;
+    mint(mintPayload: BlindAuthMintPayload, clearAuthToken: string): Promise<BlindAuthMintResponse>;
+    // (undocumented)
+    get mintUrl(): string;
+}
 
-export { CashuAuthWallet }
+// @public
+export class CashuAuthWallet {
+    constructor(mint: CashuAuthMint, options?: {
+        keys?: MintKeys[] | MintKeys;
+        keysets?: MintKeyset[];
+    });
+    getActiveKeyset(keysets: MintKeyset[]): MintKeyset;
+    getAllKeys(): Promise<MintKeys[]>;
+    getKeys(keysetId?: string, forceRefresh?: boolean): Promise<MintKeys>;
+    getKeySets(): Promise<MintKeyset[]>;
+    // (undocumented)
+    get keys(): Map<string, MintKeys>;
+    // (undocumented)
+    get keysetId(): string;
+    set keysetId(keysetId: string);
+    // (undocumented)
+    get keysets(): MintKeyset[];
+    loadMint(): Promise<void>;
+    // (undocumented)
+    mint: CashuAuthMint;
+    mintProofs(amount: number, clearAuthToken: string, options?: {
+        keysetId?: string;
+    }): Promise<Proof[]>;
+}
 
 // @public
 export class CashuMint {
-    // Warning: (ae-forgotten-export) The symbol "request" needs to be exported by the entry point index.d.ts
     constructor(_mintUrl: string, _customRequest?: typeof request | undefined, authTokenGetter?: () => Promise<string>, options?: {
         logger?: Logger;
     });
@@ -278,29 +288,31 @@ export type DeprecatedToken = {
 };
 
 // @public
-export function deriveKeysetId(keys: Keys_2, unit?: string, expiry?: number, versionByte?: number, isDeprecatedBase64?: boolean): string;
-
-export { getBlindedAuthToken }
-
-// @public
-export function getDecodedToken(tokenString: string, keysets?: MintKeyset_2[]): Token_2;
+export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versionByte?: number, isDeprecatedBase64?: boolean): string;
 
 // @public (undocumented)
-export function getDecodedTokenBinary(bytes: Uint8Array): Token_2;
-
-export { getEncodedAuthToken }
+export function getBlindedAuthToken(amount: number, url: string, clearAuthToken: string): Promise<string[]>;
 
 // @public
-export function getEncodedToken(token: Token_2, opts?: {
+export function getDecodedToken(tokenString: string, keysets?: MintKeyset[]): Token;
+
+// @public (undocumented)
+export function getDecodedTokenBinary(bytes: Uint8Array): Token;
+
+// @public
+export function getEncodedAuthToken(proof: Proof): string;
+
+// @public
+export function getEncodedToken(token: Token, opts?: {
     version?: 3 | 4;
     removeDleq?: boolean;
 }): string;
 
 // @public (undocumented)
-export function getEncodedTokenBinary(token: Token_2): Uint8Array;
+export function getEncodedTokenBinary(token: Token): Uint8Array;
 
 // @public (undocumented)
-export function getEncodedTokenV4(token: Token_2, removeDleq?: boolean): string;
+export function getEncodedTokenV4(token: Token, removeDleq?: boolean): string;
 
 // @public
 export type GetInfoResponse = {
@@ -362,7 +374,7 @@ export type GetInfoResponse = {
 };
 
 // @public
-export function hasValidDleq(proof: Proof_3, keyset: MintKeys_3): boolean;
+export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean;
 
 // @public
 export type HTLCWitness = {
@@ -638,13 +650,13 @@ export type OutputAmounts = {
 
 // @public (undocumented)
 export class OutputData implements OutputDataLike {
-    constructor(blindedMessage: SerializedBlindedMessage_2, blidingFactor: bigint, secret: Uint8Array);
+    constructor(blindedMessage: SerializedBlindedMessage, blidingFactor: bigint, secret: Uint8Array);
     // (undocumented)
-    blindedMessage: SerializedBlindedMessage_2;
+    blindedMessage: SerializedBlindedMessage;
     // (undocumented)
     blindingFactor: bigint;
     // (undocumented)
-    static createDeterministicData(amount: number, seed: Uint8Array, counter: number, keyset: MintKeys_2, customSplit?: number[]): OutputData[];
+    static createDeterministicData(amount: number, seed: Uint8Array, counter: number, keyset: MintKeys, customSplit?: number[]): OutputData[];
     // (undocumented)
     static createP2PKData(p2pk: {
         pubkey: string | string[];
@@ -652,9 +664,9 @@ export class OutputData implements OutputDataLike {
         refundKeys?: string[];
         requiredSignatures?: number;
         requiredRefundSignatures?: number;
-    }, amount: number, keyset: MintKeys_2, customSplit?: number[]): OutputData[];
+    }, amount: number, keyset: MintKeys, customSplit?: number[]): OutputData[];
     // (undocumented)
-    static createRandomData(amount: number, keyset: MintKeys_2, customSplit?: number[]): OutputData[];
+    static createRandomData(amount: number, keyset: MintKeys, customSplit?: number[]): OutputData[];
     // (undocumented)
     static createSingleDeterministicData(amount: number, seed: Uint8Array, counter: number, keysetId: string): OutputData;
     // (undocumented)
@@ -670,7 +682,7 @@ export class OutputData implements OutputDataLike {
     // (undocumented)
     secret: Uint8Array;
     // (undocumented)
-    toProof(sig: SerializedBlindedSignature_2, keyset: MintKeys_2): Proof_2;
+    toProof(sig: SerializedBlindedSignature, keyset: MintKeys): Proof;
 }
 
 // @public
@@ -710,7 +722,7 @@ export type PaymentPayload = {
 
 // @public (undocumented)
 class PaymentRequest_2 {
-    constructor(transport?: PaymentRequestTransport_2[] | undefined, id?: string | undefined, amount?: number | undefined, unit?: string | undefined, mints?: string[] | undefined, description?: string | undefined, singleUse?: boolean, nut10?: NUT10Option_2 | undefined);
+    constructor(transport?: PaymentRequestTransport[] | undefined, id?: string | undefined, amount?: number | undefined, unit?: string | undefined, mints?: string[] | undefined, description?: string | undefined, singleUse?: boolean, nut10?: NUT10Option | undefined);
     // (undocumented)
     amount?: number | undefined;
     // (undocumented)
@@ -718,23 +730,23 @@ class PaymentRequest_2 {
     // (undocumented)
     static fromEncodedRequest(encodedRequest: string): PaymentRequest_2;
     // (undocumented)
-    static fromRawRequest(rawPaymentRequest: RawPaymentRequest_2): PaymentRequest_2;
+    static fromRawRequest(rawPaymentRequest: RawPaymentRequest): PaymentRequest_2;
     // (undocumented)
-    getTransport(type: PaymentRequestTransportType_2): PaymentRequestTransport_2 | undefined;
+    getTransport(type: PaymentRequestTransportType): PaymentRequestTransport | undefined;
     // (undocumented)
     id?: string | undefined;
     // (undocumented)
     mints?: string[] | undefined;
     // (undocumented)
-    nut10?: NUT10Option_2 | undefined;
+    nut10?: NUT10Option | undefined;
     // (undocumented)
     singleUse: boolean;
     // (undocumented)
     toEncodedRequest(): string;
     // (undocumented)
-    toRawRequest(): RawPaymentRequest_2;
+    toRawRequest(): RawPaymentRequest;
     // (undocumented)
-    transport?: PaymentRequestTransport_2[] | undefined;
+    transport?: PaymentRequestTransport[] | undefined;
     // (undocumented)
     unit?: string | undefined;
 }
@@ -1025,11 +1037,11 @@ export type WebSocketSupport = {
 
 // Warnings were encountered during analysis:
 //
-// lib/types/CashuWallet.d.ts:41:9 - (ae-forgotten-export) The symbol "OutputDataFactory" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:150:5 - (ae-forgotten-export) The symbol "OutputDataLike" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:190:5 - (ae-forgotten-export) The symbol "RpcSubKinds" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/index.d.ts:218:5 - (ae-forgotten-export) The symbol "JsonRpcParams" needs to be exported by the entry point index.d.ts
-// lib/types/model/types/wallet/tokens.d.ts:103:5 - (ae-forgotten-export) The symbol "TokenEntry" needs to be exported by the entry point index.d.ts
+// lib/types/cashu-ts.d.ts:607:9 - (ae-forgotten-export) The symbol "OutputDataFactory" needs to be exported by the entry point index.d.ts
+// lib/types/cashu-ts.d.ts:1081:5 - (ae-forgotten-export) The symbol "TokenEntry" needs to be exported by the entry point index.d.ts
+// lib/types/cashu-ts.d.ts:1262:5 - (ae-forgotten-export) The symbol "JsonRpcParams" needs to be exported by the entry point index.d.ts
+// lib/types/cashu-ts.d.ts:1271:5 - (ae-forgotten-export) The symbol "RpcSubKinds" needs to be exported by the entry point index.d.ts
+// lib/types/cashu-ts.d.ts:1628:5 - (ae-forgotten-export) The symbol "OutputDataLike" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.31.0",
-				"@microsoft/api-extractor": "^7.52.4",
+				"@microsoft/api-extractor": "^7.52.13",
 				"@types/node-fetch": "^2.6.4",
 				"@types/ws": "^8.5.10",
 				"@typescript-eslint/eslint-plugin": "^8.38.0",
@@ -1040,6 +1040,29 @@
 				}
 			}
 		},
+		"node_modules/@isaacs/balanced-match": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@isaacs/brace-expansion": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@isaacs/balanced-match": "^4.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1139,9 +1162,9 @@
 			}
 		},
 		"node_modules/@microsoft/api-extractor": {
-			"version": "7.52.9",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.9.tgz",
-			"integrity": "sha512-313nyhc6DSSMVKD43jZK6Yp5XbliGw5vjN7QOw1FHzR1V6DQ67k4dzkd3BSxMtWcm+cEs1Ux8rmDqots6EABFA==",
+			"version": "7.52.13",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.13.tgz",
+			"integrity": "sha512-K6/bBt8zZfn9yc06gNvA+/NlBGJC/iJlObpdufXHEJtqcD4Dln4ITCLZpwP3DNZ5NyBFeTkKdv596go3V72qlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1150,10 +1173,10 @@
 				"@microsoft/tsdoc-config": "~0.17.1",
 				"@rushstack/node-core-library": "5.14.0",
 				"@rushstack/rig-package": "0.5.3",
-				"@rushstack/terminal": "0.15.4",
-				"@rushstack/ts-command-line": "5.0.2",
+				"@rushstack/terminal": "0.16.0",
+				"@rushstack/ts-command-line": "5.0.3",
 				"lodash": "~4.17.15",
-				"minimatch": "~3.0.3",
+				"minimatch": "10.0.3",
 				"resolve": "~1.22.1",
 				"semver": "~7.5.4",
 				"source-map": "~0.6.1",
@@ -1762,9 +1785,9 @@
 			}
 		},
 		"node_modules/@rushstack/terminal": {
-			"version": "0.15.4",
-			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.4.tgz",
-			"integrity": "sha512-OQSThV0itlwVNHV6thoXiAYZlQh4Fgvie2CzxFABsbO2MWQsI4zOh3LRNigYSTrmS+ba2j0B3EObakPzf/x6Zg==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.16.0.tgz",
+			"integrity": "sha512-WEvNuKkoR1PXorr9SxO0dqFdSp1BA+xzDrIm/Bwlc5YHg2FFg6oS+uCTYjerOhFuqCW+A3vKBm6EmKWSHfgx/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1781,13 +1804,13 @@
 			}
 		},
 		"node_modules/@rushstack/ts-command-line": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.2.tgz",
-			"integrity": "sha512-+AkJDbu1GFMPIU8Sb7TLVXDv/Q7Mkvx+wAjEl8XiXVVq+p1FmWW6M3LYpJMmoHNckSofeMecgWg5lfMwNAAsEQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.3.tgz",
+			"integrity": "sha512-bgPhQEqLVv/2hwKLYv/XvsTWNZ9B/+X1zJ7WgQE9rO5oiLzrOZvkIW4pk13yOQBhHyjcND5qMOa6p83t+Z66iQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rushstack/terminal": "0.15.4",
+				"@rushstack/terminal": "0.16.0",
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
 				"string-argv": "~0.3.1"
@@ -7351,16 +7374,19 @@
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"@isaacs/brace-expansion": "^5.0.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minimist": {
@@ -11251,6 +11277,21 @@
 			"dev": true,
 			"requires": {}
 		},
+		"@isaacs/balanced-match": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+			"dev": true
+		},
+		"@isaacs/brace-expansion": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"dev": true,
+			"requires": {
+				"@isaacs/balanced-match": "^4.0.1"
+			}
+		},
 		"@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -11323,9 +11364,9 @@
 			}
 		},
 		"@microsoft/api-extractor": {
-			"version": "7.52.9",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.9.tgz",
-			"integrity": "sha512-313nyhc6DSSMVKD43jZK6Yp5XbliGw5vjN7QOw1FHzR1V6DQ67k4dzkd3BSxMtWcm+cEs1Ux8rmDqots6EABFA==",
+			"version": "7.52.13",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.13.tgz",
+			"integrity": "sha512-K6/bBt8zZfn9yc06gNvA+/NlBGJC/iJlObpdufXHEJtqcD4Dln4ITCLZpwP3DNZ5NyBFeTkKdv596go3V72qlA==",
 			"dev": true,
 			"requires": {
 				"@microsoft/api-extractor-model": "7.30.7",
@@ -11333,10 +11374,10 @@
 				"@microsoft/tsdoc-config": "~0.17.1",
 				"@rushstack/node-core-library": "5.14.0",
 				"@rushstack/rig-package": "0.5.3",
-				"@rushstack/terminal": "0.15.4",
-				"@rushstack/ts-command-line": "5.0.2",
+				"@rushstack/terminal": "0.16.0",
+				"@rushstack/ts-command-line": "5.0.3",
 				"lodash": "~4.17.15",
-				"minimatch": "~3.0.3",
+				"minimatch": "10.0.3",
 				"resolve": "~1.22.1",
 				"semver": "~7.5.4",
 				"source-map": "~0.6.1",
@@ -11711,9 +11752,9 @@
 			}
 		},
 		"@rushstack/terminal": {
-			"version": "0.15.4",
-			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.4.tgz",
-			"integrity": "sha512-OQSThV0itlwVNHV6thoXiAYZlQh4Fgvie2CzxFABsbO2MWQsI4zOh3LRNigYSTrmS+ba2j0B3EObakPzf/x6Zg==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.16.0.tgz",
+			"integrity": "sha512-WEvNuKkoR1PXorr9SxO0dqFdSp1BA+xzDrIm/Bwlc5YHg2FFg6oS+uCTYjerOhFuqCW+A3vKBm6EmKWSHfgx/A==",
 			"dev": true,
 			"requires": {
 				"@rushstack/node-core-library": "5.14.0",
@@ -11721,12 +11762,12 @@
 			}
 		},
 		"@rushstack/ts-command-line": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.2.tgz",
-			"integrity": "sha512-+AkJDbu1GFMPIU8Sb7TLVXDv/Q7Mkvx+wAjEl8XiXVVq+p1FmWW6M3LYpJMmoHNckSofeMecgWg5lfMwNAAsEQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.3.tgz",
+			"integrity": "sha512-bgPhQEqLVv/2hwKLYv/XvsTWNZ9B/+X1zJ7WgQE9rO5oiLzrOZvkIW4pk13yOQBhHyjcND5qMOa6p83t+Z66iQ==",
 			"dev": true,
 			"requires": {
-				"@rushstack/terminal": "0.15.4",
+				"@rushstack/terminal": "0.16.0",
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
 				"string-argv": "~0.3.1"
@@ -15447,12 +15488,12 @@
 			"dev": true
 		},
 		"minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"@isaacs/brace-expansion": "^5.0.0"
 			}
 		},
 		"minimist": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@eslint/js": "^9.31.0",
-		"@microsoft/api-extractor": "^7.52.4",
+		"@microsoft/api-extractor": "^7.52.13",
 		"@types/node-fetch": "^2.6.4",
 		"@types/ws": "^8.5.10",
 		"@typescript-eslint/eslint-plugin": "^8.38.0",

--- a/post-process-dts.js
+++ b/post-process-dts.js
@@ -1,15 +1,118 @@
+//
+// IMPORTANT: Extension handling for build outputs
+//
+// - Source TS: import paths are extensionless (e.g. "./foo").
+// - Emitted runtime ESM (.js): relative imports MUST include ".js" (Node ESM).
+// - Emitted CJS (.cjs): extension doesn’t matter.
+// - Emitted type declarations (.d.ts): NEVER rewrite to ".js". Keep extensionless.
+//
+// This script must not add ".js" inside declaration files. If you ever need to
+// append ".js", only patch runtime JS files (lib/**/*.js).
+//
+
 import { replaceInFileSync } from 'replace-in-file';
+import fs from 'fs';
+import path from 'path';
 
 try {
-	const options = {
-		files: 'lib/types/**/*.d.ts',
-		from: /from\s+["'](\.\/[^"']+)["']/g,
-		to: "from '$1.js'",
-	};
+  // 1) Clean .d.ts files: ensure extensionless relative specifiers
+  const stripInDts = replaceInFileSync({
+    files: 'lib/types/**/*.d.ts',
+    from: [
+      // import … from './x.js'
+      /(\bfrom\s+['"])(\.\/[^'"]+?)\.js(['"];?)/g,
+      // export * from './x.js'
+      /(\bexport\s+\*\s+from\s+['"])(\.\/[^'"]+?)\.js(['"];?)/g,
+      // export { … } from './x.js'
+      /(\bexport\s+{[^}]*}\s+from\s+['"])(\.\/[^'"]+?)\.js(['"];?)/g,
+    ],
+    to: '$1$2$3',
+  });
 
-	const results = replaceInFileSync(options);
-	const changed = results.filter((r) => r.hasChanged).map((r) => r.file);
-	if (changed.length) console.log('Post processed .js imports in:', changed);
+  const changedDts = stripInDts.filter((r) => r.hasChanged).map((r) => r.file);
+  if (changedDts.length) {
+    console.log('Cleaned .d.ts specifiers (removed .js):', changedDts);
+  }
+
+  // ---------- Helpers ----------
+  function ensureFile(p, content) {
+    const dir = path.dirname(p);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(p, content, 'utf8'); // always overwrite to avoid stale stubs
+    console.log('Wrote', p);
+  }
+
+  // ---------- 2) Rich root index.d.ts with explicit re-exports ----------
+  const typesDir = path.resolve('lib/types');
+  const rolledModule = './cashu-ts'; // TS resolves to cashu-ts.d.ts
+  const rolledPath = path.join(typesDir, 'cashu-ts.d.ts');
+  const rootIndex = path.join(typesDir, 'index.d.ts');
+
+  let explicit = [];
+  try {
+    const src = fs.readFileSync(rolledPath, 'utf8');
+    const names = new Set();
+
+    // export declare class|function|const|enum|interface|type|namespace <Name>
+    const declRe =
+      /^\s*export\s+(?:declare\s+)?(?:class|function|const|enum|interface|type|namespace)\s+([A-Za-z0-9_$]+)/gm;
+    for (let m; (m = declRe.exec(src)); ) names.add(m[1]);
+
+    // export { A, B as C } (with or without "from")
+    const braceRe = /^\s*export\s+(?:type\s+)?{\s*([^}]+)\s*}/gm;
+    for (let m; (m = braceRe.exec(src)); ) {
+      m[1].split(',').forEach((piece) => {
+        const seg = piece.trim();
+        if (!seg) return;
+        const alias = seg.split(/\s+as\s+/i).map((s) => s.trim());
+        names.add(alias[1] || alias[0]);
+      });
+    }
+
+    // do not forward 'default'
+    names.delete('default');
+
+    if (names.size) {
+      explicit = Array.from(names)
+        .sort()
+        .map((n) => `export { ${n} } from '${rolledModule}';`);
+    }
+  } catch (e) {
+    console.warn('Could not read or parse rolled types for explicit re-exports:', e?.message || e);
+  }
+
+  // Fallback: if scraper found nothing, still ensure the two key v2 names are surfaced
+  if (explicit.length === 0) {
+    explicit = [
+      `export { CashuWallet } from '${rolledModule}';`,
+      `export { CashuMint } from '${rolledModule}';`,
+    ];
+  }
+
+  ensureFile(
+    rootIndex,
+    [
+      // keep the broad surface
+      `export * from '${rolledModule}';`,
+      // add explicit named re-exports so NodeNext cannot miss them
+      ...explicit,
+      // mark as a module
+      `export {};`,
+      ``,
+    ].join('\n'),
+  );
+
+  // ---------- 3) Subpath type shims for v2 exports map ----------
+  // These align with package.json "exports" so TypeScript can resolve subpaths under NodeNext.
+
+  ensureFile(path.join(typesDir, 'crypto/client/index.d.ts'), `export * from '../client';\nexport {};\n`);
+  ensureFile(path.join(typesDir, 'crypto/common/index.d.ts'), `export * from '../common';\nexport {};\n`);
+  ensureFile(path.join(typesDir, 'crypto/mint/index.d.ts'), `export * from '../mint';\nexport {};\n`);
+
+  // package.json currently points "./crypto/util" at "./lib/types/crypto/util/utils.d.ts"
+  // but the build emits "lib/types/crypto/util.d.ts". Provide both shims:
+  ensureFile(path.join(typesDir, 'crypto/util/index.d.ts'), `export * from '../util';\nexport {};\n`);
+  ensureFile(path.join(typesDir, 'crypto/util/utils.d.ts'), `export * from '../../util';\nexport {};\n`);
 } catch (error) {
-	console.error('Error:', error);
+  console.error('post-process-dts failed:', error);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,12 @@ export default defineConfig({
 		sourcemap: true,
 	},
 	plugins: [
-		dts({ tsconfigPath: './tsconfig.json', outDir: 'lib/types' }),
+		dts({
+			tsconfigPath: './tsconfig.json',
+			outDir: 'lib/types',
+			rollupTypes: true,
+			insertTypesEntry: true,
+		}),
 		nodePolyfills({
 			globals: { Buffer: true },
 			include: ['buffer'],


### PR DESCRIPTION
# Fixes: #365

## Description

Post-processing of d.ts files was leading to broken imports for some files. This shims v2 post processing to fix broken imports until we move to v3 (which removes submodules and rolls up types for better compat).
...

## Changes

- Adds `rollupTypes: true` to vite config
- Adds shims to post-processing to fix up NodeNext imports
- updates API Extractor to v7.52.4

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run lint` --> no warnings or errors
- [ ] run `npm run format`
- [ ] run `npm run api:check` --> run `npm run api:update` for changes to the API
