### PR TITLE
feat: add createEphemeralCounterSource function

### DIFF
--- a/docs-src/deterministic_counters.md
+++ b/docs-src/deterministic_counters.md
@@ -72,3 +72,64 @@ await wB.counters.snapshot(); // { '0111111': 137, '0122222': 10, '0133333': 456
 > **Note** The wallet does not await your callback.
 > If saveNextToDb (or similar) is async, handle errors to avoid unhandled rejections
 > For more on lifecycle management, see [WalletEvents](./wallet_events/wallet_events.md)
+
+---
+
+## Shared CounterSource across wallet instances
+
+By default each `new Wallet(...)` creates its own internal counter source. If your app creates multiple wallet instances for the same seed (e.g. short-lived wallets per operation), each instance gets an independent copy seeded from `counterInit` — and concurrent operations can reserve **overlapping counter ranges**, causing "outputs have already been signed" errors.
+
+Use `createEphemeralCounterSource()` to create a single shared source and pass it to every wallet via the `counterSource` option:
+
+```ts
+import { Wallet, createEphemeralCounterSource } from '@cashu/cashu-ts';
+
+// Create once at app start, seeded from your persisted counters
+const counters = createEphemeralCounterSource(loadCountersFromDb());
+
+// Every wallet instance shares the same source — no overlapping reservations
+const walletA = new Wallet(mintA, { unit: 'sat', bip39seed, counterSource: counters });
+const walletB = new Wallet(mintB, { unit: 'sat', bip39seed, counterSource: counters });
+```
+
+### Persisting counter state
+
+The ephemeral source is memory-only — counters do not survive page reloads. Use `wallet.on.countersReserved` to persist after every operation:
+
+```ts
+function wireCounterPersistence(wallet: Wallet) {
+  wallet.on.countersReserved(({ keysetId, next }) => {
+    saveNextToDb(keysetId, next);
+  });
+}
+
+wireCounterPersistence(walletA);
+wireCounterPersistence(walletB);
+```
+
+Because the source is shared, the global event on any wallet instance reflects the true cursor — there is no need for per-operation `onCountersReserved` callbacks in your builder chains.
+
+### counterSource vs counterInit
+
+| Option          | When to use                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `counterInit`   | Single wallet instance, or you don't need cross-wallet coordination. Seeds a wallet-local ephemeral source.               |
+| `counterSource` | Multiple wallet instances for the same seed, or you need persistence/custom storage. Takes precedence over `counterInit`. |
+
+### Custom CounterSource implementations
+
+`createEphemeralCounterSource` returns the built-in in-memory implementation. For durable storage you can implement `CounterSource` directly:
+
+```ts
+import type { CounterSource, CounterRange } from '@cashu/cashu-ts';
+
+class IndexedDbCounterSource implements CounterSource {
+  async reserve(keysetId: string, n: number): Promise<CounterRange> {
+    // atomic read-and-increment in your DB
+  }
+  async advanceToAtLeast(keysetId: string, minNext: number): Promise<void> {
+    // conditional update: SET next = max(next, minNext)
+  }
+  // Optional: snapshot(), setNext()
+}
+```

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -230,6 +230,9 @@ export function createBlindSignature(B_: WeierstrassPoint<bigint>, privateKey: U
 export const createDLEQProof: (B_: WeierstrassPoint<bigint>, a: Uint8Array) => DLEQ;
 
 // @public
+export function createEphemeralCounterSource(initial?: Record<string, number>): CounterSource;
+
+// @public
 export function createHTLCHash(preimage?: string): {
     hash: string;
     preimage: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export {
 
 // Wallet/Mint types used in the public API surface
 export type { CounterRange, CounterSource, OperationCounters } from './wallet/CounterSource';
+export { createEphemeralCounterSource } from './wallet/CounterSource';
 export type { SubscribeOpts, CancellerLike, SubscriptionCanceller } from './wallet/WalletEvents';
 export type * from './wallet/types/config';
 export type * from './wallet/types/payloads';

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -106,3 +106,20 @@ export class EphemeralCounterSource implements CounterSource {
     return Promise.resolve(Object.fromEntries(this.next.entries()));
   }
 }
+
+/**
+ * Create a shared in-memory {@link CounterSource}.
+ *
+ * Use this when multiple {@link Wallet} instances share the same seed and must allocate
+ * deterministic outputs without overlapping counter ranges. Pass the returned source to each wallet
+ * via the `counterSource` option.
+ *
+ * The source is memory-only — counters do not survive page reloads. Subscribe to
+ * {@link WalletEvents.countersReserved | wallet.on.countersReserved} to persist counter state to
+ * your own storage.
+ *
+ * @param initial - Optional seed values (`{ [keysetId]: nextCounter }`).
+ */
+export function createEphemeralCounterSource(initial?: Record<string, number>): CounterSource {
+  return new EphemeralCounterSource(initial);
+}

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -1,10 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { EphemeralCounterSource, type CounterRange } from '../../src/wallet';
+import {
+  EphemeralCounterSource,
+  type CounterRange,
+  createEphemeralCounterSource,
+} from '../../src/wallet';
 
 describe('EphemeralCounterSource', () => {
   it('constructor seeds initial next values', async () => {
     const src = new EphemeralCounterSource({ a: 5, b: 2 });
     const snap = await src.snapshot();
+    expect(snap).toEqual({ a: 5, b: 2 });
+  });
+
+  it('factory seeds initial next values', async () => {
+    const src = createEphemeralCounterSource({ a: 5, b: 2 });
+    const snap = await src.snapshot!(); // definitely implemented
     expect(snap).toEqual({ a: 5, b: 2 });
   });
 


### PR DESCRIPTION
Adds a public `createEphemeralCounterSource()` factory to the top-level API.

This gives consumers an official way to create a shared in-memory `CounterSource` for multiple wallet instances without:

- deep-importing internals
- reimplementing the built-in ephemeral source
- depending on the concrete `EphemeralCounterSource` class as public API

## Why

`CounterSource` is already the correct public abstraction for shared deterministic counter allocation, and `Wallet` already supports it via the `counterSource` option.

What was missing was an ergonomic public way to get the default in-memory implementation.

This is useful when multiple `Wallet` instances share the same seed and must allocate deterministic outputs without overlapping counter ranges.

Examples include:

- apps that recreate wallet instances across views / flows
- consumers who need a simple in-process shared source before implementing persistence

## API added

```ts
export function createEphemeralCounterSource(
  initial?: Record<string, number>,
): CounterSource