### PR TITLE
ci: make sure v2 releases are not tagged latest

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,6 +17,16 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run compile
-      - run: npm publish --provenance
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+          if [ "$MAJOR_VERSION" = "3" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=v${MAJOR_VERSION}-lts" >> $GITHUB_OUTPUT
+          fi
+      - run: npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description
Because our release pipeline is not version aware, fixes to the v2 release will get tagged as latest on npm causing `npm i @cashu/cashu-ts` to install a v2 version if it was released most recently. This PR adds a bash script to the CI workflow that will adjust the tag depending on the version specified in `package.json` 
