### PR TITLE
chore: add 7 days npm min release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
chore: add 7 days npm min release age for security