### PR TITLE
Domain separator as ASCII text

### DIFF
--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -1,7 +1,7 @@
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha2';
-import { randomBytes, bytesToHex, hexToBytes, type PrivKey } from '@noble/curves/utils';
+import { randomBytes, bytesToHex, type PrivKey, utf8ToBytes } from '@noble/curves/utils';
 import { Bytes, bytesToNumber, hexToNumber, encodeBase64toUint8 } from '../utils';
 import { type P2PKWitness } from '../model/types';
 
@@ -44,7 +44,7 @@ export type SerializedProof = {
 	witness?: string;
 };
 
-const DOMAIN_SEPARATOR = hexToBytes('536563703235366b315f48617368546f43757276655f43617368755f');
+const DOMAIN_SEPARATOR = utf8ToBytes('Secp256k1_HashToCurve_Cashu_');
 
 export function hashToCurve(secret: Uint8Array): WeierstrassPoint<bigint> {
 	const msgToHash = sha256(Bytes.concat(DOMAIN_SEPARATOR, secret));


### PR DESCRIPTION
## Description

For auditability and peace of mind, we should store our DST in plain ASCII text, and not a hex string.

That way, we can see at a glance it hasn't been tampered with.

## Changes

- DST changed from hextobytes(hex) to `utf8ToBytes('Secp256k1_HashToCurve_Cashu_')`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
