### PR TITLE
Add final_expiry to GetKeysetsResponse

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -545,6 +545,7 @@ export type MintKeyset = {
     unit: string;
     active: boolean;
     input_fee_ppk?: number;
+    final_expiry?: number;
 };
 
 // @public

--- a/src/model/types/mint/keys.ts
+++ b/src/model/types/mint/keys.ts
@@ -67,4 +67,9 @@ export type MintKeyset = {
 	 * Input fee for keyset (in ppk)
 	 */
 	input_fee_ppk?: number;
+
+	/**
+	 * Expiry of the keyset.
+	 */
+	final_expiry?: number;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -483,7 +483,6 @@ export function mergeUInt8Arrays(a1: Uint8Array, a2: Uint8Array): Uint8Array {
 	return mergedArray;
 }
 
-
 export function sortProofsById(proofs: Proof[]) {
 	return proofs.sort((a: Proof, b: Proof) => a.id.localeCompare(b.id));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -483,6 +483,7 @@ export function mergeUInt8Arrays(a1: Uint8Array, a2: Uint8Array): Uint8Array {
 	return mergedArray;
 }
 
+
 export function sortProofsById(proofs: Proof[]) {
 	return proofs.sort((a: Proof, b: Proof) => a.id.localeCompare(b.id));
 }


### PR DESCRIPTION
https://github.com/cashubtc/nuts/pull/182#issuecomment-3315077813

## Changes

- Added final_expiry to GetKeysetsResponse

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
