### PR TITLE
fix(mint): treat null amount on BOLT12 mint quote as no-amount

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -1046,7 +1046,12 @@ class Mint {
    * Mutates `data` in place, normalizing bolt12 mint-quote fields.
    */
   private normalizeMintQuoteBolt12Fields(data: Record<string, unknown>): void {
-    data.amount = data.amount === undefined ? undefined : Amount.from(data.amount as Amount);
+    // Per NUT-25, `amount` on a BOLT12 mint quote is <int|null> — null for
+    // amountless offers. CDK emits explicit null; treat absent as the same.
+    data.amount =
+      data.amount === undefined || data.amount === null
+        ? undefined
+        : Amount.from(data.amount as Amount);
     data.expiry = normalizeSafeIntegerMetadata(
       data.expiry as number,
       'mintQuoteBolt12.expiry',

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -47,6 +47,7 @@ import {
   normalizeMintKeyset,
   normalizeSafeIntegerMetadata,
   normalizeUrl,
+  undefinedIfNull,
 } from '../utils';
 
 import type {
@@ -1046,12 +1047,11 @@ class Mint {
    * Mutates `data` in place, normalizing bolt12 mint-quote fields.
    */
   private normalizeMintQuoteBolt12Fields(data: Record<string, unknown>): void {
-    // Per NUT-25, `amount` on a BOLT12 mint quote is <int|null> — null for
-    // amountless offers. CDK emits explicit null; treat absent as the same.
-    data.amount =
-      data.amount === undefined || data.amount === null
-        ? undefined
-        : Amount.from(data.amount as Amount);
+    // Per NUT-25, `amount` is <int|null> — null for amountless offers. CDK
+    // emits explicit null; the wallet's TS type is `Amount?`, so collapse
+    // null to undefined and then coerce numeric values to Amount.
+    undefinedIfNull(data, 'amount');
+    data.amount = data.amount === undefined ? undefined : Amount.from(data.amount as Amount);
     data.expiry = normalizeSafeIntegerMetadata(
       data.expiry as number,
       'mintQuoteBolt12.expiry',

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -494,6 +494,28 @@ export function isObj(v: unknown): v is object {
 }
 
 /**
+ * In-place: set listed keys to `null` if currently `undefined`. Used when normalizing mint
+ * responses where the spec defines a nullable wire field but the mint omits it (Postel-style).
+ * Pairs with TS types declared as `T | null`.
+ *
+ * @internal
+ */
+export function nullIfUndefined(o: Record<string, unknown>, ...keys: string[]): void {
+  for (const k of keys) if (o[k] === undefined) o[k] = null;
+}
+
+/**
+ * In-place: set listed keys to `undefined` if currently `null`. Used when normalizing mint
+ * responses where the spec defines a nullable wire field but the cashu-ts type uses `T?`
+ * (undefined-flavored) rather than `T | null`.
+ *
+ * @internal
+ */
+export function undefinedIfNull(o: Record<string, unknown>, ...keys: string[]): void {
+  for (const k of keys) if (o[k] === null) o[k] = undefined;
+}
+
+/**
  * Joins URL path segments, stripping leading/trailing slashes from each part.
  *
  * @internal

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -395,6 +395,29 @@ describe('Mint normalization', () => {
     expect(response.amount_issued.toBigInt()).toBe(4n);
   });
 
+  it('createMintQuoteBolt12 treats explicit null amount as no-amount (CDK quirk)', async () => {
+    // Per NUT-25 the amount is <int|null>; CDK emits explicit `null` for
+    // amountless offers. Without this, `Amount.from(null)` throws on the
+    // wallet side and the BOLT12 amountless flow is broken.
+    const requestSpy = vi.fn(async () => ({
+      quote: 'q1',
+      request: 'lno1...',
+      amount: null,
+      unit: 'sat',
+      expiry: 0,
+      pubkey: '02abcd',
+      amount_paid: 0,
+      amount_issued: 0,
+    })) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    const response = await mint.createMintQuoteBolt12({ unit: 'sat', pubkey: '02abcd' });
+
+    expect(response.amount).toBeUndefined();
+    expect(response.amount_paid.toBigInt()).toBe(0n);
+    expect(response.amount_issued.toBigInt()).toBe(0n);
+  });
+
   it('mintBolt11 posts to the expected endpoint and normalizes signature amounts', async () => {
     const requestSpy = vi.fn(async (options: ReqArgs) => {
       expect(options.endpoint).toBe(mintUrl + '/v1/mint/bolt11');


### PR DESCRIPTION
## Summary

- Fix `Amount.from(null)` crash when normalizing a BOLT12 mint quote response with `amount: null`
- Add `nullIfUndefined` / `undefinedIfNull` helpers in `src/utils/core.ts` for symmetric Postel-style coercion
- Use `undefinedIfNull` in the bolt12 normalizer

## Why

Per NUT-25, the BOLT12 mint-quote `amount` field is `<int | null>`; `null` means an amountless offer. CDK emits explicit `null` on the wire. `normalizeMintQuoteBolt12Fields` was checking `=== undefined` only, so a wire-`null` fell through to `Amount.from(null)` which throws \`AmountError: Unsupported amount input type\` — breaking every BOLT12 amountless mint flow against CDK:

\`\`\`
❌ Error: AmountError: Unsupported amount input type
    at Function.from (src/model/Amount.ts:79)
    at Mint.normalizeMintQuoteBolt12Fields (src/mint/Mint.ts:1049)
    at Mint.normalizeMintQuoteResponse (src/mint/Mint.ts:1028)
\`\`\`

## Change

Two commits:

1. `fix(mint): treat null amount on BOLT12 mint quote as no-amount` — collapses `null` into the same handling as `undefined` for the amountless case.
2. `refactor(utils): add nullIfUndefined/undefinedIfNull helpers` — extracts the two-line Postel coercion into a symmetric pair so future PRs handling other nullable wire fields (`payment_preimage`, `witness`, onchain melt fields, etc.) can pick up the right helper directly.

The helpers come as a pair on purpose. Most cashu-ts types declare nullable wire fields as `T | null` (matches spec wording), so wire-`undefined` → typed-`null` via `nullIfUndefined`. A few are typed `T?` (currently bolt12 `amount` and NUT-01 keyset metadata), needing the inverse `undefinedIfNull`. The type-design split is captured for a separate decision PR — this PR doesn't change any types.

## Test plan

- [x] Added `createMintQuoteBolt12 treats explicit null amount as no-amount (CDK quirk)` regression test in `test/mint/Mint.node.test.ts`
- [x] Verified end-to-end against `DEV=1 make cdk-up` — `examples/bolt12Wallet_example.ts` now creates a BOLT12 mint quote successfully (earlier crashed at the first quote-creation call)
- [x] Existing test suite still passes

## Related

Same Postel-style pattern as the upcoming onchain (NUT-XX) PR's handling of omitted `outpoint` / `selected_estimated_blocks` on melt-quote responses. The helpers introduced here will be reused there.