### PR TITLE
fix: retain p2bk_e in offline send

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1019,8 +1019,8 @@ class Wallet {
       includeFees,
       exactMatch,
     );
-    // Ensure witnesses are serialized, strip DLEQ if not required
-    const sendPrepared = this._prepareInputsForMint(send, requireDleq);
+    // Ensure witnesses are serialized, strip DLEQ if not required, keep p2pk_e
+    const sendPrepared = this._prepareInputsForMint(send, requireDleq, true);
     return { keep, send: sendPrepared };
   }
 
@@ -1447,15 +1447,21 @@ class Wallet {
    * Returns an array of new proof objects - does not mutate the originals.
    * @param proofs The proofs to prepare.
    * @param keepDleq Optional boolean to keep DLEQ (default: false, strips for privacy).
+   * @param keepP2pkE Optional boolean to keep NUT-28 "E" (default: false, strips for privacy).
    * @returns Prepared proofs for mint payload.
    */
-  private _prepareInputsForMint(proofs: Proof[], keepDleq: boolean = false): Proof[] {
+  private _prepareInputsForMint(
+    proofs: Proof[],
+    keepDleq: boolean = false,
+    keepP2pkE: boolean = false,
+  ): Proof[] {
     return proofs.map((p) => {
       const witness = this._normalizeWitness(p);
       const { dleq, p2pk_e, ...rest } = p; // isolate dleq and p2pk_e
-      void p2pk_e; // intentionally unused (linter)
-      // New proof object
-      return keepDleq && dleq ? { ...rest, dleq, witness } : { ...rest, witness };
+      let newProof: Proof = { ...rest, witness }; // add back normalized witness
+      if (keepP2pkE && p2pk_e) newProof = { ...newProof, p2pk_e };
+      if (keepDleq && dleq) newProof = { ...newProof, dleq };
+      return newProof;
     });
   }
 

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -187,6 +187,25 @@ describe('sendOffline witness normalization', () => {
     expect(send).toHaveLength(1);
     expect(send[0].amount).toEqual(Amount.from(1));
   });
+
+  test('preserves p2pk_e on offline send proofs', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const proofs: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(1),
+        secret: p2pkSecret,
+        C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+        p2pk_e: '02' + 'bb'.repeat(32),
+      },
+    ];
+
+    const { send } = wallet.sendOffline(1, proofs);
+    expect(send).toHaveLength(1);
+    expect(send[0].p2pk_e).toBe(proofs[0].p2pk_e);
+  });
 });
 
 describe('send', () => {
@@ -247,6 +266,27 @@ describe('send', () => {
     expect(result.keep).toHaveLength(0);
     expect(result.send).toHaveLength(1);
     expect(result.send[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+  });
+
+  test('preserves p2pk_e when exact-match send avoids swap', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const exactMatchProofs: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(1),
+        secret: p2pkSecret,
+        C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+        p2pk_e: '02' + 'cc'.repeat(32),
+      },
+    ];
+
+    const result = await wallet.send(1, exactMatchProofs);
+
+    expect(result.keep).toHaveLength(0);
+    expect(result.send).toHaveLength(1);
+    expect(result.send[0].p2pk_e).toBe(exactMatchProofs[0].p2pk_e);
   });
 
   test('test send over paying. Should return change', async () => {


### PR DESCRIPTION
Fixes a bug where NUT-28 (P2BK) ephemeral key was prematurely stripped in offline send.