### PR TITLE
feat(core): add utility functions, remove deprecation

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -120,6 +120,15 @@ export type CheckStateResponse = {
 };
 
 // @public
+export function computeMessageDigest(message: string): Uint8Array;
+
+// @public (undocumented)
+export function computeMessageDigest(message: string, asHex: false): Uint8Array;
+
+// @public (undocumented)
+export function computeMessageDigest(message: string, asHex: true): string;
+
+// @public
 export class ConsoleLogger implements Logger {
     constructor(minLevel?: LogLevel);
     // (undocumented)
@@ -259,6 +268,9 @@ export type DeviceStartResponse = {
     interval?: number;
     expires_in?: number;
 };
+
+// @public (undocumented)
+export type DigestInput = Uint8Array | string;
 
 // @public (undocumented)
 export type DLEQ = {
@@ -1520,6 +1532,9 @@ export type RpcSubKinds = 'bolt11_mint_quote' | 'bolt11_melt_quote' | 'proof_sta
 
 // @public (undocumented)
 export function sanitizeUrl(url: string): string;
+
+// @public
+export const schnorrSignDigest: (digest: DigestInput, privateKey: PrivKey) => string;
 
 // @public
 export const schnorrSignMessage: (message: string, privateKey: PrivKey) => string;

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -617,8 +617,8 @@ export function isP2PKSigAll(inputs: Proof[]): boolean {
  * Message aggregation for SIG_ALL (legacy format).
  *
  * @remarks
- * Melt transactions MUST include the quoteId.
- * @deprecated - For compatibility with NutShell (all releases), CDK < v0.14.0.
+ * Melt transactions MUST include the quoteId. For compatibility with NutShell (all releases), CDK <
+ * v0.14.0.
  * @internal
  */
 export function buildLegacyP2PKSigAllMessage(


### PR DESCRIPTION
Adds core utility functions `schnorrSignDigest`, `computeMessageDigest`.

Removes deprecation notice on `buildLegacyP2PKSigAllMessage` (Nutshell will need it a long time yet).

