### PR TITLE
Fix scalar conversion consistency

### DIFF
--- a/src/crypto/NUT01.ts
+++ b/src/crypto/NUT01.ts
@@ -3,7 +3,7 @@ import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { type RawProof, createRandomSecretKey, hashToCurve } from './core';
 import { HDKey } from '@scure/bip32';
-import { deriveKeysetId, bytesToNumber } from '../utils';
+import { deriveKeysetId } from '../utils';
 
 const DERIVATION_PATH = "m/0'/0'/0'";
 
@@ -75,6 +75,7 @@ export function createNewMintKeys(pow2height: IntRange<0, 65>, seed?: Uint8Array
 
 export function verifyProof(proof: RawProof, privKey: Uint8Array): boolean {
 	const Y: WeierstrassPoint<bigint> = hashToCurve(proof.secret);
-	const aY: WeierstrassPoint<bigint> = Y.multiply(bytesToNumber(privKey));
+	const a = secp256k1.Point.Fn.fromBytes(privKey);
+	const aY: WeierstrassPoint<bigint> = Y.multiply(a);
 	return aY.equals(proof.C);
 }

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -1,5 +1,4 @@
 import { type DLEQ, hash_e, hashToCurve, createRandomSecretKey } from './core';
-import { bytesToNumber } from '../utils';
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass.js';
 import { numberToBytesBE } from '@noble/curves/utils.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
@@ -18,10 +17,12 @@ export const verifyDLEQProof = (
 	C_: WeierstrassPoint<bigint>,
 	A: WeierstrassPoint<bigint>,
 ) => {
-	const sG = secp256k1.Point.BASE.multiply(secp256k1.Point.Fn.fromBytes(dleq.s));
-	const eA = A.multiply(bytesToNumber(dleq.e));
-	const sB_ = B_.multiply(bytesToNumber(dleq.s));
-	const eC_ = C_.multiply(bytesToNumber(dleq.e));
+	const s = secp256k1.Point.Fn.fromBytes(dleq.s);
+	const e = secp256k1.Point.Fn.fromBytes(dleq.e);
+	const sG = secp256k1.Point.BASE.multiply(s);
+	const eA = A.multiply(e);
+	const sB_ = B_.multiply(s);
+	const eC_ = C_.multiply(e);
 	const R_1 = sG.subtract(eA); // R1 = sG - eA
 	const R_2 = sB_.subtract(eC_); // R2 = sB' - eC'
 	const hash = hash_e([R_1, R_2, A, C_]); // e == hash(R1, R2, A, C')

--- a/src/crypto/NUT26.ts
+++ b/src/crypto/NUT26.ts
@@ -187,6 +187,8 @@ function deriveP2BKBlindingTweakFromECDH(
 	const Zx = point.multiply(scalar).toBytes(true).slice(1);
 	const iByte = new Uint8Array([slotIndex & 0xff]);
 	// Derive deterministic blinding factor (r):
+	// Note: bytesToNumber is safe here because we explicitly guard against
+	// out-of-range values below, throwing rather than silently normalizing.
 	let r = bytesToNumber(sha256(Bytes.concat(P2BK_DST, Zx, keysetId, iByte)));
 	if (r === 0n || r >= secp256k1.Point.CURVE().n) {
 		// Very unlikely to get here!

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -103,7 +103,8 @@ export function createBlindSignature(
 	amount: number,
 	id: string,
 ): BlindSignature {
-	const C_: WeierstrassPoint<bigint> = B_.multiply(bytesToNumber(privateKey));
+	const a = secp256k1.Point.Fn.fromBytes(privateKey);
+	const C_: WeierstrassPoint<bigint> = B_.multiply(a);
 	return { C_, amount, id };
 }
 
@@ -139,7 +140,7 @@ export function createRandomRawBlindedMessage(): RawBlindedMessage {
 export function blindMessage(secret: Uint8Array, r?: bigint): RawBlindedMessage {
 	const Y = hashToCurve(secret);
 	if (!r) {
-		r = bytesToNumber(createRandomSecretKey());
+		r = secp256k1.Point.Fn.fromBytes(createRandomSecretKey());
 	}
 	const rG = secp256k1.Point.BASE.multiply(r);
 	const B_ = Y.add(rG);

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -309,6 +309,10 @@ export class OutputData implements OutputDataLike<HasKeysetKeys> {
 		);
 	}
 
+	/**
+	 * @throws May throw if blinding factor is out of range. Caller should catch, increment counter,
+	 *   and retry per BIP32-style derivation.
+	 */
 	static createSingleDeterministicData(
 		amount: number,
 		seed: Uint8Array,
@@ -318,6 +322,8 @@ export class OutputData implements OutputDataLike<HasKeysetKeys> {
 		const secretBytes = deriveSecret(seed, keysetId, counter);
 		const secretBytesAsHex = bytesToHex(secretBytes);
 		const utf8SecretBytes = new TextEncoder().encode(secretBytesAsHex);
+		// Note: bytesToNumber is used here so invalid values bubble up as throws
+		// for BIP32-style retry logic (caller increments counter and retries).
 		const deterministicR = bytesToNumber(deriveBlindingFactor(seed, keysetId, counter));
 		const { r, B_ } = blindMessage(utf8SecretBytes, deterministicR);
 		return new OutputData(


### PR DESCRIPTION
# Fixes: #433 

## Description
Replace `bytesToNumber()` with `Point.Fn.fromBytes()` for scalar operations in elliptic curve point multiplication.

The codebase was mixing two different methods to convert bytes to scalars:
  - `Point.Fn.fromBytes()` - Noble v2 API with proper scalar reduction
  - `bytesToNumber()` - Custom utility without range validation

This inconsistency could cause issues if input bytes exceed the curve order.
  
## Changes
  - `NUT01.ts`: `verifyProof()`
  - `NUT12.ts`: `verifyDLEQProof()`
  - `core.ts`: `createBlindSignature()` and `blindMessage()`

## Not changed (intentionally)
  - `NUT26.ts` - Already has explicit guards that throw on invalid values
  - `OutputData.ts` - Should bubble up throws for BIP32-style retry logic
  
## PR Tasks
- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
