### PR TITLE
feat(wallet): warn v2 users to upgrade to v3 and add test

### DIFF
--- a/src/CashuWallet.ts
+++ b/src/CashuWallet.ts
@@ -110,13 +110,14 @@ class CashuWallet {
 		this.mint = mint;
 		this._logger = options?.logger ?? NULL_LOGGER;
 
+		// When we decide to stop v2 support we should push the warming to console.
 		// Inform consumers that there is a new v3 and they should upgrade.
 		// Keep this log lightweight and safe to run in browser and node environments
-		if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-			console.warn(
-				'cashu-ts v3 has been released. Please upgrade to access the latest features. v2 is now in minimal maintenance mode.',
-			);
-		}
+		// if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+		// 	console.warn(
+		// 		'cashu-ts v3 has been released. Please upgrade to access the latest features. v2 is now in minimal maintenance mode.',
+		// 	);
+		// }
 		this._logger.warn(
 			'cashu-ts v3 has been released. Please upgrade to access the latest features. v2 is now in minimal maintenance mode.',
 		);

--- a/test/wallet.node.test.ts
+++ b/test/wallet.node.test.ts
@@ -19,6 +19,7 @@ import { MintInfo } from '../src/model/MintInfo';
 import { OutputData } from '../src/model/OutputData';
 import { hexToBytes } from '@noble/curves/abstract/utils';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils';
+import { type Logger } from '../src/logger';
 
 injectWebSocketImpl(WebSocket);
 
@@ -90,21 +91,26 @@ afterAll(() => {
 });
 
 describe('upgrade warning to v3 in constructor', () => {
-	test('constructor emits upgrade warning', async () => {
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
-			/* no-op */
-		});
+	test('constructor emits upgrade warning via logger', async () => {
+		const logger: Logger = {
+			fatal: vi.fn(),
+			error: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+			trace: vi.fn(),
+			log: vi.fn(),
+		};
 		const mint = new CashuMint('http://localhost:3338');
 		// Constructing the wallet should trigger the console.warn
 		// eslint-disable-next-line no-new
-		new CashuWallet(mint);
-		expect(warnSpy).toHaveBeenCalled();
+		new CashuWallet(mint, { logger });
+		expect(logger.warn).toHaveBeenCalled();
 		// ensure message mention: unknowns v3 to avoid false positives
-		const calledArgs = warnSpy.mock.calls.flat();
+		const calledArgs = (logger.warn as unknown as vi.Mock).mock.calls.flat();
 		expect(
 			calledArgs.some((a: unknown) => typeof a === 'string' && a.includes('v3 has been released.')),
 		).toBe(true);
-		warnSpy.mockRestore();
 	});
 });
 


### PR DESCRIPTION
# Fixes: #400 


## Description
- Add a runtime warning in CashuWallet constructor:
'cashu-ts v3 has been released. Please upgrade to access the latest features. v2 is now in minimal maintenance mode.'
- Emits a safe console.warn informing users that v3 is available and v2 is in minimal maintenance mode.
- Guarded by typeof console checks so it is safe in browser and Node environments.
- Add unit test to spy on console.warn, constructs a CashuWallet, and asserts the warning is emitted.

This makes the upgrade visible to v2 users at runtime and ensures the warning is covered by automated tests.

## Changes
- CashuWallet.ts
- test/wallet.node.test.ts

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
