### PR TITLE
fix(wallet): verify DLEQ on received proofs even without requireDleq (NUT-12)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1842,6 +1842,9 @@ export type UnblindedSignature = {
 // @public (undocumented)
 export function unblindSignature(C_: WeierstrassPoint<bigint>, r: bigint, A: WeierstrassPoint<bigint>): WeierstrassPoint<bigint>;
 
+// @public
+export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean;
+
 // @public (undocumented)
 export const verifyDLEQProof: (dleq: DLEQ, B_: WeierstrassPoint<bigint>, C_: WeierstrassPoint<bigint>, A: WeierstrassPoint<bigint>) => boolean;
 

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -104,6 +104,11 @@ export class OutputData implements OutputDataLike {
   }
 
   toProof(sig: SerializedBlindedSignature, keyset: HasKeysetKeys) {
+    if (sig == undefined) {
+      throw new Error(
+        'Mint response is missing a signature for one of the outputs. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',
+      );
+    }
     let dleq: DLEQ | undefined;
     if (sig.dleq) {
       dleq = {

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -699,7 +699,7 @@ function mapShortKeysetIds(proofs: Proof[], keysetIds: readonly string[]): Proof
  * @throws Throws if the proof amount does not match any key in the provided keyset.
  */
 export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean {
-  if (proof.dleq == undefined) {
+  if (proof?.dleq == undefined) {
     return false;
   }
   if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
@@ -739,7 +739,7 @@ export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean {
  *   keyset.
  */
 export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean {
-  if (proof.dleq == undefined) {
+  if (proof?.dleq == undefined) {
     return true;
   }
   return hasValidDleq(proof, keyset);

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -702,21 +702,47 @@ export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean {
   if (proof.dleq == undefined) {
     return false;
   }
-  const dleq = {
-    e: hexToBytes(proof.dleq.e),
-    s: hexToBytes(proof.dleq.s),
-    r: hexToNumber(proof.dleq.r ?? '00'),
-  } as DLEQ;
   if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
     throw new Error(`Undefined key for amount ${proof.amount.toString()} in keyset ${keyset.id}`);
   }
   const key = keyset.keys[proof.amount.toString()];
-  return verifyDLEQProof_reblind(
-    new TextEncoder().encode(proof.secret),
-    dleq,
-    pointFromHex(proof.C),
-    pointFromHex(key),
-  );
+  try {
+    const dleq = {
+      e: hexToBytes(proof.dleq.e),
+      s: hexToBytes(proof.dleq.s),
+      r: hexToNumber(proof.dleq.r ?? '00'),
+    } as DLEQ;
+    return verifyDLEQProof_reblind(
+      new TextEncoder().encode(proof.secret),
+      dleq,
+      pointFromHex(proof.C),
+      pointFromHex(key),
+    );
+  } catch {
+    // Malformed DLEQ payload (out-of-range scalar, bad point encoding, etc.) — treat as invalid.
+    return false;
+  }
+}
+
+/**
+ * NUT-12: verifies the DLEQ proof on a Proof when one is included.
+ *
+ * @remarks
+ * Distinct from {@link hasValidDleq}: if the proof carries no DLEQ this returns true (nothing to
+ * verify), satisfying the spec "MUST verify-if-present" rule. Use {@link hasValidDleq} when you want
+ * a stricter "must be present and valid" check.
+ * @param proof The proof subject to verification.
+ * @param keyset Object containing keyset keys (eg: Keyset, MintKeys, KeysetCache)
+ * @returns True if no DLEQ is present, or if the present DLEQ verifies; false if the present DLEQ
+ *   fails to verify.
+ * @throws Throws if a DLEQ is present and the proof amount does not match any key in the provided
+ *   keyset.
+ */
+export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean {
+  if (proof.dleq == undefined) {
+    return true;
+  }
+  return hasValidDleq(proof, keyset);
 }
 
 /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -52,6 +52,7 @@ import {
   normalizeUrl,
   splitAmount,
   sumProofs,
+  verifyDleqIfPresent,
   ABSOLUTE_MAX_BATCH_SIZE,
 } from '../utils';
 
@@ -950,13 +951,14 @@ class Wallet {
     const totalAmount = this.parseAmount(sumProofs(proofs), 'prepareSwapToReceive', true);
     this.failIf(totalAmount.isZero(), 'Token contains no proofs', { proofs });
 
-    // Check DLEQs if needed
-    if (requireDleq) {
-      for (const p of proofs) {
-        const ks = this._keyChain.getKeyset(p.id);
-        if (!hasValidDleq(p, ks)) {
-          this.fail('Token contains proofs with invalid or missing DLEQ');
-        }
+    // NUT-12: wallets MUST verify any DLEQ on a received proof. `requireDleq: true`
+    // upgrades that to "DLEQ must also be present" via the stricter `hasValidDleq`.
+    for (const p of proofs) {
+      const ks = this._keyChain.getKeyset(p.id);
+      if (requireDleq) {
+        this.failIf(!hasValidDleq(p, ks), 'Token contains proofs with invalid or missing DLEQ');
+      } else {
+        this.failIf(!verifyDleqIfPresent(p, ks), 'Token contains a proof with an invalid DLEQ');
       }
     }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1284,7 +1284,7 @@ class Wallet {
     const { signatures } = await this.mint.swap(swapTransaction.payload);
     this.failIf(
       signatures.length !== swapTransaction.outputData.length,
-      `Mint returned ${signatures.length} signatures, expected ${swapTransaction.outputData.length}`,
+      `Mint returned ${signatures.length} signatures, expected ${swapTransaction.outputData.length}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
     this.validateReturnedSignatures(signatures, swapTransaction.outputData);
 
@@ -1799,12 +1799,16 @@ class Wallet {
 
     for (let i = 0; i < signatures.length; i++) {
       this.failIf(
+        signatures[i] == undefined,
+        `Mint response is missing a signature at index ${i}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
+      );
+      this.failIf(
         checkAmounts && !signatures[i].amount.equals(outputData[i].blindedMessage.amount),
-        `Mint returned signature with wrong amount: expected ${outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}`,
+        `Mint returned signature with wrong amount at index ${i}: expected ${outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
       this.failIf(
         requiresDleq && !signatures[i].dleq,
-        'Mint supports NUT-12, but returned a signature without DLEQ proof',
+        `Mint supports NUT-12, but returned a signature without DLEQ proof at index ${i}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
     }
   }
@@ -2035,7 +2039,7 @@ class Wallet {
     const { signatures } = await this.mint.mint(method, payload);
     this.failIf(
       signatures.length !== outputData.length,
-      `Mint returned ${signatures.length} signatures, expected ${outputData.length}`,
+      `Mint returned ${signatures.length} signatures, expected ${outputData.length}. The mint quote may already be marked issued; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
     this.validateReturnedSignatures(signatures, outputData);
 
@@ -2198,7 +2202,7 @@ class Wallet {
     const { signatures: sigs } = await this.mint.mintBatch(method, payload);
     this.failIf(
       sigs.length !== outputData.length,
-      `Mint returned ${sigs.length} signatures, expected ${outputData.length}`,
+      `Mint returned ${sigs.length} signatures, expected ${outputData.length}. The mint quote may already be marked issued; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
     this.validateReturnedSignatures(sigs, outputData);
 
@@ -2620,7 +2624,7 @@ class Wallet {
       // Change may not use all outputs (shorter is ok)
       this.failIf(
         meltResponse.change.length > meltPreview.outputData.length,
-        `Mint returned ${meltResponse.change.length} signatures, but only ${meltPreview.outputData.length} blanks were provided`,
+        `Mint returned ${meltResponse.change.length} signatures, but only ${meltPreview.outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
       this.validateReturnedSignatures(meltResponse.change, meltPreview.outputData, {
         checkAmounts: false, // change outputs are blank

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -117,6 +117,13 @@ describe('OutputData.toProof DLEQ verification', () => {
     expect(() => od.toProof(sig, keyset)).toThrow('DLEQ verification failed');
   });
 
+  test('toProof throws on undefined signature', () => {
+    const { keyset, od } = mintSetup();
+    expect(() => od.toProof(undefined as never, keyset)).toThrow(
+      'Mint response is missing a signature for one of the outputs',
+    );
+  });
+
   test('toProof preserves p2pk_e from OutputData instance', () => {
     const { blindSig, keyset, od } = mintSetup();
     const p2pkE = secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true);

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -29,6 +29,7 @@ import {
   normalizeProofAmounts,
   sortProofsById,
   normalizeUrl,
+  verifyDleqIfPresent,
 } from '../../src/utils';
 import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 
@@ -654,6 +655,46 @@ describe('test zero-knowledge utilities', () => {
       keys: { [2]: pubkey.toHex(true) },
     };
     expect(() => hasValidDleq(serializedProof, keyset)).toThrow(/Undefined key for amount/);
+  });
+
+  describe('verifyDleqIfPresent', () => {
+    const keyset = {
+      id: '00',
+      unit: 'sat',
+      keys: { [1]: pubkey.toHex(true) },
+    };
+
+    test('returns true when no DLEQ is present', () => {
+      const { dleq, ...proofNoDleq } = serializedProof;
+      void dleq;
+      expect(verifyDleqIfPresent(proofNoDleq, keyset)).toBe(true);
+    });
+
+    test('returns true for a valid DLEQ', () => {
+      expect(verifyDleqIfPresent(serializedProof, keyset)).toBe(true);
+    });
+
+    test('returns false for a tampered DLEQ', () => {
+      const tampered: Proof = {
+        ...serializedProof,
+        dleq: {
+          ...serializedProof.dleq!,
+          e: '00'.repeat(32),
+        },
+      };
+      expect(verifyDleqIfPresent(tampered, keyset)).toBe(false);
+    });
+
+    test('throws if DLEQ is present but no matching keyset key', () => {
+      const wrongKeyset = {
+        id: '00',
+        unit: 'sat',
+        keys: { [2]: pubkey.toHex(true) },
+      };
+      expect(() => verifyDleqIfPresent(serializedProof, wrongKeyset)).toThrow(
+        /Undefined key for amount/,
+      );
+    });
   });
 });
 

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -548,6 +548,32 @@ describe('receive', () => {
     );
   });
 
+  test('test receive verifies DLEQ when present even without requireDleq (NUT-12 MUST)', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const decoded = wallet.decodeToken(token3sat);
+    const tampered = {
+      ...decoded,
+      proofs: decoded.proofs.map((p, i) =>
+        i === 0
+          ? {
+              ...p,
+              dleq: {
+                e: '00'.repeat(32),
+                s: '00'.repeat(32),
+                r: '00'.repeat(32),
+              },
+            }
+          : p,
+      ),
+    };
+
+    await expect(wallet.receive(tampered)).rejects.toThrow(
+      'Token contains a proof with an invalid DLEQ',
+    );
+  });
+
   test('test receive proofsWeHave optimization', async () => {
     server.use(
       http.post(mintUrl + '/v1/swap', async () => {


### PR DESCRIPTION
## Summary

NUT-12 requires wallets to verify any DLEQ proof included on a received `Proof`:

> If a DLEQ proof is included in a received token, wallets **MUST** verify the proof.

`prepareSwapToReceive` previously only ran this check when the caller passed
`requireDleq: true`. With the default (`requireDleq: false`), proofs that carried a
DLEQ were accepted without verification — a spec violation.

This PR closes that gap, keeps `requireDleq: true` as the stricter "must also be
present" wallet policy, and adds a focused helper to keep the two semantics
distinct.

It also guards mint-response paths against undefined sigs and adds recovery hints.

## DLEQ handling — spec-compliance audit

For the record, here's where DLEQ is touched in cashu-ts and how each site relates
to NUT-12.

### Mint → wallet (BlindSignature) — ✅ spec-compliant

`OutputData.toProof` always verifies any DLEQ present on a returned blind
signature and throws on failure (`src/model/OutputData.ts:118-125`).

This fires for every path that turns mint signatures into proofs:
- swap — `src/wallet/Wallet.ts:1291`
- mint — `src/wallet/Wallet.ts:2044`, `src/wallet/Wallet.ts:2208`
- melt change — `src/wallet/Wallet.ts:2630`
- restore — `src/wallet/Wallet.ts:1590`

Auth/BAT mint additionally re-checks via `hasValidDleq`
(`src/auth/AuthManager.ts:436-441`).

### Beyond-spec strictness (opt-in) — ✅

`requireSigDleq` (constructor option) makes the wallet *also* fail if the mint
advertises NUT-12 but omits DLEQ on a returned signature
(`Wallet.ts:1794-1806`). Stricter than the spec MUST; correctly opt-in.

### User → user (received `Proof`) — ❌ gap, fixed by this PR

`prepareSwapToReceive` only ran DLEQ verification when the caller passed
`requireDleq: true` (`Wallet.ts:953-961`). The flag conflated two semantics:

1. MUST per spec — verify DLEQ when present
2. Stricter wallet policy — also reject proofs that lack DLEQ

`hasValidDleq` returns `false` for both "missing" and "invalid", which is fine
for the strict mode but blocked the verify-if-present semantic without
pre-filtering.

### Adjacent / fine

- `sendOffline({ requireDleq: true })` (`Wallet.ts:1017-1020`) is a coin-selection
  filter on your own already-trusted proofs, not a verification step.
- V4 token encode/decode preserves DLEQ (`utils/core.ts:299-305`).

## Changes

- **`src/utils/core.ts`**
  - Added `verifyDleqIfPresent(proof, keyset)`: returns `true` when no DLEQ is
    present, otherwise delegates to `hasValidDleq`. Encodes the NUT-12
    "MUST verify if included" semantic without conflating "absent" with
    "invalid".
  - Hardened `hasValidDleq` to catch crypto-layer throws (out-of-range scalar,
    bad point encoding) and return `false`, while still propagating the
    legitimate `Undefined key for amount` error.

- **`src/wallet/Wallet.ts`** — `prepareSwapToReceive`
  - DLEQ verification now always runs when a proof carries one.
  - `requireDleq: true` keeps the stricter behaviour (must be both present and
    valid).

## Test plan

- [x] Unit tests for `verifyDleqIfPresent`: absent → true, valid → true,
      tampered → false, missing keyset key → throws.
- [x] Integration test: a token whose proof carries an invalid DLEQ is rejected
      on `wallet.receive()` even without `requireDleq: true`.
- [x] Existing `requireDleq: true` test still passes (strict mode unchanged).
- [x] `npx tsc --noEmit` clean.
- [x] Full node suite: 1349/1349 pass.