### PR TITLE
fix: getDecodedToken - keysetIds is optional in v3

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -438,7 +438,7 @@ export function getDecodedToken(
   // remove prefixes
   const tokenStr = removePrefix(tokenString);
   const token: Token = handleTokens(tokenStr);
-  token.proofs = mapShortKeysetIds(token.proofs, keysetIds);
+  if (keysetIds) token.proofs = mapShortKeysetIds(token.proofs, keysetIds);
   return token;
 }
 


### PR DESCRIPTION
keysetIds is optional in v3 `getDecodedToken`. This PR fixes a potential error if these are omitted

Fix not required for v4 as keysetIds is required.