### PR TITLE
fix(wallet): treat expiry: 0 as no-expiry in validateMintQuote

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1818,6 +1818,7 @@ class Wallet {
     this.failIf(
       'expiry' in quote &&
         typeof quote.expiry === 'number' &&
+        quote.expiry > 0 && // some mints (e.g. CDK) emit 0 for "no expiry"; spec says null
         quote.expiry < Math.floor(Date.now() / 1000),
       `Mint quote ${quote.quote} has expired`,
     );

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -98,6 +98,39 @@ describe('requestTokens', () => {
     expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
   });
 
+  test('prepareMint accepts expiry: 0 as "no expiry" (CDK quirk)', async () => {
+    // Spec says expiry is <int|null> with null meaning "no expiry". CDK emits 0
+    // for the same meaning. Treat 0 as null rather than "expired in 1970".
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11', () =>
+        HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+            },
+          ],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const quote = {
+      quote: 'no-expiry-quote',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      state: MintQuoteState.PAID,
+      expiry: 0,
+    } as unknown as MintQuoteBolt11Response;
+
+    const preview = await wallet.prepareMint('bolt11', 1, quote);
+    const proofs = await wallet.completeMint(preview);
+    expect(proofs).toHaveLength(1);
+  });
+
   test('completeMint rejects missing DLEQ when mint advertises NUT-12', async () => {
     server.use(
       http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithNut12)),


### PR DESCRIPTION
## Summary

- Treat `expiry: 0` as "no expiry" in `validateMintQuote`, matching how `null` is handled
- Adds a unit test pinning the new behaviour

## Why

NUT-04 / NUT-23 / NUT-25 / NUT-XX define mint-quote `expiry` as `<int | null>` where `null` means "no expiry". CDK emits `expiry: 0` to mean the same thing. cashu-ts was reading `0` as a real Unix timestamp (epoch 1970-01-01) and rejecting all such quotes as expired before any mint attempt:

\`\`\`
Error: Mint quote ... has expired
  at validateMintQuote (src/wallet/Wallet.ts:1818)
  at prepareMint (src/wallet/Wallet.ts:1952)
\`\`\`

This affected every mint method (BOLT11, BOLT12, onchain) since `validateMintQuote` is method-agnostic.

## Change

One-line guard in `validateMintQuote` to skip the comparison when `expiry === 0`. Same Postel-leaning shape as how `null` is already handled (the `typeof === 'number'` check already excludes `null`).

## Test plan

- [x] Added `prepareMint accepts expiry: 0 as \"no expiry\" (CDK quirk)` unit test in `test/wallet/wallet-mint.node.test.ts`
- [x] Existing test suite still passes

## Note

Independent fix — no spec change needed, and CDK's behaviour is already widespread. This unblocks any wallet trying to mint against CDK with the current responses.