### PR TITLE
Change TSDOC tags from alpha -> experimental

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -234,6 +234,18 @@ export const deriveBlindingFactor: (seed: Uint8Array, keysetId: string, counter:
 // @public
 export function deriveKeysetId(keys: Keys, unit?: string, expiry?: number, versionByte?: number, isDeprecatedBase64?: boolean): string;
 
+// @public
+export function deriveP2BKBlindedPubkeys(pubkeys: string[], keysetId: string, eBytes?: Uint8Array): {
+    blinded: string[];
+    Ehex: string;
+};
+
+// @public
+export function deriveP2BKSecretKey(privkey: string | bigint, rBlind: string | bigint, blindPubkey?: Uint8Array, naturalPub?: Uint8Array): string | null;
+
+// @public
+export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[], keysetIdHex: string): string[];
+
 // @public (undocumented)
 export const deriveSecret: (seed: Uint8Array, keysetId: string, counter: number) => Uint8Array;
 
@@ -530,6 +542,9 @@ export interface Logger {
 
 // @public
 export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+// @public
+export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof: Proof): string[];
 
 // @public
 export interface MeltBlanks<T extends MeltQuoteResponse = MeltQuoteResponse> {
@@ -1044,6 +1059,9 @@ export type OutputType = ({
     data: OutputData[];
 };
 
+// @public
+export const P2BK_DST: Uint8Array<ArrayBufferLike>;
+
 // @public (undocumented)
 export class P2PKBuilder {
     // (undocumented)
@@ -1054,6 +1072,8 @@ export class P2PKBuilder {
     addTag(key: string, values?: string[] | string): this;
     // (undocumented)
     addTags(tags: P2PKTag[]): this;
+    // (undocumented)
+    blindKeys(): this;
     // (undocumented)
     static fromOptions(opts: P2PKOptions): P2PKBuilder;
     // (undocumented)

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -398,7 +398,7 @@ export const getSignedOutputs = (
  * @param privateKey Secret key (or array of secret keys)
  * @param proof The proof.
  * @returns Deduplicated list of derived secret keys (hex, 64 chars)
- * @alpha
+ * @experimental
  */
 export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof: Proof): string[] {
 	const privs = Array.isArray(privateKey) ? privateKey : [privateKey];

--- a/src/crypto/NUT26.ts
+++ b/src/crypto/NUT26.ts
@@ -8,7 +8,7 @@ import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass';
 /**
  * BIP340-style domain separation tag (DST) for P2BK.
  *
- * @alpha
+ * @experimental
  */
 export const P2BK_DST = utf8ToBytes('Cashu_P2BK_v1');
 
@@ -25,7 +25,7 @@ export const P2BK_DST = utf8ToBytes('Cashu_P2BK_v1');
  * @param eBytes Optional. Fixed ephemeral secret key to use (eg for SIG_ALL / testing)
  * @returns Blinded pubkeys in the same order, and Ehex as SEC1 compressed hex, 33 bytes.
  * @throws If a blinded key is at infinity.
- * @alpha
+ * @experimental
  */
 export function deriveP2BKBlindedPubkeys(
 	pubkeys: string[],
@@ -65,7 +65,7 @@ export function deriveP2BKBlindedPubkeys(
  * @param blindPubKey Blinded public key or array of blinded public keys, hex.
  * @param keysetIdHex Keyset identifier as hex.
  * @returns Array of derived secret keys as 64 char hex.
- * @alpha
+ * @experimental
  */
 export function deriveP2BKSecretKeys(
 	Ehex: string,
@@ -107,7 +107,7 @@ export function deriveP2BKSecretKeys(
  * @param naturalPub Optional. Pubkey calculated from private key (P = p·G), 33 byte hex.
  * @returns Derived blinded secret key as 64 char hex.
  * @throws If inputs are out of range, or the derived key would be zero.
- * @alpha
+ * @experimental
  */
 export function deriveP2BKSecretKey(
 	privkey: string | bigint,
@@ -175,7 +175,7 @@ export function deriveP2BKSecretKey(
  * @param slotIndex Zero based slot index, only lowest 8 bits (0–255) are used.
  * @returns Tweak (r) in [1, n − 1]
  * @throws If r reduces to zero after the retry.
- * @alpha
+ * @experimental
  */
 function deriveP2BKBlindingTweakFromECDH(
 	point: WeierstrassPoint<bigint>, // E or P

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -67,7 +67,7 @@ export class P2PKBuilder {
 		return this;
 	}
 	/**
-	 * @alpha
+	 * @experimental
 	 */
 	blindKeys() {
 		this._blindKeys = true;


### PR DESCRIPTION
## Description

We tagged the new P2BK functions as `alpha` to mark them as subject to change, but our vite build process excludes `alpha` and `beta` tagged items from the public API. Marking them as `experimental` allows us to surface them but flag them as subject to change.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
