### PR TITLE
fix mint proofs method name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const mintQuote = await wallet.createMintQuoteBolt11(64);
 // pay the invoice here before you continue...
 const mintQuoteChecked = await wallet.checkMintQuoteBolt11(mintQuote.quote);
 if (mintQuoteChecked.state === MintQuoteState.PAID) {
-	const proofs = await wallet.mintProofs(64, mintQuote.quote);
+	const proofs = await wallet.mintProofsBolt11(64, mintQuote.quote);
 }
 // store proofs in your app ..
 ```


### PR DESCRIPTION
# Fixes: #[issue]

## Description

README was still using function `mintProofs()` which is marked as deprecated.

Changed function to `mintProofsBolt11()`

...

## Changes

- README.md

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
