### PR TITLE
feat(nut29): wire NUT-06 max_batch_size into prepareBatchMint enforcement

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -840,7 +840,7 @@ export type MintContactInfo = {
 
 // @public (undocumented)
 export class MintInfo {
-    constructor(info: GetInfoResponse);
+    constructor(info: GetInfoResponse, logger?: Logger);
     // (undocumented)
     get cache(): GetInfoResponse;
     // (undocumented)
@@ -883,7 +883,7 @@ export class MintInfo {
     // (undocumented)
     get name(): string;
     // (undocumented)
-    static normalizeInfo(info: GetInfoResponse): GetInfoResponse;
+    static normalizeInfo(info: GetInfoResponse, logger?: Logger): GetInfoResponse;
     // (undocumented)
     get nuts(): {
         '4': {

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -413,6 +413,7 @@ export type GetInfoResponse = {
                 path: string;
             }>;
         };
+        '29'?: Nut29Info;
     };
     motd?: string;
 };
@@ -873,6 +874,11 @@ export class MintInfo {
         params?: Nut19Policy;
     };
     // (undocumented)
+    isSupported(num: 29): {
+        supported: boolean;
+        params?: Nut29Info;
+    };
+    // (undocumented)
     get motd(): string | undefined;
     // (undocumented)
     get name(): string;
@@ -940,6 +946,7 @@ export class MintInfo {
                 path: string;
             }>;
         };
+        '29'?: Nut29Info;
     };
     // (undocumented)
     get pubkey(): string;
@@ -1096,6 +1103,12 @@ export type Nut19Policy = {
         method: 'GET' | 'POST';
         path: string;
     }>;
+};
+
+// @public
+export type Nut29Info = {
+    methods?: string[];
+    max_batch_size?: number;
 };
 
 // @public (undocumented)

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -18,6 +18,7 @@ import {
   normalizeMintKeys,
   normalizeMintKeyset,
   normalizeSafeIntegerMetadata,
+  ABSOLUTE_MAX_PER_MINT,
 } from '../utils';
 import { KeyChain, type Keyset } from '../wallet';
 
