### PR TITLE
MintQuoteBolt11Response amount

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1010,7 +1010,7 @@ export type MintQuoteBolt11Request = MintQuoteBaseRequest & {
 
 // @public
 export type MintQuoteBolt11Response = MintQuoteBaseResponse & {
-    amount?: number;
+    amount: number;
     state: MintQuoteState;
     expiry: number;
 };

--- a/src/model/types/NUT23.ts
+++ b/src/model/types/NUT23.ts
@@ -26,7 +26,7 @@ export type MintQuoteBolt11Response = MintQuoteBaseResponse & {
 	/**
 	 * Amount requested for mint quote.
 	 */
-	amount?: number;
+	amount: number;
 	/**
 	 * State of the mint quote.
 	 */


### PR DESCRIPTION
## Description

`MintQuoteBolt11Response.amount` was optional for backwards compatibility. Cashu-TS now ensures amount in `createMintQuoteBolt11`, and no mints are running software old enough to matter.

This PR makes `MintQuoteBolt11Response.amount` a required param.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
