### PR TITLE
feat(types): align nullable wire fields with spec (T | null)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1046,7 +1046,7 @@ export type MintQuoteBolt12Request = MintQuoteBaseRequest & {
 
 // @public
 export type MintQuoteBolt12Response = MintQuoteBaseResponse & {
-    amount?: Amount;
+    amount: Amount | null;
     expiry: number | null;
     pubkey: string;
     amount_paid: Amount;
@@ -1764,8 +1764,8 @@ export function sumProofs(proofs: Array<Pick<ProofLike, 'amount'>>): Amount;
 export type SwapMethod = {
     method: string;
     unit: string;
-    min_amount: AmountLike;
-    max_amount: AmountLike;
+    min_amount: AmountLike | null;
+    max_amount: AmountLike | null;
     description?: boolean;
     options?: {
         description?: boolean;

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -47,7 +47,7 @@ import {
   normalizeMintKeyset,
   normalizeSafeIntegerMetadata,
   normalizeUrl,
-  undefinedIfNull,
+  nullIfUndefined,
 } from '../utils';
 
 import type {
@@ -1047,11 +1047,11 @@ class Mint {
    * Mutates `data` in place, normalizing bolt12 mint-quote fields.
    */
   private normalizeMintQuoteBolt12Fields(data: Record<string, unknown>): void {
-    // Per NUT-25, `amount` is <int|null> — null for amountless offers. CDK
-    // emits explicit null; the wallet's TS type is `Amount?`, so collapse
-    // null to undefined and then coerce numeric values to Amount.
-    undefinedIfNull(data, 'amount');
-    data.amount = data.amount === undefined ? undefined : Amount.from(data.amount as Amount);
+    // Per NUT-25, `amount` is <int|null> — null for amountless offers. Mints that
+    // omit the field altogether get coerced to null (Postel-style); numeric
+    // values are coerced to Amount.
+    nullIfUndefined(data, 'amount');
+    data.amount = data.amount === null ? null : Amount.from(data.amount as Amount);
     data.expiry = normalizeSafeIntegerMetadata(
       data.expiry as number,
       'mintQuoteBolt12.expiry',

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,4 +1,5 @@
 import { type Logger, NULL_LOGGER } from '../logger';
+import { nullIfUndefined } from '../utils/core';
 import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
@@ -43,11 +44,38 @@ export class MintInfo {
       ...info,
       nuts: {
         ...info.nuts,
+        ...(info.nuts['4']
+          ? {
+              '4': {
+                ...info.nuts['4'],
+                methods: MintInfo.normalizeSwapMethods(info.nuts['4'].methods),
+              },
+            }
+          : {}),
+        ...(info.nuts['5']
+          ? {
+              '5': {
+                ...info.nuts['5'],
+                methods: MintInfo.normalizeSwapMethods(info.nuts['5'].methods),
+              },
+            }
+          : {}),
         ...(info.nuts['19'] ? { '19': MintInfo.normalizeNut19(info.nuts['19']) } : {}),
         ...(info.nuts['22'] ? { '22': MintInfo.normalizeNut22(info.nuts['22'], logger) } : {}),
         ...(info.nuts['29'] ? { '29': MintInfo.normalizeNut29(info.nuts['29'], logger) } : {}),
       },
     };
+  }
+
+  // Per NUT-04/05/25/XX, `min_amount` and `max_amount` are `<int|null>`. Mints that omit
+  // them entirely (older Nutshell, etc.) leave the field as `undefined`; coerce to null
+  // so the runtime value matches the `AmountLike | null` type.
+  private static normalizeSwapMethods(methods: SwapMethod[]): SwapMethod[] {
+    return methods.map((m) => {
+      const next = { ...m } as Record<string, unknown>;
+      nullIfUndefined(next, 'min_amount', 'max_amount');
+      return next as SwapMethod;
+    });
   }
 
   private static normalizeNut19(

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -90,13 +90,18 @@ export type MintContactInfo = {
 };
 
 /**
- * Ecash to other MoE swap method, displayed in @type {GetInfoResponse}
+ * Ecash to other MoE swap method, displayed in @type {GetInfoResponse}.
+ *
+ * @remarks
+ * `min_amount` and `max_amount` are `<int|null>` per NUT-04/05/25/XX — null when the mint
+ * advertises no lower/upper bound. Consumers should use null-safe checks (`?? 0`, `!= null`,
+ * truthy) before passing to `Amount.from(...)`.
  */
 export type SwapMethod = {
   method: string;
   unit: string;
-  min_amount: AmountLike;
-  max_amount: AmountLike;
+  min_amount: AmountLike | null;
+  max_amount: AmountLike | null;
   description?: boolean; //added this for Nutshell =>0.16.4 compatibility, see https://github.com/cashubtc/nutshell/pull/783
   options?: {
     description?: boolean;

--- a/src/model/types/NUT25.ts
+++ b/src/model/types/NUT25.ts
@@ -23,9 +23,9 @@ export type MintQuoteBolt12Request = MintQuoteBaseRequest & {
  */
 export type MintQuoteBolt12Response = MintQuoteBaseResponse & {
   /**
-   * Amount requested for mint quote. `undefined` for amountless offers.
+   * Amount requested for mint quote. `null` for amountless offers (per NUT-25).
    */
-  amount?: Amount;
+  amount: Amount | null;
   /**
    * Timestamp of when the quote expires. `null` when the mint does not set an expiry.
    */

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -505,17 +505,6 @@ export function nullIfUndefined(o: Record<string, unknown>, ...keys: string[]): 
 }
 
 /**
- * In-place: set listed keys to `undefined` if currently `null`. Used when normalizing mint
- * responses where the spec defines a nullable wire field but the cashu-ts type uses `T?`
- * (undefined-flavored) rather than `T | null`.
- *
- * @internal
- */
-export function undefinedIfNull(o: Record<string, unknown>, ...keys: string[]): void {
-  for (const k of keys) if (o[k] === null) o[k] = undefined;
-}
-
-/**
  * Joins URL path segments, stripping leading/trailing slashes from each part.
  *
  * @internal

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -369,7 +369,7 @@ describe('Mint normalization', () => {
     expect(response.expiry).toBeNull();
   });
 
-  it('createMintQuoteBolt12 omits undefined amount and normalizes paid and issued amounts', async () => {
+  it('createMintQuoteBolt12 coerces omitted amount to null and normalizes paid and issued amounts', async () => {
     const requestSpy = vi.fn(async (options: ReqArgs) => {
       expect(options.endpoint).toBe(mintUrl + '/v1/mint/quote/bolt12');
       expect(options.method).toBe('POST');
@@ -391,15 +391,15 @@ describe('Mint normalization', () => {
       description: 'offer',
     });
 
-    expect(response.amount).toBeUndefined();
+    expect(response.amount).toBeNull();
     expect(response.amount_paid.toBigInt()).toBe(5n);
     expect(response.amount_issued.toBigInt()).toBe(4n);
   });
 
-  it('createMintQuoteBolt12 treats explicit null amount as no-amount (CDK quirk)', async () => {
+  it('createMintQuoteBolt12 preserves explicit null amount (NUT-25 amountless)', async () => {
     // Per NUT-25 the amount is <int|null>; CDK emits explicit `null` for
-    // amountless offers. Without this, `Amount.from(null)` throws on the
-    // wallet side and the BOLT12 amountless flow is broken.
+    // amountless offers. The wallet type is `Amount | null`, so null passes
+    // through unchanged (no Amount.from(null) coercion).
     const requestSpy = vi.fn(async () => ({
       quote: 'q1',
       request: 'lno1...',
@@ -414,7 +414,7 @@ describe('Mint normalization', () => {
 
     const response = await mint.createMintQuoteBolt12({ unit: 'sat', pubkey: '02abcd' });
 
-    expect(response.amount).toBeUndefined();
+    expect(response.amount).toBeNull();
     expect(response.amount_paid.toBigInt()).toBe(0n);
     expect(response.amount_issued.toBigInt()).toBe(0n);
   });

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -312,9 +312,9 @@ describe('test info', () => {
     expect(info.isSupported(5)).toEqual({
       disabled: false,
       params: [
-        { method: 'bolt11', unit: 'sat' },
-        { method: 'bolt11', unit: 'usd' },
-        { method: 'bolt11', unit: 'eur' },
+        { method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null },
+        { method: 'bolt11', unit: 'usd', min_amount: null, max_amount: null },
+        { method: 'bolt11', unit: 'eur', min_amount: null, max_amount: null },
       ],
     });
     expect(info.isSupported(17)).toEqual({
@@ -338,13 +338,17 @@ describe('test info', () => {
       ],
     });
     expect(info).toEqual(new MintInfo(mintInfoResp));
-    expect(info.cache).toEqual(mintInfoResp);
+    // info.cache exposes the *normalized* response, not the raw wire payload —
+    // compare to MintInfo.normalizeInfo() so the assertion stays honest as
+    // normalization (e.g. nullIfUndefined on min/max_amount) evolves.
+    const normalized = MintInfo.normalizeInfo(mintInfoResp);
+    expect(info.cache).toEqual(normalized);
     expect(info.contact).toEqual(mintInfoResp.contact);
     expect(info.description).toEqual(mintInfoResp.description);
     expect(info.description_long).toEqual(mintInfoResp.description_long);
     expect(info.name).toEqual(mintInfoResp.name);
     expect(info.pubkey).toEqual(mintInfoResp.pubkey);
-    expect(info.nuts).toEqual(mintInfoResp.nuts);
+    expect(info.nuts).toEqual(normalized.nuts);
     expect(info.version).toEqual(mintInfoResp.version);
     expect(info.motd).toEqual(mintInfoResp.motd);
     expect(info.supportsNut04Description('bolt12', 'sat')).toBeFalsy();


### PR DESCRIPTION
## Summary

Harmonizes typing and runtime normalization for `<X|null>` wire fields that were previously typed as `T?` (undefined-flavored) or as required despite the spec admitting `null`. After this PR, the affected fields are spec-faithful `T | null` and consistently normalized at the response boundary.

**Affected fields:**
| NUT | Field | Before | After |
|---|---|---|---|
| 25 | `MintQuoteBolt12Response.amount` | `Amount?` | `Amount \| null` |
| 04/05/25/XX | `SwapMethod.min_amount` | `AmountLike` (required) | `AmountLike \| null` |
| 04/05/25/XX | `SwapMethod.max_amount` | `AmountLike` (required) | `AmountLike \| null` |

Each is normalized via `nullIfUndefined` at the response boundary, so mints that omit the fields entirely get coerced to spec-faithful `null` rather than leaking `undefined`. Also removes the now-unused internal `undefinedIfNull` helper — its sole call site was the old bolt12 amount path.

## Why now

Two recent PRs (#653 for `payment_preimage` / `witness`, and the `maxSpendableAfterFees` work in #654) leaned on the existing `nullIfUndefined` helper. After a NUTs-spec audit, these three fields were the remaining outliers — they're the only public types that lie about nullability relative to their spec definitions. The wider keyset metadata fields (`MintKeys.input_fee_ppk`, `MintKeyset.final_expiry`, etc.) stay typed `T?` intentionally — consumers truthy-check / `??` them and there's no observed breakage, so harmonizing here has a real cost (Keyset wrapper, KeyChainCache shape, persistence) and no protocol-meaning payoff, unlike the bolt12 case.

## Compatibility

Shipping as a minor (no `!` / `BREAKING CHANGE:` marker) — the actual blast radius is small and conventional consumer patterns are unaffected.

**Untouched** (still works after this PR):
- `if (x)` truthy checks
- `x ?? fallback`
- `x?.foo` optional chains
- `x != null` checks (covers both null and undefined)

**Will need a one-line consumer update**:
- TS code comparing `q.amount === undefined` on a bolt12 mint quote response — switch to `q.amount === null` or `q.amount == null`
- Destructuring `min_amount` / `max_amount` with a default value (`const { min_amount = 0n } = m`) — defaults no longer trigger on null, switch to `m.min_amount ?? 0n`
- Variables typed as `T?` reassigned from these fields — TS will require widening

**Silent runtime change**:
- `JSON.stringify(quote)` now emits `"amount": null` instead of omitting the field for amountless bolt12 quotes. Could matter for round-trip storage; won't matter for typical wallet UX.

Bolt12 adoption is still early (Nutshell + CDK on the mint side; only a handful of wallets ship bolt12 melts), so the practical downstream impact is limited even for `q.amount` — the highest-risk field by far. `SwapMethod.min_amount`/`max_amount` are read by no internal cashu-ts code; only consumers feeding them into `Amount.from(...)` would have noticed the type lie.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Two `MintQuoteBolt12` normalization tests in `test/mint/Mint.node.test.ts` updated (`toBeUndefined()` → `toBeNull()`); names tightened to describe the new contract
- [x] Wallet-init test now compares `info.cache` to `MintInfo.normalizeInfo(mintInfoResp)` rather than the raw wire payload — that assertion was passing by accident before normalization landed for these fields
- [x] Wallet-init `isSupported(5)` assertion explicitly lists `min_amount: null, max_amount: null` per method, surfacing the new normalized shape
- [x] Full unit/MSW suite (`npx vitest run test/mint/ test/wallet/ test/model/ test/utils/`) — 2569/2569 pass
- [x] API report (`etc/cashu-ts.api.md`) regenerated

## Related
- #653 added `nullIfUndefined` for `payment_preimage` / `witness` — same Postel-style shape
- #654 added `maxSpendableAfterFees`; touches the same fee-primitive area but no overlap