### PR TITLE
feat: replace sanitizeUrl with normalizeUrl for mint URL validation

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -26,6 +26,8 @@ wallet2.loadMintFromCache(mintInfoCache, keychainCache);
 // wallet2 is now ready to use
 ```
 
+> ⚠️ **Server-side usage:** If you construct a `Wallet` (or `Mint`) using a URL from untrusted input (e.g. a received token), validate the mint URL against your own trusted-mint allowlist **before** passing it in. The library validates URL structure but cannot know which mints your application trusts.
+
 ## Custom output generation
 
 Pass `outputDataCreator` when you need to replace the default output generation logic, for

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -400,7 +400,7 @@ The following are still exported but are excluded from the trimmed type definiti
 | `numberToHexPadded64`   | Crypto scalar helper (bigint → 64-char hex).   |
 | `isObj`                 | HTTP response type guard.                      |
 | `joinUrls`              | Mint URL path builder.                         |
-| `sanitizeUrl`           | URL trailing-slash normalizer.                 |
+| `sanitizeUrl`           | Renamed to `normalizeUrl` (internal).          |
 | `invoiceHasAmountInHRP` | BOLT-11 HRP amount detector.                   |
 | `bigIntStringify`       | `JSON.stringify` replacer for `bigint` values. |
 

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -46,7 +46,7 @@ import {
   normalizeMintKeys,
   normalizeMintKeyset,
   normalizeSafeIntegerMetadata,
-  sanitizeUrl,
+  normalizeUrl,
 } from '../utils';
 
 import type {
@@ -88,7 +88,7 @@ class Mint {
       logger?: Logger;
     },
   ) {
-    this._mintUrl = sanitizeUrl(mintUrl);
+    this._mintUrl = normalizeUrl(mintUrl);
     this._request = options?.customRequest ?? request;
     this._authProvider = options?.authProvider;
     this._logger = options?.logger ?? NULL_LOGGER;
@@ -839,7 +839,6 @@ class Mint {
       if (mintUrl.pathname.endsWith('/')) mintUrl.pathname += wsSegment;
       else mintUrl.pathname += '/' + wsSegment;
 
-      // preserve query params if any, and avoid manual string building
       mintUrl.protocol = mintUrl.protocol === 'https:' ? 'wss:' : 'ws:';
       const wsUrl = mintUrl.toString();
 

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -505,12 +505,28 @@ export function joinUrls(...parts: string[]): string {
 }
 
 /**
- * Strips a trailing slash from a URL.
+ * Parses and normalizes a mint URL: validates the scheme (http/https only), rejects query
+ * parameters and fragments, and strips any trailing slashes.
  *
  * @internal
  */
-export function sanitizeUrl(url: string): string {
-  return url.replace(/\/$/, '');
+export function normalizeUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid mint URL: ${url}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid mint URL scheme: ${parsed.protocol}`);
+  }
+  if (parsed.search) {
+    throw new Error('Mint URL must not contain query parameters');
+  }
+  if (parsed.hash) {
+    throw new Error('Mint URL must not contain a fragment');
+  }
+  return parsed.href.replace(/\/+$/, '');
 }
 
 /**

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -520,10 +520,10 @@ export function normalizeUrl(url: string): string {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`Invalid mint URL scheme: ${parsed.protocol}`);
   }
-  if (parsed.search) {
+  if (parsed.search || parsed.href.includes('?')) {
     throw new Error('Mint URL must not contain query parameters');
   }
-  if (parsed.hash) {
+  if (parsed.hash || parsed.href.includes('#')) {
     throw new Error('Mint URL must not contain a fragment');
   }
   return parsed.href.replace(/\/+$/, '');

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -49,7 +49,7 @@ import {
   hasValidDleq,
   invoiceHasAmountInHRP,
   normalizeProofAmounts,
-  sanitizeUrl,
+  normalizeUrl,
   splitAmount,
   sumProofs,
   ABSOLUTE_MAX_BATCH_SIZE,
@@ -921,7 +921,7 @@ class Wallet {
       proofs = normalizeProofAmounts(token);
     } else {
       const decodedToken: Token = typeof token === 'string' ? this.decodeToken(token) : token;
-      const tokenMintUrl = sanitizeUrl(decodedToken.mint);
+      const tokenMintUrl = normalizeUrl(decodedToken.mint);
       this.failIf(tokenMintUrl !== this.mint.mintUrl, 'Token belongs to a different mint', {
         token: tokenMintUrl,
         wallet: this.mint.mintUrl,

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -21,7 +21,7 @@ type ReqArgs = {
 };
 
 const mintUrl = 'https://localhost:3338';
-const fakeWsUrl = 'wss://mint.example/cashu/v1/ws?token=abc';
+const fakeWsUrl = 'wss://mint.example/cashu/v1/ws';
 
 const makeRequest = <T>(payload: T): RequestFn => {
   return (async (options: ReqArgs): Promise<T> => {
@@ -736,7 +736,7 @@ describe('Mint normalization', () => {
   it('connectWebSocket builds the expected URL and disconnectWebSocket closes the connection', async () => {
     injectWebSocketImpl(WebSocket);
     const server = new Server(fakeWsUrl, { mock: false });
-    const mint = new Mint('https://mint.example/cashu?token=abc');
+    const mint = new Mint('https://mint.example/cashu');
     let serverSocket!: Client;
 
     try {

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -28,6 +28,7 @@ import {
   deserializeProofs,
   normalizeProofAmounts,
   sortProofsById,
+  normalizeUrl,
 } from '../../src/utils';
 import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 
@@ -1128,5 +1129,44 @@ describe('mapShortKeysetIds via getDecodedToken (v2 keyset IDs)', () => {
     // Two full IDs that share the same 16-char prefix
     const ambiguous = fullV2Id + 'aa';
     expect(() => utils.getDecodedToken(encoded, [fullV2Id, ambiguous])).toThrow(/ambiguous/);
+  });
+});
+
+describe('normalizeUrl', () => {
+  test('strips trailing slash', () => {
+    expect(normalizeUrl('https://mint.example.com/')).toBe('https://mint.example.com');
+  });
+  test('strips multiple trailing slashes', () => {
+    expect(normalizeUrl('https://mint.example.com///')).toBe('https://mint.example.com');
+  });
+  test('preserves path', () => {
+    expect(normalizeUrl('https://mint.example.com/v1/mint')).toBe(
+      'https://mint.example.com/v1/mint',
+    );
+  });
+  test('throws on malformed URL', () => {
+    expect(() => normalizeUrl('not-a-url')).toThrow('Invalid mint URL: not-a-url');
+  });
+  test('throws on non-http scheme', () => {
+    expect(() => normalizeUrl('ftp://mint.example.com')).toThrow('Invalid mint URL scheme: ftp:');
+  });
+  test('accepts http', () => {
+    expect(normalizeUrl('http://localhost:3338')).toBe('http://localhost:3338');
+  });
+  test('accepts .onion', () => {
+    expect(normalizeUrl('http://abc123.onion/path')).toBe('http://abc123.onion/path');
+  });
+  test('rejects query parameters', () => {
+    expect(() => normalizeUrl('https://mint.example.com?token=abc')).toThrow(
+      'Mint URL must not contain query parameters',
+    );
+  });
+  test('rejects fragment', () => {
+    expect(() => normalizeUrl('https://mint.example.com#section')).toThrow(
+      'Mint URL must not contain a fragment',
+    );
+  });
+  test('lowercases hostname', () => {
+    expect(normalizeUrl('https://Mint.Example.COM')).toBe('https://mint.example.com');
   });
 });

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1161,8 +1161,18 @@ describe('normalizeUrl', () => {
       'Mint URL must not contain query parameters',
     );
   });
+  test('rejects trailing ? with no query value', () => {
+    expect(() => normalizeUrl('https://mint.example.com/path?')).toThrow(
+      'Mint URL must not contain query parameters',
+    );
+  });
   test('rejects fragment', () => {
     expect(() => normalizeUrl('https://mint.example.com#section')).toThrow(
+      'Mint URL must not contain a fragment',
+    );
+  });
+  test('rejects trailing # with no fragment value', () => {
+    expect(() => normalizeUrl('https://mint.example.com/path#')).toThrow(
       'Mint URL must not contain a fragment',
     );
   });


### PR DESCRIPTION
Rename `sanitizeUrl` → `normalizeUrl` and add proper validation.

- URL parsing via `new URL()`
- http/https-only scheme check
-  query parameter and fragment rejection.
- Adds server-side SSRF warning to wallet docs.
- Adds tests

This function was made internal in v4, so a non-breaking change. Although 99% of wallets/apps are local, so not prone to SSRF issues, we added a warning (consistent with DLEQ) to remind server-side apps to treate tokens as untrusted input.