### PR TITLE
fix: validate swap signature count before constructing proofs

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1178,6 +1178,10 @@ class Wallet {
 
 		// Execute swap
 		const { signatures } = await this.mint.swap(swapTransaction.payload);
+		this.failIf(
+			signatures.length < swapTransaction.outputData.length,
+			`Mint returned ${signatures.length} signatures, expected ${swapTransaction.outputData.length}`,
+		);
 
 		// Construct proofs
 		const keyset = this.getKeyset(swapPreview.keysetId);


### PR DESCRIPTION
## Summary
Add signature count validation in swap flow, matching the pattern used in mint and melt flows.

## Changes
Validates that the number of signatures returned by the mint matches the number of outputs before constructing proofs.