### PR TITLE
feat: add requireSigDleq option to Wallet for signature DLEQ enforcement

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1875,6 +1875,7 @@ export class Wallet {
         denominationTarget?: number;
         selectProofs?: SelectProofs;
         outputDataCreator?: OutputDataCreator;
+        requireSigDleq?: boolean;
         logger?: Logger;
     });
     batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -150,6 +150,7 @@ class Wallet {
   private _boundKeysetId: string = PENDING_KEYSET_ID;
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
+  private _requireSigDleq = false;
   private _logger: Logger;
 
   /**
@@ -185,6 +186,9 @@ class Wallet {
    *   maintained implementation is the default Noble Curves based behavior exposed by
    *   `OutputData.create*()`. Custom creators are an escape hatch for runtime-specific needs, and
    *   compatibility and maintenance are the integrator's responsibility.
+   * @param options.requireSigDleq Fail mint/swap/melt responses when the mint advertises NUT-12
+   *   support but omits DLEQ proofs on returned blinded signatures. This is a fail-fast consistency
+   *   check, not protection against a malicious mint already consuming inputs or payments.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -200,6 +204,7 @@ class Wallet {
       denominationTarget?: number;
       selectProofs?: SelectProofs; // optional override
       outputDataCreator?: OutputDataCreator;
+      requireSigDleq?: boolean;
       logger?: Logger;
     },
   ) {
@@ -233,6 +238,7 @@ class Wallet {
     this.counters = new WalletCounters(this._counterSource);
     this._keyChain = new KeyChain(this.mint, this._unit);
     this._denominationTarget = options?.denominationTarget ?? this._denominationTarget;
+    this._requireSigDleq = options?.requireSigDleq ?? this._requireSigDleq;
   }
 
   // Convenience wrappers for "log and throw"
@@ -576,6 +582,7 @@ class Wallet {
       bip39seed: this._seed,
       secretsPolicy: this._secretsPolicy,
       outputDataCreator: this._outputDataCreator,
+      requireSigDleq: this._requireSigDleq,
       logger: this._logger,
       counterSource: opts?.counterSource ?? this._counterSource,
     });
@@ -1271,22 +1278,16 @@ class Wallet {
       sendOutputs,
     );
 
-    // Execute swap
+    // Execute swap and validate result
     const { signatures } = await this.mint.swap(swapTransaction.payload);
     this.failIf(
-      signatures.length < swapTransaction.outputData.length,
+      signatures.length !== swapTransaction.outputData.length,
       `Mint returned ${signatures.length} signatures, expected ${swapTransaction.outputData.length}`,
     );
+    this.validateReturnedSignatures(signatures, swapTransaction.outputData);
 
     // Construct proofs
     const keyset = this.getKeyset(swapPreview.keysetId);
-    // Verify each signature amount matches the requested amount
-    for (let i = 0; i < swapTransaction.outputData.length; i++) {
-      this.failIf(
-        !signatures[i].amount.equals(swapTransaction.outputData[i].blindedMessage.amount),
-        `Mint returned signature with wrong amount: expected ${swapTransaction.outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}`,
-      );
-    }
     const swapProofs = swapTransaction.outputData.map((d, i) => d.toProof(signatures[i], keyset));
     const reorderedProofs = Array(swapProofs.length);
     const reorderedKeepVector = Array(swapTransaction.keepVector.length);
@@ -1782,6 +1783,29 @@ class Wallet {
   // Section: Mint Proofs
   // -----------------------------------------------------------------
 
+  private validateReturnedSignatures(
+    signatures: SerializedBlindedSignature[],
+    outputData: OutputDataLike[],
+    options?: { checkAmounts?: boolean },
+  ): void {
+    // With DLEQ we can verify the returned blinded signature is paired to the original B_.
+    // Without DLEQ, equal-denomination reordering is a protocol trust assumption.
+    const requiresDleq =
+      this._requireSigDleq && (this._mintInfo?.isSupported(12).supported ?? false);
+    const checkAmounts = options?.checkAmounts ?? true;
+
+    for (let i = 0; i < signatures.length; i++) {
+      this.failIf(
+        checkAmounts && !signatures[i].amount.equals(outputData[i].blindedMessage.amount),
+        `Mint returned signature with wrong amount: expected ${outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}`,
+      );
+      this.failIf(
+        requiresDleq && !signatures[i].dleq,
+        'Mint supports NUT-12, but returned a signature without DLEQ proof',
+      );
+    }
+  }
+
   /**
    * @internal
    */
@@ -2009,18 +2033,12 @@ class Wallet {
       signatures.length !== outputData.length,
       `Mint returned ${signatures.length} signatures, expected ${outputData.length}`,
     );
+    this.validateReturnedSignatures(signatures, outputData);
 
     const keyset = this.getKeyset(keysetId);
     this._logger.debug('MINT COMPLETED', {
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
     });
-    // Verify each signature amount matches the requested amount
-    for (let i = 0; i < signatures.length; i++) {
-      this.failIf(
-        !signatures[i].amount.equals(outputData[i].blindedMessage.amount),
-        `Mint returned signature with wrong amount: expected ${outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}`,
-      );
-    }
     return outputData.map((d, i) => d.toProof(signatures[i], keyset));
   }
 
