### PR TITLE
chore: fix permissions on typescript workflow

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1831,15 +1831,6 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/@scure/bip32/node_modules/@scure/base": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-			"integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/@shikijs/engine-oniguruma": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.13.0.tgz",


### PR DESCRIPTION
Adds write permission to allow writing to the `gh-pages` branch.
