### PR TITLE
Adds isSafeInteger check to assertAmount

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -279,7 +279,7 @@ class Wallet {
 	}
 
 	/**
-	 * Asserts amount is a positive integer.
+	 * Asserts amount is a positive, safe integer.
 	 *
 	 * @param amount To check.
 	 * @param op Caller method name (or other identifier) for debug.
@@ -291,6 +291,7 @@ class Wallet {
 			'Amount must be a positive integer',
 			{ op, amount },
 		);
+		this.failIf(!Number.isSafeInteger(amount), 'Amount must be a safe integer', { op, amount });
 	}
 
 	/**

--- a/test/wallet/wallet-assertAmount.test.ts
+++ b/test/wallet/wallet-assertAmount.test.ts
@@ -8,26 +8,32 @@ const wallet = new Wallet(mintUrl) as any;
 wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
 const expMsg = 'Amount must be a positive integer';
 
-describe('assertInteger', () => {
+describe('assertAmount tests', () => {
 	test('allows valid integers', () => {
-		expect(() => wallet.assertAmount(2561)).not.toThrow();
+		expect(() => wallet.assertAmount(2561, 'test')).not.toThrow();
+		expect(() => wallet.assertAmount(Number.MAX_SAFE_INTEGER, 'test')).not.toThrow(); // exact boundary (2^53 - 1)
 	});
 
 	test('rejects non positive integer numbers', () => {
-		expect(() => wallet.assertAmount(512.0019)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(NaN)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(Infinity)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(-Infinity)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(0)).toThrow(expMsg);
+		expect(() => wallet.assertAmount(512.0019, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(NaN, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(Infinity, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(-Infinity, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(0, 'test')).toThrow(expMsg);
 	});
 
 	test('rejects non number types', () => {
-		expect(() => wallet.assertAmount('2561' as unknown)).toThrow(expMsg);
-		expect(() => wallet.assertAmount('0' as unknown)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(true as unknown)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(false as unknown)).toThrow(expMsg);
-		expect(() => wallet.assertAmount({} as unknown)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(null as unknown)).toThrow(expMsg);
-		expect(() => wallet.assertAmount(undefined as unknown)).toThrow(expMsg);
+		expect(() => wallet.assertAmount('2561' as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount('0' as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(true as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(false as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount({} as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(null as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(undefined as unknown, 'test')).toThrow(expMsg);
+	});
+	test('rejects unsafe integer', () => {
+		const expMsg = 'Amount must be a safe integer';
+		expect(() => wallet.assertAmount(9007199254740992, 'test')).toThrow(expMsg); // 2^53
+		expect(() => wallet.assertAmount(Math.pow(2, 53), 'test')).toThrow(expMsg);
 	});
 });


### PR DESCRIPTION
# Related: #437 

## Description

Until we decide the way forward with issue #437, this adds a loud throw for any amount over the safe integer threshold, rather than allowing amounts to be silently rounded.

## Changes

- Adds `Number.isSafeInteger` check to `assertAmount`
- Adds test coverage for this change

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
