### PR TITLE
fix: harden mint URL normalization

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -505,8 +505,8 @@ export function joinUrls(...parts: string[]): string {
 }
 
 /**
- * Parses and normalizes a mint URL: validates the scheme (http/https only), rejects query
- * parameters and fragments, and strips any trailing slashes.
+ * Parses and normalizes a mint URL: validates the scheme (http/https only), rejects credentials,
+ * query parameters, fragments, and encoded path delimiters, and strips any trailing slashes.
  *
  * @internal
  */
@@ -520,11 +520,17 @@ export function normalizeUrl(url: string): string {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`Invalid mint URL scheme: ${parsed.protocol}`);
   }
+  if (parsed.username || parsed.password) {
+    throw new Error('Mint URL must not contain credentials');
+  }
   if (parsed.search || parsed.href.includes('?')) {
     throw new Error('Mint URL must not contain query parameters');
   }
   if (parsed.hash || parsed.href.includes('#')) {
     throw new Error('Mint URL must not contain a fragment');
+  }
+  if (/%[0-9a-f]{2}/i.test(parsed.pathname)) {
+    throw new Error('Mint URL path must not contain percent-encoded characters');
   }
   return parsed.href.replace(/\/+$/, '');
 }

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1176,6 +1176,25 @@ describe('normalizeUrl', () => {
       'Mint URL must not contain a fragment',
     );
   });
+  test('rejects credentials', () => {
+    expect(() => normalizeUrl('https://user:pass@mint.example.com')).toThrow(
+      'Mint URL must not contain credentials',
+    );
+    expect(() => normalizeUrl('https://user@mint.example.com')).toThrow(
+      'Mint URL must not contain credentials',
+    );
+  });
+  test('rejects percent-encoded path characters', () => {
+    expect(() => normalizeUrl('https://mint.example.com/path%3Ftoken=abc')).toThrow(
+      'Mint URL path must not contain percent-encoded characters',
+    );
+    expect(() => normalizeUrl('https://mint.example.com/path%23fragment')).toThrow(
+      'Mint URL path must not contain percent-encoded characters',
+    );
+    expect(() => normalizeUrl('https://mint.example.com/path%2Fadmin')).toThrow(
+      'Mint URL path must not contain percent-encoded characters',
+    );
+  });
   test('lowercases hostname', () => {
     expect(normalizeUrl('https://Mint.Example.COM')).toBe('https://mint.example.com');
   });


### PR DESCRIPTION
## Summary

  - Tighten mint URL normalization for base endpoint inputs
  - Reject credentials in mint URLs
  - Reject percent-encoded path characters in mint URL paths
  - Add focused tests for the new normalization rules