### PR TITLE
fix: make sure private key is only required on locked quotes

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -1674,23 +1674,16 @@ class CashuWallet {
 				p2pk,
 			);
 		}
-		let mintPayload: MintPayload;
-		if (typeof quote !== 'string') {
+		const blindedMessages = newBlindingData.map((d) => d.blindedMessage);
+		const mintPayload: MintPayload = {
+			outputs: blindedMessages,
+			quote: typeof quote === 'string' ? quote : quote.quote,
+		};
+		if (typeof quote !== 'string' && quote.pubkey) {
 			if (!privateKey) {
 				throw new Error('Can not sign locked quote without private key');
 			}
-			const blindedMessages = newBlindingData.map((d) => d.blindedMessage);
-			const mintQuoteSignature = signMintQuote(privateKey, quote.quote, blindedMessages);
-			mintPayload = {
-				outputs: blindedMessages,
-				quote: quote.quote,
-				signature: mintQuoteSignature,
-			};
-		} else {
-			mintPayload = {
-				outputs: newBlindingData.map((d) => d.blindedMessage),
-				quote: quote,
-			};
+			mintPayload.signature = signMintQuote(privateKey, quote.quote, blindedMessages);
 		}
 		if (method === 'bolt12') {
 			const { signatures } = await this.mint.mintBolt12(mintPayload);

--- a/test/bolt12.test.ts
+++ b/test/bolt12.test.ts
@@ -368,8 +368,7 @@ describe('CashuWallet (BOLT12) – wrappers', () => {
 
 		// Test missing privateKey
 		await expect(
-			// @ts-expect-error testing missing privateKey runtime check (if present)
-			wallet.mintProofsBolt12(21, { quote: 'q1' } as any, undefined as any),
+			wallet.mintProofsBolt12(21, { quote: 'q1', pubkey: '1234' } as any, undefined as any),
 		).rejects.toBeTruthy();
 
 		// Test successful path with privateKey (valid secp256k1 private key)


### PR DESCRIPTION
## Description

This fixes a regression that caused _mintProofs to throw if an unlocked MintQuoteResponse was passed.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
