### PR TITLE
fix: standalone asset build in CI

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -30,7 +30,7 @@ jobs:
       - run: npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm run build:standalone
+      - run: npm run compile:standalone
       - name: Upload standalone bundle assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Our IIFE asset build was failing due to an incorrect script command in CI. Now fixed.

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
