### PR TITLE
fix(mint): coerce omitted payment_preimage and witness to null

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -47,6 +47,7 @@ import {
   normalizeMintKeyset,
   normalizeSafeIntegerMetadata,
   normalizeUrl,
+  nullIfUndefined,
   undefinedIfNull,
 } from '../utils';
 
@@ -732,6 +733,13 @@ class Mint {
       throw new Error('Invalid response from mint');
     }
 
+    // Per NUT-07, ProofState.witness is `<str | null>`. Some mints may omit the
+    // field instead of sending null; coerce undefined → null so consumers
+    // can rely on `state.witness === null` checks.
+    for (const state of data.states) {
+      nullIfUndefined(state, 'witness');
+    }
+
     return data;
   }
 
@@ -1116,6 +1124,10 @@ class Mint {
       this._logger.error('Invalid response from mint...', { data, op });
       throw new Error('Invalid response from mint');
     }
+    // Per NUT-23, payment_preimage is `<str | null>`. Some mints may omit it
+    // until the invoice is paid; coerce undefined → null so consumers can
+    // rely on `payment_preimage === null` checks.
+    nullIfUndefined(data, 'payment_preimage');
   }
 }
 

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -1188,6 +1188,31 @@ describe('generic mint/melt methods', () => {
       expect(quote.request).toBe('lnbc100...');
     });
 
+    test('bolt11 melt quote with omitted payment_preimage is coerced to null', async () => {
+      server.use(
+        http.post(mintUrl + '/v1/melt/quote/bolt11', () =>
+          HttpResponse.json({
+            quote: 'bolt11-melt-no-preimage',
+            amount: 100,
+            unit: 'sat',
+            fee_reserve: 5,
+            state: MeltQuoteState.UNPAID,
+            expiry: 3600,
+            request: 'lnbc100...',
+            // payment_preimage omitted — spec says `<str | null>`; mints often omit pre-payment
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+
+      const quote = await wallet.createMeltQuote<MeltQuoteBolt11Response>('bolt11', {
+        request: 'lnbc100...',
+      });
+
+      expect(quote.payment_preimage).toBeNull();
+    });
+
     test('custom normalize runs after base normalization', async () => {
       server.use(
         http.post(mintUrl + '/v1/melt/quote/swift', () =>

--- a/test/wallet/wallet-state.node.test.ts
+++ b/test/wallet/wallet-state.node.test.ts
@@ -37,6 +37,27 @@ describe('checkProofsStates', () => {
       expect(r.witness).toEqual('witness-asd');
     });
   });
+
+  test('checkProofsStates with omitted witness coerces undefined → null', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/checkstate', () => {
+        return HttpResponse.json({
+          states: [
+            {
+              Y: '02d5dd71f59d917da3f73defe997928e9459e9d67d8bdb771e4989c2b5f50b2fff',
+              state: 'UNSPENT',
+              // witness omitted — spec says `<str | null>`
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const result = await wallet.checkProofsStates(proofs);
+    expect(result[0].witness).toBeNull();
+  });
 });
 
 describe('groupProofsByState', () => {


### PR DESCRIPTION
## Summary
Two nullable wire fields were typed as `string | null` but never normalized at runtime. When the mint omits them, the value slips through as `undefined`, silently breaking consumer checks like `payment_preimage === null`.

- **`payment_preimage`** (NUT-23 / NUT-25): added `nullIfUndefined(data, 'payment_preimage')` to `normalizeMeltBoltFields`. Covers bolt11 and bolt12 (NUT-25's response aliases NUT-23). Common case — mints typically omit the field pre-payment.
- **`witness`** (NUT-07): in `Mint.check()`, after validating `data.states`, iterate and coerce each entry's `witness`. Common case — non-NUT-10 (plain) proofs have no witness, so most mints omit the field.

Uses the existing `nullIfUndefined` helper at `src/utils/core.ts:503`. Non-breaking: callers using truthiness checks were already getting the expected behaviour; callers using strict-equality checks now get the spec-compliant value.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] New MSW unit test in `test/wallet/wallet-mint.node.test.ts`: bolt11 melt quote with omitted `payment_preimage` → `null`
- [x] New MSW unit test in `test/wallet/wallet-state.node.test.ts`: `checkProofsStates` with omitted per-state `witness` → `null`
- [x] `npx vitest run test/mint/Mint.node.test.ts test/wallet/wallet-mint.node.test.ts test/wallet/wallet-state.node.test.ts` — 88 tests pass