### PR TITLE
fix: only set User-Agent override in non-browserlike runtimes

### DIFF
--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -13,6 +13,8 @@ export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 
 /**
  * Subset of globalThis used by {@link detectBrowserLike}; loosened for unit tests.
+ *
+ * @internal
  */
 export type GlobalLike = {
   window?: { document?: unknown };
@@ -23,6 +25,8 @@ export type GlobalLike = {
 /**
  * True in browser main thread + any Worker scope (classic/module/shared/service via
  * `WorkerGlobalScope`).
+ *
+ * @internal
  */
 export function detectBrowserLike(g: GlobalLike): boolean {
   if (g.window !== undefined && g.window.document !== undefined) return true;
@@ -34,6 +38,30 @@ export function detectBrowserLike(g: GlobalLike): boolean {
 }
 
 const IS_BROWSER_LIKE = detectBrowserLike(globalThis);
+
+/**
+ * Builds the outgoing request headers.
+ *
+ * @remarks
+ * Overrides the default User-Agent in non-browser runtimes (Node, Deno, Bun, React Native) where
+ * native HTTP stacks otherwise leak fingerprintable identifiers (undici, NSURLSession, OkHttp).
+ * Skipped in browsers + workers because Firefox/WebKit can promote it to a CORS preflight even
+ * though the Fetch spec lists it as a forbidden header. Caller-supplied `requestHeaders` always
+ * wins.
+ * @internal
+ */
+export function buildRequestHeaders(
+  body: string | undefined,
+  requestHeaders: Record<string, string> | undefined,
+  isBrowserLike: boolean = IS_BROWSER_LIKE,
+): Record<string, string> {
+  return {
+    Accept: 'application/json, text/plain, */*',
+    ...(body ? { 'Content-Type': 'application/json' } : undefined),
+    ...(isBrowserLike ? undefined : { 'User-Agent': 'Mozilla/5.0' }),
+    ...requestHeaders,
+  };
+}
 
 export type RequestArgs = {
   endpoint: string;
@@ -323,17 +351,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
   void logger;
 
   const body = requestBody ? JSONInt.stringify(requestBody) : undefined;
-  const headers: Record<string, string> = {
-    Accept: 'application/json, text/plain, */*',
-    ...(body ? { 'Content-Type': 'application/json' } : undefined),
-    // Override the default User-Agent in non-browser runtimes (Node, Deno, Bun, React
-    // Native) where native HTTP stacks otherwise leak fingerprintable identifiers
-    // (undici, NSURLSession, OkHttp). Skipped in browsers + workers because Firefox/
-    // WebKit can promote it to a CORS preflight even though the Fetch spec lists it as
-    // a forbidden header.
-    ...(IS_BROWSER_LIKE ? undefined : { 'User-Agent': 'Mozilla/5.0' }),
-    ...requestHeaders,
-  };
+  const headers = buildRequestHeaders(body, requestHeaders);
   const callerSignal = options.signal ?? undefined;
   if (callerSignal?.aborted) {
     throw new CallerAbortError('Request aborted by caller');

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -11,9 +11,29 @@ import { JSONInt } from '../utils/JSONInt';
 // Generic request function type so callers can do requestInstance<T>(...)
 export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 
-// Detect runtime at module load. Browser bundlers may polyfill `process`, but rarely
-// include `process.versions.node`, so the nested check stays browser-safe.
-const IS_NODE = typeof process !== 'undefined' && process.versions?.node != null;
+/**
+ * Subset of globalThis used by {@link detectBrowserLike}; loosened for unit tests.
+ */
+export type GlobalLike = {
+  window?: { document?: unknown };
+  self?: unknown;
+  WorkerGlobalScope?: { new (): unknown };
+};
+
+/**
+ * True in browser main thread + any Worker scope (classic/module/shared/service via
+ * `WorkerGlobalScope`).
+ */
+export function detectBrowserLike(g: GlobalLike): boolean {
+  if (g.window !== undefined && g.window.document !== undefined) return true;
+  return (
+    g.WorkerGlobalScope !== undefined &&
+    g.self !== undefined &&
+    g.self instanceof g.WorkerGlobalScope
+  );
+}
+
+const IS_BROWSER_LIKE = detectBrowserLike(globalThis);
 
 export type RequestArgs = {
   endpoint: string;
@@ -306,10 +326,12 @@ async function _request(options: RequestOptions): Promise<unknown> {
   const headers: Record<string, string> = {
     Accept: 'application/json, text/plain, */*',
     ...(body ? { 'Content-Type': 'application/json' } : undefined),
-    // Node-only: override the default `undici` identifier that would leak the runtime.
-    // Skipped in browsers because Firefox/WebKit can promote it to a CORS preflight even
-    // though the Fetch spec lists it as a forbidden header.
-    ...(IS_NODE ? { 'User-Agent': 'Mozilla/5.0' } : undefined),
+    // Override the default User-Agent in non-browser runtimes (Node, Deno, Bun, React
+    // Native) where native HTTP stacks otherwise leak fingerprintable identifiers
+    // (undici, NSURLSession, OkHttp). Skipped in browsers + workers because Firefox/
+    // WebKit can promote it to a CORS preflight even though the Fetch spec lists it as
+    // a forbidden header.
+    ...(IS_BROWSER_LIKE ? undefined : { 'User-Agent': 'Mozilla/5.0' }),
     ...requestHeaders,
   };
   const callerSignal = options.signal ?? undefined;

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -11,6 +11,10 @@ import { JSONInt } from '../utils/JSONInt';
 // Generic request function type so callers can do requestInstance<T>(...)
 export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 
+// Detect runtime at module load. Browser bundlers may polyfill `process`, but rarely
+// include `process.versions.node`, so the nested check stays browser-safe.
+const IS_NODE = typeof process !== 'undefined' && process.versions?.node != null;
+
 export type RequestArgs = {
   endpoint: string;
   requestBody?: Record<string, unknown>;
@@ -302,9 +306,10 @@ async function _request(options: RequestOptions): Promise<unknown> {
   const headers: Record<string, string> = {
     Accept: 'application/json, text/plain, */*',
     ...(body ? { 'Content-Type': 'application/json' } : undefined),
-    // Generic User-Agent to avoid fingerprinting. In browsers this is a forbidden header (silently ignored).
-    // In Node.js this overrides the default `undici` identifier that would leak the runtime.
-    'User-Agent': 'Mozilla/5.0',
+    // Node-only: override the default `undici` identifier that would leak the runtime.
+    // Skipped in browsers because Firefox/WebKit can promote it to a CORS preflight even
+    // though the Fetch spec lists it as a forbidden header.
+    ...(IS_NODE ? { 'User-Agent': 'Mozilla/5.0' } : undefined),
     ...requestHeaders,
   };
   const callerSignal = options.signal ?? undefined;

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -63,6 +63,18 @@ export function buildRequestHeaders(
   };
 }
 
+/**
+ * Returns `err.message` when `err` is an Error, otherwise `fallback`.
+ *
+ * @remarks
+ * Real fetch implementations always reject with an Error subclass, but `err` is typed `unknown`
+ * inside `catch`, so the fallback protects against pathological polyfills.
+ * @internal
+ */
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
 export type RequestArgs = {
   endpoint: string;
   requestBody?: Record<string, unknown>;
@@ -371,16 +383,12 @@ async function _request(options: RequestOptions): Promise<unknown> {
     } else {
       const combinedController = new AbortController();
       const forwardAbort = () => combinedController.abort();
-      if (callerSignal.aborted || timeoutController.signal.aborted) {
-        forwardAbort();
-      } else {
-        callerSignal.addEventListener('abort', forwardAbort, { once: true });
-        timeoutController.signal.addEventListener('abort', forwardAbort, { once: true });
-        cleanupAbortListeners = () => {
-          callerSignal.removeEventListener('abort', forwardAbort);
-          timeoutController.signal.removeEventListener('abort', forwardAbort);
-        };
-      }
+      callerSignal.addEventListener('abort', forwardAbort, { once: true });
+      timeoutController.signal.addEventListener('abort', forwardAbort, { once: true });
+      cleanupAbortListeners = () => {
+        callerSignal.removeEventListener('abort', forwardAbort);
+        timeoutController.signal.removeEventListener('abort', forwardAbort);
+      };
       signal = combinedController.signal;
     }
   }
@@ -405,14 +413,14 @@ async function _request(options: RequestOptions): Promise<unknown> {
       throw new NetworkError(`Request timed out after ${requestTimeout}ms`);
     }
     if (callerAborted) {
-      throw new CallerAbortError(err instanceof Error ? err.message : 'Request aborted by caller');
+      throw new CallerAbortError(errorMessage(err, 'Request aborted by caller'));
     }
     if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
       throw new NetworkError(err.message);
     }
     // A fetch() promise only rejects when the request fails,
     // for example, because of a badly-formed request URL or a network error.
-    throw new NetworkError(err instanceof Error ? err.message : 'Network request failed');
+    throw new NetworkError(errorMessage(err, 'Network request failed'));
   } finally {
     clearTimeout(timeoutId);
     cleanupAbortListeners?.();

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -11,7 +11,7 @@ import { HttpResponse, http, delay } from 'msw';
 import { setupServer } from 'msw/node';
 import { setGlobalRequestOptions } from '../../src';
 import request, { setRequestLogger } from '../../src/transport';
-import { parseRetryAfter } from '../../src/transport/request';
+import { parseRetryAfter, detectBrowserLike } from '../../src/transport/request';
 import { MINTCACHE } from '../consts';
 import { Nut19Policy } from '../../src';
 import { NULL_LOGGER, type Logger } from '../../src/logger';
@@ -982,6 +982,49 @@ describe('parseRetryAfter', () => {
 
   test('returns undefined for garbage string', () => {
     expect(parseRetryAfter('not-a-date-or-number')).toBeUndefined();
+  });
+});
+
+describe('detectBrowserLike', () => {
+  test('true: browser main thread (window + document)', () => {
+    expect(detectBrowserLike({ window: { document: {} } })).toBe(true);
+  });
+
+  test('true: classic worker (self instanceof WorkerGlobalScope)', () => {
+    class WorkerGlobalScope {}
+    const self = new WorkerGlobalScope();
+    expect(detectBrowserLike({ self, WorkerGlobalScope })).toBe(true);
+  });
+
+  test('true: module worker (no importScripts, but WorkerGlobalScope present)', () => {
+    // Module workers omit importScripts; the WorkerGlobalScope check still catches them.
+    class WorkerGlobalScope {}
+    const self = new WorkerGlobalScope();
+    expect(detectBrowserLike({ self, WorkerGlobalScope })).toBe(true);
+  });
+
+  test('true: service worker (subclass of WorkerGlobalScope)', () => {
+    class WorkerGlobalScope {}
+    class ServiceWorkerGlobalScope extends WorkerGlobalScope {}
+    const self = new ServiceWorkerGlobalScope();
+    expect(detectBrowserLike({ self, WorkerGlobalScope })).toBe(true);
+  });
+
+  test('false: Node-like (no window, no WorkerGlobalScope)', () => {
+    expect(detectBrowserLike({})).toBe(false);
+  });
+
+  test('false: self present but WorkerGlobalScope undefined (RN/Bun shape)', () => {
+    expect(detectBrowserLike({ self: {} })).toBe(false);
+  });
+
+  test('false: window present but document undefined (partial polyfill)', () => {
+    expect(detectBrowserLike({ window: {} })).toBe(false);
+  });
+
+  test('false: WorkerGlobalScope present but self is not an instance of it', () => {
+    class WorkerGlobalScope {}
+    expect(detectBrowserLike({ self: {}, WorkerGlobalScope })).toBe(false);
   });
 });
 

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -15,6 +15,7 @@ import {
   parseRetryAfter,
   detectBrowserLike,
   buildRequestHeaders,
+  errorMessage,
 } from '../../src/transport/request';
 import { MINTCACHE } from '../consts';
 import { Nut19Policy } from '../../src';
@@ -183,6 +184,18 @@ describe('requests', { timeout: 7500 }, () => {
     const wallet = new Wallet(mintUrl);
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     await expect(wallet.checkMeltQuoteBolt11('test')).rejects.toThrow('primitive failure');
+  });
+
+  test('maps empty error response body to bad response', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
+        return new HttpResponse('', { status: 400 });
+      }),
+    );
+
+    const wallet = new Wallet(mintUrl);
+    wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
+    await expect(wallet.checkMeltQuoteBolt11('test')).rejects.toThrow('bad response');
   });
 
   test('maps empty success response body to bad response', async () => {
@@ -1057,6 +1070,19 @@ describe('buildRequestHeaders', () => {
     expect(buildRequestHeaders(undefined, undefined, true).Accept).toBe(
       'application/json, text/plain, */*',
     );
+  });
+});
+
+describe('errorMessage', () => {
+  test('returns err.message when err is an Error', () => {
+    expect(errorMessage(new Error('boom'), 'fallback')).toBe('boom');
+  });
+
+  test('returns fallback when err is not an Error (string, null, undefined, plain object)', () => {
+    expect(errorMessage('not an error', 'fallback')).toBe('fallback');
+    expect(errorMessage(null, 'fallback')).toBe('fallback');
+    expect(errorMessage(undefined, 'fallback')).toBe('fallback');
+    expect(errorMessage({ message: 'looks like an error' }, 'fallback')).toBe('fallback');
   });
 });
 

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -11,7 +11,11 @@ import { HttpResponse, http, delay } from 'msw';
 import { setupServer } from 'msw/node';
 import { setGlobalRequestOptions } from '../../src';
 import request, { setRequestLogger } from '../../src/transport';
-import { parseRetryAfter, detectBrowserLike } from '../../src/transport/request';
+import {
+  parseRetryAfter,
+  detectBrowserLike,
+  buildRequestHeaders,
+} from '../../src/transport/request';
 import { MINTCACHE } from '../consts';
 import { Nut19Policy } from '../../src';
 import { NULL_LOGGER, type Logger } from '../../src/logger';
@@ -1025,6 +1029,34 @@ describe('detectBrowserLike', () => {
   test('false: WorkerGlobalScope present but self is not an instance of it', () => {
     class WorkerGlobalScope {}
     expect(detectBrowserLike({ self: {}, WorkerGlobalScope })).toBe(false);
+  });
+});
+
+describe('buildRequestHeaders', () => {
+  test('non-browser runtimes get the Mozilla/5.0 User-Agent override', () => {
+    expect(buildRequestHeaders(undefined, undefined, false)['User-Agent']).toBe('Mozilla/5.0');
+  });
+
+  test('browser-like runtimes omit the User-Agent override', () => {
+    expect(buildRequestHeaders(undefined, undefined, true)['User-Agent']).toBeUndefined();
+  });
+
+  test('caller-supplied User-Agent always wins', () => {
+    expect(buildRequestHeaders(undefined, { 'User-Agent': 'X' }, false)['User-Agent']).toBe('X');
+    expect(buildRequestHeaders(undefined, { 'User-Agent': 'X' }, true)['User-Agent']).toBe('X');
+  });
+
+  test('Content-Type is added only when body is present', () => {
+    expect(buildRequestHeaders('{"x":1}', undefined, false)['Content-Type']).toBe(
+      'application/json',
+    );
+    expect(buildRequestHeaders(undefined, undefined, false)['Content-Type']).toBeUndefined();
+  });
+
+  test('Accept is always present', () => {
+    expect(buildRequestHeaders(undefined, undefined, true).Accept).toBe(
+      'application/json, text/plain, */*',
+    );
   });
 });
 


### PR DESCRIPTION
 ## Summary

 `User-Agent: Mozilla/5.0` is now only set in non-browserlike runtimes. The Fetch spec lists `User-Agent` as a forbidden header that browsers should silently strip, but Firefox and WebKit can promote a JS-set value to a CORS preflight, which strict mints reject. Node still needs the override to mask the default `undici` identifier.

 Caller-supplied `requestHeaders` still take precedence in either environment.

Also bumps test coverage of request to 100%