### PR TITLE
docs: add descriptions to implemented NUTs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,32 +30,32 @@ Wallet Features:
 
 Implemented [NUTs](https://github.com/cashubtc/nuts/):
 
-- [x] [NUT-00](https://github.com/cashubtc/nuts/blob/main/00.md)
-- [x] [NUT-01](https://github.com/cashubtc/nuts/blob/main/01.md)
-- [x] [NUT-02](https://github.com/cashubtc/nuts/blob/main/02.md)
-- [x] [NUT-03](https://github.com/cashubtc/nuts/blob/main/03.md)
-- [x] [NUT-04](https://github.com/cashubtc/nuts/blob/main/04.md)
-- [x] [NUT-05](https://github.com/cashubtc/nuts/blob/main/05.md)
-- [x] [NUT-06](https://github.com/cashubtc/nuts/blob/main/06.md)
-- [x] [NUT-07](https://github.com/cashubtc/nuts/blob/main/07.md)
-- [x] [NUT-08](https://github.com/cashubtc/nuts/blob/main/08.md)
-- [x] [NUT-09](https://github.com/cashubtc/nuts/blob/main/09.md)
-- [x] [NUT-10](https://github.com/cashubtc/nuts/blob/main/10.md)
-- [x] [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md)
-- [x] [NUT-12](https://github.com/cashubtc/nuts/blob/main/12.md)
-- [x] [NUT-13](https://github.com/cashubtc/nuts/blob/main/13.md)
-- [x] [NUT-14](https://github.com/cashubtc/nuts/blob/main/14.md)
-- [ ] [NUT-15](https://github.com/cashubtc/nuts/blob/main/15.md)
-- [ ] [NUT-16](https://github.com/cashubtc/nuts/blob/main/16.md)
-- [x] [NUT-17](https://github.com/cashubtc/nuts/blob/main/17.md)
-- [x] [NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md)
-- [ ] [NUT-19](https://github.com/cashubtc/nuts/blob/main/19.md)
-- [x] [NUT-20](https://github.com/cashubtc/nuts/blob/main/20.md)
-- [x] [NUT-21](https://github.com/cashubtc/nuts/blob/main/21.md)
-- [x] [NUT-22](https://github.com/cashubtc/nuts/blob/main/22.md)
-- [x] [NUT-23](https://github.com/cashubtc/nuts/blob/main/23.md)
-- [ ] [NUT-24](https://github.com/cashubtc/nuts/blob/main/24.md)
-- [x] [NUT-25](https://github.com/cashubtc/nuts/blob/main/25.md)
+- [x] [NUT-00](https://github.com/cashubtc/nuts/blob/main/00.md) | Notation, Utilization, and Terminology |
+- [x] [NUT-01](https://github.com/cashubtc/nuts/blob/main/01.md) | Mint public key exchange |
+- [x] [NUT-02](https://github.com/cashubtc/nuts/blob/main/02.md) | Keysets and fees |
+- [x] [NUT-03](https://github.com/cashubtc/nuts/blob/main/03.md) | Swap tokens |
+- [x] [NUT-04](https://github.com/cashubtc/nuts/blob/main/04.md) | Mint tokens |
+- [x] [NUT-05](https://github.com/cashubtc/nuts/blob/main/05.md) | Melting tokens |
+- [x] [NUT-06](https://github.com/cashubtc/nuts/blob/main/06.md) | Mint information |
+- [x] [NUT-07](https://github.com/cashubtc/nuts/blob/main/07.md) | Token state check |
+- [x] [NUT-08](https://github.com/cashubtc/nuts/blob/main/08.md) | Lightning fee return |
+- [x] [NUT-09](https://github.com/cashubtc/nuts/blob/main/09.md) | Restore signatures |
+- [x] [NUT-10](https://github.com/cashubtc/nuts/blob/main/10.md) | Spending conditions |
+- [x] [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md) | Pay to Public Key (P2PK) |
+- [x] [NUT-12](https://github.com/cashubtc/nuts/blob/main/12.md) | Offline ecash signature validation |
+- [x] [NUT-13](https://github.com/cashubtc/nuts/blob/main/13.md) | Deterministic Secrets |
+- [x] [NUT-14](https://github.com/cashubtc/nuts/blob/main/14.md) | Hashed Timelock Contracts (HTLCs) |
+- [ ] [NUT-15](https://github.com/cashubtc/nuts/blob/main/15.md) | Partial multi-path payments |
+- [ ] [NUT-16](https://github.com/cashubtc/nuts/blob/main/16.md) | Animated QR codes |
+- [x] [NUT-17](https://github.com/cashubtc/nuts/blob/main/17.md) | WebSockets |
+- [x] [NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md) | Payment Requests |
+- [ ] [NUT-19](https://github.com/cashubtc/nuts/blob/main/19.md) | Cached Responses |
+- [x] [NUT-20](https://github.com/cashubtc/nuts/blob/main/20.md) | Signature on Mint Quote |
+- [x] [NUT-21](https://github.com/cashubtc/nuts/blob/main/21.md) | Clear Authentication |
+- [x] [NUT-22](https://github.com/cashubtc/nuts/blob/main/22.md) | Blind Authentication |
+- [x] [NUT-23](https://github.com/cashubtc/nuts/blob/main/23.md) | BOLT11 |
+- [ ] [NUT-24](https://github.com/cashubtc/nuts/blob/main/24.md) | HTTP 402 Payment Required |
+- [x] [NUT-25](https://github.com/cashubtc/nuts/blob/main/25.md) | BOLT12 |
 
 Supported token formats:
 


### PR DESCRIPTION
## Description
Currently, the README lists implemented NUTs by number only. This requires developers to cross-reference the spec or click through to see which NUT is which feature.

## Changes

- Added official descriptions/titles next to each NUT link in the Implemented NUTs section. I took the exact naming from each page.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API

**Note:**
This is a documentation-only update (`README.md`). It does not alter any logic or API surfaces, so I have marked the test/api checks as passed/not applicable.
