### PR TITLE
docs(examples): add README and align bolt12 example with Makefile port

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# cashu-ts examples
+
+Runnable demos of common cashu-ts flows. Examples are TypeScript files run directly with `tsx` — no build step needed.
+
+## Running
+
+From the repo root:
+
+```sh
+npx tsx examples/<example>.ts
+```
+
+`tsx` is already a devDependency (no global install needed). If you're outside the repo, copy the example and replace the `'../src'` import with `'@cashu/cashu-ts'`.
+
+## Local mints
+
+The repo's top-level `Makefile` spins up local CDK or Nutshell mints with a fake-wallet LN backend (auto-pays invoices). It requires `DEV=1` as an explicit opt-in. Both bind to `127.0.0.1:3338` by default — override with `PORT=...`.
+
+```sh
+DEV=1 make cdk-up        # then: DEV=1 make cdk-down
+DEV=1 make nutshell-up   # then: DEV=1 make nutshell-down
+```
+
+Run `make print-mint-images` to see which versions are pinned. The auth demos have their own docker setup — see `auth_mint/Makefile`.
+
+## Examples
+
+| File                      | Mint required                          | Description                                                                                                                                        |
+| ------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `simpleWallet_example.ts` | `DEV=1 make nutshell-up` (or `cdk-up`) | End-to-end BOLT11 mint, send, receive, and melt against a fake-wallet LN backend.                                                                  |
+| `bolt12Wallet_example.ts` | `DEV=1 make cdk-up`                    | Reusable BOLT12 offer flow: mint via BOLT11, pay the offer, mint again from accumulated payments. CDK's fakewallet handles both BOLT11 and BOLT12. |
+| `auth_mint/`              | Keycloak + CDK mint via docker         | OAuth2 / OIDC blind-auth (NUT-21 / NUT-22) demos. See `auth_mint/Makefile` (`make up`, `make demo-device`, `make down`).                           |
+| `paymentApi_example.js`   | —                                      | Code snippet for receiving locked ecash inside a Firebase Cloud Function. Not runnable standalone.                                                 |
+
+## Notes
+
+- `dns.setDefaultResultOrder('ipv4first')` is set in each example to avoid Node's IPv6-first DNS resolution stalling on `localhost` (see Node issue #40537).

--- a/examples/bolt12Wallet_example.ts
+++ b/examples/bolt12Wallet_example.ts
@@ -6,7 +6,7 @@ import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 dns.setDefaultResultOrder('ipv4first');
 
 // Configuration
-const MINT_URL = 'http://localhost:8085';
+const MINT_URL = 'http://localhost:3338';
 const INITIAL_MINT_AMOUNT = 5000;
 const PAYMENT_AMOUNT = 1000;
 const PAYMENT_CYCLES = 1;


### PR DESCRIPTION
## Summary

- Add `examples/README.md` covering how to run each demo and the top-level Makefile mint targets
- Update `bolt12Wallet_example.ts` `MINT_URL` from `:8085` → `:3338` so it works with the standard `DEV=1 make cdk-up` flow

## Why

The `examples/` directory had no README — readers had to spelunk through each file's header comments to figure out how to run them. Worse, the bolt12 example's `MINT_URL = http://localhost:8085` predated the top-level `Makefile` (added later, binds to `:3338`), so it required a `PORT=8085` override that wasn't documented anywhere. There's no technical reason for `8085`; it was just the original author's local convention.

## Change

- New `examples/README.md` with:
  - One-liner on running TS examples (`npx tsx examples/<file>.ts`)
  - "Local mints" section pointing at `DEV=1 make cdk-up` / `nutshell-up`
  - Per-example table with what mint each needs and a short description
  - Note on the `dns.setDefaultResultOrder('ipv4first')` quirk
- `bolt12Wallet_example.ts`: change `MINT_URL` to `http://localhost:3338` so it works out-of-the-box with `DEV=1 make cdk-up`.

## Test plan

- [x] Both examples now share the standard `:3338` port
- [x] No library code touched
- [x] README matches the actual Makefile targets and example imports

## Note

The bolt12 example also requires the fixes in #648 (expiry: 0 handling) and #649 (BOLT12 amount: null handling) to complete an end-to-end run against CDK fakewallet. Those are independent PRs; this one is purely cosmetic / docs.