### PR TITLE
refactor: compress builder pattern

### DIFF
--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -60,8 +60,8 @@ export class WalletOps {
  *     	.run();
  */
 export class SendBuilder {
-	readonly sendOutputType = new OutputTypeBuilder();
-	readonly keepOutputType = new OutputTypeBuilder();
+	readonly sendOutputType = new OutputTypeBuilder(this);
+	readonly keepOutputType = new OutputTypeBuilder(this);
 	private config: SendConfig = {};
 	private offlineExact?: { requireDleq: boolean };
 	private offlineClose?: { requireDleq: boolean };
@@ -183,7 +183,7 @@ export class SendBuilder {
  *     	.run();
  */
 export class ReceiveBuilder {
-	readonly outputType = new OutputTypeBuilder();
+	readonly outputType = new OutputTypeBuilder(this);
 	private config: ReceiveConfig = {};
 
 	constructor(
@@ -260,7 +260,7 @@ export class ReceiveBuilder {
  *     	.run();
  */
 export class MintBuilder {
-	readonly outputType = new OutputTypeBuilder();
+	readonly outputType = new OutputTypeBuilder(this);
 	private config: MintProofsConfig = {};
 
 	constructor(
@@ -346,7 +346,7 @@ export class MintBuilder {
  * ```
  */
 export class MeltBuilder {
-	readonly outputType = new OutputTypeBuilder();
+	readonly outputType = new OutputTypeBuilder(this);
 	private config: MeltProofsConfig = {};
 
 	constructor(
@@ -410,26 +410,31 @@ export class MeltBuilder {
 
 class OutputTypeBuilder {
 	private outputType?: OutputType;
+	private parentBuilder: SendBuilder | ReceiveBuilder | MintBuilder | MeltBuilder;
+
+	constructor(parentBuilder: SendBuilder | ReceiveBuilder | MintBuilder | MeltBuilder) {
+		this.parentBuilder = parentBuilder;
+	}
 
 	asRandom(denoms?: number[]) {
 		this.outputType = { type: 'random', denominations: denoms };
-		return this;
+		return this.parentBuilder;
 	}
 	asDeterministic(counter = 0, denoms?: number[]) {
 		this.outputType = { type: 'deterministic', counter, denominations: denoms };
-		return this;
+		return this.parentBuilder;
 	}
 	asP2PK(options: P2PKOptions, denoms?: number[]) {
 		this.outputType = { type: 'p2pk', options, denominations: denoms };
-		return this;
+		return this.parentBuilder;
 	}
 	asFactory(factory: OutputDataFactory, denoms?: number[]) {
 		this.outputType = { type: 'factory', factory, denominations: denoms };
-		return this;
+		return this.parentBuilder;
 	}
 	asCustom(data: OutputData[]) {
 		this.outputType = { type: 'custom', data };
-		return this;
+		return this.parentBuilder;
 	}
 	toOutputType(): OutputType | undefined {
 		return this.outputType;


### PR DESCRIPTION
## Description

This is a proposal to compress the builder pattern in WalletOps.ts. Instead of redeclaring all the OutputType methods all the time we use composition and a central OutputTypeBuilder. The benefit is less repeated code. The drawback is that the API becomes slightly more verbose due to composition:

```ts
// Old API
wallet.ops.send()
.asRandom()
.keepAsDeterministic()
.run();

// New API
wallet.ops.send()
.sendOutput.asRandom()
.keepOutput.asDeterministic()
.run();
```

## Changes

- Add a OutputTypeBuilder
- Compose OutputTypeBuilder into WalletOps builders

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [ ] run `npm run lint` --> no warnings or errors
- [ ] run `npm run format`
- [ ] run `npm run api:check` --> run `npm run api:update` for changes to the API
