### PR TITLE
Chore: Upgrade MSW

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"eslint-plugin-promise": "^7.2.1",
 				"globals": "^16.3.0",
 				"mock-socket": "^9.3.1",
-				"msw": "^2.6.6",
+				"msw": "^2.12.4",
 				"node-fetch": "^3.3.2",
 				"playwright": "^1.54.1",
 				"prettier": "^3.6.2",
@@ -148,26 +148,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@bundled-es-modules/cookie": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
-			"integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cookie": "^0.7.2"
-			}
-		},
-		"node_modules/@bundled-es-modules/statuses": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
-			"integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"statuses": "^2.0.1"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -1218,9 +1198,9 @@
 			}
 		},
 		"node_modules/@mswjs/interceptors": {
-			"version": "0.39.6",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
-			"integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.40.0.tgz",
+			"integrity": "sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1993,13 +1973,6 @@
 			"dependencies": {
 				"@types/deep-eql": "*"
 			}
-		},
-		"node_modules/@types/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
@@ -3896,13 +3869,17 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/core-util-is": {
@@ -5648,9 +5625,9 @@
 			"license": "MIT"
 		},
 		"node_modules/graphql": {
-			"version": "16.11.0",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-			"integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+			"integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7461,30 +7438,29 @@
 			"license": "MIT"
 		},
 		"node_modules/msw": {
-			"version": "2.11.3",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-2.11.3.tgz",
-			"integrity": "sha512-878imp8jxIpfzuzxYfX0qqTq1IFQz/1/RBHs/PyirSjzi+xKM/RRfIpIqHSCWjH0GxidrjhgiiXC+DWXNDvT9w==",
+			"version": "2.12.4",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-2.12.4.tgz",
+			"integrity": "sha512-rHNiVfTyKhzc0EjoXUBVGteNKBevdjOlVC6GlIRXpy+/3LHEIGRovnB5WPjcvmNODVQ1TNFnoa7wsGbd0V3epg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@bundled-es-modules/cookie": "^2.0.1",
-				"@bundled-es-modules/statuses": "^1.0.1",
 				"@inquirer/confirm": "^5.0.0",
-				"@mswjs/interceptors": "^0.39.1",
+				"@mswjs/interceptors": "^0.40.0",
 				"@open-draft/deferred-promise": "^2.2.0",
-				"@types/cookie": "^0.6.0",
-				"@types/statuses": "^2.0.4",
-				"graphql": "^16.8.1",
+				"@types/statuses": "^2.0.6",
+				"cookie": "^1.0.2",
+				"graphql": "^16.12.0",
 				"headers-polyfill": "^4.0.2",
 				"is-node-process": "^1.2.0",
 				"outvariant": "^1.4.3",
 				"path-to-regexp": "^6.3.0",
 				"picocolors": "^1.1.1",
 				"rettime": "^0.7.0",
+				"statuses": "^2.0.2",
 				"strict-event-emitter": "^0.5.1",
 				"tough-cookie": "^6.0.0",
-				"type-fest": "^4.26.1",
+				"type-fest": "^5.2.0",
 				"until-async": "^3.0.2",
 				"yargs": "^17.7.2"
 			},
@@ -9273,6 +9249,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/tapable": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
@@ -9674,13 +9663,16 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.3.1.tgz",
+			"integrity": "sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"eslint-plugin-promise": "^7.2.1",
 		"globals": "^16.3.0",
 		"mock-socket": "^9.3.1",
-		"msw": "^2.6.6",
+		"msw": "^2.12.4",
 		"node-fetch": "^3.3.2",
 		"playwright": "^1.54.1",
 		"prettier": "^3.6.2",


### PR DESCRIPTION
## Description

Mock Service Worker (MSW) was outdated and causing test errors in Node 25.x due to localStorage handling.

```bash
TypeError: localStorage.getItem is not a function
 ❯ CookieStore.getCookieStoreIndex node_modules/msw/src/core/utils/cookieStore.ts:43:40
 ❯ new CookieStore node_modules/msw/src/core/utils/cookieStore.ts:25:34
 ❯ node_modules/msw/src/core/utils/cookieStore.ts:88:28
```

## Changes

- Upgraded `msw` package to latest (v2.12.4)

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
