### PR TITLE
feat: widen selectProofsToSend and groupProofsByState to accept ProofLike

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1920,10 +1920,10 @@ export class Wallet {
     getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount;
     getKeyset(id?: string): Keyset;
     getMintInfo(): MintInfo;
-    groupProofsByState(proofs: Proof[]): Promise<{
-        unspent: Proof[];
-        pending: Proof[];
-        spent: Proof[];
+    groupProofsByState<T extends ProofLike = Proof>(proofs: T[]): Promise<{
+        unspent: T[];
+        pending: T[];
+        spent: T[];
     }>;
     get keyChain(): KeyChain;
     get keysetId(): string;
@@ -1955,7 +1955,7 @@ export class Wallet {
         proofs: Proof[];
         lastCounterWithSignature?: number;
     }>;
-    selectProofsToSend(proofs: Proof[], amountToSend: AmountLike, includeFees?: boolean, exactMatch?: boolean): SendResponse;
+    selectProofsToSend(proofs: ProofLike[], amountToSend: AmountLike, includeFees?: boolean, exactMatch?: boolean): SendResponse;
     send(amount: AmountLike, proofs: ProofLike[], config?: SendConfig, outputConfig?: OutputConfig): Promise<SendResponse>;
     sendOffline(amount: AmountLike, proofs: ProofLike[], config?: SendOfflineConfig): SendResponse;
     signP2PKProofs(proofs: ProofLike[], privkey: string | string[], outputData?: OutputDataLike[], quoteId?: string): Proof[];

--- a/migration-4.0.0.SKILL.md
+++ b/migration-4.0.0.SKILL.md
@@ -150,6 +150,8 @@ Migration rule: treat wallet/mint/API/JSON proofs as `ProofLike[]` until normali
 
 Core wallet flows now accept `ProofLike[]` directly. If those proofs are only being passed into wallet APIs such as `send`, `sendOffline`, `receive`, `prepareSwapToSend`, `meltProofs...`, or `signP2PKProofs`, you can often skip manual normalization. The same applies to `WalletOps` / builder entry points such as `wallet.ops.send(...)`, `wallet.ops.receive(...)`, and `wallet.ops.meltBolt11(...)`.
 
+`wallet.selectProofsToSend()` and `wallet.groupProofsByState()` also accept `ProofLike[]`. Proofs from storage with `amount: number` can be passed directly. `groupProofsByState` is generic — it preserves the input type in its output.
+
 ---
 
 ## Step 3 — `Amount` value object (was `number`)
@@ -468,7 +470,25 @@ const factory: OutputDataFactory = (amount: AmountLike, keys: HasKeysetKeys) => 
 
 ---
 
-## Step 18 — Type-check and test
+## Step 18 — Shared `CounterSource` (optional improvement)
+
+Search: `counterInit`, manual counter increment/persist patterns.
+
+If the app creates multiple wallet instances for the same seed with independent `counterInit` snapshots, consider using `createEphemeralCounterSource()` (new in v4) to share a single counter source:
+
+```ts
+import { createEphemeralCounterSource } from '@cashu/cashu-ts';
+
+const counterSource = createEphemeralCounterSource(loadCountersFromDb());
+const wallet = new Wallet(mintUrl, { unit, bip39seed, counterSource });
+wallet.on.countersReserved(({ keysetId, next }) => saveNextToDb(keysetId, next));
+```
+
+This is not a breaking change — existing `counterInit` usage continues to work. The factory is a DX improvement for apps that need shared counter allocation across wallet instances.
+
+---
+
+## Step 19 — Type-check and test
 
 ```bash
 # Usually, but check your app:

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -426,6 +426,8 @@ Migration rule: treat wallet/mint/API/JSON proofs as `ProofLike[]` until normali
 
 **Tip**: Core wallet flows now accept `ProofLike[]` directly. If you already have deserialized proof objects from JSON or storage, you can usually pass them straight into wallet APIs such as `wallet.receive(...)`, `wallet.send(...)`, `wallet.sendOffline(...)`, `wallet.prepareSwapToSend(...)`, `wallet.meltProofs...(...)`, and `wallet.signP2PKProofs(...)` without calling `normalizeProofAmounts(...)` yourself first. The same applies to `WalletOps` / builder entry points such as `wallet.ops.send(...)`, `wallet.ops.receive(...)`, and `wallet.ops.meltBolt11(...)`.
 
+`wallet.selectProofsToSend()` and `wallet.groupProofsByState()` also accept `ProofLike[]`, so proofs loaded from storage (with `amount: number`) can be passed directly without conversion. `groupProofsByState` preserves the input type in its output — pass `MyProof[]` in, get `MyProof[]` back.
+
 ```ts
 import { serializeProofs, deserializeProofs } from '@cashu/cashu-ts';
 
@@ -894,5 +896,21 @@ const adjusted = estInvAmount.scaledBy(tokenAmount, neededAmount).subtract(1);
 const bounded = fee.clamp(MIN_FEE, tokenAmount);
 if (msats.inRange(data.minSendable, data.maxSendable)) { ... }
 ```
+
+---
+
+## New: `createEphemeralCounterSource` factory
+
+v4 adds a public factory for the built-in in-memory `CounterSource`:
+
+```ts
+import { createEphemeralCounterSource } from '@cashu/cashu-ts';
+
+const counters = createEphemeralCounterSource(loadCountersFromDb());
+```
+
+Previously, consumers who needed a shared `CounterSource` across multiple wallet instances had to either deep-import the internal `EphemeralCounterSource` class or reimplement the interface. The factory provides the same capability without exposing the concrete class.
+
+This is useful when your app creates multiple short-lived wallet instances for the same seed — passing a shared `counterSource` prevents concurrent operations from reserving overlapping counter ranges. See the [deterministic counters guide](./docs-src/deterministic_counters.md) for the full pattern.
 
 ---

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1325,7 +1325,8 @@ class Wallet {
    * @remarks
    * Uses an adapted Randomized Greedy with Local Improvement (RGLI) algorithm, which has a time
    * complexity O(n log n) and space complexity O(n).
-   * @param proofs Array of Proof objects available to select from.
+   * @param proofs Array of proofs available to select from. Accepts {@link ProofLike} so proofs
+   *   loaded from storage (with `amount: number`) work without manual conversion.
    * @param amountToSend The target amount to send.
    * @param includeFees Optional boolean to include fees; Default: false.
    * @param exactMatch Optional boolean to require exact match; Default: false.
@@ -1334,7 +1335,7 @@ class Wallet {
    * @see https://crypto.ethz.ch/publications/files/Przyda02.pdf
    */
   selectProofsToSend(
-    proofs: Proof[],
+    proofs: ProofLike[],
     amountToSend: AmountLike,
     includeFees = false,
     exactMatch = false,
@@ -2681,17 +2682,20 @@ class Wallet {
   /**
    * Groups proofs by their corresponding state, preserving order within each group.
    *
-   * @param proofs (only the `secret` field is required)
+   * @remarks
+   * Returns the same type you supply, eg: pass `MyProof[]` in, get `MyProof[]` back.
+   * @param proofs Accepts {@link ProofLike} so proofs from storage work without conversion. Only the
+   *   `secret` field is used for the state check; amounts are passed through as-is.
    * @returns An object with arrays of proofs grouped by CheckStateEnum state.
    */
-  async groupProofsByState(
-    proofs: Proof[],
-  ): Promise<{ unspent: Proof[]; pending: Proof[]; spent: Proof[] }> {
+  async groupProofsByState<T extends ProofLike = Proof>(
+    proofs: T[],
+  ): Promise<{ unspent: T[]; pending: T[]; spent: T[] }> {
     const states: ProofState[] = await this.checkProofsStates(proofs);
     const result = {
-      unspent: [] as Proof[],
-      pending: [] as Proof[],
-      spent: [] as Proof[],
+      unspent: [] as T[],
+      pending: [] as T[],
+      spent: [] as T[],
     };
     for (let i = 0; i < states.length; i++) {
       const proof = proofs[i];


### PR DESCRIPTION
Consumers storing proofs with `amount: number` no longer need a manual conversion wrapper before calling these methods.
- `selectProofsToSend`
- `groupProofsByState`

` groupProofsByState` is now generic and preserves the input type in its output.

