### PR TITLE
bugfix:deprecated mint types were linked to melt types

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -592,7 +592,7 @@ export type KeysetPair = {
 };
 
 // @public @deprecated (undocumented)
-export type LockedMintQuoteResponse = MeltQuoteBolt11Response;
+export type LockedMintQuoteResponse = MintQuoteBolt11Response;
 
 // @public (undocumented)
 export type LockState = 'PERMANENT' | 'ACTIVE' | 'EXPIRED';
@@ -1037,7 +1037,7 @@ export type MintQuoteFor<M extends MintMethod> = M extends 'bolt11' ? string | M
 export type MintQuotePayload = MintQuoteBolt11Request;
 
 // @public @deprecated (undocumented)
-export type MintQuoteResponse = MeltQuoteBolt11Response;
+export type MintQuoteResponse = MintQuoteBolt11Response;
 
 // @public (undocumented)
 export const MintQuoteState: {
@@ -1305,7 +1305,7 @@ export function parseSecret(secret: string | Secret): Secret;
 export type PartialMeltQuoteResponse = MeltQuoteBolt11Response;
 
 // @public @deprecated
-export type PartialMintQuoteResponse = MeltQuoteBolt11Response;
+export type PartialMintQuoteResponse = MintQuoteBolt11Response;
 
 // @public (undocumented)
 class PaymentRequest_2 {

--- a/src/mint/types/_deprecated.ts
+++ b/src/mint/types/_deprecated.ts
@@ -1,4 +1,5 @@
 import {
+	type MintQuoteBolt11Response,
 	type MintQuoteBolt12Response,
 	type MeltQuoteBolt11Response,
 	type MeltQuoteBolt12Response,
@@ -26,17 +27,17 @@ export type Bolt12MeltQuoteResponse = MeltQuoteBolt12Response;
  *
  * @deprecated - Use MintQuoteBolt11Response or MintQuoteBolt12Response.
  */
-export type PartialMintQuoteResponse = MeltQuoteBolt11Response;
+export type PartialMintQuoteResponse = MintQuoteBolt11Response;
 
 /**
  * @deprecated - Use MintQuoteBolt11Response.
  */
-export type MintQuoteResponse = MeltQuoteBolt11Response;
+export type MintQuoteResponse = MintQuoteBolt11Response;
 
 /**
  * @deprecated - Use MintQuoteBolt11Response.
  */
-export type LockedMintQuoteResponse = MeltQuoteBolt11Response;
+export type LockedMintQuoteResponse = MintQuoteBolt11Response;
 
 /**
  * Response from the mint after requesting a BOLT12 mint quote. Contains a Lightning Network offer


### PR DESCRIPTION
## Description

Fixes a bug where deprecated mint types were incorrectly linked to the melt type (`MeltQuoteBolt11Response`), not the mint type (`MintQuoteBolt11Response`)

## Changes

- `LockedMintQuoteResponse`
- `MintQuoteResponse`
- `PartialMintQuoteResponse `

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