@@ -2180,18 +2198,13 @@ class Wallet {
       sigs.length !== outputData.length,
       `Mint returned ${sigs.length} signatures, expected ${outputData.length}`,
     );
+    this.validateReturnedSignatures(sigs, outputData);
 
     const keyset = this.getKeyset(keysetId);
     this._logger.debug('BATCH MINT COMPLETED', {
       quotes: payload.quotes.length,
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
     });
-    for (let i = 0; i < sigs.length; i++) {
-      this.failIf(
-        !sigs[i].amount.equals(outputData[i].blindedMessage.amount),
-        `Mint returned signature with wrong amount: expected ${outputData[i].blindedMessage.amount.toString()}, got ${sigs[i].amount.toString()}`,
-      );
-    }
     return outputData.map((d, i) => d.toProof(sigs[i], keyset));
   }
 
@@ -2596,18 +2609,23 @@ class Wallet {
       ...(preferAsync ? { prefer_async: true } : {}),
     };
 
+    // Execute melt and validate result
     const meltResponse: MeltQuoteBaseResponse = await this.mint.melt<TQuote>(
       meltPreview.method,
       meltPayload,
     );
+    if (meltResponse.change) {
+      // Change may not use all outputs (shorter is ok)
+      this.failIf(
+        meltResponse.change.length > meltPreview.outputData.length,
+        `Mint returned ${meltResponse.change.length} signatures, but only ${meltPreview.outputData.length} blanks were provided`,
+      );
+      this.validateReturnedSignatures(meltResponse.change, meltPreview.outputData, {
+        checkAmounts: false, // change outputs are blank
+      });
+    }
 
-    // Check for too many blind signatures before mapping
-    this.failIf(
-      (meltResponse.change?.length ?? 0) > meltPreview.outputData.length,
-      `Mint returned ${meltResponse.change?.length ?? 0} signatures, but only ${meltPreview.outputData.length} blanks were provided`,
-    );
-
-    // Construct change (shorter ok)
+    // Construct change
     const change =
       meltResponse.change?.map((s, i) => meltPreview.outputData[i].toProof(s, keyset)) ?? [];
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -152,6 +152,17 @@ describe('mint api', () => {
     // expect that the sum of all tokens.proofs.amount is equal to the requested amount
     expect(sumProofs(proofs).equals(1337)).toBeTruthy();
   });
