### PR TITLE
v3 version of PR #363 - change checkProofsStates type to only require secrets

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1546,7 +1546,7 @@ export class Wallet {
     checkMintQuote(quote: string | MintQuoteResponse): Promise<MintQuoteResponse | PartialMintQuoteResponse>;
     checkMintQuoteBolt11(quote: string | MintQuoteResponse): Promise<MintQuoteResponse | PartialMintQuoteResponse>;
     checkMintQuoteBolt12(quote: string): Promise<Bolt12MintQuoteResponse>;
-    checkProofsStates(proofs: Proof[]): Promise<ProofState[]>;
+    checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]>;
     completeMelt<T extends MeltQuoteResponse>(blanks: MeltBlanks<T>): Promise<MeltProofsResponse>;
     readonly counters: WalletCounters;
     createLockedMintQuote(amount: number, pubkey: string, description?: string): Promise<LockedMintQuoteResponse>;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1844,9 +1844,11 @@ class Wallet {
 	 * @param proofs (only the `secret` field is required)
 	 * @returns NUT-07 state for each proof, in same order.
 	 */
-	async checkProofsStates(proofs: Proof[]): Promise<ProofState[]> {
+	async checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]> {
 		const enc = new TextEncoder();
-		const Ys = proofs.map((p: Proof) => hashToCurve(enc.encode(p.secret)).toHex(true));
+		const Ys = proofs.map((p: Pick<Proof, 'secret'>) =>
+			hashToCurve(enc.encode(p.secret)).toHex(true),
+		);
 		// TODO: Replace this with a value from the info endpoint of the mint eventually
 		const BATCH_SIZE = 100;
 		const states: ProofState[] = [];


### PR DESCRIPTION
# Related: #363 

## Description

This is the v3 version of the change in #363 

## Changes

- Narrows `Proof` type in `checkProofStates` to only require secret.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
