### PR TITLE
feat(errors): add CTSError base class

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -519,7 +519,9 @@ export type HTLCWitness = {
 
 // @public
 export class HttpResponseError extends CTSError {
-    constructor(message: string, status: number);
+    constructor(message: string, status: number, options?: {
+        cause?: unknown;
+    });
     // (undocumented)
     status: number;
 }
@@ -1095,7 +1097,9 @@ export type MPPMethod = {
 
 // @public
 export class NetworkError extends CTSError {
-    constructor(message: string);
+    constructor(message: string, options?: {
+        cause?: unknown;
+    });
 }
 
 // @public

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -56,7 +56,7 @@ export class Amount {
 }
 
 // @public (undocumented)
-export class AmountError extends Error {
+export class AmountError extends CTSError {
     constructor(message: string);
 }
 
@@ -260,6 +260,15 @@ export function createRandomSecretKey(): Uint8Array<ArrayBufferLike>;
 
 // @public
 export function createSecret(kind: SecretKind, data: string, tags?: string[][]): string;
+
+// @public
+export class CTSError extends Error {
+    constructor(message: string, options?: {
+        cause?: unknown;
+    });
+    // (undocumented)
+    readonly cause?: unknown;
+}
 
 // @public
 export function decodePaymentRequest(paymentRequest: string): PaymentRequest_2;
@@ -509,7 +518,7 @@ export type HTLCWitness = {
 };
 
 // @public
-export class HttpResponseError extends Error {
+export class HttpResponseError extends CTSError {
     constructor(message: string, status: number);
     // (undocumented)
     status: number;
@@ -1085,7 +1094,7 @@ export type MPPMethod = {
 };
 
 // @public
-export class NetworkError extends Error {
+export class NetworkError extends CTSError {
     constructor(message: string);
 }
 

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -1,5 +1,6 @@
 import { type Logger, NULL_LOGGER } from '../logger';
 import { Amount } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import { OutputData } from '../model/OutputData';
 import type {
@@ -258,7 +259,7 @@ export class AuthManager implements AuthProvider {
     return this.withLock(async () => {
       await this.ensure(1);
       if (this.pool.length === 0) {
-        throw new Error('AuthManager: no BATs available and minting failed');
+        throw new CTSError('AuthManager: no BATs available and minting failed');
       }
       // Pop one BAT and serialize without DLEQ for the header. Per NUT-22, wallets
       // SHOULD delete BAT even on error, so no need to track it in-flight.
@@ -378,7 +379,7 @@ export class AuthManager implements AuthProvider {
    * Gets the BAT minting limit: lower of manager limit and Mint’s NUT-22 limit.
    */
   private getBatMaxMint(): number {
-    if (!this.info) throw new Error('AuthManager: mint info not loaded');
+    if (!this.info) throw new CTSError('AuthManager: mint info not loaded');
     const n22 = this.info.nuts['22'];
     const mintMax = normalizeSafeIntegerMetadata(
       n22?.bat_max_mint,
@@ -389,7 +390,7 @@ export class AuthManager implements AuthProvider {
   }
 
   private getActiveKeys(): Keyset {
-    if (!this.keychain) throw new Error('AuthManager: keyset not loaded for active keyset');
+    if (!this.keychain) throw new CTSError('AuthManager: keyset not loaded for active keyset');
     return this.keychain.getCheapestKeyset();
   }
 
@@ -397,7 +398,7 @@ export class AuthManager implements AuthProvider {
    * Mint a batch of BATs using the current CAT if the endpoint is protected by NUT-21.
    */
   private async topUp(n: number): Promise<void> {
-    if (!this.info) throw new Error('AuthManager: mint info not loaded');
+    if (!this.info) throw new CTSError('AuthManager: mint info not loaded');
 
     // Check NUT-21 protection of the BAT mint endpoint
     const needsCAT = this.info.requiresClearAuthToken('POST', '/v1/auth/blind/mint');
@@ -405,7 +406,7 @@ export class AuthManager implements AuthProvider {
     if (needsCAT) {
       cat = await this.ensureCAT();
       if (!cat) {
-        throw new Error(
+        throw new CTSError(
           'AuthManager: Clear-auth token required for /v1/auth/blind/mint but not available. Authenticate with the mint to obtain a CAT first.',
         );
       }
@@ -425,7 +426,7 @@ export class AuthManager implements AuthProvider {
       requestBody: payload,
     });
     if (!Array.isArray(res?.signatures) || res.signatures.length !== outputs.length) {
-      throw new Error('AuthManager: bad BAT mint response');
+      throw new CTSError('AuthManager: bad BAT mint response');
     }
     // Normalize signature amounts (raw JSON has numbers, not Amount objects)
     const signatures = res.signatures.map((sig) => ({
@@ -436,7 +437,7 @@ export class AuthManager implements AuthProvider {
     const proofs = outputs.map((d, i) => d.toProof(signatures[i], keys));
     for (const p of proofs) {
       if (!hasValidDleq(p, keys)) {
-        throw new Error('AuthManager: mint returned BAT with invalid DLEQ');
+        throw new CTSError('AuthManager: mint returned BAT with invalid DLEQ');
       }
     }
     // Add BAT proofs to pool

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -2,6 +2,7 @@ import { randomBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import { type Logger, NULL_LOGGER, safeCallback } from '../logger';
+import { CTSError } from '../model/Errors';
 import { type GetInfoResponse } from '../model/types';
 import { Bytes, encodeUint8toBase64Url } from '../utils';
 
@@ -54,7 +55,7 @@ export class OIDCAuth {
   static fromMintInfo(info: { nuts: GetInfoResponse['nuts'] }, opts?: OIDCAuthOptions): OIDCAuth {
     const n21 = info?.nuts?.['21'];
     if (!n21?.openid_discovery) {
-      throw new Error('OIDCAuth: mint does not advertise NUT-21 openid_discovery');
+      throw new CTSError('OIDCAuth: mint does not advertise NUT-21 openid_discovery');
     }
     const clientId = opts?.clientId ?? n21.client_id ?? 'cashu-client';
     return new OIDCAuth(n21.openid_discovery, { ...opts, clientId });
@@ -99,11 +100,11 @@ export class OIDCAuth {
       this.logger.warn('OIDCAuth: bad discovery JSON', { err });
     }
     if (!res.ok || !json) {
-      throw new Error('OIDCAuth: invalid discovery document');
+      throw new CTSError('OIDCAuth: invalid discovery document');
     }
     const cfg = json as OIDCConfig;
     if (typeof cfg.token_endpoint !== 'string' || cfg.token_endpoint.length === 0) {
-      throw new Error('OIDCAuth: invalid discovery document, missing token_endpoint');
+      throw new CTSError('OIDCAuth: invalid discovery document, missing token_endpoint');
     }
     this.config = cfg;
     return cfg;
@@ -153,7 +154,7 @@ export class OIDCAuth {
     if (input.state) params.set('state', input.state);
 
     if (!cfg.authorization_endpoint) {
-      throw new Error('OIDCAuth: discovery lacks authorization_endpoint');
+      throw new CTSError('OIDCAuth: discovery lacks authorization_endpoint');
     }
     return `${cfg.authorization_endpoint}?${params.toString()}`;
   }
@@ -180,7 +181,7 @@ export class OIDCAuth {
   async deviceStart(): Promise<DeviceStartResponse> {
     const cfg = await this.loadConfig();
     const ep = cfg.device_authorization_endpoint;
-    if (!ep) throw new Error('OIDCAuth: provider lacks device_authorization_endpoint');
+    if (!ep) throw new CTSError('OIDCAuth: provider lacks device_authorization_endpoint');
 
     const form = this.toForm({ client_id: this.clientId, scope: this.scope });
     return this.postFormStrict<DeviceStartResponse>(ep, form);
@@ -209,7 +210,7 @@ export class OIDCAuth {
         continue;
       }
       const msg = res.error_description || err || 'device authorization failed';
-      throw new Error(`OIDCAuth: ${msg}`);
+      throw new CTSError(`OIDCAuth: ${msg}`);
     }
   }
 
@@ -235,7 +236,7 @@ export class OIDCAuth {
       const cfg = await this.loadConfig();
       let delay = Math.max(1, interval);
       while (true) {
-        if (aborted) throw new Error('OIDCAuth: device polling cancelled');
+        if (aborted) throw new CTSError('OIDCAuth: device polling cancelled');
         await this.sleep(delay * 1000);
         const form = this.toForm({
           grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
@@ -254,7 +255,7 @@ export class OIDCAuth {
           continue;
         }
         const msg = res.error_description || err || 'device authorization failed';
-        throw new Error(`OIDCAuth: ${msg}`);
+        throw new CTSError(`OIDCAuth: ${msg}`);
       }
     };
 
@@ -304,7 +305,7 @@ export class OIDCAuth {
   private handleTokens(t: TokenResponse): void {
     if (!t.access_token) {
       const msg = t.error_description || t.error || 'token response missing access_token';
-      throw new Error(`OIDCAuth: ${msg}`);
+      throw new CTSError(`OIDCAuth: ${msg}`);
     }
     // Schedule on microtask queue so we never block the caller and we avoid sync throws leaking.
     queueMicrotask(() =>
@@ -352,7 +353,7 @@ export class OIDCAuth {
       if (!res.ok) {
         const err = (json ?? {}) as TokenResponse;
         const msg = err.error_description || err.error || `HTTP ${res.status}`;
-        throw new Error(`OIDCAuth: ${msg}`);
+        throw new CTSError(`OIDCAuth: ${msg}`);
       }
       this.logger.debug('OIDCAuth Response', { json });
       return (json ?? {}) as TSuccess;

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -94,13 +94,15 @@ export class OIDCAuth {
     });
     const text = await res.text();
     let json: unknown;
+    let parseError: unknown;
     try {
       json = text ? JSON.parse(text) : undefined;
     } catch (err) {
+      parseError = err;
       this.logger.warn('OIDCAuth: bad discovery JSON', { err });
     }
     if (!res.ok || !json) {
-      throw new CTSError('OIDCAuth: invalid discovery document');
+      throw new CTSError('OIDCAuth: invalid discovery document', { cause: parseError });
     }
     const cfg = json as OIDCConfig;
     if (typeof cfg.token_endpoint !== 'string' || cfg.token_endpoint.length === 0) {
@@ -345,15 +347,17 @@ export class OIDCAuth {
       });
       const text = await res.text();
       let json: unknown;
+      let parseError: unknown;
       try {
         json = text ? JSON.parse(text) : undefined;
       } catch (err) {
+        parseError = err;
         this.logger.warn('OIDCAuth: bad JSON (strict)', { err });
       }
       if (!res.ok) {
         const err = (json ?? {}) as TokenResponse;
         const msg = err.error_description || err.error || `HTTP ${res.status}`;
-        throw new CTSError(`OIDCAuth: ${msg}`);
+        throw new CTSError(`OIDCAuth: ${msg}`, { cause: parseError });
       }
       this.logger.debug('OIDCAuth Response', { json });
       return (json ?? {}) as TSuccess;

--- a/src/crypto/NUT01.ts
+++ b/src/crypto/NUT01.ts
@@ -3,6 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { HDKey } from '@scure/bip32';
 
+import { CTSError } from '../model/Errors';
 import { deriveKeysetId } from '../utils';
 
 import { type UnblindedSignature, createRandomSecretKey, hashToCurve } from './core';
@@ -84,7 +85,7 @@ export function createNewMintKeys(
       if (k) {
         privKeys[index] = k;
       } else {
-        throw new Error(`Could not derive Private key from: ${DERIVATION_PATH}/${counter}`);
+        throw new CTSError(`Could not derive Private key from: ${DERIVATION_PATH}/${counter}`);
       }
     } else {
       privKeys[index] = createRandomSecretKey();

--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -1,5 +1,7 @@
 import { bytesToHex, randomBytes } from '@noble/curves/utils.js';
 
+import { CTSError } from '../model/Errors';
+
 export type SecretKind = 'P2PK' | 'HTLC' | (string & {}); // union with any string
 
 export interface SecretData {
@@ -49,7 +51,7 @@ export function parseSecret(secret: string | Secret): Secret {
       parsed = secret; // Pass through
     }
   } catch {
-    throw new Error("Can't parse secret");
+    throw new CTSError("Can't parse secret");
   }
 
   // Validate NUT-10 shape
@@ -61,16 +63,16 @@ export function parseSecret(secret: string | Secret): Secret {
     parsed[0].trim().length === 0 ||
     parsed[1] === null
   ) {
-    throw new Error('Invalid NUT-10 secret');
+    throw new CTSError('Invalid NUT-10 secret');
   }
   const [kind, data] = parsed as [SecretKind, Record<string, unknown>];
   if (typeof data.nonce !== 'string' || typeof data.data !== 'string') {
-    throw new Error('Invalid NUT-10 secret nonce / data');
+    throw new CTSError('Invalid NUT-10 secret nonce / data');
   }
   if (data.tags) {
     // Check data.tags is an array
     if (!Array.isArray(data.tags)) {
-      throw new Error('Invalid NUT-10 secret tags');
+      throw new CTSError('Invalid NUT-10 secret tags');
     }
     // Check individual tags are non-empty arrays of strings
     const invalid = data.tags.some(
@@ -78,7 +80,7 @@ export function parseSecret(secret: string | Secret): Secret {
         !Array.isArray(t) || t.length === 0 || t.some((tt) => typeof tt !== 'string' || !tt.length),
     );
     if (invalid) {
-      throw new Error('Invalid NUT-10 tag(s)');
+      throw new CTSError('Invalid NUT-10 tag(s)');
     }
   }
 
@@ -112,7 +114,7 @@ export function assertSecretKind(
   const parsed = parseSecret(secret);
   const actual = parsed[0];
   if (!kinds.includes(actual)) {
-    throw new Error(`Invalid secret kind: ${actual} Allowed: ${kinds.join(', ')}`);
+    throw new CTSError(`Invalid secret kind: ${actual} Allowed: ${kinds.join(', ')}`);
   }
   return parsed;
 }

--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -50,8 +50,8 @@ export function parseSecret(secret: string | Secret): Secret {
     } else {
       parsed = secret; // Pass through
     }
-  } catch {
-    throw new CTSError("Can't parse secret");
+  } catch (e) {
+    throw new CTSError("Can't parse secret", { cause: e });
   }
 
   // Validate NUT-10 shape

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -2,6 +2,7 @@ import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 
 import { type Logger, NULL_LOGGER } from '../logger';
+import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
 
@@ -175,7 +176,7 @@ function normalizePubkey(pk: string): string {
   const hex = pk.toLowerCase();
   if (hex.length === 66 && (hex.startsWith('02') || hex.startsWith('03'))) return hex;
   if (hex.length === 64) return `02${hex}`;
-  throw new Error(
+  throw new CTSError(
     `Invalid pubkey, expected 33 byte compressed or 32 byte x only, got length ${hex.length}`,
   );
 }
@@ -217,11 +218,11 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   const pubkeys = dedupeP2PKPubkeys(Array.isArray(p2pk.pubkey) ? p2pk.pubkey : [p2pk.pubkey]);
   const refundKeys = dedupeP2PKPubkeys(p2pk.refundKeys ?? []);
   if (pubkeys.length === 0) {
-    throw new Error('P2PK requires at least one pubkey');
+    throw new CTSError('P2PK requires at least one pubkey');
   }
   const totalKeys = pubkeys.length + refundKeys.length;
   if (totalKeys > 10) {
-    throw new Error(`Too many pubkeys, ${totalKeys} provided, maximum allowed is 10 in total`);
+    throw new CTSError(`Too many pubkeys, ${totalKeys} provided, maximum allowed is 10 in total`);
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
 
@@ -399,7 +400,7 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
   const pubkey = bytesToHex(schnorr.getPublicKey(privKeyBytes)); // x-only
   const witnesses = getP2PKExpectedWitnessPubkeys(secret);
   if (!witnesses.length || !witnesses.some((w) => w.includes(pubkey))) {
-    throw new Error(`Signature not required from [02|03]${pubkey}`);
+    throw new CTSError(`Signature not required from [02|03]${pubkey}`);
   }
 
   // Check if the public key has already signed
@@ -409,7 +410,7 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
   });
 
   if (alreadySigned) {
-    throw new Error(`Proof already signed by [02|03]${pubkey}`);
+    throw new CTSError(`Proof already signed by [02|03]${pubkey}`);
   }
 
   // Add new signature
@@ -436,7 +437,7 @@ export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: strin
   }
   // Check if message is needed
   if (isP2PKSigAll([proof]) && !message) {
-    throw new Error('Cannot verify a SIG_ALL proof without the message to sign');
+    throw new CTSError('Cannot verify a SIG_ALL proof without the message to sign');
   }
   message = message ?? proof.secret; // default message is secret
 
@@ -484,7 +485,7 @@ export function verifyP2PKSpendingConditions(
   // Check if message is needed
   if (isP2PKSigAll([proof]) && !message) {
     logger.error('Cannot verify a SIG_ALL proof without the message to sign');
-    throw new Error('Cannot verify a SIG_ALL proof without the message to sign');
+    throw new CTSError('Cannot verify a SIG_ALL proof without the message to sign');
   }
 
   // Parse once — all tag reads below use the pre-parsed Secret (no re-parsing)
@@ -614,20 +615,20 @@ export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof:
  * @internal
  */
 export function assertSigAllInputs(inputs: Proof[]): void {
-  if (inputs.length === 0) throw new Error('No proofs');
+  if (inputs.length === 0) throw new CTSError('No proofs');
   // Check first proof
   const first = parseP2PKSecret(inputs[0].secret);
-  if (getP2PKSigFlag(first) !== 'SIG_ALL') throw new Error('First proof is not SIG_ALL');
+  if (getP2PKSigFlag(first) !== 'SIG_ALL') throw new CTSError('First proof is not SIG_ALL');
   const data0 = first[1].data;
   const tags0 = JSON.stringify(first[1].tags ?? []);
   // Compare remaining proofs
   for (let i = 1; i < inputs.length; i++) {
     const si = parseP2PKSecret(inputs[i].secret);
-    if (si[0] !== first[0]) throw new Error(`Proof #${i + 1} is not ${first[0]}`);
-    if (getP2PKSigFlag(si) !== 'SIG_ALL') throw new Error(`Proof #${i + 1} is not SIG_ALL`);
-    if (si[1].data !== data0) throw new Error('SIG_ALL inputs must share identical Secret.data');
+    if (si[0] !== first[0]) throw new CTSError(`Proof #${i + 1} is not ${first[0]}`);
+    if (getP2PKSigFlag(si) !== 'SIG_ALL') throw new CTSError(`Proof #${i + 1} is not SIG_ALL`);
+    if (si[1].data !== data0) throw new CTSError('SIG_ALL inputs must share identical Secret.data');
     if (JSON.stringify(si[1].tags ?? []) !== tags0)
-      throw new Error('SIG_ALL inputs must share identical Secret.tags');
+      throw new CTSError('SIG_ALL inputs must share identical Secret.tags');
   }
 }
 
@@ -692,7 +693,7 @@ function assertNoDuplicateP2PKTags(tags: string[][]): void {
     const key = tag[0];
     if (!P2PK_KNOWN_TAG_KEYS.has(key)) continue;
     if (seen.has(key)) {
-      throw new Error(`Duplicate P2PK tag "${key}"`);
+      throw new CTSError(`Duplicate P2PK tag "${key}"`);
     }
     seen.add(key);
   }
@@ -700,13 +701,13 @@ function assertNoDuplicateP2PKTags(tags: string[][]): void {
 
 function assertSigFlag(flag: string): asserts flag is SigFlag {
   if (!VALID_SIG_FLAGS.has(flag as SigFlag)) {
-    throw new Error(`Invalid sigflag "${flag}": must be "SIG_INPUTS" or "SIG_ALL"`);
+    throw new CTSError(`Invalid sigflag "${flag}": must be "SIG_INPUTS" or "SIG_ALL"`);
   }
 }
 
 function assertPositiveInteger(value: number, field: string): number {
   if (!Number.isInteger(value) || value < 1) {
-    throw new Error(`${field} must be a positive integer, got ${value}`);
+    throw new CTSError(`${field} must be a positive integer, got ${value}`);
   }
   return value;
 }
@@ -731,7 +732,7 @@ function assertSpendingConditionRules(params: {
   if (nSigs !== undefined) {
     assertPositiveInteger(nSigs, 'requiredSignatures (n_sigs)');
     if (nSigs > mainKeyCount) {
-      throw new Error(
+      throw new CTSError(
         `requiredSignatures (n_sigs) (${nSigs}) exceeds available pubkeys (${mainKeyCount})`,
       );
     }
@@ -740,17 +741,17 @@ function assertSpendingConditionRules(params: {
   if (nSigsRefund !== undefined) {
     assertPositiveInteger(nSigsRefund, 'requiredRefundSignatures (n_sigs_refund)');
     if (refundKeyCount === 0) {
-      throw new Error('requiredRefundSignatures (n_sigs_refund) requires refund keys');
+      throw new CTSError('requiredRefundSignatures (n_sigs_refund) requires refund keys');
     }
     if (nSigsRefund > refundKeyCount) {
-      throw new Error(
+      throw new CTSError(
         `requiredRefundSignatures (n_sigs_refund) (${nSigsRefund}) exceeds available refund keys (${refundKeyCount})`,
       );
     }
   }
 
   if (refundKeyCount > 0 && !hasLocktime) {
-    throw new Error('refund keys require a locktime');
+    throw new CTSError('refund keys require a locktime');
   }
 }
 
@@ -759,7 +760,7 @@ function getP2PKWitnessPubkeys(secret: Secret): string[] {
   const pubkeys = getTag(secret, 'pubkeys') ?? [];
   const keys = (data ? [data, ...pubkeys] : pubkeys).map((key) => normalizePubkey(key));
   if (dedupeP2PKPubkeys(keys).length !== keys.length) {
-    throw new Error('Duplicate main pubkeys are not allowed');
+    throw new CTSError('Duplicate main pubkeys are not allowed');
   }
   return keys;
 }
@@ -767,7 +768,7 @@ function getP2PKWitnessPubkeys(secret: Secret): string[] {
 function getP2PKWitnessRefundkeys(secret: Secret): string[] {
   const keys = (getTag(secret, 'refund') ?? []).map((key) => normalizePubkey(key));
   if (dedupeP2PKPubkeys(keys).length !== keys.length) {
-    throw new Error('Duplicate refund pubkeys are not allowed');
+    throw new CTSError('Duplicate refund pubkeys are not allowed');
   }
   return keys;
 }

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -5,6 +5,7 @@ import { hmac } from '@noble/hashes/hmac.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
+import { CTSError } from '../model/Errors';
 import { Bytes } from '../utils';
 
 import { type DLEQ, hash_e, hashToCurve } from './core';
@@ -29,7 +30,7 @@ function deriveDLEQNonce(
     if (r !== 0n) return r;
   }
   /* c8 ignore next */
-  throw new Error('DLEQ nonce derivation failed');
+  throw new CTSError('DLEQ nonce derivation failed');
 }
 
 export const verifyDLEQProof = (
@@ -56,7 +57,8 @@ export const verifyDLEQProof_reblind = (
   C: WeierstrassPoint<bigint>, // unblinded e-cash signature point
   A: WeierstrassPoint<bigint>, // mint public key point
 ) => {
-  if (dleq.r === undefined) throw new Error('verifyDLEQProof_reblind: Undefined blinding factor');
+  if (dleq.r === undefined)
+    throw new CTSError('verifyDLEQProof_reblind: Undefined blinding factor');
   const Y = hashToCurve(secret);
   const C_ = C.add(A.multiply(dleq.r)); // Re-blind the e-cash signature
   const bG = secp256k1.Point.BASE.multiply(dleq.r);

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -3,6 +3,7 @@ import { hmac } from '@noble/hashes/hmac.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { HDKey } from '@scure/bip32';
 
+import { CTSError } from '../model/Errors';
 import { Bytes, isBase64String } from '../utils';
 
 import { getKeysetIdInt } from './core';
@@ -27,7 +28,7 @@ export const deriveSecret = (seed: Uint8Array, keysetId: string, counter: number
   } else if (isValidHex && keysetId.startsWith('01')) {
     return derive(seed, keysetId, counter, DerivationType.SECRET);
   }
-  throw new Error(`Unrecognized keyset ID version ${keysetId.slice(0, 2)}`);
+  throw new CTSError(`Unrecognized keyset ID version ${keysetId.slice(0, 2)}`);
 };
 
 export const deriveBlindingFactor = (
@@ -45,7 +46,7 @@ export const deriveBlindingFactor = (
   } else if (isValidHex && keysetId.startsWith('01')) {
     return derive(seed, keysetId, counter, DerivationType.BLINDING_FACTOR);
   }
-  throw new Error(`Unrecognized keyset ID version ${keysetId.slice(0, 2)}`);
+  throw new CTSError(`Unrecognized keyset ID version ${keysetId.slice(0, 2)}`);
 };
 
 const derive = (
@@ -76,7 +77,7 @@ const derive = (
     // is 256 bits and SECP256K1_N is ~2^256, so x can exceed N by at most once.
     const reduced = x >= SECP256K1_N ? x - SECP256K1_N : x;
     if (reduced === 0n) {
-      throw new Error('Derived invalid blinding scalar r == 0');
+      throw new CTSError('Derived invalid blinding scalar r == 0');
     }
     return numberToBytesBE(reduced, 32); // preserves 32-byte width
   }
@@ -95,7 +96,7 @@ const derive_deprecated = (
   const derivationPath = `${STANDARD_DERIVATION_PATH}/${keysetIdInt}'/${counter}'/${secretOrBlinding}`;
   const derived = hdkey.derive(derivationPath);
   if (derived.privateKey === null) {
-    throw new Error('Could not derive private key');
+    throw new CTSError('Could not derive private key');
   }
   return derived.privateKey;
 };

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -2,6 +2,7 @@ import { bytesToHex, hexToBytes, randomBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import { type Logger, NULL_LOGGER } from '../logger';
+import { CTSError } from '../model/Errors';
 import { type HTLCWitness, type Proof } from '../model/types';
 
 import {
@@ -55,7 +56,7 @@ export function parseHTLCSecret(secret: string | Secret): Secret {
 export function createHTLCHash(preimage?: string): { hash: string; preimage: string } {
   const hasPreimage = preimage !== undefined;
   if (hasPreimage && !/^[0-9a-f]{64}$/i.test(preimage)) {
-    throw new Error('Preimage must be a 64 character hexadecimal string (32 bytes).');
+    throw new CTSError('Preimage must be a 64 character hexadecimal string (32 bytes).');
   }
   // Create hash
   const piBytes = hasPreimage ? hexToBytes(preimage) : randomBytes(32);

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -3,6 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
+import { CTSError } from '../model/Errors';
 import { Bytes, hexToNumber, numberToHexPadded64 } from '../utils';
 
 import { pointFromHex } from './core';
@@ -39,7 +40,7 @@ export function deriveP2BKBlindedPubkeys(
     const P = pointFromHex(pubkey);
     const r = deriveP2BKBlindingTweakFromECDH(P, e, i);
     const P_ = P.add(secp256k1.Point.BASE.multiply(r));
-    if (P_.equals(secp256k1.Point.ZERO)) throw new Error('Blinded key at infinity');
+    if (P_.equals(secp256k1.Point.ZERO)) throw new CTSError('Blinded key at infinity');
     return P_.toHex(true);
   });
   return { blinded, Ehex: bytesToHex(E) };
@@ -110,20 +111,20 @@ export function deriveP2BKSecretKey(
   const n = secp256k1.Point.CURVE().n;
   const p = typeof privkey === 'string' ? hexToNumber(privkey) : privkey;
   const r = typeof rBlind === 'string' ? hexToNumber(rBlind) : rBlind;
-  if (p <= 0n || p >= n) throw new Error('Invalid private key');
-  if (r <= 0n || r >= n) throw new Error('Invalid scalar r');
+  if (p <= 0n || p >= n) throw new CTSError('Invalid private key');
+  if (r <= 0n || r >= n) throw new CTSError('Invalid scalar r');
   // If caller didn't provide P = p·G, compute it in compressed form (33 bytes)
   naturalPub = naturalPub ?? secp256k1.Point.BASE.multiply(p).toBytes(true);
-  if (naturalPub.length !== 33) throw new Error('naturalPub must be 33 bytes');
+  if (naturalPub.length !== 33) throw new CTSError('naturalPub must be 33 bytes');
   // Calculate both sk candidates for constant time (add/subtract is cheap)
   const skStd: bigint = (p + r) % n;
   const skNeg: bigint = (n - p + r) % n;
   // Return skStd if no blinded pubkey was provided to verify against
   if (!blindPubkey) {
-    if (skStd === 0n) throw new Error('Derived secret key is zero');
+    if (skStd === 0n) throw new CTSError('Derived secret key is zero');
     return numberToHexPadded64(skStd);
   }
-  if (blindPubkey.length !== 33) throw new Error('blindPubkey must be 33 bytes');
+  if (blindPubkey.length !== 33) throw new CTSError('blindPubkey must be 33 bytes');
   // Decode P′, compute R and unblind
   const P_ = secp256k1.Point.fromHex(bytesToHex(blindPubkey)); // valid point
   const R = secp256k1.Point.BASE.multiply(r); // R = r·G
@@ -139,7 +140,7 @@ export function deriveP2BKSecretKey(
   const yP = P.toBytes(true)[0] & 1;
   const yNaturalPub = naturalPub[0] & 1;
   const out = yP === yNaturalPub ? skStd : skNeg;
-  if (out === 0n) throw new Error('Derived secret key is zero');
+  if (out === 0n) throw new CTSError('Derived secret key is zero');
   return numberToHexPadded64(out);
 }
 
@@ -182,7 +183,7 @@ function deriveP2BKBlindingTweakFromECDH(
     // Very unlikely to get here!
     r = Bytes.toBigInt(sha256(Bytes.concat(P2BK_DST, Zx, iByte, new Uint8Array([0xff]))));
     if (r === 0n || r >= secp256k1.Point.CURVE().n) {
-      throw new Error('P2BK: tweak derivation failed');
+      throw new CTSError('P2BK: tweak derivation failed');
     }
   }
   return r;

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -4,12 +4,14 @@ import { randomBytes, bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { utf8ToBytes } from '@noble/hashes/utils.js';
 
+import { CTSError } from '../model/Errors';
+import { Bytes, hexToNumber, encodeBase64toUint8 } from '../utils';
+
 /**
  * Private key type - can be hex string or Uint8Array.
  */
 export type PrivKey = Uint8Array | string;
 export type DigestInput = Uint8Array | string; // hex string or bytes
-import { Bytes, hexToNumber, encodeBase64toUint8 } from '../utils';
 export type BlindSignature = {
   C_: WeierstrassPoint<bigint>;
   id: string;
@@ -48,7 +50,7 @@ export function hashToCurve(secret: Uint8Array): WeierstrassPoint<bigint> {
       counter[0]++;
     }
   }
-  throw new Error('No valid point found');
+  throw new CTSError('No valid point found');
 }
 
 export function hash_e(pubkeys: Array<WeierstrassPoint<bigint>>): Uint8Array {
@@ -116,7 +118,7 @@ export function blindMessage(secret: Uint8Array, r?: bigint): RawBlindedMessage 
   if (r === undefined) {
     r = secp256k1.Point.Fn.fromBytes(createRandomSecretKey());
   } else if (r === 0n) {
-    throw new Error('Blinding factor r must be non-zero');
+    throw new CTSError('Blinding factor r must be non-zero');
   }
   const rG = secp256k1.Point.BASE.multiply(r);
   const B_ = Y.add(rG);
@@ -239,7 +241,7 @@ export function findSigningKey(pubkey: string, privkeys: string | string[]): str
     const derived = bytesToHex(secp256k1.getPublicKey(hexToBytes(key), true));
     if (derived.toLowerCase() === pubkey.toLowerCase()) return key;
   }
-  throw new Error(`No private key matches quote pubkey ${pubkey}`);
+  throw new CTSError(`No private key matches quote pubkey ${pubkey}`);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export type {
 // Logging & errors
 export { type LogLevel, ConsoleLogger, type Logger } from './logger';
 export {
+  CTSError,
   MintOperationError,
   NetworkError,
   HttpResponseError,

--- a/src/logger/helpers.ts
+++ b/src/logger/helpers.ts
@@ -1,3 +1,5 @@
+import { CTSError } from '../model/Errors';
+
 import { type Logger } from './Logger';
 import { NULL_LOGGER } from './NullLogger';
 
@@ -15,7 +17,7 @@ export function fail(
   context?: Record<string, unknown>,
 ): never {
   logger.error(message, context);
-  throw new Error(message);
+  throw new CTSError(message);
 }
 
 /**

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -864,7 +864,7 @@ class Mint {
         // silence
       }
       this.ws = undefined;
-      throw new CTSError('Failed to connect to WebSocket...');
+      throw new CTSError('Failed to connect to WebSocket...', { cause: e });
     }
   }
 

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -9,6 +9,7 @@ import type { AuthProvider } from '../auth/AuthProvider';
 import { OIDCAuth, type OIDCAuthOptions } from '../auth/OIDCAuth';
 import { type Logger, NULL_LOGGER, failIf } from '../logger';
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import {
   type MintQuoteBaseResponse,
@@ -130,7 +131,7 @@ class Mint {
   async oidcAuth(opts?: OIDCAuthOptions): Promise<OIDCAuth> {
     const n21 = (await this.getLazyMintInfo()).nuts['21'];
     if (!n21?.openid_discovery) {
-      throw new Error('Mint: no NUT-21 openid_discovery');
+      throw new CTSError('Mint: no NUT-21 openid_discovery');
     }
     return new OIDCAuth(n21.openid_discovery, {
       ...opts,
@@ -195,7 +196,7 @@ class Mint {
 
     if (!isObj(data) || !Array.isArray(data?.signatures)) {
       this._logger.error('Invalid response from mint...', { data, op: 'swap' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
     data.signatures = this.normalizeSignatureAmounts(data.signatures);
 
@@ -402,7 +403,7 @@ class Mint {
 
     if (!isObj(data) || !Array.isArray(data?.signatures)) {
       this._logger.error('Invalid response from mint...', { data, op: `mint.${method}` });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
     data.signatures = this.normalizeSignatureAmounts(data.signatures);
     return options?.normalize ? options.normalize(data) : data;
@@ -477,7 +478,7 @@ class Mint {
 
     if (!isObj(data) || !Array.isArray(data?.signatures)) {
       this._logger.error('Invalid response from mint...', { data, op: `mintBatch.${method}` });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
     data.signatures = this.normalizeSignatureAmounts(data.signatures);
     return options?.normalize ? options.normalize(data) : data;
@@ -729,7 +730,7 @@ class Mint {
 
     if (!isObj(data) || !Array.isArray(data?.states)) {
       this._logger.error('Invalid response from mint...', { data, op: 'check' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
 
     // Per NUT-07, ProofState.witness is `<str | null>`. Some mints may omit the
@@ -772,7 +773,7 @@ class Mint {
 
     if (!isObj(data) || !Array.isArray(data.keysets)) {
       this._logger.error('Invalid response from mint...', { data, op: 'getKeys' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
 
     return {
@@ -795,7 +796,7 @@ class Mint {
     });
     if (!isObj(data) || !Array.isArray(data.keysets)) {
       this._logger.error('Invalid response from mint...', { data, op: 'getKeySets' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
     return {
       ...data,
@@ -824,7 +825,7 @@ class Mint {
 
     if (!isObj(data) || !Array.isArray(data?.outputs) || !Array.isArray(data?.signatures)) {
       this._logger.error('Invalid response from mint...', { data, op: 'restore' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
 
     data.outputs = this.normalizeMessageAmounts(data.outputs);
@@ -863,7 +864,7 @@ class Mint {
         // silence
       }
       this.ws = undefined;
-      throw new Error('Failed to connect to WebSocket...');
+      throw new CTSError('Failed to connect to WebSocket...');
     }
   }
 
@@ -1110,7 +1111,7 @@ class Mint {
       !Object.values(MeltQuoteState).includes(data.state as MeltQuoteState)
     ) {
       this._logger.error('Invalid response from mint...', { data, op });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
   }
 
@@ -1121,7 +1122,7 @@ class Mint {
     data.fee_reserve = Amount.from(data.fee_reserve as AmountLike);
     if (typeof data.request !== 'string' || !(data.fee_reserve instanceof Amount)) {
       this._logger.error('Invalid response from mint...', { data, op });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
     // Per NUT-23, payment_preimage is `<str | null>`. Some mints may omit it
     // until the invoice is paid; coerce undefined → null so consumers can

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -1,7 +1,10 @@
-export class AmountError extends Error {
+import { CTSError } from './Errors';
+
+export class AmountError extends CTSError {
   constructor(message: string) {
     super(message);
     this.name = 'AmountError';
+    Object.setPrototypeOf(this, AmountError.prototype);
   }
 }
 

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -7,7 +7,7 @@ export class CTSError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message);
     this.name = 'CTSError';
-    if (options && 'cause' in options) {
+    if (options?.cause !== undefined) {
       Object.defineProperty(this, 'cause', {
         configurable: true,
         enumerable: false,
@@ -24,8 +24,8 @@ export class CTSError extends Error {
  */
 export class HttpResponseError extends CTSError {
   status: number;
-  constructor(message: string, status: number) {
-    super(message);
+  constructor(message: string, status: number, options?: { cause?: unknown }) {
+    super(message, options);
     this.status = status;
     this.name = 'HttpResponseError';
     Object.setPrototypeOf(this, HttpResponseError.prototype);
@@ -36,8 +36,8 @@ export class HttpResponseError extends CTSError {
  * This error is thrown when a network request fails.
  */
 export class NetworkError extends CTSError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
     this.name = 'NetworkError';
     Object.setPrototypeOf(this, NetworkError.prototype);
   }

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -1,7 +1,28 @@
 /**
+ * Base error for errors raised by cashu-ts itself.
+ */
+export class CTSError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = 'CTSError';
+    if (options && 'cause' in options) {
+      Object.defineProperty(this, 'cause', {
+        configurable: true,
+        enumerable: false,
+        value: options.cause,
+        writable: true,
+      });
+    }
+    Object.setPrototypeOf(this, CTSError.prototype);
+  }
+}
+
+/**
  * This error is thrown when a HTTP response is not 2XX nor a protocol error.
  */
-export class HttpResponseError extends Error {
+export class HttpResponseError extends CTSError {
   status: number;
   constructor(message: string, status: number) {
     super(message);
@@ -14,7 +35,7 @@ export class HttpResponseError extends Error {
 /**
  * This error is thrown when a network request fails.
  */
-export class NetworkError extends Error {
+export class NetworkError extends CTSError {
   constructor(message: string) {
     super(message);
     this.name = 'NetworkError';

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -3,6 +3,7 @@ import { nullIfUndefined } from '../utils/core';
 import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
+import { CTSError } from './Errors';
 import {
   type GetInfoResponse,
   type MPPMethod,
@@ -194,7 +195,7 @@ export class MintInfo {
         return this.checkNut29();
       }
       default: {
-        throw new Error('nut is not supported by cashu-ts');
+        throw new CTSError('nut is not supported by cashu-ts');
       }
     }
   }

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -17,6 +17,7 @@ import { Bytes, numberToHexPadded64, splitAmount } from '../utils';
 
 import { Amount, type AmountLike } from './Amount';
 import { BlindedMessage } from './BlindedMessage';
+import { CTSError } from './Errors';
 import {
   type HasKeysetKeys,
   type Proof,
@@ -73,9 +74,9 @@ export const RESERVED_P2PK_TAGS = new Set([
  * @throws If not a string, or is a reserved string.
  */
 export function assertValidTagKey(key: string) {
-  if (!key || typeof key !== 'string') throw new Error('tag key must be a non empty string');
+  if (!key || typeof key !== 'string') throw new CTSError('tag key must be a non empty string');
   if (RESERVED_P2PK_TAGS.has(key)) {
-    throw new Error(`additionalTags must not use reserved key "${key}"`);
+    throw new CTSError(`additionalTags must not use reserved key "${key}"`);
   }
 }
 
@@ -105,7 +106,7 @@ export class OutputData implements OutputDataLike {
 
   toProof(sig: SerializedBlindedSignature, keyset: HasKeysetKeys) {
     if (sig == undefined) {
-      throw new Error(
+      throw new CTSError(
         'Mint response is missing a signature for one of the outputs. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',
       );
     }
@@ -125,7 +126,7 @@ export class OutputData implements OutputDataLike {
       const B_ = pointFromHex(this.blindedMessage.B_);
       const C_ = pointFromHex(sig.C_);
       if (!verifyDLEQProof(dleq, B_, C_, A)) {
-        throw new Error('DLEQ verification failed on mint response');
+        throw new CTSError('DLEQ verification failed on mint response');
       }
     }
 
@@ -244,7 +245,9 @@ export class OutputData implements OutputDataLike {
     // Same semantics as Nutshell python: len(str)
     const charCount = [...parsed].length;
     if (charCount > MAX_SECRET_LENGTH) {
-      throw new Error(`Secret too long (${charCount} characters), maximum is ${MAX_SECRET_LENGTH}`);
+      throw new CTSError(
+        `Secret too long (${charCount} characters), maximum is ${MAX_SECRET_LENGTH}`,
+      );
     }
 
     // blind the message

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -11,6 +11,7 @@ import type {
 } from '../wallet/types';
 
 import { Amount, type AmountLike } from './Amount';
+import { CTSError } from './Errors';
 
 export class PaymentRequest {
   public amount?: Amount;
@@ -170,11 +171,11 @@ export class PaymentRequest {
 
     // Version A: CBOR encoding (creqA...)
     if (!encodedRequest.startsWith('creq')) {
-      throw new Error('unsupported pr: invalid prefix');
+      throw new CTSError('unsupported pr: invalid prefix');
     }
     const version = encodedRequest[4];
     if (version !== 'A') {
-      throw new Error('unsupported pr version');
+      throw new CTSError('unsupported pr version');
     }
     const encodedData = encodedRequest.slice(5);
     const data = encodeBase64toUint8(encodedData);

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -9,6 +9,7 @@ import { Bytes, JSONInt, encodeUint8toBase64Url } from '../utils';
 import type { MeltPreview, SwapPreview } from '../wallet/types';
 
 import { Amount } from './Amount';
+import { CTSError } from './Errors';
 import type { Proof, MeltQuoteBaseResponse, SerializedBlindedMessage } from './types';
 
 /**
@@ -110,7 +111,7 @@ function deserializePackage(
   options?: { validateDigest?: boolean },
 ): SigAllSigningPackage {
   if (!input.startsWith(SIGALL_PREFIX)) {
-    throw new Error(`Invalid signing package: must start with "${SIGALL_PREFIX}"`);
+    throw new CTSError(`Invalid signing package: must start with "${SIGALL_PREFIX}"`);
   }
 
   const base64url = input.slice(SIGALL_PREFIX.length);
@@ -119,7 +120,7 @@ function deserializePackage(
   try {
     json = Bytes.toString(Bytes.fromBase64(base64url));
   } catch (e) {
-    throw new Error(
+    throw new CTSError(
       `Failed to parse signing package: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
@@ -129,57 +130,57 @@ function deserializePackage(
   try {
     data = JSONInt.parse(json);
   } catch (e) {
-    throw new Error(
+    throw new CTSError(
       `Failed to parse signing package JSON: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
 
   if (!data || typeof data !== 'object') {
-    throw new Error('Signing package must be a JSON object');
+    throw new CTSError('Signing package must be a JSON object');
   }
 
   const pkg = data as SigAllSigningPackage;
 
   const version = pkg.version as string;
   if (version !== SIGALL_PREFIX) {
-    throw new Error(`Invalid signing package version: ${version}`);
+    throw new CTSError(`Invalid signing package version: ${version}`);
   }
 
   const type = pkg.type as string;
   if (type !== 'swap' && type !== 'melt') {
-    throw new Error(`Invalid signing package type: ${type}`);
+    throw new CTSError(`Invalid signing package type: ${type}`);
   }
 
   if (!Array.isArray(pkg.inputs)) {
-    throw new Error('Signing package inputs must be an array');
+    throw new CTSError('Signing package inputs must be an array');
   }
 
   for (let i = 0; i < pkg.inputs.length; i++) {
     const inp = pkg.inputs[i] as Record<string, unknown>;
 
-    if (!inp || typeof inp !== 'object') throw new Error(`Invalid input at index ${i}`);
+    if (!inp || typeof inp !== 'object') throw new CTSError(`Invalid input at index ${i}`);
 
-    if (typeof inp.secret !== 'string') throw new Error(`Input ${i}: secret must be string`);
+    if (typeof inp.secret !== 'string') throw new CTSError(`Input ${i}: secret must be string`);
 
-    if (typeof inp.C !== 'string') throw new Error(`Input ${i}: C must be string`);
+    if (typeof inp.C !== 'string') throw new CTSError(`Input ${i}: C must be string`);
   }
 
   if (!Array.isArray(pkg.outputs)) {
-    throw new Error('Signing package outputs must be an array');
+    throw new CTSError('Signing package outputs must be an array');
   }
 
   for (let i = 0; i < pkg.outputs.length; i++) {
     const output = pkg.outputs[i] as Record<string, unknown>;
 
-    if (!output || typeof output !== 'object') throw new Error(`Invalid output at index ${i}`);
+    if (!output || typeof output !== 'object') throw new CTSError(`Invalid output at index ${i}`);
 
     if (typeof output.amount !== 'number' && typeof output.amount !== 'bigint') {
-      throw new Error(`Output ${i}: amount must be a number or bigint`);
+      throw new CTSError(`Output ${i}: amount must be a number or bigint`);
     }
 
-    if (!output.B_ || typeof output.B_ !== 'string') throw new Error(`Output ${i}: B_ invalid`);
+    if (!output.B_ || typeof output.B_ !== 'string') throw new CTSError(`Output ${i}: B_ invalid`);
 
-    if (!output.id || typeof output.id !== 'string') throw new Error(`Output ${i}: id invalid`);
+    if (!output.id || typeof output.id !== 'string') throw new CTSError(`Output ${i}: id invalid`);
 
     // Rehydrate SerializedBlindedMessage.amount
     output.amount = Amount.from(output.amount);
@@ -187,17 +188,17 @@ function deserializePackage(
 
   const digests = pkg.digests as Record<string, string> | undefined;
   if (!digests || typeof digests.current !== 'string' || digests.current.length === 0) {
-    throw new Error('Signing package digests.current is required');
+    throw new CTSError('Signing package digests.current is required');
   }
 
   // Optional digest validation
   if (options?.validateDigest) {
     const recomputed = computeDigests(pkg.inputs, pkg.outputs, pkg.quote);
     if (recomputed.current !== digests.current) {
-      throw new Error('Digest validation failed: current digest mismatch');
+      throw new CTSError('Digest validation failed: current digest mismatch');
     }
     if (digests.legacy && recomputed.legacy !== digests.legacy) {
-      throw new Error('Digest validation failed: legacy digest mismatch');
+      throw new CTSError('Digest validation failed: legacy digest mismatch');
     }
   }
 
@@ -208,7 +209,7 @@ function signPackage(pkg: SigAllSigningPackage, privkey: string): SigAllSigningP
   const newSigs: string[] = [];
 
   if (!pkg.digests?.current) {
-    throw new Error('digests.current is required to sign package');
+    throw new CTSError('digests.current is required to sign package');
   }
 
   // Sign precomputed digests
@@ -219,7 +220,7 @@ function signPackage(pkg: SigAllSigningPackage, privkey: string): SigAllSigningP
 
   // validate that signing actually produced signatures
   if (newSigs.length === 0) {
-    throw new Error('No signatures produced during signing');
+    throw new CTSError('No signatures produced during signing');
   }
 
   return {
@@ -264,7 +265,7 @@ function buildSigningPackage(
   const expected = computeMessageDigest(msg, true);
 
   if (digests.current !== expected) {
-    throw new Error(
+    throw new CTSError(
       'SIG_ALL digest computation mismatch - current digest does not match expected value',
     );
   }
@@ -294,7 +295,7 @@ function mergeMeltPackage<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'>>(
 
 function mergeSignatures(proofs: Proof[], pkg: SigAllSigningPackage): Proof[] {
   if (!pkg.witness?.signatures.length) {
-    throw new Error('No signatures to merge');
+    throw new CTSError('No signatures to merge');
   }
 
   if (proofs.length === 0) return proofs;

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -122,6 +122,7 @@ function deserializePackage(
   } catch (e) {
     throw new CTSError(
       `Failed to parse signing package: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e },
     );
   }
 
@@ -132,6 +133,7 @@ function deserializePackage(
   } catch (e) {
     throw new CTSError(
       `Failed to parse signing package JSON: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e },
     );
   }
 

--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -1,4 +1,5 @@
 import { type Logger, NULL_LOGGER } from '../logger';
+import { CTSError } from '../model/Errors';
 import { type JsonRpcMessage, type JsonRpcReqParams, type RpcSubId } from '../model/types';
 
 import { getWebSocketImpl } from './ws';
@@ -111,7 +112,7 @@ export class WSConnection {
       const fail = (e: unknown) => {
         this.connectionPromise = undefined;
         cleanupSocket();
-        const err = e instanceof Error ? e : new Error(String(e));
+        const err = e instanceof Error ? e : new CTSError(String(e), { cause: e });
         this.failPendingRpc(err);
         settle(() => reject(err));
       };
@@ -124,7 +125,7 @@ export class WSConnection {
       }
 
       timer = setTimeout(() => {
-        fail(new Error(`WebSocket connect timeout after ${timeoutMs}ms`));
+        fail(new CTSError(`WebSocket connect timeout after ${timeoutMs}ms`));
       }, timeoutMs);
 
       this.ws.onopen = () => {
@@ -134,7 +135,7 @@ export class WSConnection {
 
       this.ws.onerror = (ev) => {
         if (!opened) {
-          fail(new Error('Failed to open WebSocket'));
+          fail(new CTSError('Failed to open WebSocket'));
           return;
         }
         this._logger.error('WebSocket error after open', { ev });
@@ -153,7 +154,7 @@ export class WSConnection {
 
         if (!opened) {
           const reason = e?.reason ? `, ${e.reason}` : '';
-          fail(new Error(`WebSocket closed before open (code ${e?.code ?? 0}${reason})`));
+          fail(new CTSError(`WebSocket closed before open (code ${e?.code ?? 0}${reason})`));
           return;
         }
 
@@ -167,7 +168,7 @@ export class WSConnection {
 
         const abnormal = !wasClean || (code !== 1000 && code !== 1001);
         if (abnormal) {
-          this.failPendingRpc(new Error(`WebSocket closed (code ${code}${reason})`));
+          this.failPendingRpc(new CTSError(`WebSocket closed (code ${code}${reason})`));
         } else {
           this.rpcListeners = {};
         }
@@ -187,7 +188,7 @@ export class WSConnection {
         return;
       }
       this._logger.error('Attempted sendRequest, but socket was not open');
-      throw new Error('Socket not open');
+      throw new CTSError('Socket not open');
     }
 
     const id = this.rpcId;
@@ -230,7 +231,7 @@ export class WSConnection {
     id: number,
   ): void {
     if (this.ws?.readyState !== this._WS.OPEN) {
-      throw new Error('Socket not open');
+      throw new CTSError('Socket not open');
     }
 
     const message = JSON.stringify({ jsonrpc: '2.0', method, params, id });
@@ -251,7 +252,7 @@ export class WSConnection {
       this.ws = undefined;
       this.stopMessageHandling();
 
-      const err = e instanceof Error ? e : new Error(String(e));
+      const err = e instanceof Error ? e : new CTSError(String(e), { cause: e });
       this.failPendingRpc(err);
       throw err;
     }
@@ -309,7 +310,7 @@ export class WSConnection {
         }
       } else if ('error' in parsed && parsed.id != undefined) {
         if (this.rpcListeners[parsed.id]) {
-          this.rpcListeners[parsed.id].errorCallback(new Error(parsed.error.message));
+          this.rpcListeners[parsed.id].errorCallback(new CTSError(parsed.error.message));
           this.removeRpcListener(parsed.id);
         }
       } else if ('method' in parsed) {
@@ -345,7 +346,7 @@ export class WSConnection {
   ): string {
     if (this.ws?.readyState !== this._WS.OPEN) {
       this._logger.error('Attempted createSubscription, but socket was not open');
-      throw new Error('Socket is not open');
+      throw new CTSError('Socket is not open');
     }
 
     const subId = (Math.random() + 1).toString(36).substring(7);

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -411,17 +411,17 @@ async function _request(options: RequestOptions): Promise<unknown> {
     const timedOut = !!timeoutController?.signal.aborted;
     const callerAborted = !!callerSignal?.aborted;
     if (timedOut) {
-      throw new NetworkError(`Request timed out after ${requestTimeout}ms`);
+      throw new NetworkError(`Request timed out after ${requestTimeout}ms`, { cause: err });
     }
     if (callerAborted) {
       throw new CallerAbortError(errorMessage(err, 'Request aborted by caller'));
     }
     if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
-      throw new NetworkError(err.message);
+      throw new NetworkError(err.message, { cause: err });
     }
     // A fetch() promise only rejects when the request fails,
     // for example, because of a badly-formed request URL or a network error.
-    throw new NetworkError(errorMessage(err, 'Network request failed'));
+    throw new NetworkError(errorMessage(err, 'Network request failed'), { cause: err });
   } finally {
     clearTimeout(timeoutId);
     cleanupAbortListeners?.();
@@ -449,9 +449,11 @@ async function _request(options: RequestOptions): Promise<unknown> {
 
   if (!response.ok) {
     let errorData: ApiError;
+    let errorDataCause: unknown;
     try {
       errorData = parseErrorBody(await response.text());
-    } catch {
+    } catch (err) {
+      errorDataCause = err;
       errorData = { error: 'bad response' };
     }
 
@@ -476,7 +478,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
       errorMessage = errorData.detail;
     }
 
-    throw new HttpResponseError(errorMessage, response.status);
+    throw new HttpResponseError(errorMessage, response.status, { cause: errorDataCause });
   }
 
   try {
@@ -487,7 +489,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
     return JSONInt.parse(responseText);
   } catch (err) {
     requestLogger.error('Failed to parse HTTP response', { err });
-    throw new HttpResponseError('bad response', response.status);
+    throw new HttpResponseError('bad response', response.status, { cause: err });
   }
 }
 

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -1,5 +1,6 @@
 import { type Logger, NULL_LOGGER, safeCallback } from '../logger';
 import {
+  CTSError,
   HttpResponseError,
   NetworkError,
   MintOperationError,
@@ -481,7 +482,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
   try {
     const responseText = await response.text();
     if (!responseText) {
-      throw new Error('Empty response body');
+      throw new CTSError('Empty response body');
     }
     return JSONInt.parse(responseText);
   } catch (err) {

--- a/src/transport/ws.ts
+++ b/src/transport/ws.ts
@@ -1,3 +1,4 @@
+import { CTSError } from '../model/Errors';
 let _WS: typeof WebSocket | undefined;
 
 if (typeof WebSocket !== 'undefined') {
@@ -13,7 +14,7 @@ export function injectWebSocketImpl(ws: typeof WebSocket) {
  */
 export function getWebSocketImpl() {
   if (_WS === undefined) {
-    throw new Error('WebSocket implementation not initialized');
+    throw new CTSError('WebSocket implementation not initialized');
   }
   return _WS;
 }

--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -1,3 +1,4 @@
+import { CTSError } from '../model/Errors';
 type Base64Encoding = 'base64';
 
 interface BufferLike {
@@ -20,18 +21,18 @@ export class Bytes {
       return new Uint8Array(0);
     }
     if (hex.length < 2 || hex.length & 1) {
-      throw new Error('Invalid hex string: odd length.');
+      throw new CTSError('Invalid hex string: odd length.');
     }
     if (hex.startsWith('0x') || hex.startsWith('0X')) {
       hex = hex.slice(2);
     }
     const match = hex.match(/^[0-9a-fA-F]*$/);
     if (!match) {
-      throw new Error('Invalid hex string: contains non-hex characters');
+      throw new CTSError('Invalid hex string: contains non-hex characters');
     }
     const matches = hex.match(/.{1,2}/g);
     if (!matches) {
-      throw new Error('Invalid hex string');
+      throw new CTSError('Invalid hex string');
     }
     return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
   }

--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -1,4 +1,5 @@
 import { Amount } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 
 /**
  * BigInt-safe JSON parser/stringifier.
@@ -290,7 +291,7 @@ class Parser {
         case 'string':
           return token;
         case 'error':
-          throw new Error('BigInt is not available in this runtime');
+          throw new CTSError('BigInt is not available in this runtime');
       }
     }
 
@@ -386,7 +387,7 @@ function parse(source: string, reviver?: ReviverFn, options?: ParseOptions): unk
   const strict = options?.strict === true;
   const fallbackTo = options?.fallbackTo ?? 'number';
   if (fallbackTo !== 'number' && fallbackTo !== 'string' && fallbackTo !== 'error') {
-    throw new Error(
+    throw new CTSError(
       `Incorrect value for fallbackTo option, must be "number", "string", "error" or undefined but passed ${String(options?.fallbackTo)}`,
     );
   }
@@ -399,7 +400,7 @@ function parse(source: string, reviver?: ReviverFn, options?: ParseOptions): unk
 function quoteString(value: string): string {
   const quoted = JSON.stringify(value);
   if (typeof quoted !== 'string') {
-    throw new Error('Failed to stringify string value');
+    throw new CTSError('Failed to stringify string value');
   }
   return quoted;
 }
@@ -436,7 +437,7 @@ function stringify(
   }
 
   if (replacer && typeof replacer !== 'function' && !Array.isArray(replacer)) {
-    throw new Error('stringify: replacer must be a function or array');
+    throw new CTSError('stringify: replacer must be a function or array');
   }
 
   const propertyList = Array.isArray(replacer) ? replacer.map((k) => String(k)) : undefined;

--- a/src/utils/bech32m.ts
+++ b/src/utils/bech32m.ts
@@ -1,5 +1,7 @@
 import { bech32m } from '@scure/base';
 
+import { CTSError } from '../model/Errors';
+
 type Bech32mString = `${string}1${string}`;
 
 const LIMIT_LENGTH = 1023;
@@ -14,7 +16,7 @@ const LIMIT_LENGTH = 1023;
 function assertBech32mFormat(str: string): asserts str is Bech32mString {
   const separatorIndex = str.lastIndexOf('1');
   if (separatorIndex < 1 || separatorIndex === str.length - 1) {
-    throw new Error('Invalid bech32m string: missing or misplaced separator');
+    throw new CTSError('Invalid bech32m string: missing or misplaced separator');
   }
 }
 

--- a/src/utils/cbor.ts
+++ b/src/utils/cbor.ts
@@ -1,3 +1,4 @@
+import { CTSError } from '../model/Errors';
 /*
  * Lightweight CBOR encoder/decoder (purpose and limitations)
  *
@@ -95,7 +96,7 @@ function encodeItem(value: unknown, buffer: number[]) {
   ) {
     encodeObject(value as Record<string, unknown>, buffer);
   } else {
-    throw new Error('Unsupported type');
+    throw new CTSError('Unsupported type');
   }
 }
 
@@ -155,7 +156,7 @@ function encodeUnsignedBigInt(majorType: number, value: bigint, buffer: number[]
       lo & 0xff,
     );
   } else {
-    throw new Error('BigInt value out of uint64 range');
+    throw new CTSError('BigInt value out of uint64 range');
   }
 }
 
@@ -224,7 +225,7 @@ function encodeByteString(value: Uint8Array, buffer: number[]) {
       length & 0xff,
     );
   } else {
-    throw new Error('Byte string too long to encode');
+    throw new CTSError('Byte string too long to encode');
   }
 
   for (let i = 0; i < value.length; i++) {
@@ -251,7 +252,7 @@ function encodeString(value: string, buffer: number[]) {
       length & 0xff,
     );
   } else {
-    throw new Error('String too long to encode');
+    throw new CTSError('String too long to encode');
   }
 
   for (let i = 0; i < utf8.length; i++) {
@@ -268,7 +269,7 @@ function encodeArray(value: unknown[], buffer: number[]) {
   } else if (length < 65536) {
     buffer.push(0x99, (length >>> 8) & 0xff, length & 0xff);
   } else {
-    throw new Error('Unsupported array length');
+    throw new CTSError('Unsupported array length');
   }
 
   for (const item of value) {
@@ -282,7 +283,7 @@ function encodeObject(value: Record<string, unknown>, buffer: number[]) {
 
   // Guardrail: we only support map lengths up to 2^32-1 (same as encodeUnsigned max)
   if (length >= 4294967296) {
-    throw new Error('Object has too many keys to encode');
+    throw new CTSError('Object has too many keys to encode');
   }
 
   // Write initial byte for major type 5 (map) and additional info based on length
@@ -315,7 +316,7 @@ export function decodeCBOR(data: Uint8Array): ResultValue {
 
 function decodeItem(view: DataView, offset: number): DecodeResult<ResultValue> {
   if (offset >= view.byteLength) {
-    throw new Error('Unexpected end of data');
+    throw new CTSError('Unexpected end of data');
   }
   const initialByte = view.getUint8(offset++);
   const majorType = initialByte >> 5;
@@ -337,13 +338,13 @@ function decodeItem(view: DataView, offset: number): DecodeResult<ResultValue> {
     case 7:
       return decodeSimpleAndFloat(view, offset, additionalInfo);
     default:
-      throw new Error(`Unsupported major type: ${majorType}`);
+      throw new CTSError(`Unsupported major type: ${majorType}`);
   }
 }
 
 function ensureAvailable(view: DataView, offset: number, needed: number) {
   if (offset + needed > view.byteLength) {
-    throw new Error('Unexpected end of data');
+    throw new CTSError('Unexpected end of data');
   }
 }
 
@@ -380,7 +381,7 @@ function decodeLength(
     }
     return { value, offset };
   }
-  throw new Error(`Unsupported length: ${additionalInfo}`);
+  throw new CTSError(`Unsupported length: ${additionalInfo}`);
 }
 
 function decodeUnsigned(
@@ -416,7 +417,7 @@ function decodeByteString(
   const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
   const len = Number(length);
   if (newOffset + len > view.byteLength) {
-    throw new Error('Byte string length exceeds data length');
+    throw new CTSError('Byte string length exceeds data length');
   }
   const value = new Uint8Array(view.buffer, view.byteOffset + newOffset, len);
   return { value, offset: newOffset + len };
@@ -430,7 +431,7 @@ function decodeString(
   const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
   const len = Number(length);
   if (newOffset + len > view.byteLength) {
-    throw new Error('String length exceeds data length');
+    throw new CTSError('String length exceeds data length');
   }
   const bytes = new Uint8Array(view.buffer, view.byteOffset + newOffset, len);
   const value = new TextDecoder().decode(bytes);
@@ -466,7 +467,7 @@ function decodeMap(
   for (let i = 0; i < len; i++) {
     const keyResult = decodeItem(view, currentOffset);
     if (!isResultKeyType(keyResult.value)) {
-      throw new Error('Invalid key type');
+      throw new CTSError('Invalid key type');
     }
     const valueResult = decodeItem(view, keyResult.offset);
     map[String(keyResult.value)] = valueResult.value;
@@ -504,7 +505,7 @@ function decodeSimpleAndFloat(
       case 23:
         return { value: undefined, offset };
       default:
-        throw new Error(`Unknown simple value: ${additionalInfo}`);
+        throw new CTSError(`Unknown simple value: ${additionalInfo}`);
     }
   }
   if (additionalInfo === 24) {
@@ -529,5 +530,5 @@ function decodeSimpleAndFloat(
     offset += 8;
     return { value, offset };
   }
-  throw new Error(`Unknown simple or float value: ${additionalInfo}`);
+  throw new CTSError(`Unknown simple or float value: ${additionalInfo}`);
 }

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -526,8 +526,8 @@ export function normalizeUrl(url: string): string {
   let parsed: URL;
   try {
     parsed = new URL(url);
-  } catch {
-    throw new CTSError(`Invalid mint URL: ${url}`);
+  } catch (e) {
+    throw new CTSError(`Invalid mint URL: ${url}`, { cause: e });
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new CTSError(`Invalid mint URL scheme: ${parsed.protocol}`);

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -3,6 +3,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 
 import { type DLEQ, pointFromHex, verifyDLEQProof_reblind } from '../crypto';
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import { PaymentRequest } from '../model/PaymentRequest';
 import type {
   TokenMetadata,
@@ -56,12 +57,14 @@ export function splitAmount(
     const positive = normalizedSplit.filter((amt) => !amt.isZero());
     const totalPositive = Amount.sum(positive);
     if (totalPositive.greaterThan(remainingValue)) {
-      throw new Error(
+      throw new CTSError(
         `Split is greater than total amount: ${totalPositive.toString()} > ${remainingValue.toString()}`,
       );
     }
     if (positive.some((amt) => !hasCorrespondingKey(amt, keyset))) {
-      throw new Error('Provided amount preferences do not match the amounts of the mint keyset.');
+      throw new CTSError(
+        'Provided amount preferences do not match the amounts of the mint keyset.',
+      );
     }
 
     // if caller supplied an exact custom split, preserve their order
@@ -79,7 +82,7 @@ export function splitAmount(
   // Denomination fill for the remaining value
   const sortedKeyAmounts = getKeysetAmountsAsAmount(keyset, 'desc');
   if (sortedKeyAmounts.length === 0) {
-    throw new Error('Cannot split amount, keyset is inactive or contains no keys');
+    throw new CTSError('Cannot split amount, keyset is inactive or contains no keys');
   }
   for (const amtAsAmount of sortedKeyAmounts) {
     if (amtAsAmount.isZero()) continue;
@@ -92,7 +95,7 @@ export function splitAmount(
     if (remainingValue.isZero()) break;
   }
   if (!remainingValue.isZero()) {
-    throw new Error(`Unable to split remaining amount: ${remainingValue.toString()}`);
+    throw new CTSError(`Unable to split remaining amount: ${remainingValue.toString()}`);
   }
 
   // Only sort when we performed a fill and it was requested
@@ -136,7 +139,7 @@ export function hasCorrespondingKey(amount: AmountLike, keyset: Keys): boolean {
 function toAmount(amount: AmountLike, op: string, allowZero = false): Amount {
   const parsed = Amount.from(amount);
   if (!allowZero && parsed.isZero()) {
-    throw new Error(`Amount must be positive: ${parsed.toString()}, op: ${op}`);
+    throw new CTSError(`Amount must be positive: ${parsed.toString()}, op: ${op}`);
   }
   return parsed;
 }
@@ -202,7 +205,7 @@ export function getEncodedToken(token: Token, opts?: { removeDleq?: boolean }): 
   // Normalize amounts for untyped (JS) callers who may pass JSON.parse'd tokens directly.
   const proofs = normalizeProofAmounts(token.proofs);
   if (hasNonHexId(proofs)) {
-    throw new Error(
+    throw new CTSError(
       'Proofs contain a legacy keyset ID and cannot be encoded. Swap them at the mint first.',
     );
   }
@@ -222,12 +225,12 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
   // Make sure each DLEQ has its blinding factor
   proofs.forEach((p) => {
     if (p.dleq && p.dleq.r == undefined) {
-      throw new Error('Missing blinding factor in included DLEQ proof');
+      throw new CTSError('Missing blinding factor in included DLEQ proof');
     }
   });
   const nonHex = hasNonHexId(proofs);
   if (nonHex) {
-    throw new Error('can not encode to v4 token if proofs contain non-hex keyset id');
+    throw new CTSError('can not encode to v4 token if proofs contain non-hex keyset id');
   }
   // Map keyset IDs to short IDs
   proofs = convertToShortKeysetId(proofs);
@@ -369,7 +372,7 @@ function handleTokens(token: string): Token {
   if (version === 'A') {
     const parsedV3Token = encodeBase64ToJson<DeprecatedToken>(encodedToken);
     if (parsedV3Token.token.length > 1) {
-      throw new Error('Multi entry token are not supported');
+      throw new CTSError('Multi entry token are not supported');
     }
     const entry = parsedV3Token.token[0];
     const proofs = entry.proofs.map((p) => ({
@@ -390,7 +393,7 @@ function handleTokens(token: string): Token {
     const tokenData = decodeCBOR(uInt8Token) as TokenV4Template;
     return tokenFromTemplate(tokenData);
   }
-  throw new Error('Token version is not supported');
+  throw new CTSError('Token version is not supported');
 }
 
 export type DeriveKeysetIdOptions = {
@@ -443,7 +446,7 @@ export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): str
     }
     case 1: {
       if (!unit) {
-        throw new Error('Cannot compute keyset ID version 01: unit is required.');
+        throw new CTSError('Cannot compute keyset ID version 01: unit is required.');
       }
       const sortedEntries = Object.entries(keys).sort(([amountA], [amountB]) =>
         Amount.from(amountA).compareTo(amountB),
@@ -462,7 +465,7 @@ export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): str
       return '01' + hashHex;
     }
     default:
-      throw new Error(`Unrecognized keyset ID version: ${versionByte}`);
+      throw new CTSError(`Unrecognized keyset ID version: ${versionByte}`);
   }
 }
 
@@ -524,22 +527,22 @@ export function normalizeUrl(url: string): string {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`Invalid mint URL: ${url}`);
+    throw new CTSError(`Invalid mint URL: ${url}`);
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(`Invalid mint URL scheme: ${parsed.protocol}`);
+    throw new CTSError(`Invalid mint URL scheme: ${parsed.protocol}`);
   }
   if (parsed.username || parsed.password) {
-    throw new Error('Mint URL must not contain credentials');
+    throw new CTSError('Mint URL must not contain credentials');
   }
   if (parsed.search || parsed.href.includes('?')) {
-    throw new Error('Mint URL must not contain query parameters');
+    throw new CTSError('Mint URL must not contain query parameters');
   }
   if (parsed.hash || parsed.href.includes('#')) {
-    throw new Error('Mint URL must not contain a fragment');
+    throw new CTSError('Mint URL must not contain a fragment');
   }
   if (/%[0-9a-f]{2}/i.test(parsed.pathname)) {
-    throw new Error('Mint URL path must not contain percent-encoded characters');
+    throw new CTSError('Mint URL path must not contain percent-encoded characters');
   }
   return parsed.href.replace(/\/+$/, '');
 }
@@ -656,23 +659,25 @@ function mapShortKeysetIds(proofs: Proof[], keysetIds: readonly string[]): Proof
       newProofs.push(proof);
     } else if (idBytes[0] === 0x01) {
       if (!uniqueIds.length) {
-        throw new Error('A short keyset ID v2 was encountered, but got no keysets to map it to.');
+        throw new CTSError(
+          'A short keyset ID v2 was encountered, but got no keysets to map it to.',
+        );
       }
       // Look for a match: prefix(keyset ID) == short ID
       const shortId = proof.id.toLowerCase();
       const matches = uniqueIds.filter((id) => shortId === id.slice(0, shortId.length));
       if (matches.length > 1) {
-        throw new Error(`Short keyset ID ${proof.id} is ambiguous.`);
+        throw new CTSError(`Short keyset ID ${proof.id} is ambiguous.`);
       }
       if (matches.length === 0) {
-        throw new Error(
+        throw new CTSError(
           `Couldn't map short keyset ID ${proof.id} to any known keysets of the current Mint`,
         );
       }
       proof.id = matches[0];
       newProofs.push(proof);
     } else {
-      throw new Error(`Unknown keyset ID version: ${idBytes[0]}`);
+      throw new CTSError(`Unknown keyset ID version: ${idBytes[0]}`);
     }
   }
 
@@ -692,7 +697,9 @@ export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean {
     return false;
   }
   if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
-    throw new Error(`Undefined key for amount ${proof.amount.toString()} in keyset ${keyset.id}`);
+    throw new CTSError(
+      `Undefined key for amount ${proof.amount.toString()} in keyset ${keyset.id}`,
+    );
   }
   const key = keyset.keys[proof.amount.toString()];
   try {
@@ -756,7 +763,7 @@ export function getDecodedTokenBinary(bytes: Uint8Array): Token {
   const prefix = utfDecoder.decode(bytes.slice(0, 4));
   const version = utfDecoder.decode(new Uint8Array([bytes[4]]));
   if (prefix !== 'craw' || version !== 'B') {
-    throw new Error('not a valid binary token');
+    throw new CTSError('not a valid binary token');
   }
   const binaryToken = bytes.slice(5);
   const decoded = decodeCBOR(binaryToken) as TokenV4Template;

--- a/src/utils/normalizeNumbers.ts
+++ b/src/utils/normalizeNumbers.ts
@@ -1,4 +1,5 @@
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import type { MintKeys, MintKeyset } from '../model/types';
 
 /**
@@ -23,12 +24,12 @@ export function normalizeSafeIntegerMetadata<TFallback extends number | null | u
     if (arguments.length >= 3) {
       return fallback as TFallback;
     }
-    throw new Error(`Invalid ${context}: missing value`);
+    throw new CTSError(`Invalid ${context}: missing value`);
   }
   try {
     return Amount.from(value).toNumber();
   } catch (e) {
-    throw new Error(`Invalid ${context}: ${(e as Error).message}`);
+    throw new CTSError(`Invalid ${context}: ${(e as Error).message}`);
   }
 }
 

--- a/src/utils/normalizeNumbers.ts
+++ b/src/utils/normalizeNumbers.ts
@@ -29,7 +29,8 @@ export function normalizeSafeIntegerMetadata<TFallback extends number | null | u
   try {
     return Amount.from(value).toNumber();
   } catch (e) {
-    throw new CTSError(`Invalid ${context}: ${(e as Error).message}`);
+    const message = e instanceof Error ? e.message : String(e);
+    throw new CTSError(`Invalid ${context}: ${message}`, { cause: e });
   }
 }
 

--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -1,5 +1,6 @@
 import { bech32 } from '@scure/base';
 
+import { CTSError } from '../model/Errors';
 import { PaymentRequestTransportType } from '../wallet/types/payment-requests';
 import type { PaymentRequestTransport } from '../wallet/types/payment-requests';
 
@@ -173,7 +174,7 @@ function decodeAllParts(data: Uint8Array): TLVPart[] {
  */
 function decodeNextPart(data: Uint8Array): TLVPart {
   if (data.length < 3) {
-    throw new Error('TLV data too short: need at least 3 bytes for tag and length');
+    throw new CTSError('TLV data too short: need at least 3 bytes for tag and length');
   }
 
   const dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
@@ -181,7 +182,7 @@ function decodeNextPart(data: Uint8Array): TLVPart {
   const length = dataView.getUint16(1, false); // big-endian
 
   if (data.length < 3 + length) {
-    throw new Error(`TLV data too short: expected ${3 + length} bytes, got ${data.length}`);
+    throw new CTSError(`TLV data too short: expected ${3 + length} bytes, got ${data.length}`);
   }
 
   const value = data.subarray(3, 3 + length);
@@ -194,14 +195,14 @@ function parseString(value: Uint8Array): string {
 
 function parseU64(value: Uint8Array): bigint {
   if (value.length !== 8) {
-    throw new Error(`Invalid u64: expected 8 bytes, got ${value.length}`);
+    throw new CTSError(`Invalid u64: expected 8 bytes, got ${value.length}`);
   }
   return new DataView(value.buffer, value.byteOffset, value.byteLength).getBigUint64(0, false);
 }
 
 function parseU8(value: Uint8Array): number {
   if (value.length !== 1) {
-    throw new Error(`Invalid u8: expected 1 byte, got ${value.length}`);
+    throw new CTSError(`Invalid u8: expected 1 byte, got ${value.length}`);
   }
   return value[0];
 }
@@ -213,7 +214,7 @@ function transportKindToType(kind: number): PaymentRequestTransportType {
     case TRANSPORT_KIND_HTTP_POST:
       return 'post' as PaymentRequestTransportType;
     default:
-      throw new Error(`Unsupported transport kind: ${kind}`);
+      throw new CTSError(`Unsupported transport kind: ${kind}`);
   }
 }
 
@@ -224,7 +225,7 @@ function nut10KindToType(kind: number): string {
     case NUT10_KIND_HTLC:
       return 'HTLC';
     default:
-      throw new Error(`Unsupported NUT-10 kind: ${kind}`);
+      throw new CTSError(`Unsupported NUT-10 kind: ${kind}`);
   }
 }
 
@@ -253,10 +254,10 @@ function parseTransport(value: Uint8Array): PaymentRequestTransport {
   }
 
   if (kind === undefined) {
-    throw new Error('Transport missing required kind field');
+    throw new CTSError('Transport missing required kind field');
   }
   if (targetBytes === undefined) {
-    throw new Error('Transport missing required target field');
+    throw new CTSError('Transport missing required target field');
   }
 
   // Parse target based on kind
@@ -313,10 +314,10 @@ function parseNut10(value: Uint8Array): Nut10SpendingCondition {
   }
 
   if (kindNum === undefined) {
-    throw new Error('NUT-10 spending condition missing required kind field');
+    throw new CTSError('NUT-10 spending condition missing required kind field');
   }
   if (data === undefined) {
-    throw new Error('NUT-10 spending condition missing required data field');
+    throw new CTSError('NUT-10 spending condition missing required data field');
   }
 
   // Return undefined for tags if empty
@@ -353,7 +354,7 @@ function parseTagTuple(value: Uint8Array): string[] {
     offset += 1;
 
     if (value.length - offset < length) {
-      throw new Error(
+      throw new CTSError(
         `Tag tuple data too short: expected ${length} bytes, got ${value.length - offset}`,
       );
     }
@@ -443,7 +444,7 @@ export function encodeTLV(request: DecodedTLVPaymentRequest): Uint8Array {
 function encodeTLVPart(tag: number, value: Uint8Array): Uint8Array {
   const length = value.length;
   if (length > 0xffff) {
-    throw new Error(`TLV value too long: ${length} bytes (max 65535)`);
+    throw new CTSError(`TLV value too long: ${length} bytes (max 65535)`);
   }
 
   const result = new Uint8Array(3 + length);
@@ -478,7 +479,7 @@ function transportTypeToKind(type: PaymentRequestTransportType): number {
     case PaymentRequestTransportType.POST:
       return TRANSPORT_KIND_HTTP_POST;
     default:
-      throw new Error(`Unsupported transport type: ${type as string}`);
+      throw new CTSError(`Unsupported transport type: ${type as string}`);
   }
 }
 
@@ -489,7 +490,7 @@ function nut10TypeToKind(type: string): number {
     case 'HTLC':
       return NUT10_KIND_HTLC;
     default:
-      throw new Error(`Unsupported NUT-10 type: ${type}`);
+      throw new CTSError(`Unsupported NUT-10 type: ${type}`);
   }
 }
 
@@ -591,7 +592,7 @@ function encodeTagTuple(tuple: string[]): Uint8Array {
   for (const str of tuple) {
     const encoded = encoder.encode(str);
     if (encoded.length > 255) {
-      throw new Error(`Tag tuple string too long: ${str} (max 255 bytes)`);
+      throw new CTSError(`Tag tuple string too long: ${str} (max 255 bytes)`);
     }
     // 1-byte length prefix + string bytes
     const part = new Uint8Array(1 + encoded.length);
@@ -622,7 +623,7 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
   // Decode bech32m
   const decoded = bech32.decode(nprofile as `${string}1${string}`, 1024);
   if (decoded.prefix !== 'nprofile') {
-    throw new Error(`Invalid nprofile: expected prefix 'nprofile', got '${decoded.prefix}'`);
+    throw new CTSError(`Invalid nprofile: expected prefix 'nprofile', got '${decoded.prefix}'`);
   }
 
   const tlvData = bech32.fromWords(decoded.words);
@@ -635,7 +636,7 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
 
   while (offset < data.length) {
     if (offset + 2 > data.length) {
-      throw new Error('Nprofile TLV data too short');
+      throw new CTSError('Nprofile TLV data too short');
     }
 
     const tag = data[offset];
@@ -643,7 +644,7 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
     offset += 2;
 
     if (offset + length > data.length) {
-      throw new Error(`Nprofile TLV value too short: expected ${length} bytes`);
+      throw new CTSError(`Nprofile TLV value too short: expected ${length} bytes`);
     }
 
     const value = data.subarray(offset, offset + length);
@@ -652,7 +653,7 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
     if (tag === 0x00) {
       // Pubkey
       if (value.length !== 32) {
-        throw new Error(`Invalid pubkey length: expected 32 bytes, got ${value.length}`);
+        throw new CTSError(`Invalid pubkey length: expected 32 bytes, got ${value.length}`);
       }
       pubkey = value;
     } else if (tag === 0x01) {
@@ -663,7 +664,7 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
   }
 
   if (!pubkey) {
-    throw new Error('Nprofile missing required pubkey');
+    throw new CTSError('Nprofile missing required pubkey');
   }
 
   return { pubkey, relays };
@@ -696,7 +697,7 @@ export function encodeNprofile(pubkey: Uint8Array, relays: string[]): string {
  */
 function encodePubkeyRelaysTLV(pubkey: Uint8Array, relays: string[]): Uint8Array {
   if (pubkey.length !== 32) {
-    throw new Error(`Invalid pubkey: expected 32 bytes, got ${pubkey.length}`);
+    throw new CTSError(`Invalid pubkey: expected 32 bytes, got ${pubkey.length}`);
   }
 
   const encoder = new TextEncoder();
@@ -705,7 +706,7 @@ function encodePubkeyRelaysTLV(pubkey: Uint8Array, relays: string[]): Uint8Array
   // Validate relay lengths fit in 1 byte
   for (let i = 0; i < encodedRelays.length; i++) {
     if (encodedRelays[i].length > 255) {
-      throw new Error(`Relay URL too long: ${relays[i]} (max 255 bytes)`);
+      throw new CTSError(`Relay URL too long: ${relays[i]} (max 255 bytes)`);
     }
   }
 

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -1,3 +1,4 @@
+import { CTSError } from '../model/Errors';
 /**
  * Usable counters in range is [start, start+count-1]
  *
@@ -79,7 +80,7 @@ export class EphemeralCounterSource implements CounterSource {
   }
 
   async reserve(keysetId: string, n: number): Promise<CounterRange> {
-    if (n < 0) throw new Error('reserve called with negative count');
+    if (n < 0) throw new CTSError('reserve called with negative count');
     return this.withLock(keysetId, () => {
       const cur = this.next.get(keysetId) ?? 0;
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
@@ -97,7 +98,7 @@ export class EphemeralCounterSource implements CounterSource {
 
   async setNext(keysetId: string, next: number): Promise<void> {
     await this.withLock(keysetId, () => {
-      if (next < 0) throw new Error('setNext: negative next not allowed');
+      if (next < 0) throw new CTSError('setNext: negative next not allowed');
       this.next.set(keysetId, next);
     });
   }

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -1,4 +1,5 @@
 import { Mint } from '../mint';
+import { CTSError } from '../model/Errors';
 import type {
   MintKeyset,
   MintKeys,
@@ -26,7 +27,7 @@ export class KeyChain {
 
   private assertInitialized(): void {
     if (Object.keys(this.keysets).length === 0) {
-      throw new Error('KeyChain not initialized');
+      throw new CTSError('KeyChain not initialized');
     }
   }
 
@@ -194,7 +195,7 @@ export class KeyChain {
   getKeyset(id?: string): Keyset {
     const keyset = id ? this.keysets[id] : this.getCheapestKeyset();
     if (!keyset) {
-      throw new Error(`Keyset '${id}' not found`);
+      throw new CTSError(`Keyset '${id}' not found`);
     }
     return keyset;
   }
@@ -209,13 +210,13 @@ export class KeyChain {
    */
   getCheapestKeyset(): Keyset {
     if (Object.keys(this.keysets).length === 0) {
-      throw new Error('KeyChain not initialized');
+      throw new CTSError('KeyChain not initialized');
     }
     const activeKeysets = Object.values(this.keysets).filter(
       (k) => k.unit === this.unit && k.isActive && k.hasHexId && k.hasKeys,
     );
     if (activeKeysets.length === 0) {
-      throw new Error(`No active keyset found for unit: ${this.unit}`);
+      throw new CTSError(`No active keyset found for unit: ${this.unit}`);
     }
     return activeKeysets.sort((a, b) => a.fee - b.fee)[0];
   }
@@ -231,7 +232,7 @@ export class KeyChain {
     // Check keyset exists
     const existing = this.keysets[id];
     if (!existing) {
-      throw new Error(`Keyset '${id}' not found`);
+      throw new CTSError(`Keyset '${id}' not found`);
     }
 
     // Already usable
@@ -250,14 +251,14 @@ export class KeyChain {
       const res = await this.mint.getKeys(id);
       const mk = res.keysets.find((k) => k.id === id);
       if (!mk || !mk.keys || Object.keys(mk.keys).length === 0) {
-        throw new Error(`Mint returned no keys for keyset '${id}'`);
+        throw new CTSError(`Mint returned no keys for keyset '${id}'`);
       }
 
       // Rebuild from existing meta plus fetched keys
       const meta = existing.toMintKeyset();
       const rebuilt = Keyset.fromMintApi(meta, mk);
       if (!rebuilt.verify()) {
-        throw new Error(`Keyset verification failed for ID ${id}`);
+        throw new CTSError(`Keyset verification failed for ID ${id}`);
       }
 
       // Replace keyset with rebuilt one
@@ -284,7 +285,7 @@ export class KeyChain {
     this.assertInitialized();
     const unitKeysets = Object.values(this.keysets).filter((k) => k.unit === this.unit);
     if (unitKeysets.length === 0) {
-      throw new Error(`No keysets found for unit: ${this.unit}`);
+      throw new CTSError(`No keysets found for unit: ${this.unit}`);
     }
     return unitKeysets;
   }

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -1,5 +1,6 @@
 import { hexToBytes } from '@noble/curves/utils.js';
 
+import { CTSError } from '../model/Errors';
 import { type MintKeyset, type MintKeys } from '../model/types';
 import { isValidHex, deriveKeysetId, isBase64String } from '../utils';
 import { normalizeMintKeyset, normalizeMintKeys } from '../utils/normalizeNumbers';
@@ -154,17 +155,17 @@ export class Keyset {
     // Sanity checks
     if (nKeys) {
       if (nKeys.id !== nMeta.id) {
-        throw new Error(`Mismatched keyset ids: meta=${nMeta.id}, keys=${nKeys.id}`);
+        throw new CTSError(`Mismatched keyset ids: meta=${nMeta.id}, keys=${nKeys.id}`);
       }
       if (nKeys.unit !== nMeta.unit) {
-        throw new Error(`Mismatched keyset units: meta=${nMeta.unit}, keys=${nKeys.unit}`);
+        throw new CTSError(`Mismatched keyset units: meta=${nMeta.unit}, keys=${nKeys.unit}`);
       }
       if (
         nKeys.final_expiry !== undefined &&
         nMeta.final_expiry !== undefined &&
         nKeys.final_expiry !== nMeta.final_expiry
       ) {
-        throw new Error(`Mismatched keyset expiry for id=${nMeta.id}`);
+        throw new CTSError(`Mismatched keyset expiry for id=${nMeta.id}`);
       }
       // All good
       ks.keys = nKeys.keys;

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -1,4 +1,5 @@
 import { dedupeP2PKPubkeys, type P2PKOptions, type P2PKTag, type SigFlag } from '../crypto';
+import { CTSError } from '../model/Errors';
 import { assertValidTagKey, OutputData } from '../model/OutputData';
 
 function toUnixSeconds(input: Date | number): number {
@@ -37,14 +38,14 @@ export class P2PKBuilder {
 
   requireLockSignatures(n: number) {
     if (!Number.isInteger(n) || n < 1)
-      throw new Error(`requiredSignatures (n_sigs) must be a positive integer, got ${n}`);
+      throw new CTSError(`requiredSignatures (n_sigs) must be a positive integer, got ${n}`);
     this.nSigs = n;
     return this;
   }
 
   requireRefundSignatures(n: number) {
     if (!Number.isInteger(n) || n < 1)
-      throw new Error(
+      throw new CTSError(
         `requiredRefundSignatures (n_sigs_refund) must be a positive integer, got ${n}`,
       );
     this.nSigsRefund = n;
@@ -85,7 +86,7 @@ export class P2PKBuilder {
     const locks = this.lockKeys;
     const refunds = this.refundKeys;
 
-    if (locks.length === 0) throw new Error('At least one lock pubkey is required');
+    if (locks.length === 0) throw new CTSError('At least one lock pubkey is required');
 
     const pubkey: string | string[] = locks.length === 1 ? locks[0] : locks;
 

--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -1,6 +1,7 @@
 // Minimal types to avoid importing the whole wallet, keeps this module independent
 import { fail, failIf, failIfNullish, type Logger, NULL_LOGGER, measureTime } from '../logger';
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import type { Proof, ProofLike } from '../model/types/proof';
 import { normalizeProofAmounts } from '../utils';
 
@@ -55,10 +56,12 @@ export function selectProofsRGLI(
     try {
       return keyChain.getKeyset(proof.id).fee;
     } catch (e) {
-      fail(`Could not get fee. No keyset found for keyset id: ${proof.id}`, _logger, {
+      const message = `Could not get fee. No keyset found for keyset id: ${proof.id}`;
+      _logger.error(message, {
         error: e,
         keychain: keyChain.getKeysets(),
       });
+      throw new CTSError(message, { cause: e });
     }
   };
   // Calculate net amount after fees

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -20,6 +20,7 @@ import {
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import { OutputData, type OutputDataLike } from '../model/OutputData';
 import { DefaultOutputDataCreator, type OutputDataCreator } from '../model/OutputDataCreator';
@@ -1099,7 +1100,7 @@ class Wallet {
         if (outputConfig.keep && !isPlainRandom(outputConfig.keep))
           reasons.push('non-default keep output type');
 
-        throw new Error(`Options require a swap: ${reasons.join(', ')}`);
+        throw new CTSError(`Options require a swap: ${reasons.join(', ')}`);
       }
 
       // Proceed with offline exact-match attempt
@@ -1186,7 +1187,7 @@ class Wallet {
     // 	selectedProofs: selectedProofs.map(p=>p.amount.toString()),
     // });
     if (selectedProofs.length === 0) {
-      throw new Error('Not enough funds available to send');
+      throw new CTSError('Not enough funds available to send');
     }
 
     // Calculate our expected change from the swap (and sanity check!)

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -283,7 +283,9 @@ class Wallet {
       }
       return parsed;
     } catch (e) {
-      this.fail((e as Error).message, { op, amount });
+      const message = e instanceof Error ? e.message : String(e);
+      this._logger.error(message, { op, amount });
+      throw new CTSError(message, { cause: e });
     }
   }
 
@@ -1423,10 +1425,12 @@ class Wallet {
       // We must NOT fallback to wallet's keyset
       return this._keyChain.getKeyset(proof.id).fee;
     } catch (e) {
-      this.fail(`Could not get fee. No keyset found for keyset id: ${proof.id}`, {
+      const message = `Could not get fee. No keyset found for keyset id: ${proof.id}`;
+      this._logger.error(message, {
         e,
         keychain: this._keyChain.getKeysets(),
       });
+      throw new CTSError(message, { cause: e });
     }
   }
 
@@ -1443,7 +1447,9 @@ class Wallet {
       const feePPK = this._keyChain.getKeyset(keysetId).fee;
       return Amount.from(Math.floor(Math.max((nInputs * feePPK + 999) / 1000, 0)));
     } catch (e) {
-      this.fail(`No keyset found with ID ${keysetId}`, { e });
+      const message = `No keyset found with ID ${keysetId}`;
+      this._logger.error(message, { e });
+      throw new CTSError(message, { cause: e });
     }
   }
 

--- a/src/wallet/WalletCounters.ts
+++ b/src/wallet/WalletCounters.ts
@@ -1,3 +1,5 @@
+import { CTSError } from '../model/Errors';
+
 import type { CounterSource } from './CounterSource';
 
 /**
@@ -32,7 +34,7 @@ export class WalletCounters {
       await this.src.setNext(keysetId, next);
       return;
     }
-    throw new Error('CounterSource does not support setNext()');
+    throw new CTSError('CounterSource does not support setNext()');
   }
   /**
    * Returns the current "next" per keyset (what will be reserved next).
@@ -44,6 +46,6 @@ export class WalletCounters {
     if (typeof this.src.snapshot === 'function') {
       return await this.src.snapshot();
     }
-    throw new Error('CounterSource does not support snapshot()');
+    throw new CTSError('CounterSource does not support snapshot()');
   }
 }

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -1,5 +1,6 @@
 import { hashToCurve } from '../crypto';
 import { safeCallback } from '../logger';
+import { CTSError } from '../model/Errors';
 import { MintQuoteState, MeltQuoteState } from '../model/types';
 import type {
   Proof,
@@ -16,8 +17,6 @@ export type SubscriptionCanceller = () => void;
 export type CancellerLike = SubscriptionCanceller | Promise<SubscriptionCanceller>;
 
 export type SubscribeOpts = { signal?: AbortSignal };
-
-type ErrorWithCause = Error & { cause?: unknown };
 
 function safeStringify(obj: unknown): string {
   const seen = new WeakSet<object>();
@@ -37,9 +36,7 @@ function safeStringify(obj: unknown): string {
 function normalizeError(err: unknown): Error {
   if (err instanceof Error) return err;
   const message = typeof err === 'string' ? err : safeStringify(err);
-  const e: ErrorWithCause = new Error(message);
-  e.cause = err;
-  return e;
+  return new CTSError(message, { cause: err });
 }
 
 function makeAbortError(): Error {
@@ -133,7 +130,7 @@ export class WalletEvents {
 
       // Start a timeout if requested.
       if (opts?.timeoutMs && opts.timeoutMs > 0) {
-        to = setTimeout(() => cleanup(new Error(timeoutMsg)), opts.timeoutMs);
+        to = setTimeout(() => cleanup(new CTSError(timeoutMsg)), opts.timeoutMs);
       }
 
       // Subscribe to the actual event. Canceller returned is saved to cancelP.
@@ -209,7 +206,7 @@ export class WalletEvents {
   ): Promise<SubscriptionCanceller> {
     await this.wallet.mint.connectWebSocket();
     const ws = this.wallet.mint.webSocketConnection;
-    if (!ws) throw new Error('Failed to establish WebSocket connection.');
+    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const uniq = Array.from(new Set(ids));
     const subId = ws.createSubscription({ kind: 'bolt11_mint_quote', filters: uniq }, cb, err);
@@ -257,7 +254,7 @@ export class WalletEvents {
   ): Promise<SubscriptionCanceller> {
     await this.wallet.mint.connectWebSocket();
     const ws = this.wallet.mint.webSocketConnection;
-    if (!ws) throw new Error('Failed to establish WebSocket connection.');
+    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const uniq = Array.from(new Set(ids));
     const subId = ws.createSubscription({ kind: 'bolt11_melt_quote', filters: uniq }, cb, err);
@@ -305,7 +302,7 @@ export class WalletEvents {
   ): Promise<SubscriptionCanceller> {
     await this.wallet.mint.connectWebSocket();
     const ws = this.wallet.mint.webSocketConnection;
-    if (!ws) throw new Error('Failed to establish WebSocket connection.');
+    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const enc = new TextEncoder();
     const proofMap: Record<string, Proof> = {};
@@ -434,12 +431,12 @@ export class WalletEvents {
 
       if (opts?.timeoutMs && opts.timeoutMs > 0) {
         to = setTimeout(
-          () => cleanup(new Error('Timeout waiting for any mint paid')),
+          () => cleanup(new CTSError('Timeout waiting for any mint paid')),
           opts.timeoutMs,
         );
       }
 
-      if (unique.length === 0) return cleanup(new Error('No quote ids provided'));
+      if (unique.length === 0) return cleanup(new CTSError('No quote ids provided'));
 
       for (const quoteId of unique) {
         const c = this.mintQuotePaid(
@@ -463,7 +460,7 @@ export class WalletEvents {
             }
 
             if (fullyRegistered && cancels.size === 0) {
-              cleanup(lastError ?? new Error('No subscriptions remaining'));
+              cleanup(lastError ?? new CTSError('No subscriptions remaining'));
             }
           },
         );
@@ -485,7 +482,7 @@ export class WalletEvents {
           }
 
           if (fullyRegistered && cancels.size === 0) {
-            cleanup(lastError ?? new Error('No subscriptions remaining'));
+            cleanup(lastError ?? new CTSError('No subscriptions remaining'));
           }
         });
       }

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -1,5 +1,6 @@
 import { type P2PKOptions } from '../crypto';
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import { type OutputDataLike, type OutputDataFactory } from '../model/OutputData';
 import {
   type MeltQuoteBolt11Response,
@@ -303,7 +304,7 @@ export class SendBuilder {
     // If an offline mode is requested, forbid custom OutputTypes,
     // because offline uses existing proofs and cannot honour new outputs.
     if ((this.offlineExact || this.offlineClose) && (this.sendOT || this.keepOT)) {
-      throw new Error(
+      throw new CTSError(
         'Offline selection cannot be combined with custom output types. Remove send/keep output configuration, or use an online swap.',
       );
     }
@@ -663,7 +664,7 @@ export class MintBuilder<
       this.wallet.validateMintQuote(quote);
       // Enforce privkey when the quote is locked
       if (quote.pubkey && !this.config.privkey) {
-        throw new Error('privkey is required for locked BOLT11 mint quotes');
+        throw new CTSError('privkey is required for locked BOLT11 mint quotes');
       }
       return this.wallet.prepareMint(
         this.method,
@@ -682,7 +683,7 @@ export class MintBuilder<
     const bolt12 = this.quote as MintQuoteBolt12Response;
     this.wallet.validateMintQuote(bolt12);
     if (!this.config.privkey) {
-      throw new Error('privkey is required for BOLT12 mint quotes');
+      throw new CTSError('privkey is required for BOLT12 mint quotes');
     }
     return this.wallet.prepareMint(
       this.method,

--- a/test/crypto/NUT10.test.ts
+++ b/test/crypto/NUT10.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { getTagInt, hasTag, parseHTLCSecret, parseSecret } from '../../src/crypto';
-import { Amount, Proof } from '../../src';
+import { Amount, CTSError, Proof } from '../../src';
 
 const proof: Proof = {
   amount: Amount.from(2),
@@ -23,6 +23,12 @@ describe('NUT10 module core functions', () => {
     expect(() => {
       parseHTLCSecret(secretStr);
     }).toThrow("Can't parse secret");
+    try {
+      parseHTLCSecret(secretStr);
+    } catch (e) {
+      expect(e).toBeInstanceOf(CTSError);
+      expect((e as CTSError).cause).toBeInstanceOf(SyntaxError);
+    }
   });
 
   test('parseSecret throws for invalid NUT-10 secret (bad kind)', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -43,6 +43,7 @@ import {
   HasKeysetKeys,
   NetworkError,
   AmountLike,
+  CTSError,
 } from '../src';
 import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -761,7 +762,10 @@ describe('dleq', () => {
     });
     expect(() => {
       wallet.sendOffline(4, proofs, { requireDleq: true });
-    }).toThrow(new Error('Not enough funds available to send'));
+    }).toThrow(CTSError);
+    expect(() => {
+      wallet.sendOffline(4, proofs, { requireDleq: true });
+    }).toThrow('Not enough funds available to send');
   });
   test('receive with invalid dleq', async () => {
     const wallet = new Wallet(mintUrl);
@@ -786,7 +790,8 @@ describe('dleq', () => {
       unit: wallet.unit,
     } as Token;
     const exc = await wallet.receive(token, { requireDleq: true }).catch((e) => e);
-    expect(exc).toEqual(new Error('Token contains proofs with invalid or missing DLEQ'));
+    expect(exc).toBeInstanceOf(CTSError);
+    expect(exc).toMatchObject({ message: 'Token contains proofs with invalid or missing DLEQ' });
   });
 });
 describe('Custom Outputs', () => {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -206,7 +206,10 @@ describe('requests', { timeout: 7500 }, () => {
       }),
     );
 
-    await expect(request({ endpoint })).rejects.toThrow(new HttpResponseError('bad response', 200));
+    const thrown = await request({ endpoint }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect(thrown).toMatchObject({ message: 'bad response', status: 200 });
+    expect(thrown.cause).toMatchObject({ message: 'Empty response body' });
   });
 
   test('maps malformed success JSON to bad response and logs parsing failure', async () => {
@@ -228,7 +231,10 @@ describe('requests', { timeout: 7500 }, () => {
 
     setRequestLogger(logger);
     try {
-      await expect(request({ endpoint })).rejects.toThrow('bad response');
+      const thrown = await request({ endpoint }).catch((e) => e);
+      expect(thrown).toBeInstanceOf(HttpResponseError);
+      expect(thrown).toMatchObject({ message: 'bad response' });
+      expect(thrown.cause).toBeInstanceOf(Error);
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to parse HTTP response',
         expect.objectContaining({ err: expect.any(Error) }),
@@ -240,14 +246,17 @@ describe('requests', { timeout: 7500 }, () => {
 
   test('maps AbortError fetch failures to NetworkError without timeout policy', async () => {
     const endpoint = mintUrl + '/v1/keys';
+    const abortError = new Error('aborted by runtime');
+    abortError.name = 'AbortError';
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
-      const abortError = new Error('aborted by runtime');
-      abortError.name = 'AbortError';
       throw abortError;
     });
 
     try {
-      await expect(request({ endpoint })).rejects.toThrow('aborted by runtime');
+      const thrown = await request({ endpoint }).catch((e) => e);
+      expect(thrown).toBeInstanceOf(NetworkError);
+      expect(thrown).toMatchObject({ message: 'aborted by runtime' });
+      expect(thrown.cause).toBe(abortError);
     } finally {
       fetchMock.mockRestore();
     }
@@ -255,17 +264,21 @@ describe('requests', { timeout: 7500 }, () => {
 
   test('falls back to bad response when reading error body throws', async () => {
     const endpoint = mintUrl + '/v1/keys';
+    const bodyReadError = new Error('body read failed');
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,
       status: 503,
       headers: new Headers(),
       text: vi.fn(async () => {
-        throw new Error('body read failed');
+        throw bodyReadError;
       }),
     } as unknown as Response);
 
     try {
-      await expect(request({ endpoint })).rejects.toThrow('bad response');
+      const thrown = await request({ endpoint }).catch((e) => e);
+      expect(thrown).toBeInstanceOf(HttpResponseError);
+      expect(thrown).toMatchObject({ message: 'bad response', status: 503 });
+      expect(thrown.cause).toBe(bodyReadError);
     } finally {
       fetchMock.mockRestore();
     }

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
-import { Wallet, Amount, type Proof } from '../../src';
+import { Wallet, Amount, CTSError, type Proof } from '../../src';
 import { mint, unit, mintUrl, useTestServer } from './_setup';
 
 const server = useTestServer();
@@ -79,5 +79,43 @@ describe('wallet.maxSpendableAfterFees', () => {
 
     // 100 - 10 (feeReserve) - 3 (inputFee) = 87
     expect(result.equals(87)).toBe(true);
+  });
+
+  test('throws with cause when a proof keyset fee lookup fails', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const call = () =>
+      wallet.maxSpendableAfterFees([
+        {
+          id: '00missingkeyset',
+          amount: Amount.from(1),
+          secret: 'secret',
+          C: 'C',
+        },
+      ]);
+
+    expect(call).toThrow(/Could not get fee\. No keyset found for keyset id: 00missingkeyset/);
+    try {
+      call();
+    } catch (e) {
+      expect(e).toBeInstanceOf(CTSError);
+      expect((e as CTSError).cause).toBeInstanceOf(Error);
+    }
+  });
+
+  test('throws with cause when a keyset fee lookup fails', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const call = () => wallet.getFeesForKeyset(1, '00missingkeyset');
+
+    expect(call).toThrow(/No keyset found with ID 00missingkeyset/);
+    try {
+      call();
+    } catch (e) {
+      expect(e).toBeInstanceOf(CTSError);
+      expect((e as CTSError).cause).toBeInstanceOf(Error);
+    }
   });
 });

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -4,6 +4,7 @@ import { test, describe, expect } from 'vitest';
 import {
   Wallet,
   Amount,
+  CTSError,
   OutputData,
   type Proof,
   type ProofLike,
@@ -608,7 +609,8 @@ describe('send', () => {
 
     const result = await wallet.send(2, proofs).catch((e) => e);
 
-    expect(result).toEqual(new Error('Not enough funds available to send'));
+    expect(result).toBeInstanceOf(CTSError);
+    expect(result).toMatchObject({ message: 'Not enough funds available to send' });
   });
   test('test send bad response', async () => {
     server.use(


### PR DESCRIPTION
## Summary

  - add `CTSError` as the library base error and export it publicly
  - make existing cashu-ts custom errors extend `CTSError`
  - replace generic library-created `Error` throws with `CTSError`
  - preserve original thrown values as `cause` when wrapping lower-level failures
  - add coverage for cause propagation in request and NUT-10 parsing paths

  ## Notes

  This is intended to make downstream error attribution easier in layered consumers, e.g. app -> coco -> cashu-ts.

  The public API change is additive:
  - new exported `CTSError`
  - optional `{ cause }` constructor options on `HttpResponseError` and `NetworkError`