### PR TITLE
fix: typedocs were not running on release-please

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -3,14 +3,15 @@ permissions:
   contents: write
   id-token: write
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v4.*'
   workflow_dispatch:
 
 jobs:
   build:
-    # Run only when manually triggered, or for a non-prerelease release from main.
-    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && github.event.release.target_commitish == 'main') }}
+    # Run on manual dispatch, or on non-prerelease v4 tags from mainline releases.
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Now just v4. releases without hyphen