@@ -28,7 +29,7 @@ export type AuthManagerOptions = {
   /**
    * Hard limit to target when minting BATs in one request. If omitted, we'll read
    * `nuts['22'].bat_max_mint` from the mint "/v1/info" endpoint. Values above the
-   * `AuthManager.ABSOLUTE_MAX_PER_MINT` internal hard cap are clamped.
+   * `ABSOLUTE_MAX_PER_MINT` internal hard cap are clamped.
    */
   maxPerMint?: number;
   /**
@@ -70,8 +71,6 @@ type BlindAuthMintResponse = {
  * - Supplies serialized BATs for 'Blind-auth' and CAT for 'Clear-auth'
  */
 export class AuthManager implements AuthProvider {
-  private static readonly ABSOLUTE_MAX_PER_MINT = 100;
-
   private readonly mintUrl: string;
   private readonly req: RequestFn;
   private readonly logger: Logger;
@@ -86,8 +85,8 @@ export class AuthManager implements AuthProvider {
 
   // Blind Auth Token (BAT) pool
   private pool: Proof[] = [];
-  private desiredPoolSize = AuthManager.ABSOLUTE_MAX_PER_MINT;
-  private maxPerMint = AuthManager.ABSOLUTE_MAX_PER_MINT;
+  private desiredPoolSize = ABSOLUTE_MAX_PER_MINT;
+  private maxPerMint = ABSOLUTE_MAX_PER_MINT;
 
   // Keychain for 'auth' unit
   private keychain?: KeyChain;
@@ -99,8 +98,8 @@ export class AuthManager implements AuthProvider {
     const desiredPoolSize = Math.max(1, opts?.desiredPoolSize ?? this.desiredPoolSize);
     const maxPerMint = Math.max(1, opts?.maxPerMint ?? this.maxPerMint);
 
-    this.desiredPoolSize = Math.min(desiredPoolSize, AuthManager.ABSOLUTE_MAX_PER_MINT);
-    this.maxPerMint = Math.min(maxPerMint, AuthManager.ABSOLUTE_MAX_PER_MINT);
+    this.desiredPoolSize = Math.min(desiredPoolSize, ABSOLUTE_MAX_PER_MINT);
+    this.maxPerMint = Math.min(maxPerMint, ABSOLUTE_MAX_PER_MINT);
 
     if (this.desiredPoolSize !== desiredPoolSize) {
       this.logger.warn('AuthManager: desiredPoolSize exceeds internal cap and was clamped', {

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -350,7 +350,7 @@ export class AuthManager implements AuthProvider {
         endpoint: joinUrls(this.mintUrl, '/v1/info'),
         method: 'GET',
       });
-      this.info = new MintInfo(info);
+      this.info = new MintInfo(info, this.logger);
     }
     if (!this.keychain) {
       // fetch blind keysets and keys for unit 'auth'

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export * from './model/types/NUT07';
 export type * from './model/types/NUT19';
 export type * from './model/types/NUT23';
 export type * from './model/types/NUT25';
-export type { BatchMintRequest } from './model/types/NUT29';
+export type { BatchMintRequest, Nut29Info } from './model/types/NUT29';
 export type * from './model/types/proof';
 export type { Token, TokenMetadata } from './model/types/token';
 

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -162,7 +162,7 @@ class Mint {
       return this._mintInfo;
     }
     const data = await this.getInfo(customRequest);
-    this._mintInfo = new MintInfo(data);
+    this._mintInfo = new MintInfo(data, this._logger);
     return this._mintInfo;
   }
 
@@ -170,7 +170,7 @@ class Mint {
    * Seeds the mint-info cache from already-fetched data.
    */
   setMintInfo(mintInfo: MintInfo | GetInfoResponse): void {
-    this._mintInfo = mintInfo instanceof MintInfo ? mintInfo : new MintInfo(mintInfo);
+    this._mintInfo = mintInfo instanceof MintInfo ? mintInfo : new MintInfo(mintInfo, this._logger);
   }
 
   // -----------------------------------------------------------------

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,3 +1,4 @@
+import { type Logger, NULL_LOGGER } from '../logger';
 import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
@@ -26,8 +27,9 @@ export class MintInfo {
   // NUT-21, Clear-auth protected endpoints
   private readonly _protected21?: ProtectedIndex;
 
-  constructor(info: GetInfoResponse) {
-    this._mintInfo = MintInfo.normalizeInfo(info);
+  constructor(info: GetInfoResponse, logger?: Logger) {
+    const log = logger ?? NULL_LOGGER;
+    this._mintInfo = MintInfo.normalizeInfo(info, log);
 
     const pe22 = this.toEndpoints(this._mintInfo?.nuts?.[22]?.protected_endpoints);
     this._protected22 = this.buildIndex(pe22);
@@ -36,14 +38,14 @@ export class MintInfo {
     this._protected21 = this.buildIndex(pe21);
   }
 
-  static normalizeInfo(info: GetInfoResponse): GetInfoResponse {
+  static normalizeInfo(info: GetInfoResponse, logger: Logger = NULL_LOGGER): GetInfoResponse {
     return {
       ...info,
       nuts: {
         ...info.nuts,
         ...(info.nuts['19'] ? { '19': MintInfo.normalizeNut19(info.nuts['19']) } : {}),
-        ...(info.nuts['22'] ? { '22': MintInfo.normalizeNut22(info.nuts['22']) } : {}),
-        ...(info.nuts['29'] ? { '29': MintInfo.normalizeNut29(info.nuts['29']) } : {}),
+        ...(info.nuts['22'] ? { '22': MintInfo.normalizeNut22(info.nuts['22'], logger) } : {}),
+        ...(info.nuts['29'] ? { '29': MintInfo.normalizeNut29(info.nuts['29'], logger) } : {}),
       },
     };
   }
@@ -61,29 +63,26 @@ export class MintInfo {
 
   private static normalizeNut22(
     nut22: GetInfoResponse['nuts']['22'],
+    logger: Logger,
   ): GetInfoResponse['nuts']['22'] {
     if (!nut22) return nut22;
 
-    let bat_max_mint: number | undefined;
-    if (nut22.bat_max_mint != null) {
-      try {
-        bat_max_mint = normalizeSafeIntegerMetadata(
-          nut22.bat_max_mint,
-          'nuts.22.bat_max_mint',
-          ABSOLUTE_MAX_PER_MINT,
-        );
-      } catch {
-        // Malformed value from mint (e.g. float, NaN, negative).
-        // Static method — no instance logger available; console.warn is intentional here.
-        console.warn('MintInfo: nuts.22.bat_max_mint is malformed, defaulting to internal cap', {
-          value: nut22.bat_max_mint,
-        });
-      }
+    let bat_max_mint = ABSOLUTE_MAX_PER_MINT;
+    try {
+      bat_max_mint = normalizeSafeIntegerMetadata(
+        nut22.bat_max_mint,
+        'nuts.22.bat_max_mint',
+        ABSOLUTE_MAX_PER_MINT,
+      );
+    } catch {
+      logger.warn('MintInfo: nuts.22.bat_max_mint is malformed, defaulting to internal cap', {
+        value: nut22.bat_max_mint,
+      });
+      // bat_max_mint stays at ABSOLUTE_MAX_PER_MINT — initialized above
     }
 
-    if (bat_max_mint != null && bat_max_mint > ABSOLUTE_MAX_PER_MINT) {
-      // Static method — no instance logger available; console.warn is intentional here.
-      console.warn('MintInfo: nuts.22.bat_max_mint exceeds internal cap and was clamped', {
+    if (bat_max_mint > ABSOLUTE_MAX_PER_MINT) {
+      logger.warn('MintInfo: nuts.22.bat_max_mint exceeds internal cap and was clamped', {
         advertised: bat_max_mint,
         clampedTo: ABSOLUTE_MAX_PER_MINT,
       });
@@ -92,47 +91,43 @@ export class MintInfo {
 
     return {
       ...nut22,
-      bat_max_mint: bat_max_mint ?? ABSOLUTE_MAX_PER_MINT,
+      bat_max_mint,
     };
   }
 
   private static normalizeNut29(
     nut29: GetInfoResponse['nuts']['29'],
+    logger: Logger,
   ): GetInfoResponse['nuts']['29'] {
     if (!nut29) return nut29;
 
-    let max_batch_size: number | undefined;
-    if (nut29.max_batch_size != null) {
-      try {
-        max_batch_size = normalizeSafeIntegerMetadata(
-          nut29.max_batch_size,
-          'nuts.29.max_batch_size',
-          ABSOLUTE_MAX_BATCH_SIZE,
-        );
-      } catch {
-        // Malformed value from mint (e.g. float, NaN, negative).
-        // Treat as unset per NUT-29 spec
-        // Static method — no instance logger available; console.warn is intentional here.
-        console.warn('MintInfo: nuts.29.max_batch_size is malformed and will be treated as unset', {
-          value: nut29.max_batch_size,
-        });
-      }
+    let max_batch_size = ABSOLUTE_MAX_BATCH_SIZE;
+    try {
+      max_batch_size = normalizeSafeIntegerMetadata(
+        nut29.max_batch_size,
+        'nuts.29.max_batch_size',
+        ABSOLUTE_MAX_BATCH_SIZE,
+      );
+    } catch {
+      logger.warn('MintInfo: nuts.29.max_batch_size is malformed, defaulting to internal cap', {
+        value: nut29.max_batch_size,
+      });
+      // max_batch_size stays at ABSOLUTE_MAX_BATCH_SIZE — initialized above
     }
 
-    if (max_batch_size != null && max_batch_size > ABSOLUTE_MAX_BATCH_SIZE) {
-      // Static method — no instance logger available; console.warn is intentional here.
-      console.warn('MintInfo: nuts.29.max_batch_size exceeds internal cap and was clamped', {
+    if (max_batch_size > ABSOLUTE_MAX_BATCH_SIZE) {
+      logger.warn('MintInfo: nuts.29.max_batch_size exceeds internal cap and was clamped', {
         advertised: max_batch_size,
         clampedTo: ABSOLUTE_MAX_BATCH_SIZE,
       });
       max_batch_size = ABSOLUTE_MAX_BATCH_SIZE;
     }
 
-    // Note: intentionally does not spread ...nut29 to prevent malformed
-    // max_batch_size from surviving the catch path. Fields are listed explicitly.
+    // Explicit reconstruction — do not spread ...nut29 here.
+    // A spread would reintroduce a malformed max_batch_size from the original object.
     return {
       methods: nut29.methods,
-      ...(max_batch_size != null ? { max_batch_size } : {}),
+      max_batch_size,
     };
   }
 

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,3 +1,4 @@
+import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
 import {
@@ -63,9 +64,35 @@ export class MintInfo {
   ): GetInfoResponse['nuts']['22'] {
     if (!nut22) return nut22;
 
+    let bat_max_mint: number | undefined;
+    if (nut22.bat_max_mint != null) {
+      try {
+        bat_max_mint = normalizeSafeIntegerMetadata(
+          nut22.bat_max_mint,
+          'nuts.22.bat_max_mint',
+          ABSOLUTE_MAX_PER_MINT,
+        );
+      } catch {
+        // Malformed value from mint (e.g. float, NaN, negative).
+        // Static method — no instance logger available; console.warn is intentional here.
+        console.warn('MintInfo: nuts.22.bat_max_mint is malformed, defaulting to internal cap', {
+          value: nut22.bat_max_mint,
+        });
+      }
+    }
+
+    if (bat_max_mint != null && bat_max_mint > ABSOLUTE_MAX_PER_MINT) {
+      // Static method — no instance logger available; console.warn is intentional here.
+      console.warn('MintInfo: nuts.22.bat_max_mint exceeds internal cap and was clamped', {
+        advertised: bat_max_mint,
+        clampedTo: ABSOLUTE_MAX_PER_MINT,
+      });
+      bat_max_mint = ABSOLUTE_MAX_PER_MINT;
+    }
+
     return {
       ...nut22,
-      bat_max_mint: normalizeSafeIntegerMetadata(nut22.bat_max_mint, 'nuts.22.bat_max_mint'),
+      bat_max_mint: bat_max_mint ?? ABSOLUTE_MAX_PER_MINT,
     };
   }
 
@@ -74,16 +101,38 @@ export class MintInfo {
   ): GetInfoResponse['nuts']['29'] {
     if (!nut29) return nut29;
 
+    let max_batch_size: number | undefined;
+    if (nut29.max_batch_size != null) {
+      try {
+        max_batch_size = normalizeSafeIntegerMetadata(
+          nut29.max_batch_size,
+          'nuts.29.max_batch_size',
+          ABSOLUTE_MAX_BATCH_SIZE,
+        );
+      } catch {
+        // Malformed value from mint (e.g. float, NaN, negative).
+        // Treat as unset per NUT-29 spec
+        // Static method — no instance logger available; console.warn is intentional here.
+        console.warn('MintInfo: nuts.29.max_batch_size is malformed and will be treated as unset', {
+          value: nut29.max_batch_size,
+        });
+      }
+    }
+
+    if (max_batch_size != null && max_batch_size > ABSOLUTE_MAX_BATCH_SIZE) {
+      // Static method — no instance logger available; console.warn is intentional here.
+      console.warn('MintInfo: nuts.29.max_batch_size exceeds internal cap and was clamped', {
+        advertised: max_batch_size,
+        clampedTo: ABSOLUTE_MAX_BATCH_SIZE,
+      });
+      max_batch_size = ABSOLUTE_MAX_BATCH_SIZE;
+    }
+
+    // Note: intentionally does not spread ...nut29 to prevent malformed
+    // max_batch_size from surviving the catch path. Fields are listed explicitly.
     return {
-      ...nut29,
-      ...(nut29.max_batch_size != null
-        ? {
-            max_batch_size: normalizeSafeIntegerMetadata(
-              nut29.max_batch_size,
-              'nuts.29.max_batch_size',
-            ),
-          }
-        : {}),
+      methods: nut29.methods,
+      ...(max_batch_size != null ? { max_batch_size } : {}),
     };
   }
 

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -3,6 +3,7 @@ import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 import {
   type GetInfoResponse,
   type MPPMethod,
+  type Nut29Info,
   type SwapMethod,
   type WebSocketSupport,
   type Nut19Policy,
@@ -41,6 +42,7 @@ export class MintInfo {
         ...info.nuts,
         ...(info.nuts['19'] ? { '19': MintInfo.normalizeNut19(info.nuts['19']) } : {}),
         ...(info.nuts['22'] ? { '22': MintInfo.normalizeNut22(info.nuts['22']) } : {}),
+        ...(info.nuts['29'] ? { '29': MintInfo.normalizeNut29(info.nuts['29']) } : {}),
       },
     };
   }
@@ -67,11 +69,30 @@ export class MintInfo {
     };
   }
 
+  private static normalizeNut29(
+    nut29: GetInfoResponse['nuts']['29'],
+  ): GetInfoResponse['nuts']['29'] {
+    if (!nut29) return nut29;
+
+    return {
+      ...nut29,
+      ...(nut29.max_batch_size != null
+        ? {
+            max_batch_size: normalizeSafeIntegerMetadata(
+              nut29.max_batch_size,
+              'nuts.29.max_batch_size',
+            ),
+          }
+        : {}),
+    };
+  }
+
   isSupported(num: 4 | 5): { disabled: boolean; params: SwapMethod[] };
   isSupported(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20): { supported: boolean };
   isSupported(num: 17): { supported: boolean; params?: WebSocketSupport[] };
   isSupported(num: 15): { supported: boolean; params?: MPPMethod[] };
   isSupported(num: 19): { supported: boolean; params?: Nut19Policy };
+  isSupported(num: 29): { supported: boolean; params?: Nut29Info };
   isSupported(num: number) {
     switch (num) {
       case 4:
@@ -96,6 +117,9 @@ export class MintInfo {
       }
       case 19: {
         return this.checkNut19();
+      }
+      case 29: {
+        return this.checkNut29();
       }
       default: {
         throw new Error('nut is not supported by cashu-ts');
@@ -169,6 +193,14 @@ export class MintInfo {
           cached_endpoints: rawPolicy.cached_endpoints,
         } as Nut19Policy,
       };
+    }
+    return { supported: false };
+  }
+
+  private checkNut29() {
+    const nut29 = this._mintInfo.nuts?.[29];
+    if (nut29) {
+      return { supported: true, params: nut29 };
     }
     return { supported: false };
   }

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -1,5 +1,7 @@
 import type { AmountLike } from '../Amount';
 
+import type { Nut29Info } from './NUT29';
+
 /**
  * Response from mint at /info endpoint.
  */
@@ -77,6 +79,7 @@ export type GetInfoResponse = {
       bat_max_mint: number;
       protected_endpoints: Array<{ method: 'GET' | 'POST'; path: string }>;
     };
+    '29'?: Nut29Info;
   };
   motd?: string;
 };

--- a/src/model/types/NUT29.ts
+++ b/src/model/types/NUT29.ts
@@ -1,6 +1,14 @@
 import { type SerializedBlindedMessage } from './blinded';
 
 /**
+ * NUT-29 batch minting info advertised by the mint in the NUT-06 info response.
+ */
+export type Nut29Info = {
+  methods?: string[];
+  max_batch_size?: number;
+};
+
+/**
  * Payload that needs to be sent to the mint when requesting a NUT-29 batched mint.
  */
 export type BatchMintRequest = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './base64';
 export * from './bech32m';
 export * from './Bytes';
 export * from './cbor';
+export * from './limits';
 export * from './core';
 export * from './JSONInt';
 export * from './normalizeNumbers';

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -1,0 +1,13 @@
+/**
+ * NUT-22: Hard ceiling for `bat_max_mint`, the maximum number of blind authentication tokens a
+ * wallet may request in a single mint call. Values advertised by a mint above this cap are
+ * clamped.
+ */
+export const ABSOLUTE_MAX_PER_MINT = 100;
+
+/**
+ * NUT-29: Hard ceiling for batch-mint size, the maximum number of quote entries a wallet may
+ * include in a single `prepareBatchMint` call. Values advertised by a mint above this cap are
+ * clamped.
+ */
+export const ABSOLUTE_MAX_BATCH_SIZE = 100;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -286,7 +286,7 @@ class Wallet {
     if (!this._mintInfo || forceRefresh) {
       promises.push(
         this.mint.getInfo().then((info) => {
-          this._mintInfo = new MintInfo(info);
+          this._mintInfo = new MintInfo(info, this._logger);
           this.mint.setMintInfo(this._mintInfo);
           return null;
         }),
@@ -310,7 +310,7 @@ class Wallet {
    * The `cache` argument should usually come from `wallet.keyChain.cache`.
    */
   loadMintFromCache(mintInfo: GetInfoResponse, cache: KeyChainCache): void {
-    this._mintInfo = new MintInfo(mintInfo);
+    this._mintInfo = new MintInfo(mintInfo, this._logger);
     this.mint.setMintInfo(this._mintInfo);
     this._keyChain.loadFromCache(cache);
     this.finishInit();

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2004,6 +2004,26 @@ class Wallet {
   ): Promise<BatchMintPreview<TQuote>> {
     this.failIf(entries.length === 0, 'prepareBatchMint: no entries provided');
 
+    // Enforce NUT-29 batch-size limit advertised by the mint
+    const nut29 = this._mintInfo?.isSupported(29);
+    const nut29Params = nut29?.supported ? nut29.params : undefined;
+    if (nut29Params?.max_batch_size != null) {
+      this.failIf(
+        entries.length > nut29Params.max_batch_size,
+        `prepareBatchMint: batch size ${entries.length} exceeds mint's ` +
+          `advertised limit of ${nut29Params.max_batch_size}`,
+      );
+    }
+
+    // Warn if the requested method is not in the mint's NUT-29 supported methods
+    if (nut29Params?.methods?.length) {
+      if (!nut29Params.methods.includes(method)) {
+        this._logger.warn(
+          `prepareBatchMint: method '${method}' is not in mint's advertised NUT-29 methods`,
+        );
+      }
+    }
+
     const { privkey, keysetId, proofsWeHave, onCountersReserved } = config ?? {};
 
     // Validate all quotes

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -50,6 +50,7 @@ import {
   sanitizeUrl,
   splitAmount,
   sumProofs,
+  ABSOLUTE_MAX_BATCH_SIZE,
 } from '../utils';
 
 import { getKeepAmounts } from './_internal';
@@ -2004,14 +2005,20 @@ class Wallet {
   ): Promise<BatchMintPreview<TQuote>> {
     this.failIf(entries.length === 0, 'prepareBatchMint: no entries provided');
 
-    // Enforce NUT-29 batch-size limit advertised by the mint
+    // Enforce NUT-29 batch-size limit advertised by the mint, clamped to our absolute cap.
+    // If the mint does not advertise NUT-29 info, the absolute cap still applies.
     const nut29 = this._mintInfo?.isSupported(29);
     const nut29Params = nut29?.supported ? nut29.params : undefined;
-    if (nut29Params?.max_batch_size != null) {
+
+    const effectiveLimit = nut29Params?.max_batch_size ?? ABSOLUTE_MAX_BATCH_SIZE;
+
+    if (entries.length > effectiveLimit) {
+      const limitSource =
+        nut29Params?.max_batch_size != null ? `mint's advertised limit` : `cashu-ts internal cap`;
       this.failIf(
-        entries.length > nut29Params.max_batch_size,
-        `prepareBatchMint: batch size ${entries.length} exceeds mint's ` +
-          `advertised limit of ${nut29Params.max_batch_size}`,
+        true,
+        `prepareBatchMint: batch size ${entries.length} exceeds ` +
+          `${limitSource} of ${effectiveLimit}`,
       );
     }
 

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -335,3 +335,100 @@ describe('MintInfo NUT-29 batch minting info', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 });
+
+describe('MintInfo NUT-22 bat_max_mint normalization', () => {
+  function mockLogger() {
+    return {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+  }
+
+  it('defaults bat_max_mint to internal cap when malformed (float)', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          22: {
+            bat_max_mint: 2.5,
+            protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
+          },
+        },
+      } as any,
+      logger,
+    );
+    expect(info.nuts['22']?.bat_max_mint).toBe(100);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('malformed'),
+      expect.objectContaining({ value: 2.5 }),
+    );
+  });
+
+  it('clamps bat_max_mint above 100 to 100', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          22: {
+            bat_max_mint: 500,
+            protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
+          },
+        },
+      } as any,
+      logger,
+    );
+    expect(info.nuts['22']?.bat_max_mint).toBe(100);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('clamped'),
+      expect.objectContaining({ advertised: 500, clampedTo: 100 }),
+    );
+  });
+
+  it('does not clamp bat_max_mint at or below 100', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          22: {
+            bat_max_mint: 50,
+            protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
+          },
+        },
+      } as any,
+      logger,
+    );
+    expect(info.nuts['22']?.bat_max_mint).toBe(50);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('skips normalization when nuts["22"] is absent', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+      },
+    });
+    expect(info.nuts['22']).toBeUndefined();
+  });
+
+  it('skips NUT-29 normalization when nuts["29"] is absent', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+      },
+    });
+    expect(info.nuts['29']).toBeUndefined();
+    expect(info.isSupported(29)).toEqual({ supported: false });
+  });
+});

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MintInfo } from '../../src/model/MintInfo';
 import { MINTINFORESP } from '../consts';
 
@@ -220,5 +220,97 @@ describe('MintInfo NUT-29 batch minting info', () => {
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
     expect(result.params?.max_batch_size).toBe(100);
+  });
+
+  it('does not throw when max_batch_size is a float — treats as unset', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: 2.5, methods: ['bolt11'] },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params?.max_batch_size).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed'),
+      expect.objectContaining({ value: 2.5 }),
+    );
+    spy.mockRestore();
+  });
+
+  it('does not throw when max_batch_size is NaN — treats as unset', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: NaN },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params?.max_batch_size).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed'),
+      expect.objectContaining({ value: NaN }),
+    );
+    spy.mockRestore();
+  });
+
+  it('does not throw when max_batch_size is negative — treats as unset', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: -1 },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params?.max_batch_size).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed'),
+      expect.objectContaining({ value: -1 }),
+    );
+    spy.mockRestore();
+  });
+
+  it('clamps max_batch_size above 100 to 100', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: 500 },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params?.max_batch_size).toBe(100);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('clamped'),
+      expect.objectContaining({ advertised: 500, clampedTo: 100 }),
+    );
+    spy.mockRestore();
+  });
+
+  it('does not clamp max_batch_size of exactly 100', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: 100 },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params?.max_batch_size).toBe(100);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -159,6 +159,17 @@ describe('MintInfo protected endpoint matching', () => {
 });
 
 describe('MintInfo NUT-29 batch minting info', () => {
+  function mockLogger() {
+    return {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+  }
+
   it('returns supported:false when nuts["29"] is absent', () => {
     const info = new MintInfo({
       ...MINTINFORESP,
@@ -183,7 +194,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
     });
   });
 
-  it('returns supported:true with params when max_batch_size is omitted', () => {
+  it('defaults max_batch_size to internal cap when omitted', () => {
     const info = new MintInfo({
       ...MINTINFORESP,
       nuts: {
@@ -193,7 +204,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
     } as any);
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
-    expect(result.params).toEqual({ methods: ['bolt11'] });
+    expect(result.params).toEqual({ methods: ['bolt11'], max_batch_size: 100 });
   });
 
   it('returns supported:true with params when methods is omitted', () => {
@@ -222,95 +233,105 @@ describe('MintInfo NUT-29 batch minting info', () => {
     expect(result.params?.max_batch_size).toBe(100);
   });
 
-  it('does not throw when max_batch_size is a float — treats as unset', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const info = new MintInfo({
-      ...MINTINFORESP,
-      nuts: {
-        ...MINTINFORESP.nuts,
-        29: { max_batch_size: 2.5, methods: ['bolt11'] },
-      },
-    } as any);
+  it('does not throw when max_batch_size is a float — defaults to internal cap', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          29: { max_batch_size: 2.5, methods: ['bolt11'] },
+        },
+      } as any,
+      logger,
+    );
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
-    expect(result.params?.max_batch_size).toBeUndefined();
-    expect(spy).toHaveBeenCalledWith(
+    expect(result.params?.max_batch_size).toBe(100);
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('malformed'),
       expect.objectContaining({ value: 2.5 }),
     );
-    spy.mockRestore();
   });
 
-  it('does not throw when max_batch_size is NaN — treats as unset', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const info = new MintInfo({
-      ...MINTINFORESP,
-      nuts: {
-        ...MINTINFORESP.nuts,
-        29: { max_batch_size: NaN },
-      },
-    } as any);
+  it('does not throw when max_batch_size is NaN — defaults to internal cap', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          29: { max_batch_size: NaN },
+        },
+      } as any,
+      logger,
+    );
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
-    expect(result.params?.max_batch_size).toBeUndefined();
-    expect(spy).toHaveBeenCalledWith(
+    expect(result.params?.max_batch_size).toBe(100);
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('malformed'),
       expect.objectContaining({ value: NaN }),
     );
-    spy.mockRestore();
   });
 
-  it('does not throw when max_batch_size is negative — treats as unset', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const info = new MintInfo({
-      ...MINTINFORESP,
-      nuts: {
-        ...MINTINFORESP.nuts,
-        29: { max_batch_size: -1 },
-      },
-    } as any);
+  it('does not throw when max_batch_size is negative — defaults to internal cap', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          29: { max_batch_size: -1 },
+        },
+      } as any,
+      logger,
+    );
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
-    expect(result.params?.max_batch_size).toBeUndefined();
-    expect(spy).toHaveBeenCalledWith(
+    expect(result.params?.max_batch_size).toBe(100);
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('malformed'),
       expect.objectContaining({ value: -1 }),
     );
-    spy.mockRestore();
   });
 
   it('clamps max_batch_size above 100 to 100', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const info = new MintInfo({
-      ...MINTINFORESP,
-      nuts: {
-        ...MINTINFORESP.nuts,
-        29: { max_batch_size: 500 },
-      },
-    } as any);
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          29: { max_batch_size: 500 },
+        },
+      } as any,
+      logger,
+    );
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
     expect(result.params?.max_batch_size).toBe(100);
