### PR TITLE
chore(sigall): remove interim sig_all message format

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -614,40 +614,11 @@ export function isP2PKSigAll(inputs: Proof[]): boolean {
 // ------------------------------
 
 /**
- * Message aggregation for SIG_ALL (interim format).
- *
- * @remarks
- * Melt transactions MUST include the quoteId.
- * @deprecated - For compatibility with NutShell < v18.2.
- * @internal
- */
-export function buildInterimP2PKSigAllMessage(
-	inputs: Proof[],
-	outputs: OutputDataLike[],
-	quoteId?: string,
-): string {
-	const parts: string[] = [];
-	// Concat inputs: secret_0 || C_0 ...
-	for (const p of inputs) {
-		parts.push(p.secret, p.C);
-	}
-	// Concat outputs: amount_0 || id_0 || B_0 ...
-	for (const o of outputs) {
-		parts.push(String(o.blindedMessage.amount), o.blindedMessage.id, o.blindedMessage.B_);
-	}
-	// Add quoteId for melts
-	if (quoteId) {
-		parts.push(quoteId);
-	}
-	return parts.join('');
-}
-
-/**
  * Message aggregation for SIG_ALL (legacy format).
  *
  * @remarks
  * Melt transactions MUST include the quoteId.
- * @deprecated - For compatibility with NutShell < v18.0, CDK < v0.14.1.
+ * @deprecated - For compatibility with NutShell (all releases), CDK < v0.14.0.
  * @internal
  */
 export function buildLegacyP2PKSigAllMessage(

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -37,7 +37,6 @@ import {
 	buildP2PKSigAllMessage,
 	assertSigAllInputs,
 	buildLegacyP2PKSigAllMessage,
-	buildInterimP2PKSigAllMessage,
 } from '../crypto';
 import { Mint } from '../mint';
 import { MintInfo } from '../model/MintInfo';
@@ -1339,7 +1338,6 @@ class Wallet {
 		let signedFirst = first;
 		const messages = [
 			buildLegacyP2PKSigAllMessage(proofs, outputData, quoteId),
-			buildInterimP2PKSigAllMessage(proofs, outputData, quoteId),
 			buildP2PKSigAllMessage(proofs, outputData, quoteId),
 		];
 		for (const msg of messages) {

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -25,7 +25,6 @@ import {
 	buildP2PKSigAllMessage,
 	assertSigAllInputs,
 	buildLegacyP2PKSigAllMessage,
-	buildInterimP2PKSigAllMessage,
 	createSecret,
 	getP2PKNSigsRefund,
 	isHTLCSpendAuthorised,
@@ -962,8 +961,8 @@ describe('branch coverage helpers', () => {
 	});
 });
 
-describe('SIG_ALL, all three message formats are actually signed', () => {
-	test('first proof witness contains signatures for legacy, interim and final SIG_ALL messages', () => {
+describe('SIG_ALL, both message formats are actually signed', () => {
+	test('first proof witness contains signatures for legacy and final SIG_ALL messages', () => {
 		// 1. Set up a keypair and a SIG_ALL P2PK secret
 		const privBytes = schnorr.utils.randomSecretKey();
 		const privHex = bytesToHex(privBytes);
@@ -1002,10 +1001,9 @@ describe('SIG_ALL, all three message formats are actually signed', () => {
 
 		// 4. Build the three distinct SIG_ALL messages the wallet is supposed to sign
 		const legacyMsg = buildLegacyP2PKSigAllMessage(proofs, outputs, quoteId);
-		const interimMsg = buildInterimP2PKSigAllMessage(proofs, outputs, quoteId);
 		const finalMsg = buildP2PKSigAllMessage(proofs, outputs, quoteId);
 
-		const messages = [legacyMsg, interimMsg, finalMsg];
+		const messages = [legacyMsg, finalMsg];
 
 		// 5. Mimic the wallet SIG_ALL path:
 		//    start from the first proof, then sign it three times with the three messages,
@@ -1018,8 +1016,8 @@ describe('SIG_ALL, all three message formats are actually signed', () => {
 
 		const sigs = getP2PKWitnessSignatures(signedFirst.witness);
 
-		// Sanity: we really appended three signatures
-		expect(sigs.length).toBe(3);
+		// Sanity: we really appended two signatures
+		expect(sigs.length).toBe(2);
 
 		// 6. For each message variant, there must be at least one signature that verifies
 		//    against that specific message and this pubkey.


### PR DESCRIPTION
Nutshell never released the interim sig_all format (which included keyset ID), it was reverted before actual release.

Added: https://github.com/cashubtc/nutshell/pull/804
Reverted: https://github.com/cashubtc/nutshell/pull/810

So cleaning it out now, before v4 cashu-ts. It was marked as @internal, so does not affect public API.

## PR Tasks

- [x] Open PR (base: `main` branch)
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run lint` --> no warnings or errors
- [x] run `npm run format`
- [x] run `npm run api:check` --> run `npm run api:update` for changes to the API
