### PR TITLE
fix: validate proof amounts in token decoding

### DIFF
--- a/test/wallet/wallet-assertAmount.test.ts
+++ b/test/wallet/wallet-assertAmount.test.ts
@@ -6,7 +6,6 @@ import { MINTCACHE } from '../consts';
 const mintUrl = 'http://localhost:3338';
 const wallet = new Wallet(mintUrl) as any;
 wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
-const expMsg = 'Amount must be a positive integer';
 
 describe('assertAmount tests', () => {
 	test('allows valid integers', () => {
@@ -14,26 +13,35 @@ describe('assertAmount tests', () => {
 		expect(() => wallet.assertAmount(Number.MAX_SAFE_INTEGER, 'test')).not.toThrow(); // exact boundary (2^53 - 1)
 	});
 
-	test('rejects non positive integer numbers', () => {
-		expect(() => wallet.assertAmount(512.0019, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(NaN, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(Infinity, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(-Infinity, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(0, 'test')).toThrow(expMsg);
+	test('rejects non-integer numbers', () => {
+		expect(() => wallet.assertAmount(512.0019, 'test')).toThrow('Invalid amount: 512.0019');
+		expect(() => wallet.assertAmount(NaN, 'test')).toThrow('Invalid amount: NaN');
+		expect(() => wallet.assertAmount(Infinity, 'test')).toThrow('Invalid amount: Infinity');
+		expect(() => wallet.assertAmount(-Infinity, 'test')).toThrow('Invalid amount: -Infinity');
+	});
+
+	test('rejects zero', () => {
+		expect(() => wallet.assertAmount(0, 'test')).toThrow('Amount must be positive: 0');
 	});
 
 	test('rejects non number types', () => {
-		expect(() => wallet.assertAmount('2561' as unknown, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount('0' as unknown, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(true as unknown, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(false as unknown, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount({} as unknown, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(null as unknown, 'test')).toThrow(expMsg);
-		expect(() => wallet.assertAmount(undefined as unknown, 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount('2561' as unknown, 'test')).toThrow('Invalid amount: 2561');
+		expect(() => wallet.assertAmount('0' as unknown, 'test')).toThrow('Invalid amount: 0');
+		expect(() => wallet.assertAmount(true as unknown, 'test')).toThrow('Invalid amount: true');
+		expect(() => wallet.assertAmount(false as unknown, 'test')).toThrow('Invalid amount: false');
+		expect(() => wallet.assertAmount({} as unknown, 'test')).toThrow('Invalid amount:');
+		expect(() => wallet.assertAmount(null as unknown, 'test')).toThrow('Invalid amount: null');
+		expect(() => wallet.assertAmount(undefined as unknown, 'test')).toThrow(
+			'Invalid amount: undefined',
+		);
 	});
+
 	test('rejects unsafe integer', () => {
-		const expMsg = 'Amount must be a safe integer';
-		expect(() => wallet.assertAmount(9007199254740992, 'test')).toThrow(expMsg); // 2^53
-		expect(() => wallet.assertAmount(Math.pow(2, 53), 'test')).toThrow(expMsg);
+		expect(() => wallet.assertAmount(9007199254740992, 'test')).toThrow(
+			'Amount must be a safe integer',
+		); // 2^53
+		expect(() => wallet.assertAmount(Math.pow(2, 53), 'test')).toThrow(
+			'Amount must be a safe integer',
+		);
 	});
 });


### PR DESCRIPTION
## Summary

  - Add validation to ensure proof amounts are finite non-negative integers when decoding tokens
  - Applies to both V3 (cashuA) and V4 (cashuB) token formats
  - Rejects tokens with invalid amount values (non-numeric, negative, non-integer, ornon-finite)

  ## Changes

  - Added `validateProofAmount()` helper function in `src/utils/core.ts`
  - Validation is applied in `tokenFromTemplate()` for V4 tokens
  - Validation is applied in `handleTokens()` for V3 tokens
  - Added test coverage for the validation logic

  ## Test plan

  - [x] All existing tests pass (`npm test`)
  - [x] Lint passes (`npm run lint`)
  - [x] Format passes (`npm run format`)
  - [x] Build passes (`npm run compile`)
  - [x] API unchanged (`npm run api:check`)

  