+  test('mint tokens with requireSigDleq', async () => {
+    const wallet = new Wallet(mintUrl, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+    const request = await wallet.createMintQuoteBolt11(1337);
+    await untilMintQuotePaid(wallet, request);
+    expect(request).toBeDefined();
+    expect(request.request).toContain('lnbc1337');
+    const proofs = await wallet.mintProofsBolt11(1337, request.quote);
+    expect(proofs).toBeDefined();
+    expect(sumProofs(proofs).equals(1337)).toBeTruthy();
+  });
   test('invoice with description', async () => {
     const wallet = new Wallet(mintUrl, { unit });
     await wallet.loadMint();
@@ -184,7 +195,9 @@ describe('mint api', () => {
     // get the quote from the mint
     const quote_ = await wallet.checkMeltQuoteBolt11(meltQuote.quote);
     expect(quote_).toBeDefined();
-    const sendResponse = await wallet.send(fee.add(2000), proofs, { includeFees: true });
+    const sendResponse = await wallet.send(fee.add(meltQuote.amount), proofs, {
+      includeFees: true,
+    });
     const response = await wallet.meltProofsBolt11(meltQuote, sendResponse.send);
     expect(response).toBeDefined();
     // expect that we have not received the fee back, since it was external
@@ -198,6 +211,38 @@ describe('mint api', () => {
       expect(state.witness).toBeNull();
     });
     // expect none of the sendResponse.keep to be spent
+    const keepProofsStates = await wallet.checkProofsStates(sendResponse.keep);
+    expect(keepProofsStates).toBeDefined();
+    keepProofsStates.forEach((state) => {
+      expect(state.state).toBe(CheckStateEnum.UNSPENT);
+      expect(state.witness).toBeNull();
+    });
+  });
+  test('pay external invoice with requireSigDleq', async () => {
+    const invoice =
+      'lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs';
+    const wallet = new Wallet(mintUrl, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+    const request = await wallet.createMintQuoteBolt11(3000);
+    await untilMintQuotePaid(wallet, request);
+    const proofs = await wallet.mintProofsBolt11(3000, request.quote);
+    const meltQuote = await wallet.createMeltQuoteBolt11(invoice);
+    const fee = meltQuote.fee_reserve;
+    expect(fee.greaterThan(0)).toBeTruthy();
+    const quote_ = await wallet.checkMeltQuoteBolt11(meltQuote.quote);
+    expect(quote_).toBeDefined();
+    const sendResponse = await wallet.send(fee.add(meltQuote.amount), proofs, {
+      includeFees: true,
+    });
+    const response = await wallet.meltProofsBolt11(meltQuote, sendResponse.send);
+    expect(response).toBeDefined();
+    expect(sumProofs(response.change).lessThan(fee)).toBeTruthy();
+    const sentProofsStates = await wallet.checkProofsStates(sendResponse.send);
+    expect(sentProofsStates).toBeDefined();
+    sentProofsStates.forEach((state) => {
+      expect(state.state).toBe(CheckStateEnum.SPENT);
+      expect(state.witness).toBeNull();
+    });
     const keepProofsStates = await wallet.checkProofsStates(sendResponse.keep);
     expect(keepProofsStates).toBeDefined();
     keepProofsStates.forEach((state) => {
@@ -232,6 +277,21 @@ describe('mint api', () => {
     expect(sendResponse.send.length).toBe(2); // 2,8
     // The 32 would have been selected (fee: 1 sat), leaving 4,64 unspent
     // We expect: 16, 4, 1 change + 4,64 unspent = 5 proofs (total 89)
+    expect(sendResponse.keep.length).toBe(5);
+    expect(sumProofs(sendResponse.send).equals(10)).toBeTruthy();
+    expect(sumProofs(sendResponse.keep).equals(89)).toBeTruthy();
+  });
+  test('test send tokens with change with requireSigDleq', async () => {
+    const wallet = new Wallet(mintUrl, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+    const request = await wallet.createMintQuoteBolt11(100);
+    await untilMintQuotePaid(wallet, request);
+    const proofs = await wallet.mintProofsBolt11(100, request.quote);
+    const sendResponse = await wallet.send(10, proofs, { includeFees: false });
+    expect(sendResponse).toBeDefined();
+    expect(sendResponse.send).toBeDefined();
+    expect(sendResponse.keep).toBeDefined();
+    expect(sendResponse.send.length).toBe(2);
     expect(sendResponse.keep.length).toBe(5);
     expect(sumProofs(sendResponse.send).equals(10)).toBeTruthy();
     expect(sumProofs(sendResponse.keep).equals(89)).toBeTruthy();

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -15,9 +15,13 @@ import {
 } from '../../src';
 
 import { randomBytes } from '@noble/hashes/utils.js';
-import { useTestServer, mint, mintUrl, unit, invoice, logger } from './_setup';
+import { useTestServer, mint, mintUrl, unit, invoice, logger, mintInfoResp } from './_setup';
 
 const server = useTestServer();
+const mintInfoRespWithNut12 = {
+  ...mintInfoResp,
+  nuts: { ...mintInfoResp.nuts, 12: { supported: true } },
+};
 
 describe('melt proofs', () => {
   test('test melt proofs base case', async () => {
@@ -101,7 +105,7 @@ describe('melt proofs', () => {
         });
       }),
     );
-    const wallet = new Wallet(mint, { unit });
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();
 
     const meltQuote: MeltQuoteBolt11Response = {
@@ -133,6 +137,62 @@ describe('melt proofs', () => {
     expect(response.quote.state).toBe(MeltQuoteState.PAID);
     expect(response.quote.payment_preimage).toBe('preimage');
     expect(response.change).toHaveLength(0);
+  });
+
+  test('rejects missing DLEQ on melt change when mint advertises NUT-12', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithNut12)),
+      http.post(mintUrl + '/v1/melt/bolt11', () =>
+        HttpResponse.json({
+          quote: 'test_melt_quote',
+          amount: 10,
+          unit: 'sat',
+          fee_reserve: 3,
+          state: MeltQuoteState.PAID,
+          expiry: 1234567890,
+          payment_preimage: 'preimage',
+          request: 'bolt11request',
+          change: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+
+    const meltQuote: MeltQuoteBolt11Response = {
+      quote: 'test_melt_quote',
+      amount: Amount.from(10),
+      fee_reserve: Amount.from(3),
+      request: 'bolt11request',
+      state: MeltQuoteState.UNPAID,
+      expiry: 1234567890,
+      payment_preimage: null,
+      unit: 'sat',
+    };
+    const proofsToSend: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(8),
+        secret: 'secret1',
+        C: 'C1',
+      },
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(5),
+        secret: 'secret2',
+        C: 'C2',
+      },
+    ];
+
+    await expect(wallet.meltProofsBolt11(meltQuote, proofsToSend)).rejects.toThrow(
+      'Mint supports NUT-12, but returned a signature without DLEQ proof',
+    );
   });
 
   test('test melt proofs accepts deserialized ProofLike[] input', async () => {

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -19,6 +19,10 @@ import { hexToBytes } from '@noble/curves/utils.js';
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
 
 const server = useTestServer();
+const mintInfoRespWithNut12 = {
+  ...mintInfoResp,
+  nuts: { ...mintInfoResp.nuts, 12: { supported: true } },
+};
 
 describe('requestTokens', () => {
   test('test requestTokens', async () => {
@@ -92,6 +96,38 @@ describe('requestTokens', () => {
     expect(mintCalls).toBe(1);
     expect(proofs).toHaveLength(1);
     expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+  });
+
+  test('completeMint rejects missing DLEQ when mint advertises NUT-12', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithNut12)),
+      http.post(mintUrl + '/v1/mint/bolt11', () =>
+        HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+            },
+          ],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 1, {
+      quote: 'quote-dleq-required',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      state: MintQuoteState.UNPAID,
+      expiry: null,
+    });
+
+    await expect(wallet.completeMint(preview)).rejects.toThrow(
+      'Mint supports NUT-12, but returned a signature without DLEQ proof',
+    );
   });
 
   test('prepareBatchMint consolidates outputs and completeBatchMint sends batch request', async () => {
@@ -235,6 +271,42 @@ describe('requestTokens', () => {
     const proofs = await wallet.completeBatchMint(batchPreview);
     const totalAmount = sumProofs(proofs);
     expect(totalAmount.equals(5)).toBe(true);
+  });
+
+  test('completeBatchMint rejects missing DLEQ when mint advertises NUT-12', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithNut12)),
+      http.post(mintUrl + '/v1/mint/bolt11/batch', async ({ request }) => {
+        const body = (await request.json()) as { outputs: Array<{ amount: unknown }> };
+        return HttpResponse.json({
+          signatures: body.outputs.map((o) => ({
+            id: '00bd033559de27d0',
+            amount: o.amount,
+            C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+
+    const batchPreview = await wallet.prepareBatchMint('bolt11', [
+      {
+        amount: 1,
+        quote: {
+          quote: 'quote-a',
+          request: 'lnbc...',
+          amount: Amount.from(1),
+          unit: 'sat',
+          state: MintQuoteState.UNPAID,
+          expiry: null,
+        },
+      },
+    ]);
+
+    await expect(wallet.completeBatchMint(batchPreview)).rejects.toThrow(
+      'Mint supports NUT-12, but returned a signature without DLEQ proof',
+    );
   });
 
   test('prepareBatchMint omits signatures when all quotes are unlocked', async () => {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -13,9 +13,13 @@ import {
 import { Bytes } from '../../src/utils';
 import { hexToBytes } from '@noble/curves/utils.js';
 
-import { useTestServer, mint, mintUrl, unit, logger } from './_setup';
+import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
 
 const server = useTestServer();
+const mintInfoRespWithNut12 = {
+  ...mintInfoResp,
+  nuts: { ...mintInfoResp.nuts, 12: { supported: true } },
+};
 
 function expectNUT10SecretDataToEqual(p: Array<Proof>, s: string) {
   p.forEach((p) => {
@@ -40,7 +44,7 @@ const p2pkSecret = JSON.stringify([
 
 describe('sendOffline witness normalization', () => {
   test('strips witness from plain (non-NUT-10) secret', async () => {
-    const wallet = new Wallet(mint, { unit });
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();
 
     const proofs: Proof[] = [
@@ -59,7 +63,7 @@ describe('sendOffline witness normalization', () => {
   });
 
   test('preserves witness on NUT-10 P2PK secret', async () => {
-    const wallet = new Wallet(mint, { unit });
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();
 
     const witnessStr = JSON.stringify({ signatures: ['cafebabe'] });
@@ -79,7 +83,7 @@ describe('sendOffline witness normalization', () => {
   });
 
   test('serializes object witness on NUT-10 secret to JSON string', async () => {
-    const wallet = new Wallet(mint, { unit });
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();
 
     const witnessObj = { signatures: ['cafebabe'] };
@@ -99,7 +103,7 @@ describe('sendOffline witness normalization', () => {
   });
 
   test('no-change when proof has no witness', async () => {
-    const wallet = new Wallet(mint, { unit });
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();
 
     const proofs: Proof[] = [
@@ -117,7 +121,7 @@ describe('sendOffline witness normalization', () => {
   });
 
   test('preserves witness on NUT-10 unknown secret kind', async () => {
-    const wallet = new Wallet(mint, { unit });
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();
 
     const witnessStr = JSON.stringify({ signatures: ['cafebabe'] });
@@ -241,6 +245,42 @@ describe('send', () => {
     expect(result.send[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
     expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
+  });
+
+  test('rejects missing DLEQ on swap when mint advertises NUT-12', async () => {
+    const swapProofs: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(2),
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      },
+    ];
+    server.use(
+      http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithNut12)),
+      http.post(mintUrl + '/v1/swap', () =>
+        HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d423',
+            },
+          ],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true });
+    await wallet.loadMint();
+
+    await expect(wallet.send(1, swapProofs)).rejects.toThrow(
+      'Mint supports NUT-12, but returned a signature without DLEQ proof',
+    );
   });
 
   test('test send accepts AmountLike values', async () => {


### PR DESCRIPTION
Add optional strict DLEQ enforcement for returned blind signatures and tighten swap response validation.

This introduces a wallet option, `requireSigDleq`, that fails mint/swap/melt responses when the mint advertises NUT-12  support but omits DLEQ proofs on returned blinded signatures. The option is disabled by default.

The change also makes swap require an exact number of returned signatures, matching the requested outputs and the existing mint/batch-mint behavior.

NB: preserves melt behavior where change signatures may be fewer than the number of blank outputs

##  Why
Without DLEQ, the wallet cannot cryptographically verify pairing between a returned BlindSignature and the original   BlindedMessage for equal-denomination outputs. That means same-amount reordering remains a trust assumption unless   DLEQ is present.

##  Changes

- Add wallet constructor option requireSigDleq
- Enforce missing-DLEQ failure on returned blind signatures only when:
     - requireSigDleq is enabled, and
     - the mint advertises NUT-12 support
 - Keep amount validation for mint/swap/batch-mint responses
 - Skip amount matching for melt change signatures because NUT-08 change uses blank outputs
 - Require exact signature count for swap responses
 - Clarify wallet option docs around the trust/compatibility tradeoff