-    expect(spy).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('clamped'),
       expect.objectContaining({ advertised: 500, clampedTo: 100 }),
     );
-    spy.mockRestore();
   });
 
   it('does not clamp max_batch_size of exactly 100', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const info = new MintInfo({
-      ...MINTINFORESP,
-      nuts: {
-        ...MINTINFORESP.nuts,
-        29: { max_batch_size: 100 },
-      },
-    } as any);
+    const logger = mockLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          29: { max_batch_size: 100 },
+        },
+      } as any,
+      logger,
+    );
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
     expect(result.params?.max_batch_size).toBe(100);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -157,3 +157,68 @@ describe('MintInfo protected endpoint matching', () => {
     ).toThrow('nuts.19.ttl');
   });
 });
+
+describe('MintInfo NUT-29 batch minting info', () => {
+  it('returns supported:false when nuts["29"] is absent', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+      },
+    });
+    expect(info.isSupported(29)).toEqual({ supported: false });
+  });
+
+  it('returns supported:true with correct params when both max_batch_size and methods are present', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: 100, methods: ['bolt11', 'bolt12'] },
+      },
+    } as any);
+    expect(info.isSupported(29)).toEqual({
+      supported: true,
+      params: { max_batch_size: 100, methods: ['bolt11', 'bolt12'] },
+    });
+  });
+
+  it('returns supported:true with params when max_batch_size is omitted', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { methods: ['bolt11'] },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params).toEqual({ methods: ['bolt11'] });
+  });
+
+  it('returns supported:true with params when methods is omitted', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: 50 },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params).toEqual({ max_batch_size: 50 });
+  });
+
+  it('normalizes non-integer max_batch_size to integer', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: '100' as any },
+      },
+    } as any);
+    const result = info.isSupported(29);
+    expect(result.supported).toBe(true);
+    expect(result.params?.max_batch_size).toBe(100);
+  });
+});

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw';
-import { test, describe, expect } from 'vitest';
+import { test, describe, expect, vi } from 'vitest';
 
 import {
   Wallet,
@@ -16,7 +16,7 @@ import {
 
 import { Bytes } from '../../src/utils';
 import { hexToBytes } from '@noble/curves/utils.js';
-import { useTestServer, mint, mintUrl, unit, logger } from './_setup';
+import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
 
 const server = useTestServer();
 
@@ -481,6 +481,120 @@ describe('requestTokens', () => {
     const secrets = preview.outputData.map((p) => Bytes.toHex(p.secret));
     expect(new Set(secrets).size).toBe(secrets.length);
     expect(await wallet.counters.peekNext(keysetId)).toBe(preview.outputData.length);
+  });
+});
+
+describe('NUT-29 max_batch_size enforcement', () => {
+  function makeBatchHandler() {
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11/batch', async ({ request }) => {
+        const body = (await request.json()) as { outputs: Array<{ amount: unknown }> };
+        return HttpResponse.json({
+          signatures: body.outputs.map((o) => ({
+            id: '00bd033559de27d0',
+            amount: o.amount,
+            C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+          })),
+        });
+      }),
+    );
+  }
+
+  function overrideMintInfo(nut29?: Record<string, unknown>) {
+    const nuts = { ...mintInfoResp.nuts, ...(nut29 !== undefined ? { 29: nut29 } : {}) };
+    server.use(
+      http.get(mintUrl + '/v1/info', () => {
+        return HttpResponse.json({ ...mintInfoResp, nuts });
+      }),
+    );
+  }
+
+  function makeQuotes(n: number): Array<{ amount: number; quote: { quote: string } }> {
+    return Array.from({ length: n }, (_, i) => ({
+      amount: 1,
+      quote: { quote: `quote-${i}` },
+    }));
+  }
+
+  test('throws when entries.length exceeds max_batch_size', async () => {
+    overrideMintInfo({ max_batch_size: 2 });
+    const wallet = new Wallet(mintUrl, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.prepareBatchMint('bolt11', makeQuotes(3))).rejects.toThrow(
+      /batch size 3.*limit of 2/,
+    );
+  });
+
+  test('does not throw when entries.length equals max_batch_size', async () => {
+    overrideMintInfo({ max_batch_size: 3 });
+    makeBatchHandler();
+    const wallet = new Wallet(mintUrl, { unit });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareBatchMint('bolt11', makeQuotes(3));
+    expect(preview.payload.quotes).toHaveLength(3);
+  });
+
+  test('does not throw when entries.length is below max_batch_size', async () => {
+    overrideMintInfo({ max_batch_size: 5 });
+    makeBatchHandler();
+    const wallet = new Wallet(mintUrl, { unit });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareBatchMint('bolt11', makeQuotes(2));
+    expect(preview.payload.quotes).toHaveLength(2);
+  });
+
+  test('does not throw when mint does not advertise NUT-29 info', async () => {
+    // Default mint info has no nuts['29'] key
+    makeBatchHandler();
+    const wallet = new Wallet(mintUrl, { unit });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareBatchMint('bolt11', makeQuotes(10));
+    expect(preview.payload.quotes).toHaveLength(10);
+  });
+
+  function mockLogger() {
+    return {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+  }
+
+  test('logs a warning when method is not in advertised NUT-29 methods', async () => {
+    overrideMintInfo({ methods: ['bolt12'] });
+    const spyLogger = mockLogger();
+    const wallet = new Wallet(mintUrl, { unit, logger: spyLogger });
+    await wallet.loadMint();
+
+    await wallet.prepareBatchMint('bolt11', makeQuotes(1));
+    expect(spyLogger.warn).toHaveBeenCalledWith(expect.stringContaining("method 'bolt11'"));
+  });
+
+  test('does not warn when method IS in advertised NUT-29 methods', async () => {
+    overrideMintInfo({ methods: ['bolt11', 'bolt12'] });
+    const spyLogger = mockLogger();
+    const wallet = new Wallet(mintUrl, { unit, logger: spyLogger });
+    await wallet.loadMint();
+
+    await wallet.prepareBatchMint('bolt11', makeQuotes(1));
+    expect(spyLogger.warn).not.toHaveBeenCalled();
+  });
+
+  test('does not warn when nuts["29"].methods is absent', async () => {
+    overrideMintInfo({ max_batch_size: 10 });
+    const spyLogger = mockLogger();
+    const wallet = new Wallet(mintUrl, { unit, logger: spyLogger });
+    await wallet.loadMint();
+
+    await wallet.prepareBatchMint('bolt11', makeQuotes(2));
+    expect(spyLogger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -596,6 +596,28 @@ describe('NUT-29 max_batch_size enforcement', () => {
     await wallet.prepareBatchMint('bolt11', makeQuotes(2));
     expect(spyLogger.warn).not.toHaveBeenCalled();
   });
+
+  test('throws when entries exceed ABSOLUTE_MAX_BATCH_SIZE even without NUT-29 info', async () => {
+    // Default mint info has no nuts['29'] key — absolute cap still applies
+    const wallet = new Wallet(mintUrl, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.prepareBatchMint('bolt11', makeQuotes(101))).rejects.toThrow(
+      /batch size 101.*internal cap.*100/,
+    );
+  });
+
+  test('throws when entries exceed ABSOLUTE_MAX_BATCH_SIZE even with higher mint limit', async () => {
+    // Mint advertises 500, but normalizeNut29 clamps to 100.
+    // Belt-and-suspenders: even if clamping were skipped, the wallet enforces the cap.
+    overrideMintInfo({ max_batch_size: 500 });
+    const wallet = new Wallet(mintUrl, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.prepareBatchMint('bolt11', makeQuotes(101))).rejects.toThrow(
+      /batch size 101.*limit of 100/,
+    );
+  });
 });
 
 describe('generic mint/melt methods', () => {


### PR DESCRIPTION
## Description

Follow-up to #478 (NUT-29 batch minting). That PR implemented the batch mint flow but did not read or enforce the `max_batch_size` and `methods` fields that mints can advertise via NUT-06 mint info. This PR closes that gap.

---

## Changes

- `Nut29Info` added to `NUT29.ts`
- `GetInfoResponse.nuts['29']` added to `NUT06.ts`
- `isSupported(29)` overload returning `{ supported: boolean; params?: Nut29Info }`
- `normalizeNut29()` normalizes `max_batch_size`
- `prepareBatchMint` enforces `max_batch_size` before building outputs — fails fast with a message that includes both the attempted size and the advertised limit
- `prepareBatchMint` warns when the requested method is absent from the mint's advertised NUT-29 methods (string match only, no unit filtering — matches spec)
- `completeBatchMint` is unchanged — errors from the mint propagate with their original type and message intact
- All new checks are gated on `this._mintInfo?.isSupported(29)`. Mints that do not advertise NUT-29 info are completely unaffected.

---

## Alignment & Discussion

- Was an issue opened prior to this PR? [No]
- Does this PR align with the current project direction and scope? [Yes]

---

## Reviewer Notes

- `BATCH_SIZE_EXCEEDED` has no registered numeric error code in the NUT spec yet. The `prepareBatchMint` pre-flight check covers the common case. Once a formal error code is registered in the spec, a targeted catch on `e.code` can be added to `completeBatchMint` to handle mints that enforce the limit server-side without advertising it via NUT-06.

---
