### PR TITLE
feat(nut12): deterministic DLEQ nonce derivation

### DIFF
--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -25,6 +25,7 @@ function deriveDLEQNonce(
     const r = bytesToNumberBE(h) % n;
     if (r !== 0n) return r;
   }
+  /* c8 ignore next */
   throw new Error('DLEQ nonce derivation failed');
 }
 

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -1,10 +1,32 @@
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { numberToBytesBE } from '@noble/curves/utils.js';
+import { bytesToNumberBE, numberToBytesBE } from '@noble/curves/utils.js';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { Bytes } from '../utils';
 
-import { type DLEQ, hash_e, hashToCurve, createRandomSecretKey } from './core';
+import { type DLEQ, hash_e, hashToCurve } from './core';
+
+const DST_R = utf8ToBytes('Cashu_DLEQ_R_v1');
+
+function deriveDLEQNonce(
+  a: Uint8Array,
+  A: WeierstrassPoint<bigint>,
+  B_: WeierstrassPoint<bigint>,
+  C_: WeierstrassPoint<bigint>,
+): bigint {
+  const hmacKey = sha256(a);
+  const base = concatBytes(DST_R, A.toBytes(false), B_.toBytes(false), C_.toBytes(false));
+  const n = secp256k1.Point.CURVE().n;
+  for (let ctr = 0; ctr < 256; ctr++) {
+    const h = hmac(sha256, hmacKey, concatBytes(base, new Uint8Array([ctr])));
+    const r = bytesToNumberBE(h) % n;
+    if (r !== 0n) return r;
+  }
+  throw new Error('DLEQ nonce derivation failed');
+}
 
 export const verifyDLEQProof = (
   dleq: DLEQ,
@@ -44,12 +66,12 @@ export const verifyDLEQProof_reblind = (
  * https://en.wikipedia.org/wiki/Timing_attack for information about timing attacks.
  */
 export const createDLEQProof = (B_: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
-  const r = secp256k1.Point.Fn.fromBytes(createRandomSecretKey()); // r <- random (Uint8Array)
+  const scalar_a = secp256k1.Point.Fn.fromBytes(a);
+  const A = secp256k1.Point.BASE.multiply(scalar_a); // A  = aG
+  const C_ = B_.multiply(scalar_a); // C_ = aB_
+  const r = deriveDLEQNonce(a, A, B_, C_);
   const R_1 = secp256k1.Point.BASE.multiply(r); // R1 = rG
   const R_2 = B_.multiply(r); // R2 = rB_
-  const scalar_a = secp256k1.Point.Fn.fromBytes(a);
-  const C_ = B_.multiply(scalar_a); // C_ = aB_
-  const A = secp256k1.Point.BASE.multiply(scalar_a); // A = aG
   const e = hash_e([R_1, R_2, A, C_]); // e = hash(R1, R2, A, C_)
   const scalar_e = secp256k1.Point.Fn.fromBytes(e);
   // Use field operations for constant-time addition and multiplication

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -18,10 +18,9 @@ function deriveDLEQNonce(
   B_: WeierstrassPoint<bigint>,
   C_: WeierstrassPoint<bigint>,
 ): bigint {
-  const hmacKey = sha256(a);
   const base = concatBytes(DST_R, A.toBytes(false), B_.toBytes(false), C_.toBytes(false));
   for (let ctr = 0; ctr < 256; ctr++) {
-    const h = hmac(sha256, hmacKey, concatBytes(base, new Uint8Array([ctr])));
+    const h = hmac(sha256, a, concatBytes(base, new Uint8Array([ctr])));
     const x = bytesToNumberBE(h);
     // Reduce modulo curve order. Single subtraction suffices since HMAC output
     // is 256 bits and SECP256K1_N is ~2^256, so x can exceed N by at most once.

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -10,6 +10,7 @@ import { Bytes } from '../utils';
 import { type DLEQ, hash_e, hashToCurve } from './core';
 
 const DST_R = utf8ToBytes('Cashu_DLEQ_R_v1');
+const SECP256K1_N = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141');
 
 function deriveDLEQNonce(
   a: Uint8Array,
@@ -19,10 +20,12 @@ function deriveDLEQNonce(
 ): bigint {
   const hmacKey = sha256(a);
   const base = concatBytes(DST_R, A.toBytes(false), B_.toBytes(false), C_.toBytes(false));
-  const n = secp256k1.Point.CURVE().n;
   for (let ctr = 0; ctr < 256; ctr++) {
     const h = hmac(sha256, hmacKey, concatBytes(base, new Uint8Array([ctr])));
-    const r = bytesToNumberBE(h) % n;
+    const x = bytesToNumberBE(h);
+    // Reduce modulo curve order. Single subtraction suffices since HMAC output
+    // is 256 bits and SECP256K1_N is ~2^256, so x can exceed N by at most once.
+    const r = x >= SECP256K1_N ? x - SECP256K1_N : x;
     /* c8 ignore next */
     if (r !== 0n) return r;
   }

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -23,6 +23,7 @@ function deriveDLEQNonce(
   for (let ctr = 0; ctr < 256; ctr++) {
     const h = hmac(sha256, hmacKey, concatBytes(base, new Uint8Array([ctr])));
     const r = bytesToNumberBE(h) % n;
+    /* c8 ignore next */
     if (r !== 0n) return r;
   }
   /* c8 ignore next */

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -77,10 +77,10 @@ describe('deterministic nonce derivation — spec test vectors', () => {
     const B_ = pointFromHex('02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2');
     const proof = createDLEQProof(B_, a);
     expect(bytesToHex(proof.e)).toBe(
-      'be53688e1952a916726cf4f031584404c6a79b32ccf0b58f3db9a46794abc1dc',
+      '2a16ffee280aff3c429045607f9b8e0bf8b35910c44c1b20b9dfaf01b263d7b3',
     );
     expect(bytesToHex(proof.s)).toBe(
-      '1d6ecdf7ca128c90f65bd64e1f894fad985be8af6b350fece5ca4e9e259a54ad',
+      '9df27731238334718d120d4f74611a7c668233f988e687ac3fb188f0a34a2dab',
     );
   });
 

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -1,5 +1,5 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { bytesToHex } from '@noble/hashes/utils.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
 import {
   createBlindSignature,
@@ -68,6 +68,64 @@ describe('test DLEQ scheme', () => {
     // Wallet(Carol)
     const isValid = verifyDLEQProof_reblind(blindMessage.secret, dleqProof, proof.C, mintPubKey);
     expect(isValid).toBe(true);
+  });
+});
+
+describe('deterministic nonce derivation — spec test vectors', () => {
+  test('reproduces exact (e, s) for known (a, B_)', () => {
+    const a = hexToBytes('0000000000000000000000000000000000000000000000000000000000000002');
+    const B_ = pointFromHex('02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2');
+    const proof = createDLEQProof(B_, a);
+    expect(bytesToHex(proof.e)).toBe(
+      'be53688e1952a916726cf4f031584404c6a79b32ccf0b58f3db9a46794abc1dc',
+    );
+    expect(bytesToHex(proof.s)).toBe(
+      '1d6ecdf7ca128c90f65bd64e1f894fad985be8af6b350fece5ca4e9e259a54ad',
+    );
+  });
+
+  test('proof verifies for known vector', () => {
+    const a = hexToBytes('0000000000000000000000000000000000000000000000000000000000000002');
+    const B_ = pointFromHex('02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2');
+    const A = pointFromHex('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
+    const C_ = pointFromHex('0244eccfc7a348274458bb38044c7f3c389b3c2086c7ec18b5812d2877ab937787');
+    const proof = createDLEQProof(B_, a);
+    expect(verifyDLEQProof(proof, B_, C_, A)).toBe(true);
+  });
+});
+
+describe('deterministic nonce derivation', () => {
+  test('same key + same B_ always produces identical (e, s)', () => {
+    const mintPrivKey = secp256k1.utils.randomSecretKey();
+    const blindMsg = createRandomRawBlindedMessage();
+
+    const proof1 = createDLEQProof(blindMsg.B_, mintPrivKey);
+    const proof2 = createDLEQProof(blindMsg.B_, mintPrivKey);
+
+    expect(bytesToHex(proof1.e)).toBe(bytesToHex(proof2.e));
+    expect(bytesToHex(proof1.s)).toBe(bytesToHex(proof2.s));
+  });
+
+  test('different B_ produces different (e, s)', () => {
+    const mintPrivKey = secp256k1.utils.randomSecretKey();
+    const blindMsg1 = createRandomRawBlindedMessage();
+    const blindMsg2 = createRandomRawBlindedMessage();
+
+    const proof1 = createDLEQProof(blindMsg1.B_, mintPrivKey);
+    const proof2 = createDLEQProof(blindMsg2.B_, mintPrivKey);
+
+    expect(bytesToHex(proof1.e)).not.toBe(bytesToHex(proof2.e));
+  });
+
+  test('different key produces different (e, s) for same B_', () => {
+    const key1 = secp256k1.utils.randomSecretKey();
+    const key2 = secp256k1.utils.randomSecretKey();
+    const blindMsg = createRandomRawBlindedMessage();
+
+    const proof1 = createDLEQProof(blindMsg.B_, key1);
+    const proof2 = createDLEQProof(blindMsg.B_, key2);
+
+    expect(bytesToHex(proof1.e)).not.toBe(bytesToHex(proof2.e));
   });
 });
 


### PR DESCRIPTION
Implements the [proposed change to NUT-12 spec](https://github.com/cashubtc/nuts/pull/368), switching createDLEQProof to derive `r` deterministically via HMAC-SHA256, keyed on mint's private key (`a`) and bound to the proof context (A, B', C'):

```
r = HMAC-SHA256(key=a, data="Cashu_DLEQ_R_v1" || A || B' || C' || ctr) mod n
```

This is not a breaking change. Verifiers reconstruct R1 and R2 from (e, s) — how the prover derived r is opaque to the verification equation. Existing proofs continue to verify.

## Changes

- `src/crypto/NUT12.ts` replaces `createRandomSecretKey()` with `deriveDLEQNonce()`. Function signature of createDLEQProof is unchanged.
- `test/crypto/NUT12.test.ts` — adds spec test vectors plus unit tests