### PR TITLE
V3: Adds public decodeToken method

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1432,6 +1432,7 @@ export class Wallet {
         description?: string;
     }): Promise<Bolt12MintQuoteResponse>;
     createMultiPathMeltQuote(invoice: string, millisatPartialAmount: number): Promise<MeltQuoteResponse>;
+    decodeToken(token: string): Token;
     defaultOutputType(): OutputType;
     getFeesForKeyset(nInputs: number, keysetId: string): number;
     getFeesForProofs(proofs: Proof[]): number;


### PR DESCRIPTION
Token decoding requires keyset info to rehydrate short keyset IDs to their full representation.

This convenience method makes it simple for consumers to decode tokens properly while hiding the implementation details of rehydration.

## Notes

This PR is built for v3-alpha-2

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
