### PR TITLE
chore: trusted npm publishing on v3-dev

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -43,8 +43,6 @@ jobs:
           fi
 
       - name: Publish to npm (skip if already published)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -57,7 +55,7 @@ jobs:
           if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
             echo "Already published ${PKG}@${VERSION}, skipping npm publish"
           else
-            npm publish --provenance --tag "${{ steps.npm-tag.outputs.tag }}"
+            npm publish --tag "${{ steps.npm-tag.outputs.tag }}"
           fi
 
       - run: npm run compile:standalone


### PR DESCRIPTION
## Summary

Backports the trusted npm publishing workflow update to `v3-dev`.

## Changes

- Runs the release publish workflow on Node 24 so npm supports OIDC trusted publishing.
- Removes the expired `NPM_TOKEN` dependency from `npm publish`.
- Lets npm generate provenance automatically for trusted publishes instead of passing `--provenance` explicitly.

## Validation

- Parsed `.github/workflows/version.yml` as YAML locally.
- Confirmed the workflow still has `id-token: write` and no longer references `NODE_AUTH_TOKEN`.
- Pre-push hook ran `npm run check-lint` and passed.