### PR TITLE
fix(batch minting): type BatchMintRequest.quote_amounts was incorrect

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -129,7 +129,7 @@ export interface BatchMintPreview<TQuote extends Pick<MintQuoteBaseResponse, 'qu
 // @public
 export type BatchMintRequest = {
     quotes: string[];
-    quote_amounts: bigint[];
+    quote_amounts: Amount[];
     outputs: SerializedBlindedMessage[];
     signatures?: Array<string | null>;
 };

--- a/src/model/types/NUT29.ts
+++ b/src/model/types/NUT29.ts
@@ -1,3 +1,5 @@
+import { type Amount } from '../Amount';
+
 import { type SerializedBlindedMessage } from './blinded';
 
 /**
@@ -19,7 +21,7 @@ export type BatchMintRequest = {
   /**
    * Array of amounts that shall be minted per quote id.
    */
-  quote_amounts: bigint[];
+  quote_amounts: Amount[];
   /**
    * Outputs (blinded messages) to be signed by the mint.
    */

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2117,9 +2117,7 @@ class Wallet {
 
     // Parse amounts and determine keyset
     const keyset = this.getKeyset(keysetId);
-    const amounts = entries.map((e) =>
-      this.parseAmount(e.amount, `prepareBatchMint: ${method}`).toBigInt(),
-    );
+    const amounts = entries.map((e) => this.parseAmount(e.amount, `prepareBatchMint: ${method}`));
     const totalAmount = Amount.sum(amounts);
 
     // Shape consolidated outputs over the total amount

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -7,6 +7,7 @@ import {
   WSConnection,
   injectWebSocketImpl,
   RateLimitError,
+  Amount,
 } from '../../src';
 import type { AuthProvider, Logger, RequestFn } from '../../src';
 import { HttpResponse, http } from 'msw';
@@ -648,7 +649,7 @@ describe('Mint normalization', () => {
 
     const response = await mint.mintBatchBolt11({
       quotes: ['q1', 'q2'],
-      quote_amounts: [1n, 2n] as any,
+      quote_amounts: [Amount.from(1), Amount.from(2)] as any,
       outputs: [],
     });
 
@@ -669,7 +670,7 @@ describe('Mint normalization', () => {
 
     const response = await mint.mintBatchBolt12({
       quotes: ['q1'],
-      quote_amounts: [4n] as any,
+      quote_amounts: [Amount.from(4)] as any,
       outputs: [],
     });
 
@@ -693,7 +694,11 @@ describe('Mint normalization', () => {
     });
 
     await expect(
-      mint.mintBatch('bolt11', { quotes: ['q1'], quote_amounts: [1n] as any, outputs: [] }),
+      mint.mintBatch('bolt11', {
+        quotes: ['q1'],
+        quote_amounts: [Amount.from(1)] as any,
+        outputs: [],
+      }),
     ).rejects.toThrow('Invalid response from mint');
     expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
       data: { not_signatures: true },
@@ -709,7 +714,11 @@ describe('Mint normalization', () => {
     });
 
     await expect(
-      mint.mintBatch('bolt11', { quotes: ['q1'], quote_amounts: [1n] as any, outputs: [] }),
+      mint.mintBatch('bolt11', {
+        quotes: ['q1'],
+        quote_amounts: [Amount.from(1)] as any,
+        outputs: [],
+      }),
     ).rejects.toThrow('Invalid response from mint');
     expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
       data: { signatures: {} },


### PR DESCRIPTION
## Summary
Fix incorrect type on `BatchMintRequest.quote_amounts: bigint[] → Amount[]`, aligning the NUT-29 batch mint request with the rest of the Amount-on-domain-models migration.

Drop the now-unnecessary .toBigInt() conversion in `Wallet.prepareBatchMint`, since `Amount.sum` already accepts Amount[].

Update mint normalization tests to construct quote_amounts with Amount.from(...) instead of bigint literals.

## Why
`quote_amounts` is part of a domain model, so should use the `Amount` value object like the other amount-bearing fields (`Proof.amount`, `SerializedBlindedMessage.amount` etc).

The previous `bigint[]` typing was an oversight that forced callers to convert at the boundary.

## Notes
This is technically a breaking change to the public type `BatchMintRequest`, but treating as a minor as batch minting is not widely supported or used yet, the payload is short lived, and the consumer is this library