### PR TITLE
chore: remove deps from ci playwright for speed

### DIFF
--- a/.github/workflows/consumers.yml
+++ b/.github/workflows/consumers.yml
@@ -26,6 +26,6 @@ jobs:
         run: npm ci
       - name: Prepare Playwright (for iife test)
         if: ${{ matrix['test-type'] == 'iife' }}
-        run: npm run test:prepare # Installs Chromium and deps
+        run: npm run test:prepare:ci # Installs Chromium only; avoid apt deps on CI
       - name: Run ${{ matrix['test-type'] }} Test
         run: npm run test:${{ matrix['test-type'] }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run compile
-      - run: npm run test:prepare
+      - run: npm run test:prepare:ci
       - run: npm test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Install Test dependencies
-        run: npm run test:prepare
+        run: npm run test:prepare:ci
 
       - name: Update Makefile Docker versions
         id: update

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run compile
 
       - name: Prepare Tests
-        run: npm run test:prepare
+        run: npm run test:prepare:ci
 
       - name: Run Tests
         run: npm test

--- a/docs-src/DEVELOPER.md
+++ b/docs-src/DEVELOPER.md
@@ -57,7 +57,7 @@ This callout is important — please don't skip it when moving between major bra
 
 - Node: >=22.4.0
 - Recommended tools: `npm` (node package manager), `git`, optional `nvm`/`volta` for Node version management.
-- Optional: Playwright browsers for integration tests (`npm run test:prepare`).
+- Optional: Playwright browsers for browser-based tests (`npm run test:prepare`).
 
 ## Hooks internals
 
@@ -144,6 +144,8 @@ npm run test:consumer
 ```
 
 **Note**: the consumer smoke tests are run in CI but are not part of the git hooks; running `npm run test:consumer` locally before pushing helps reproduce CI behavior.
+
+CI uses `npm run test:prepare:ci`, which installs Chromium without `--with-deps` to avoid slow apt package downloads on Ubuntu runners. Local setup should keep using `npm run test:prepare`.
 
 The `test:consumer` aggregator runs the following scripts (you can run them individually):
 
@@ -265,6 +267,8 @@ npm run test:prepare
 # then run the integration tests
 npm run test-integration
 ```
+
+In CI, prefer `npm run test:prepare:ci` unless you explicitly need Playwright to install system packages too.
 
 If tests are flaky locally, run with increased verbosity or use `--run --inspect` / `--watch` where supported.
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:reactnative": "node test/consumer/reactnative/run-test.js",
     "test:consumer": "npm run test:bundler && npm run test:iife && npm run test:nodenext && npm run test:reactnative",
     "test:prepare": "npx playwright install chromium --with-deps",
+    "test:prepare:ci": "npx playwright install chromium",
     "test": "vitest run --coverage --project node --project browser",
     "test-integration": "vitest run --coverage --project integration",
     "dev": "tsc --watch",


### PR DESCRIPTION
Playwright with deps can be very slow. GH runners should be ok without... let's see.