### PR TITLE
fix: use string matching for protected endpoint patterns

### DIFF
--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -11,7 +11,7 @@ type Endpoint = { method: Method; path: string };
 type ProtectedIndex = {
 	cache: Record<string, boolean>; // "METHOD /v1/foo"
 	exact: Array<{ method: Method; path: string }>;
-	regex: Array<{ method: Method; regex: RegExp }>;
+	prefix: Array<{ method: Method; path: string }>;
 };
 
 export class MintInfo {
@@ -21,8 +21,6 @@ export class MintInfo {
 	private readonly _protected22?: ProtectedIndex;
 	// NUT-21, Clear-auth protected endpoints
 	private readonly _protected21?: ProtectedIndex;
-	// detects regex intent
-	private readonly REGEX_METACHAR = /[\\^$.*+?()[\]{}|]/;
 
 	constructor(info: GetInfoResponse) {
 		this._mintInfo = info;
@@ -82,11 +80,11 @@ export class MintInfo {
 		if (typeof cached === 'boolean') return cached;
 
 		const exactHit = idx.exact.some((e) => e.method === method && e.path === path);
-		const regexHit = exactHit
+		const prefixHit = exactHit
 			? false
-			: idx.regex.some((e) => e.method === method && e.regex.test(path));
+			: idx.prefix.some((e) => e.method === method && path.startsWith(e.path));
 
-		const res = exactHit || regexHit;
+		const res = exactHit || prefixHit;
 		idx.cache[cacheKey] = res;
 		return res;
 	}
@@ -142,25 +140,21 @@ export class MintInfo {
 		if (!endpoints || endpoints.length === 0) return undefined;
 
 		const exact: ProtectedIndex['exact'] = [];
-		const regex: ProtectedIndex['regex'] = [];
-		const metachar = this.REGEX_METACHAR;
+		const prefix: ProtectedIndex['prefix'] = [];
 
 		for (const e of endpoints) {
-			const looksRegex = e.path.startsWith('^') || e.path.endsWith('$') || metachar.test(e.path);
-			if (looksRegex) {
-				try {
-					regex.push({ method: e.method, regex: new RegExp(e.path) });
-					continue;
-				} catch {
-					// fall back to exact on malformed patterns
-				}
+			let p = e.path;
+			if (p.startsWith('^')) p = p.slice(1);
+			if (p.endsWith('$')) p = p.slice(0, -1);
+			if (p.endsWith('.*')) {
+				prefix.push({ method: e.method, path: p.slice(0, -2) });
+			} else {
+				exact.push({ method: e.method, path: p });
 			}
-			exact.push({ method: e.method, path: e.path });
 		}
 
-		// plain object avoids the unsafe any from Object.create(null)
 		const cache: Record<string, boolean> = {};
-		return { cache, exact, regex };
+		return { cache, exact, prefix };
 	}
 
 	// ---------- getters ----------

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { MintInfo } from '../../src/model/MintInfo';
+
+const baseMintInfo = {
+	name: 'Test Mint',
+	pubkey: '0000',
+	version: 'test/0.1',
+	nuts: {},
+};
+
+describe('MintInfo protected endpoint matching', () => {
+	it('matches exact literal path', () => {
+		const info = new MintInfo({
+			...baseMintInfo,
+			nuts: {
+				22: {
+					protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
+				},
+			},
+		});
+		expect(info.requiresBlindAuthToken('POST', '/v1/swap')).toBe(true);
+		expect(info.requiresBlindAuthToken('POST', '/v1/swap/')).toBe(false);
+		expect(info.requiresBlindAuthToken('POST', '/v1/swapx')).toBe(false);
+		expect(info.requiresBlindAuthToken('GET', '/v1/swap')).toBe(false);
+	});
+
+	it('matches exact anchored path ^...$', () => {
+		const info = new MintInfo({
+			...baseMintInfo,
+			nuts: {
+				22: {
+					protected_endpoints: [{ method: 'POST', path: '^/v1/mint/bolt11$' }],
+				},
+			},
+		});
+		expect(info.requiresBlindAuthToken('POST', '/v1/mint/bolt11')).toBe(true);
+		expect(info.requiresBlindAuthToken('POST', '/v1/mint/bolt11/')).toBe(false);
+		expect(info.requiresBlindAuthToken('POST', '/v1/mint/bolt11/extra')).toBe(false);
+	});
+
+	it('matches prefix pattern ^/path/.*', () => {
+		const info = new MintInfo({
+			...baseMintInfo,
+			nuts: {
+				22: {
+					protected_endpoints: [{ method: 'GET', path: '^/v1/mint/quote/bolt11/.*' }],
+				},
+			},
+		});
+		expect(info.requiresBlindAuthToken('GET', '/v1/mint/quote/bolt11/')).toBe(true);
+		expect(info.requiresBlindAuthToken('GET', '/v1/mint/quote/bolt11/abc123')).toBe(true);
+		expect(info.requiresBlindAuthToken('GET', '/v1/mint/quote/bolt11')).toBe(false);
+		expect(info.requiresBlindAuthToken('POST', '/v1/mint/quote/bolt11/abc')).toBe(false);
+	});
+
+	it('matches prefix pattern ^/path/.*$', () => {
+		const info = new MintInfo({
+			...baseMintInfo,
+			nuts: {
+				22: {
+					protected_endpoints: [{ method: 'POST', path: '^/v1/melt/.*$' }],
+				},
+			},
+		});
+		expect(info.requiresBlindAuthToken('POST', '/v1/melt/')).toBe(true);
+		expect(info.requiresBlindAuthToken('POST', '/v1/melt/quote/bolt11')).toBe(true);
+		expect(info.requiresBlindAuthToken('POST', '/v1/melt')).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- Replace regex-based endpoint matching with simple string operations
- Supports the same NUT-22 patterns: exact match, anchored exact, and prefix with `.*`

## Changes
- `^/v1/foo/bar$` → exact match with `===`
- `^/v1/foo/.*` → prefix match with `startsWith()`
- Plain `/v1/foo/bar` → exact match with `===`