### PR TITLE
refactor(mint): cast wire values as AmountLike, not Amount, in normalizers

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -8,7 +8,7 @@
 import type { AuthProvider } from '../auth/AuthProvider';
 import { OIDCAuth, type OIDCAuthOptions } from '../auth/OIDCAuth';
 import { type Logger, NULL_LOGGER, failIf } from '../logger';
-import { Amount } from '../model/Amount';
+import { Amount, type AmountLike } from '../model/Amount';
 import { MintInfo } from '../model/MintInfo';
 import {
   type MintQuoteBaseResponse,
@@ -1035,7 +1035,7 @@ class Mint {
    * Mutates `data` in place, normalizing bolt11 mint-quote fields.
    */
   private normalizeMintQuoteBolt11Fields(data: Record<string, unknown>): void {
-    data.amount = Amount.from(data.amount as Amount);
+    data.amount = Amount.from(data.amount as AmountLike);
     data.expiry = normalizeSafeIntegerMetadata(
       data.expiry as number,
       'mintQuoteBolt11.expiry',
@@ -1051,14 +1051,14 @@ class Mint {
     // emits explicit null; the wallet's TS type is `Amount?`, so collapse
     // null to undefined and then coerce numeric values to Amount.
     undefinedIfNull(data, 'amount');
-    data.amount = data.amount === undefined ? undefined : Amount.from(data.amount as Amount);
+    data.amount = data.amount === undefined ? undefined : Amount.from(data.amount as AmountLike);
     data.expiry = normalizeSafeIntegerMetadata(
       data.expiry as number,
       'mintQuoteBolt12.expiry',
       null,
     );
-    data.amount_paid = Amount.from(data.amount_paid as Amount);
-    data.amount_issued = Amount.from(data.amount_issued as Amount);
+    data.amount_paid = Amount.from(data.amount_paid as AmountLike);
+    data.amount_issued = Amount.from(data.amount_issued as AmountLike);
   }
 
   /**
@@ -1084,7 +1084,7 @@ class Mint {
    * Mutates `data` in place, normalizing protocol-mandatory melt base fields.
    */
   private normalizeMeltBaseFields(data: Record<string, unknown>, op: string): void {
-    data.amount = Amount.from(data.amount as Amount);
+    data.amount = Amount.from(data.amount as AmountLike);
     data.expiry = normalizeSafeIntegerMetadata(
       data.expiry as number,
       'meltQuote.expiry',
@@ -1111,7 +1111,7 @@ class Mint {
    * Mutates `data` in place, normalizing bolt11/bolt12-specific melt fields.
    */
   private normalizeMeltBoltFields(data: Record<string, unknown>, op: string): void {
-    data.fee_reserve = Amount.from(data.fee_reserve as Amount);
+    data.fee_reserve = Amount.from(data.fee_reserve as AmountLike);
     if (typeof data.request !== 'string' || !(data.fee_reserve instanceof Amount)) {
       this._logger.error('Invalid response from mint...', { data, op });
       throw new Error('Invalid response from mint');


### PR DESCRIPTION
## Summary
- The `normalize*Fields` helpers in `src/mint/Mint.ts` feed JSON-parsed wire values through `Amount.from(...)`. Those values arrive as `number | bigint | string` (i.e. `AmountLike`), never as `Amount` instances.
- Casting them `as Amount` made the call sites read as if `Amount` instances arrive on the wire. `as AmountLike` is the honest cast and would catch future drift if `Amount` gains a field that wire data wouldn't satisfy.
- 6 sites updated across `normalizeMintQuoteBolt11Fields`, `normalizeMintQuoteBolt12Fields`, `normalizeMeltBaseFields`, and `normalizeMeltBoltFields`. Added `type AmountLike` to the existing `../model/Amount` import.

No behaviour change.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/mint/Mint.node.test.ts test/wallet/wallet-mint.node.test.ts` — 84 tests pass