### PR TITLE
Fix v3 minting

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1460,22 +1460,17 @@ class Wallet {
 		// Create outputs and mint payload
 		const outputs = this.createOutputData(mintAmount, keyset, mintOT);
 		const blindedMessages = outputs.map((d) => d.blindedMessage);
-		let mintPayload: MintPayload;
-		if (typeof quote === 'string') {
-			mintPayload = {
-				outputs: blindedMessages,
-				quote: quote,
-			};
-		} else {
+		const mintPayload: MintPayload = {
+			outputs: blindedMessages,
+			quote: typeof quote === 'string' ? quote : quote.quote,
+		};
+
+		// Sign payload if the quote carries a public key
+		if (typeof quote !== 'string' && quote.pubkey) {
 			this.failIf(!privkey, 'Can not sign locked quote without private key');
 			const mintQuoteSignature = signMintQuote(privkey!, quote.quote, blindedMessages);
-			mintPayload = {
-				outputs: blindedMessages,
-				quote: quote.quote,
-				signature: mintQuoteSignature,
-			};
+			mintPayload.signature = mintQuoteSignature;
 		}
-
 		// Mint proofs
 		let signatures;
 		if (method === 'bolt12') {

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -337,13 +337,17 @@ describe('Wallet (BOLT12) – wrappers', () => {
 		]);
 		// Test missing privkey
 		await expect(
-			wallet.mintProofsBolt12(21, { quote: 'q1', request: 'lno1offer...' } as any, ''),
+			wallet.mintProofsBolt12(
+				21,
+				{ quote: 'q1', request: 'lno1offer...', pubkey: '1234' } as any,
+				'',
+			),
 		).rejects.toThrow('Can not sign locked quote without private key');
 		// Test successful path with privkey (valid secp256k1 private key)
 		const privkey = '0000000000000000000000000000000000000000000000000000000000000001';
 		const proofs = await wallet.mintProofsBolt12(
 			21,
-			{ quote: 'q1', request: 'lno1offer...' } as any,
+			{ quote: 'q1', request: 'lno1offer...', pubkey: '1234' } as any,
 			privkey,
 		);
 		expect(proofs).toHaveLength(3);


### PR DESCRIPTION
# Fixes: #374

## Description

This makes sure we check explicitly for a `pubkey` on a MintQuoteResponse and don't assume its locked just from the shape.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
