### PR TITLE
feat(wallet): add maxSpendableAfterFees method

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1934,6 +1934,7 @@ export class Wallet {
     loadMintFromCache(mintInfo: GetInfoResponse, cache: KeyChainCache): void;
     // (undocumented)
     get logger(): Logger;
+    maxSpendableAfterFees(proofs: ProofLike[], feeReserve?: AmountLike): Amount;
     meltProofs<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(method: string, meltQuote: TQuote, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<TQuote>>;
     meltProofsBolt11(meltQuote: MeltQuoteBolt11Response, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<MeltQuoteBolt11Response>>;
     meltProofsBolt12(meltQuote: MeltQuoteBolt12Response, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<MeltQuoteBolt12Response>>;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1445,6 +1445,24 @@ class Wallet {
   }
 
   /**
+   * Largest spendable amount from a proof set after subtracting the per-proof input fees the mint
+   * charges and optionally a melt quote's `fee_reserve`.
+   *
+   * @remarks
+   * Single step of a "melt all" iteration: fetch a melt quote, call this with the quote's
+   * `fee_reserve` to get the largest amount that fits, then re-quote for that amount (since
+   * `fee_reserve` may shrink with the smaller amount). Repeat until the result stabilises.
+   * @param proofs Proofs the caller intends to spend.
+   * @param feeReserve Optional. `fee_reserve` from a related melt quote (default: 0)
+   * @returns The largest spendable amount, or zero if fees exceed the available total.
+   */
+  maxSpendableAfterFees(proofs: ProofLike[], feeReserve: AmountLike = 0): Amount {
+    const total = sumProofs(proofs);
+    const overhead = this.getFeesForProofs(proofs).add(feeReserve);
+    return overhead.greaterThanOrEqual(total) ? Amount.zero() : total.subtract(overhead);
+  }
+
+  /**
    * Prepares inputs for a mint operation.
    *
    * @remarks

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -1,0 +1,83 @@
+import { HttpResponse, http } from 'msw';
+import { test, describe, expect } from 'vitest';
+import { Wallet, Amount, type Proof } from '../../src';
+import { mint, unit, mintUrl, useTestServer } from './_setup';
+
+const server = useTestServer();
+
+const proofsTotalling = (amounts: number[]): Proof[] =>
+  amounts.map((a, i) => ({
+    id: '00bd033559de27d0',
+    amount: Amount.from(a),
+    secret: `secret-${i}`,
+    C: `C-${i}`,
+  }));
+
+describe('wallet.maxSpendableAfterFees', () => {
+  test('returns total minus feeReserve when input fees are zero', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const proofs = proofsTotalling([64, 32, 4]); // total = 100
+    const result = wallet.maxSpendableAfterFees(proofs, 10);
+
+    expect(result.equals(90)).toBe(true);
+  });
+
+  test('returns zero when feeReserve exactly consumes total', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const proofs = proofsTotalling([64, 32, 4]); // total = 100
+    const result = wallet.maxSpendableAfterFees(proofs, 100);
+
+    expect(result.isZero()).toBe(true);
+  });
+
+  test('clamps to zero when fees exceed total (no underflow)', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const proofs = proofsTotalling([10]);
+    const result = wallet.maxSpendableAfterFees(proofs, 50);
+
+    expect(result.isZero()).toBe(true);
+  });
+
+  test('returns total when feeReserve is omitted and input fees are zero', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const proofs = proofsTotalling([64, 32, 4]); // total = 100
+    const result = wallet.maxSpendableAfterFees(proofs);
+
+    expect(result.equals(100)).toBe(true);
+  });
+
+  test('subtracts per-proof input fees when keyset charges input_fee_ppk', async () => {
+    // Override keyset metadata to advertise input_fee_ppk = 1000 (= 1 sat per proof).
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              id: '00bd033559de27d0',
+              unit: 'sat',
+              active: true,
+              input_fee_ppk: 1000,
+              final_expiry: undefined,
+            },
+          ],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const proofs = proofsTotalling([64, 32, 4]); // total = 100, 3 proofs → inputFee = 3
+    const result = wallet.maxSpendableAfterFees(proofs, 10);
+
+    // 100 - 10 (feeReserve) - 3 (inputFee) = 87
+    expect(result.equals(87)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `Wallet.maxSpendableAfterFees(proofs, feeReserve?)` — returns the largest amount a caller can melt given a proof set, after subtracting:
1. The per-proof input fees the mint charges (via the existing `getFeesForProofs`)
2. Optionally, a melt quote's `fee_reserve`

Single step of a "melt all funds" iteration: caller fetches a quote, calls this with the quote's `fee_reserve`, re-quotes for the returned amount, repeats until the result stabilises (smaller amount → potentially smaller fee_reserve).

## Design notes
- `feeReserve`  defaults to zero, so the helper also serves "max spendable from this proof set" use cases (balance display, pre-quote estimation) without forcing `Amount.from(0)` boilerplate.
- Clamps to `Amount.zero()` rather than throwing on insufficient, which keeps callers inside their iteration loop without underflow handling.

