### PR TITLE
feat: add new glob prefix wildcard match for nut-21/22

### DIFF
--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -66,4 +66,21 @@ describe('MintInfo protected endpoint matching', () => {
 		expect(info.requiresBlindAuthToken('POST', '/v1/melt/quote/bolt11')).toBe(true);
 		expect(info.requiresBlindAuthToken('POST', '/v1/melt')).toBe(false);
 	});
+
+	it('matches prefix pattern /path/*', () => {
+		const info = new MintInfo({
+			...baseMintInfo,
+			nuts: {
+				22: {
+					protected_endpoints: [{ method: 'GET', path: '/v1/mint/quote/bolt*' }],
+				},
+			},
+		});
+		expect(info.requiresBlindAuthToken('GET', '/v1/mint/quote/bolt11/')).toBe(true);
+		expect(info.requiresBlindAuthToken('GET', '/v1/mint/quote/bolt11/abc123')).toBe(true);
+		expect(info.requiresBlindAuthToken('GET', '/v1/mint/quote/bolt12')).toBe(true);
+		expect(info.requiresBlindAuthToken('GET', '/v1/melt/quote')).toBe(false);
+		expect(info.requiresBlindAuthToken('POST', '/v1/mint/quote/bolt11/abc')).toBe(false);
+		expect(info.requiresBlindAuthToken('GET', '/v1/melt/quote/bolt12')).toBe(false);
+	});
 });


### PR DESCRIPTION
# Fixes: https://github.com/cashubtc/nuts/pull/334

## Description

Adds the new glob style wildcard matching rules and tests.
## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
