### PR TITLE
chore: publish v3 releases under lts dist-tag

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -36,11 +36,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
-          if [ "$MAJOR_VERSION" = "3" ]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          else
-            echo "tag=v${MAJOR_VERSION}-lts" >> $GITHUB_OUTPUT
-          fi
+          echo "tag=v${MAJOR_VERSION}-lts" >> $GITHUB_OUTPUT
 
       - name: Publish to npm (skip if already published)
         run: |


### PR DESCRIPTION
## Summary

Keeps v3 maintenance publishes off npm's `latest` dist-tag.

## Changes

- Changes the `v3-dev` release workflow to publish stable releases under `v${MAJOR_VERSION}-lts`.
- This means `v3.7.0` will publish with `--tag v3-lts` instead of moving `latest` away from v4.

## Validation

- Checked npm registry state: `@cashu/cashu-ts@3.7.0` is not currently published.
- Checked npm dist-tags: `latest` currently points to `4.1.0`.
- Parsed `.github/workflows/version.yml` as YAML locally.
- Pre-push hook ran `npm run check-lint` and passed.