### PR TITLE
Use public API imports in integration tests

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -39,16 +39,14 @@ import {
 	OutputType,
 	P2PKBuilder,
 	MintQuoteBaseResponse,
-} from '../src';
-import ws from 'ws';
-import {
 	getDecodedToken,
 	getEncodedToken,
 	getEncodedTokenV4,
 	hexToNumber,
 	numberToHexPadded64,
 	sumProofs,
-} from '../src/utils';
+} from '../src';
+import ws from 'ws';
 import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils';
 import { sha256 } from '@noble/hashes/sha2';
 dns.setDefaultResultOrder('ipv4first');


### PR DESCRIPTION
 Fixes: #221

  ## Description

  Consolidates imports in `integration.test.ts` to use only the public API entry point (`src/index.ts`), removing direct imports from `src/utils`.

  ## Changes

  - Merged utilities (`getDecodedToken`, `getEncodedToken`, `getEncodedTokenV4`, `hexToNumber`, `numberToHexPadded64`, `sumProofs`) from `../src/utils` into the existing `../src` import

  ## PR Tasks

  - [x] Open PR
  - [x] run `npm run test` --> no failing unit tests
  - [x] run `npm run lint` --> no warnings or errors
  - [x] run `npm run format`
  - [x] run `npm run api:check` --> no API changes (test file only)