### PR TITLE
refactor(output): restore OutputData as canonical creator implementation

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -34,7 +34,7 @@ example to use a platform specific implementation for deterministic secrets.
 `OutputDataCreator` is the injectable strategy interface used by `Wallet`. The canonical default
 creation surface remains `OutputData.create*()`, so custom creators can delegate back to it for the standard random and P2PK behavior.
 
-> [!IMPORTANT]
+> [!CAUTION]
 > The only officially supported and maintained `OutputDataCreator` is the default Noble Curves based
 > implementation exposed by `OutputData.create*()`. Custom creators are an escape hatch for
 > runtime-specific needs, but their compatibility and maintenance are the integrator's

--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -31,8 +31,14 @@ wallet2.loadMintFromCache(mintInfoCache, keychainCache);
 Pass `outputDataCreator` when you need to replace the default output generation logic, for
 example to use a platform specific implementation for deterministic secrets.
 
-`OutputDataCreator` is the injectable strategy interface used by `Wallet`. The supported default
+`OutputDataCreator` is the injectable strategy interface used by `Wallet`. The canonical default
 creation surface remains `OutputData.create*()`, so custom creators can delegate back to it for the standard random and P2PK behavior.
+
+> [!IMPORTANT]
+> The only officially supported and maintained `OutputDataCreator` is the default Noble Curves based
+> implementation exposed by `OutputData.create*()`. Custom creators are an escape hatch for
+> runtime-specific needs, but their compatibility and maintenance are the integrator's
+> responsibility.
 
 ```typescript
 import { OutputData, type OutputDataCreator, Wallet } from '@cashu/cashu-ts';

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1218,7 +1218,7 @@ export class OutputData implements OutputDataLike {
     toProof(sig: SerializedBlindedSignature, keyset: HasKeysetKeys): Proof;
 }
 
-// @public (undocumented)
+// @public
 export interface OutputDataCreator {
     // (undocumented)
     createDeterministicData(amount: AmountLike, seed: Uint8Array, counter: number, keyset: HasKeysetKeys, customSplit?: AmountLike[]): OutputDataLike[];

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -1,17 +1,22 @@
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils.js';
 
 import {
+  blindMessage,
   constructUnblindedSignature,
+  deriveBlindingFactor,
+  deriveP2BKBlindedPubkeys,
+  deriveSecret,
+  normalizeP2PKOptions,
   pointFromHex,
   verifyDLEQProof,
   type DLEQ,
   type BlindSignature,
   type P2PKOptions,
 } from '../crypto';
-import { numberToHexPadded64 } from '../utils';
+import { Bytes, numberToHexPadded64, splitAmount } from '../utils';
 
 import { Amount, type AmountLike } from './Amount';
-import { defaultOutputDataCreator } from './OutputDataCreator';
+import { BlindedMessage } from './BlindedMessage';
 import {
   type HasKeysetKeys,
   type Proof,
@@ -148,19 +153,124 @@ export class OutputData implements OutputDataLike {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputData[] {
-    return defaultOutputDataCreator.createP2PKData(p2pk, amount, keyset, customSplit);
+    const amounts = splitAmount(amount, keyset.keys, customSplit);
+    return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id));
   }
 
-  static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string) {
-    return defaultOutputDataCreator.createSingleP2PKData(p2pk, amount, keysetId);
+  static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData {
+    const amountValue = Amount.from(amount);
+    const normalized = normalizeP2PKOptions(p2pk);
+    const lockKeys = Array.isArray(normalized.pubkey) ? normalized.pubkey : [normalized.pubkey];
+    const refundKeys = normalized.refundKeys ?? [];
+    const reqLock = normalized.requiredSignatures ?? 1;
+    const reqRefund = normalized.requiredRefundSignatures ?? 1;
+
+    // Init vars
+    const hashlock = normalized.hashlock;
+    const isHTLC = typeof hashlock === 'string' && hashlock.length > 0;
+    let data = isHTLC ? hashlock : lockKeys[0];
+    let pubkeys = isHTLC ? lockKeys : lockKeys.slice(1);
+    let refund = refundKeys;
+
+    // Optional key blinding (P2BK)
+    let Ehex: string | undefined;
+    if (p2pk.blindKeys) {
+      const ordered = [...lockKeys, ...refundKeys];
+      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered);
+      if (isHTLC) {
+        // hashlock is in data, all locking keys into pubkeys
+        pubkeys = blinded.slice(0, lockKeys.length);
+      } else {
+        // first locking key in data, rest into pubkeys
+        data = blinded[0];
+        pubkeys = blinded.slice(1, lockKeys.length);
+      }
+      refund = blinded.slice(lockKeys.length);
+      Ehex = _E;
+    }
+
+    // build P2PK Tags (NUT-11)
+    const tags: string[][] = [];
+
+    const ts = normalized.locktime ?? NaN;
+    if (Number.isSafeInteger(ts) && ts >= 0) {
+      tags.push(['locktime', String(ts)]);
+    }
+
+    if (pubkeys.length > 0) {
+      tags.push(['pubkeys', ...pubkeys]);
+      if (reqLock > 1) {
+        tags.push(['n_sigs', String(reqLock)]);
+      }
+    }
+
+    if (refund.length > 0) {
+      tags.push(['refund', ...refund]);
+      if (reqRefund > 1) {
+        tags.push(['n_sigs_refund', String(reqRefund)]);
+      }
+    }
+
+    if (normalized.sigFlag == 'SIG_ALL') {
+      tags.push(['sigflag', 'SIG_ALL']);
+    }
+
+    // Append additional tags if any
+    if (normalized.additionalTags?.length) {
+      const extraTags = normalized.additionalTags.map(([k, ...vals]) => {
+        assertValidTagKey(k); // Validate key
+        return [k, ...vals.map(String)]; // all to strings
+      });
+      tags.push(...extraTags);
+    }
+
+    // Construct secret
+    const kind = isHTLC ? 'HTLC' : 'P2PK';
+    const newSecret: [string, { nonce: string; data: string; tags: string[][] }] = [
+      kind,
+      {
+        nonce: bytesToHex(randomBytes(32)),
+        data,
+        tags,
+      },
+    ];
+    const parsed = JSON.stringify(newSecret);
+
+    // Check secret length, counting Unicode code points
+    // Same semantics as Nutshell python: len(str)
+    const charCount = [...parsed].length;
+    if (charCount > MAX_SECRET_LENGTH) {
+      throw new Error(`Secret too long (${charCount} characters), maximum is ${MAX_SECRET_LENGTH}`);
+    }
+
+    // blind the message
+    const secretBytes = new TextEncoder().encode(parsed);
+    const { r, B_ } = blindMessage(secretBytes);
+
+    // create OutputData
+    return new OutputData(
+      new BlindedMessage(amountValue, B_, keysetId).getSerializedBlindedMessage(),
+      r,
+      secretBytes,
+      Ehex,
+    );
   }
 
   static createRandomData(amount: AmountLike, keyset: HasKeysetKeys, customSplit?: AmountLike[]) {
-    return defaultOutputDataCreator.createRandomData(amount, keyset, customSplit);
+    const amounts = splitAmount(amount, keyset.keys, customSplit);
+    return amounts.map((a) => this.createSingleRandomData(a, keyset.id));
   }
 
-  static createSingleRandomData(amount: AmountLike, keysetId: string) {
-    return defaultOutputDataCreator.createSingleRandomData(amount, keysetId);
+  static createSingleRandomData(amount: AmountLike, keysetId: string): OutputData {
+    const amountValue = Amount.from(amount);
+    const randomHex = bytesToHex(randomBytes(32));
+    const secretBytes = new TextEncoder().encode(randomHex);
+    const { r, B_ } = blindMessage(secretBytes);
+    return new OutputData(
+      new BlindedMessage(amountValue, B_, keysetId).getSerializedBlindedMessage(),
+      r,
+      secretBytes,
+    );
   }
 
   static createDeterministicData(
@@ -170,12 +280,9 @@ export class OutputData implements OutputDataLike {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputData[] {
-    return defaultOutputDataCreator.createDeterministicData(
-      amount,
-      seed,
-      counter,
-      keyset,
-      customSplit,
+    const amounts = splitAmount(amount, keyset.keys, customSplit);
+    return amounts.map((a, i) =>
+      this.createSingleDeterministicData(a, seed, counter + i, keyset.id),
     );
   }
 
@@ -188,8 +295,20 @@ export class OutputData implements OutputDataLike {
     seed: Uint8Array,
     counter: number,
     keysetId: string,
-  ) {
-    return defaultOutputDataCreator.createSingleDeterministicData(amount, seed, counter, keysetId);
+  ): OutputData {
+    const amountValue = Amount.from(amount);
+    const secretBytes = deriveSecret(seed, keysetId, counter);
+    const secretBytesAsHex = bytesToHex(secretBytes);
+    const utf8SecretBytes = new TextEncoder().encode(secretBytesAsHex);
+    // Note: Bytes.toBigInt is used here so invalid values bubble up as throws
+    // for BIP32-style retry logic (caller increments counter and retries).
+    const deterministicR = Bytes.toBigInt(deriveBlindingFactor(seed, keysetId, counter));
+    const { r, B_ } = blindMessage(utf8SecretBytes, deterministicR);
+    return new OutputData(
+      new BlindedMessage(amountValue, B_, keysetId).getSerializedBlindedMessage(),
+      r,
+      utf8SecretBytes,
+    );
   }
 
   /**

--- a/src/model/OutputDataCreator.ts
+++ b/src/model/OutputDataCreator.ts
@@ -1,4 +1,5 @@
 import { type P2PKOptions } from '../crypto';
+import { splitAmount } from '../utils';
 
 import { type AmountLike } from './Amount';
 import { OutputData, type OutputDataLike } from './OutputData';
@@ -45,6 +46,8 @@ export interface OutputDataCreator {
 /**
  * Thin adapter exposing the canonical `OutputData.create*()` implementation via
  * {@link OutputDataCreator}.
+ *
+ * @internal
  */
 export class DefaultOutputDataCreator implements OutputDataCreator {
   createP2PKData(
@@ -53,7 +56,8 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputDataLike[] {
-    return OutputData.createP2PKData(p2pk, amount, keyset, customSplit);
+    const amounts = splitAmount(amount, keyset.keys, customSplit);
+    return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id));
   }
 
   createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputDataLike {
@@ -65,7 +69,8 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputDataLike[] {
-    return OutputData.createRandomData(amount, keyset, customSplit);
+    const amounts = splitAmount(amount, keyset.keys, customSplit);
+    return amounts.map((a) => this.createSingleRandomData(a, keyset.id));
   }
 
   createSingleRandomData(amount: AmountLike, keysetId: string): OutputDataLike {
@@ -79,7 +84,10 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputDataLike[] {
-    return OutputData.createDeterministicData(amount, seed, counter, keyset, customSplit);
+    const amounts = splitAmount(amount, keyset.keys, customSplit);
+    return amounts.map((a, i) =>
+      this.createSingleDeterministicData(a, seed, counter + i, keyset.id),
+    );
   }
 
   /**

--- a/src/model/OutputDataCreator.ts
+++ b/src/model/OutputDataCreator.ts
@@ -1,25 +1,18 @@
-import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
+import { type P2PKOptions } from '../crypto';
 
-import {
-  blindMessage,
-  deriveBlindingFactor,
-  deriveP2BKBlindedPubkeys,
-  deriveSecret,
-  normalizeP2PKOptions,
-  type P2PKOptions,
-} from '../crypto';
-import { Bytes, splitAmount } from '../utils';
-
-import { Amount, type AmountLike } from './Amount';
-import { BlindedMessage } from './BlindedMessage';
-import {
-  assertValidTagKey,
-  MAX_SECRET_LENGTH,
-  OutputData,
-  type OutputDataLike,
-} from './OutputData';
+import { type AmountLike } from './Amount';
+import { OutputData, type OutputDataLike } from './OutputData';
 import type { HasKeysetKeys } from './types';
 
+/**
+ * Injectable output-construction strategy used by {@link Wallet}.
+ *
+ * @remarks
+ * The canonical and maintained implementation is the Noble Curves based default exposed through
+ * `OutputData.create*()` and adapted by {@link DefaultOutputDataCreator}. This interface provides an
+ * escape hatch for runtime-specific needs, but compatibility and maintenance outside the default
+ * implementation are the integrator's responsibility.
+ */
 export interface OutputDataCreator {
   createP2PKData(
     p2pk: P2PKOptions,
@@ -49,136 +42,34 @@ export interface OutputDataCreator {
   ): OutputDataLike;
 }
 
+/**
+ * Thin adapter exposing the canonical `OutputData.create*()` implementation via
+ * {@link OutputDataCreator}.
+ */
 export class DefaultOutputDataCreator implements OutputDataCreator {
   createP2PKData(
     p2pk: P2PKOptions,
     amount: AmountLike,
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
-  ): OutputData[] {
-    const amounts = splitAmount(amount, keyset.keys, customSplit);
-    return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id));
+  ): OutputDataLike[] {
+    return OutputData.createP2PKData(p2pk, amount, keyset, customSplit);
   }
 
-  createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData {
-    const amountValue = Amount.from(amount);
-    const normalized = normalizeP2PKOptions(p2pk);
-    const lockKeys = Array.isArray(normalized.pubkey) ? normalized.pubkey : [normalized.pubkey];
-    const refundKeys = normalized.refundKeys ?? [];
-    const reqLock = normalized.requiredSignatures ?? 1;
-    const reqRefund = normalized.requiredRefundSignatures ?? 1;
-
-    // Init vars
-    const hashlock = normalized.hashlock;
-    const isHTLC = typeof hashlock === 'string' && hashlock.length > 0;
-    let data = isHTLC ? hashlock : lockKeys[0];
-    let pubkeys = isHTLC ? lockKeys : lockKeys.slice(1);
-    let refund = refundKeys;
-
-    // Optional key blinding (P2BK)
-    let Ehex: string | undefined;
-    if (p2pk.blindKeys) {
-      const ordered = [...lockKeys, ...refundKeys];
-      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered);
-      if (isHTLC) {
-        // hashlock is in data, all locking keys into pubkeys
-        pubkeys = blinded.slice(0, lockKeys.length);
-      } else {
-        // first locking key in data, rest into pubkeys
-        data = blinded[0];
-        pubkeys = blinded.slice(1, lockKeys.length);
-      }
-      refund = blinded.slice(lockKeys.length);
-      Ehex = _E;
-    }
-
-    // build P2PK Tags (NUT-11)
-    const tags: string[][] = [];
-
-    const ts = normalized.locktime ?? NaN;
-    if (Number.isSafeInteger(ts) && ts >= 0) {
-      tags.push(['locktime', String(ts)]);
-    }
-
-    if (pubkeys.length > 0) {
-      tags.push(['pubkeys', ...pubkeys]);
-      if (reqLock > 1) {
-        tags.push(['n_sigs', String(reqLock)]);
-      }
-    }
-
-    if (refund.length > 0) {
-      tags.push(['refund', ...refund]);
-      if (reqRefund > 1) {
-        tags.push(['n_sigs_refund', String(reqRefund)]);
-      }
-    }
-
-    if (normalized.sigFlag == 'SIG_ALL') {
-      tags.push(['sigflag', 'SIG_ALL']);
-    }
-
-    // Append additional tags if any
-    if (normalized.additionalTags?.length) {
-      const extraTags = normalized.additionalTags.map(([k, ...vals]) => {
-        assertValidTagKey(k); // Validate key
-        return [k, ...vals.map(String)]; // all to strings
-      });
-      tags.push(...extraTags);
-    }
-
-    // Construct secret
-    const kind = isHTLC ? 'HTLC' : 'P2PK';
-    const newSecret: [string, { nonce: string; data: string; tags: string[][] }] = [
-      kind,
-      {
-        nonce: bytesToHex(randomBytes(32)),
-        data,
-        tags,
-      },
-    ];
-
-    // blind the message
-    const parsed = JSON.stringify(newSecret);
-
-    // Check secret length, counting Unicode code points
-    // Same semantics as Nutshell python: len(str)
-    const charCount = [...parsed].length;
-    if (charCount > MAX_SECRET_LENGTH) {
-      throw new Error(`Secret too long (${charCount} characters), maximum is ${MAX_SECRET_LENGTH}`);
-    }
-    // blind the message
-    const secretBytes = new TextEncoder().encode(parsed);
-    const { r, B_ } = blindMessage(secretBytes);
-
-    // create OutputData
-    return new OutputData(
-      new BlindedMessage(amountValue, B_, keysetId).getSerializedBlindedMessage(),
-      r,
-      secretBytes,
-      Ehex,
-    );
+  createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputDataLike {
+    return OutputData.createSingleP2PKData(p2pk, amount, keysetId);
   }
 
   createRandomData(
     amount: AmountLike,
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
-  ): OutputData[] {
-    const amounts = splitAmount(amount, keyset.keys, customSplit);
-    return amounts.map((a) => this.createSingleRandomData(a, keyset.id));
+  ): OutputDataLike[] {
+    return OutputData.createRandomData(amount, keyset, customSplit);
   }
 
-  createSingleRandomData(amount: AmountLike, keysetId: string): OutputData {
-    const amountValue = Amount.from(amount);
-    const randomHex = bytesToHex(randomBytes(32));
-    const secretBytes = new TextEncoder().encode(randomHex);
-    const { r, B_ } = blindMessage(secretBytes);
-    return new OutputData(
-      new BlindedMessage(amountValue, B_, keysetId).getSerializedBlindedMessage(),
-      r,
-      secretBytes,
-    );
+  createSingleRandomData(amount: AmountLike, keysetId: string): OutputDataLike {
+    return OutputData.createSingleRandomData(amount, keysetId);
   }
 
   createDeterministicData(
@@ -187,11 +78,8 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
     counter: number,
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
-  ): OutputData[] {
-    const amounts = splitAmount(amount, keyset.keys, customSplit);
-    return amounts.map((a, i) =>
-      this.createSingleDeterministicData(a, seed, counter + i, keyset.id),
-    );
+  ): OutputDataLike[] {
+    return OutputData.createDeterministicData(amount, seed, counter, keyset, customSplit);
   }
 
   /**
@@ -203,21 +91,7 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
     seed: Uint8Array,
     counter: number,
     keysetId: string,
-  ): OutputData {
-    const amountValue = Amount.from(amount);
-    const secretBytes = deriveSecret(seed, keysetId, counter);
-    const secretBytesAsHex = bytesToHex(secretBytes);
-    const utf8SecretBytes = new TextEncoder().encode(secretBytesAsHex);
-    // Note: Bytes.toBigInt is used here so invalid values bubble up as throws
-    // for BIP32-style retry logic (caller increments counter and retries).
-    const deterministicR = Bytes.toBigInt(deriveBlindingFactor(seed, keysetId, counter));
-    const { r, B_ } = blindMessage(utf8SecretBytes, deterministicR);
-    return new OutputData(
-      new BlindedMessage(amountValue, B_, keysetId).getSerializedBlindedMessage(),
-      r,
-      utf8SecretBytes,
-    );
+  ): OutputDataLike {
+    return OutputData.createSingleDeterministicData(amount, seed, counter, keysetId);
   }
 }
-
-export const defaultOutputDataCreator = new DefaultOutputDataCreator();

--- a/src/model/OutputDataCreator.ts
+++ b/src/model/OutputDataCreator.ts
@@ -9,8 +9,8 @@ import type { HasKeysetKeys } from './types';
  *
  * @remarks
  * The canonical and maintained implementation is the Noble Curves based default exposed through
- * `OutputData.create*()` and adapted by {@link DefaultOutputDataCreator}. This interface provides an
- * escape hatch for runtime-specific needs, but compatibility and maintenance outside the default
+ * `OutputData.create*()` and adapted by DefaultOutputDataCreator. This interface provides an escape
+ * hatch for runtime-specific needs, but compatibility and maintenance outside the default
  * implementation are the integrator's responsibility.
  */
 export interface OutputDataCreator {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -22,7 +22,7 @@ import { Mint } from '../mint';
 import { Amount, type AmountLike } from '../model/Amount';
 import { MintInfo } from '../model/MintInfo';
 import { OutputData, type OutputDataLike } from '../model/OutputData';
-import { defaultOutputDataCreator, type OutputDataCreator } from '../model/OutputDataCreator';
+import { DefaultOutputDataCreator, type OutputDataCreator } from '../model/OutputDataCreator';
 import type {
   GetInfoResponse,
   MeltRequest,
@@ -181,7 +181,10 @@ class Wallet {
    *   counterSource is also provided.
    * @param options.denominationTarget Target proofs per denomination, default 3.
    * @param options.selectProofs Custom proof selection function.
-   * @param options.outputDataCreator Custom OutputDataCreator implementation.
+   * @param options.outputDataCreator Custom OutputDataCreator implementation. The canonical and
+   *   maintained implementation is the default Noble Curves based behavior exposed by
+   *   `OutputData.create*()`. Custom creators are an escape hatch for runtime-specific needs, and
+   *   compatibility and maintenance are the integrator's responsibility.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -204,7 +207,7 @@ class Wallet {
     this.on = new WalletEvents(this);
     this._logger = options?.logger ?? NULL_LOGGER; // init early (seed can throw)
     this._selectProofs = options?.selectProofs ?? selectProofsRGLI; // vital
-    this._outputDataCreator = options?.outputDataCreator ?? defaultOutputDataCreator;
+    this._outputDataCreator = options?.outputDataCreator ?? new DefaultOutputDataCreator();
     this.mint =
       typeof mint === 'string'
         ? new Mint(mint, { authProvider: options?.authProvider, logger: this._logger })


### PR DESCRIPTION
Restores OutputData as the canonical home of the default output-creation logic and reduces DefaultOutputDataCreator to a thin adapter for Wallet injection.

This removes the OutputData <-> OutputDataCreator source-level cycle introduced in #608 while preserving theOutputDataCreator interface and the existing OutputData.create*() public API.

## Changes
- moves the default random / deterministic / P2PK output creation logic back into OutputData.create*()
- makes DefaultOutputDataCreator a thin wrapper over OutputData.create*()
- removes the shared defaultOutputDataCreator singleton and instantiate DefaultOutputDataCreator in Wallet
- tighten docs and API wording so OutputData.create*() is clearly documented as the canonical, maintained default  implementation
- clarify that OutputDataCreator exists as an escape hatch for runtime-specific integrations, and that custom  implementations are not part of the library’s maintained default path
