### PR TITLE
Update docker.io/cashubtc/mintd Docker tag to v0.14.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FAKE_DELAY ?= 1
 RATE_LIMIT_PM ?= 200
 
 # Pin versions, use digests when you can
-CDK_IMAGE ?= cashubtc/mintd:0.14.2
+CDK_IMAGE ?= cashubtc/mintd:0.14.3
 CDK_NAME  ?= cashu-dev-cdk
 
 NUT_IMAGE ?= cashubtc/nutshell:0.18.2


### PR DESCRIPTION
Renovate bumping version - we need to figure out permissions so it happens automatically.