### PR TITLE
feat(wallet): improve async melt change handling

### DIFF
--- a/docs-src/usage/melt_token.md
+++ b/docs-src/usage/melt_token.md
@@ -73,12 +73,12 @@ await wallet.completeMelt(preview, undefined, true); // preferAsync = true
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
 ```
 
 - `OutputData.serialize` / `OutputData.deserialize` are the JSON-safe round-trip primitives
   (decimal-encoded bigints, hex-encoded bytes; preserves `ephemeralE` for P2BK).
-- `wallet.hydrateMeltChange` runs the same validation as the synchronous path and is also
+- `wallet.createMeltChangeProofs` runs the same validation as the synchronous path and is also
   callable directly if you've persisted output data outside the helpers above (crash recovery,
   process hand-off, etc.).
 - For the same pattern using the WalletOps builder (`.prepare()`), see

--- a/docs-src/usage/melt_token.md
+++ b/docs-src/usage/melt_token.md
@@ -50,7 +50,41 @@ const meltPreview = await wallet.prepareMelt('bolt11', meltQuote, proofsToSend);
 const meltResponse = await wallet.completeMelt(meltPreview);
 ```
 
-## 3) Generic melt for custom payment methods
+## 3) Async melt with later change recovery (NUT-06 `prefer_async`)
+
+For mints that support NUT-06 asynchronous melts, the melt response can return before the
+Lightning payment completes, meaning the response will not yet carry NUT-08 change signatures.
+
+To reclaim that change later, persist the prepared output data while the melt is pending, then
+hydrate change proofs from the eventual paid quote response.
+
+```ts
+import { OutputData, type SerializedOutputData } from '@cashu/cashu-ts';
+
+// 1. Prepare the melt and persist the change-output data alongside the pending quote.
+const preview = await wallet.prepareMelt('bolt11', meltQuote, myProofs);
+const stored = JSON.stringify(preview.outputData.map((o) => OutputData.serialize(o)));
+await wallet.completeMelt(preview, undefined, true); // preferAsync = true
+
+// 2. ... time passes ... use checkMeltQuote*() or wallet.on.onceMeltPaid() to learn the
+// quote is paid. The paid response carries the change signatures.
+
+// 3. Restore the output data and reconstruct spendable change proofs.
+const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
+  OutputData.deserialize(s),
+);
+const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+```
+
+- `OutputData.serialize` / `OutputData.deserialize` are the JSON-safe round-trip primitives
+  (decimal-encoded bigints, hex-encoded bytes; preserves `ephemeralE` for P2BK).
+- `wallet.hydrateMeltChange` runs the same validation as the synchronous path and is also
+  callable directly if you've persisted output data outside the helpers above (crash recovery,
+  process hand-off, etc.).
+- For the same pattern using the WalletOps builder (`.prepare()`), see
+  [Wallet Operations – Melt § 4](../wallet_ops/melt.md).
+
+## 4) Generic melt for custom payment methods
 
 The generic `createMeltQuote()` / `meltProofs()` methods support arbitrary payment methods without
 requiring first-class library support.

--- a/docs-src/wallet_ops/melt.md
+++ b/docs-src/wallet_ops/melt.md
@@ -45,7 +45,7 @@ const { quote, change } = await wallet.completeMelt(preview);
 ## 4) Async melt with later change recovery (NUT-06 `prefer_async`)
 
 For mints that support NUT-06 async melts, `.prepare()` pairs with `OutputData.serialize` to
-persist the change-output blanks while the payment is in flight, and `wallet.hydrateMeltChange`
+persist the change-output blanks while the payment is in flight, and `wallet.createMeltChangeProofs`
 reconstructs change proofs once the quote is paid.
 
 ```ts
@@ -59,7 +59,7 @@ await wallet.completeMelt(preview, undefined, true); // preferAsync = true
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
 ```
 
 - See [Melt Token § 3 — Async melt with later change recovery](../usage/melt_token.md) for the

--- a/docs-src/wallet_ops/melt.md
+++ b/docs-src/wallet_ops/melt.md
@@ -42,6 +42,37 @@ const { quote, change } = await wallet.completeMelt(preview);
 - `run()` is equivalent to `const preview = await prepare(); await wallet.completeMelt(preview)`.
 - This pairs well with NUT-19 cached-response retries on mints that advertise the melt endpoint.
 
+## 4) Async melt with later change recovery (NUT-06 `prefer_async`)
+
+For mints that support NUT-06 asynchronous melts, the melt response can return before the
+Lightning payment completes — meaning the response will not yet carry NUT-08 change
+signatures. To reclaim that change later, persist the prepared output data while the melt
+is pending, then hydrate change proofs from the eventual paid quote response.
+
+```ts
+import { OutputData, type SerializedOutputData } from '@cashu/cashu-ts';
+
+// 1. Prepare the melt and persist the change-output data alongside the pending quote.
+const preview = await wallet.prepareMelt('bolt11', meltQuote, myProofs);
+const stored = JSON.stringify(preview.outputData.map((o) => OutputData.serialize(o)));
+await wallet.completeMelt(preview, undefined, true); // preferAsync = true
+
+// 2. ... time passes ... use checkMeltQuote*() or wallet.on.onceMeltPaid() to learn the
+//    quote is paid. The paid response carries the change signatures.
+
+// 3. Restore the output data and reconstruct spendable change proofs.
+const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
+  OutputData.deserialize(s),
+);
+const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+```
+
+- `OutputData.serialize` / `OutputData.deserialize` are the JSON-safe round-trip primitives
+  (decimal-encoded bigints, hex-encoded bytes; preserves `ephemeralE` for P2BK).
+- `wallet.hydrateMeltChange` runs the same validation as the synchronous path and is also
+  callable directly if you've persisted output data outside the helpers above (crash
+  recovery, process hand-off, etc.).
+
 ## Custom payment methods
 
 For custom payment methods (e.g., BACS, SWIFT), use the generic wallet methods directly:

--- a/docs-src/wallet_ops/melt.md
+++ b/docs-src/wallet_ops/melt.md
@@ -44,34 +44,26 @@ const { quote, change } = await wallet.completeMelt(preview);
 
 ## 4) Async melt with later change recovery (NUT-06 `prefer_async`)
 
-For mints that support NUT-06 asynchronous melts, the melt response can return before the
-Lightning payment completes — meaning the response will not yet carry NUT-08 change
-signatures. To reclaim that change later, persist the prepared output data while the melt
-is pending, then hydrate change proofs from the eventual paid quote response.
+For mints that support NUT-06 async melts, `.prepare()` pairs with `OutputData.serialize` to
+persist the change-output blanks while the payment is in flight, and `wallet.hydrateMeltChange`
+reconstructs change proofs once the quote is paid.
 
 ```ts
 import { OutputData, type SerializedOutputData } from '@cashu/cashu-ts';
 
-// 1. Prepare the melt and persist the change-output data alongside the pending quote.
-const preview = await wallet.prepareMelt('bolt11', meltQuote, myProofs);
+const preview = await wallet.ops.meltBolt11(meltQuote, myProofs).asDeterministic().prepare();
 const stored = JSON.stringify(preview.outputData.map((o) => OutputData.serialize(o)));
 await wallet.completeMelt(preview, undefined, true); // preferAsync = true
 
-// 2. ... time passes ... use checkMeltQuote*() or wallet.on.onceMeltPaid() to learn the
-//    quote is paid. The paid response carries the change signatures.
-
-// 3. Restore the output data and reconstruct spendable change proofs.
+// ... later, once the quote is paid ...
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
 const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
 ```
 
-- `OutputData.serialize` / `OutputData.deserialize` are the JSON-safe round-trip primitives
-  (decimal-encoded bigints, hex-encoded bytes; preserves `ephemeralE` for P2BK).
-- `wallet.hydrateMeltChange` runs the same validation as the synchronous path and is also
-  callable directly if you've persisted output data outside the helpers above (crash
-  recovery, process hand-off, etc.).
+- See [Melt Token § 3 — Async melt with later change recovery](../usage/melt_token.md) for the
+  full annotated lifecycle using the low-level wallet methods directly.
 
 ## Custom payment methods
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1939,6 +1939,7 @@ export class Wallet {
     completeSwap(swapPreview: SwapPreview, privkey?: string | string[]): Promise<SendResponse>;
     readonly counters: WalletCounters;
     createLockedMintQuote(amount: AmountLike, pubkey: string, description?: string): Promise<MintQuoteBolt11Response>;
+    createMeltChangeProofs(outputData: OutputDataLike[], changeSigs: SerializedBlindedSignature[]): Proof[];
     createMeltQuote<TRes extends MeltQuoteBaseResponse = MeltQuoteBaseResponse>(method: string, payload: Record<string, unknown>, options?: {
         normalize?: (raw: Record<string, unknown>) => TRes;
     }): Promise<TRes>;
@@ -1964,7 +1965,6 @@ export class Wallet {
         pending: T[];
         spent: T[];
     }>;
-    hydrateMeltChange(outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[];
     get keyChain(): KeyChain;
     get keysetId(): string;
     loadMint(forceRefresh?: boolean): Promise<void>;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1231,10 +1231,12 @@ export class OutputData implements OutputDataLike {
     static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData;
     // (undocumented)
     static createSingleRandomData(amount: AmountLike, keysetId: string): OutputData;
+    static deserialize(serialized: SerializedOutputData): OutputData;
     // (undocumented)
     ephemeralE?: string;
     // (undocumented)
     secret: Uint8Array;
+    static serialize(output: OutputDataLike): SerializedOutputData;
     static sumOutputAmounts(outputs: OutputDataLike[]): Amount;
     // (undocumented)
     toProof(sig: SerializedBlindedSignature, keyset: HasKeysetKeys): Proof;
@@ -1682,9 +1684,27 @@ export type SerializedDLEQ = {
     r?: string;
 };
 
+// @public
+export type SerializedMeltChangeData = {
+    keysetId: string;
+    outputData: SerializedOutputData[];
+};
+
 // @public (undocumented)
 export type SerializedMintKeys = {
     [k: string]: string;
+};
+
+// @public
+export type SerializedOutputData = {
+    blindedMessage: {
+        amount: string;
+        B_: string;
+        id: string;
+    };
+    blindingFactor: string;
+    secret: string;
+    ephemeralE?: string;
 };
 
 // @public (undocumented)
@@ -1941,6 +1961,7 @@ export class Wallet {
     createMultiPathMeltQuote(invoice: string, millisatPartialAmount: AmountLike): Promise<MeltQuoteBolt11Response>;
     decodeToken(token: string): Token;
     defaultOutputType(): OutputType;
+    exportMeltChangeData(preview: MeltPreview): SerializedMeltChangeData;
     getFeesForKeyset(nInputs: number, keysetId: string): Amount;
     getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount;
     getKeyset(id?: string): Keyset;
@@ -1950,6 +1971,11 @@ export class Wallet {
         pending: T[];
         spent: T[];
     }>;
+    hydrateMeltChange(keysetId: string, outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[];
+    importMeltChangeData(blob: SerializedMeltChangeData): {
+        keysetId: string;
+        outputData: OutputData[];
+    };
     get keyChain(): KeyChain;
     get keysetId(): string;
     loadMint(forceRefresh?: boolean): Promise<void>;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1684,12 +1684,6 @@ export type SerializedDLEQ = {
     r?: string;
 };
 
-// @public
-export type SerializedMeltChangeData = {
-    keysetId: string;
-    outputData: SerializedOutputData[];
-};
-
 // @public (undocumented)
 export type SerializedMintKeys = {
     [k: string]: string;
@@ -1961,7 +1955,6 @@ export class Wallet {
     createMultiPathMeltQuote(invoice: string, millisatPartialAmount: AmountLike): Promise<MeltQuoteBolt11Response>;
     decodeToken(token: string): Token;
     defaultOutputType(): OutputType;
-    exportMeltChangeData(preview: MeltPreview): SerializedMeltChangeData;
     getFeesForKeyset(nInputs: number, keysetId: string): Amount;
     getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount;
     getKeyset(id?: string): Keyset;
@@ -1971,11 +1964,7 @@ export class Wallet {
         pending: T[];
         spent: T[];
     }>;
-    hydrateMeltChange(keysetId: string, outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[];
-    importMeltChangeData(blob: SerializedMeltChangeData): {
-        keysetId: string;
-        outputData: OutputData[];
-    };
+    hydrateMeltChange(outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[];
     get keyChain(): KeyChain;
     get keysetId(): string;
     loadMint(forceRefresh?: boolean): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export {
 // Low-level helpers/types that appear in public surfaces
 export { Amount, AmountError, type AmountLike } from './model/Amount';
 export { OutputData } from './model/OutputData';
-export type { OutputDataLike, OutputDataFactory } from './model/OutputData';
+export type { OutputDataLike, OutputDataFactory, SerializedOutputData } from './model/OutputData';
 export type { OutputDataCreator } from './model/OutputDataCreator';
 export { MintInfo } from './model/MintInfo';
 export { WSConnection, injectWebSocketImpl, setGlobalRequestOptions } from './transport';

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -348,7 +348,23 @@ export class OutputData implements OutputDataLike {
    * Converts output data to a JSON-safe representation.
    *
    * @remarks
-   * This is useful when persisting melt change outputs for later hydration.
+   * Pair with {@link OutputData.deserialize} to persist prepared melt change outputs (e.g. across a
+   * NUT-06 async melt's pending window) and reconstruct spendable change proofs via
+   * `wallet.hydrateMeltChange` once the quote is paid.
+   * @example
+   *
+   * ```ts
+   * // Save while async melt is pending:
+   * const preview = await wallet.prepareMelt('bolt11', meltQuote, proofs);
+   * const stored = JSON.stringify(preview.outputData.map((o) => OutputData.serialize(o)));
+   * await wallet.completeMelt(preview, undefined, true); // prefer_async
+   *
+   * // ... time passes, quote pays ...
+   * const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
+   *   OutputData.deserialize(s),
+   * );
+   * const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+   * ```
    */
   static serialize(output: OutputDataLike): SerializedOutputData {
     return {
@@ -368,6 +384,7 @@ export class OutputData implements OutputDataLike {
    *
    * @throws {@link CTSError} If any field fails validation (non-canonical blindingFactor, malformed
    *   hex secret/ephemeralE, or an Amount that cannot be parsed).
+   * @see {@link OutputData.serialize} for the persist/restore lifecycle example.
    */
   static deserialize(serialized: SerializedOutputData): OutputData {
     try {

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -350,7 +350,7 @@ export class OutputData implements OutputDataLike {
    * @remarks
    * Pair with {@link OutputData.deserialize} to persist prepared melt change outputs (e.g. across a
    * NUT-06 async melt's pending window) and reconstruct spendable change proofs via
-   * `wallet.hydrateMeltChange` once the quote is paid.
+   * `wallet.createMeltChangeProofs` once the quote is paid.
    * @example
    *
    * ```ts
@@ -363,7 +363,7 @@ export class OutputData implements OutputDataLike {
    * const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
    *   OutputData.deserialize(s),
    * );
-   * const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+   * const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
    * ```
    */
   static serialize(output: OutputDataLike): SerializedOutputData {

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -54,6 +54,27 @@ export interface OutputDataLike {
 export type OutputDataFactory = (amount: AmountLike, keys: HasKeysetKeys) => OutputDataLike;
 
 /**
+ * JSON-safe representation of an {@link OutputData} entry.
+ */
+export type SerializedOutputData = {
+  /**
+   * Storage shape: `amount` is a decimal string, not an {@link Amount} instance like the wire-shape
+   * {@link SerializedBlindedMessage}.
+   */
+  blindedMessage: {
+    amount: string;
+    B_: string;
+    id: string;
+  };
+  /**
+   * Decimal-encoded bigint.
+   */
+  blindingFactor: string;
+  secret: string;
+  ephemeralE?: string;
+};
+
+/**
  * Core P2PK tags that must not be settable in additional tags.
  *
  * @internal
@@ -321,6 +342,52 @@ export class OutputData implements OutputDataLike {
    */
   static sumOutputAmounts(outputs: OutputDataLike[]): Amount {
     return Amount.sum(outputs.map((output) => output.blindedMessage.amount));
+  }
+
+  /**
+   * Converts output data to a JSON-safe representation.
+   *
+   * @remarks
+   * This is useful when persisting melt change outputs for later hydration.
+   */
+  static serialize(output: OutputDataLike): SerializedOutputData {
+    return {
+      blindedMessage: {
+        amount: output.blindedMessage.amount.toString(),
+        B_: output.blindedMessage.B_,
+        id: output.blindedMessage.id,
+      },
+      blindingFactor: output.blindingFactor.toString(),
+      secret: bytesToHex(output.secret),
+      ...(output.ephemeralE && { ephemeralE: output.ephemeralE }),
+    };
+  }
+
+  /**
+   * Reconstructs concrete {@link OutputData} from its JSON-safe representation.
+   *
+   * @throws {@link CTSError} If any field fails validation (non-canonical blindingFactor, malformed
+   *   hex secret/ephemeralE, or an Amount that cannot be parsed).
+   */
+  static deserialize(serialized: SerializedOutputData): OutputData {
+    try {
+      if (!/^(0|[1-9]\d*)$/.test(serialized.blindingFactor)) {
+        throw new Error('blindingFactor must be a canonical decimal integer');
+      }
+      return new OutputData(
+        {
+          amount: Amount.from(serialized.blindedMessage.amount),
+          B_: serialized.blindedMessage.B_,
+          id: serialized.blindedMessage.id,
+        },
+        BigInt(serialized.blindingFactor),
+        hexToBytes(serialized.secret),
+        serialized.ephemeralE,
+      );
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      throw new CTSError(`Invalid SerializedOutputData: ${message}`, { cause: e });
+    }
   }
 }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -81,7 +81,6 @@ import {
   type SendResponse,
   type RestoreConfig,
   type SecretsPolicy,
-  type SerializedMeltChangeData,
   type SwapPreview,
   type MintPreview,
   type BatchMintPreview,
@@ -2647,11 +2646,7 @@ class Wallet {
     );
 
     // Create any change Proofs
-    const change = this.hydrateMeltChange(
-      meltPreview.keysetId,
-      meltPreview.outputData,
-      meltResponse.change ?? [],
-    );
+    const change = this.hydrateMeltChange(meltPreview.outputData, meltResponse.change ?? []);
 
     if (preferAsync) {
       this._logger.debug('ASYNC MELT REQUESTED', meltResponse);
@@ -2667,72 +2662,33 @@ class Wallet {
   }
 
   /**
-   * Constructs melt change proofs from a melt response and prepared change data.
+   * Constructs melt change proofs from a melt response and prepared output data.
    *
    * @remarks
-   * This is useful for NUT-06 asynchronous melts. Call `completeMelt(preview, privkey, true)` to
-   * request async processing, keep the original preview, then pass the later paid quote response
-   * from `checkMeltQuote*()` or `wallet.on.onceMeltPaid()` here to hydrate any returned NUT-08
-   * change signatures into spendable proofs.
-   * @param keysetId Keyset ID used to prepare the outputs.
-   * @param outputData Outputs from prepareMelt(), or deserialized persisted output data.
-   * @param change The response containing optional `change` signatures.
-   * @returns Spendable change proofs.
-   * @throws If signatures don't match output count or cannot be verified.
+   * Called internally by `completeMelt`. Also exposed for NUT-06 async melts: call
+   * `completeMelt(preview, privkey, true)` to request async processing, persist
+   * `preview.outputData` via {@link OutputData.serialize}, then once the quote is paid (via
+   * `checkMeltQuote*()` or `wallet.on.onceMeltPaid()`) reconstruct the output data with
+   * {@link OutputData.deserialize} and pass it here alongside the response's `change` signatures to
+   * obtain spendable proofs. See {@link OutputData.serialize} for the full lifecycle example.
+   * @param outputData Outputs from `prepareMelt()`, or deserialised persisted output data.
+   * @param change The optional `change` signatures from the melt response or paid quote.
+   * @returns Spendable change proofs (possibly empty).
+   * @throws {@link CTSError} If signature count exceeds output count or signatures cannot be
+   *   verified.
    */
-  hydrateMeltChange(
-    keysetId: string,
-    outputData: OutputDataLike[],
-    change: SerializedBlindedSignature[],
-  ): Proof[] {
-    const keyset = this.getKeyset(keysetId);
+  hydrateMeltChange(outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[] {
     // Change may not use all outputs (shorter is ok)
     this.failIf(
       change.length > outputData.length,
       `Mint returned ${change.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
+    if (outputData.length === 0) return [];
+    const keyset = this.getKeyset(outputData[0].blindedMessage.id);
     this.validateReturnedSignatures(change, outputData, {
       checkAmounts: false, // change outputs are blank
     });
     return change.map((s, i) => outputData[i].toProof(s, keyset));
-  }
-
-  /**
-   * Produces a JSON-safe envelope of the change-recovery data from a melt preview.
-   *
-   * @remarks
-   * Use this alongside `completeMelt(preview, privkey, true)` (NUT-06 async melt) to persist the
-   * prepared change outputs across the pending window. When the quote is later paid, call
-   * `importMeltChangeData(blob)` and pass its result to `hydrateMeltChange` along with the `change`
-   * signatures from the paid quote response.
-   * @param preview The MeltPreview returned by `prepareMelt()`.
-   * @returns A JSON-safe `{ keysetId, outputData }` envelope.
-   */
-  exportMeltChangeData(preview: MeltPreview): SerializedMeltChangeData {
-    return {
-      keysetId: preview.keysetId,
-      outputData: preview.outputData.map((o) => OutputData.serialize(o)),
-    };
-  }
-
-  /**
-   * Reconstructs concrete `OutputData` from a persisted melt change-data envelope, ready to pass to
-   * `hydrateMeltChange` once the paid quote response is available.
-   *
-   * @param blob The envelope produced by `exportMeltChangeData`.
-   * @returns The keyset id and reconstructed output data.
-   * @throws {@link CTSError} If the keyset is unknown to this wallet, or any output entry is
-   *   malformed.
-   */
-  importMeltChangeData(blob: SerializedMeltChangeData): {
-    keysetId: string;
-    outputData: OutputData[];
-  } {
-    this.getKeyset(blob.keysetId);
-    return {
-      keysetId: blob.keysetId,
-      outputData: blob.outputData.map((s) => OutputData.deserialize(s)),
-    };
   }
 
   // -----------------------------------------------------------------

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2697,7 +2697,7 @@ class Wallet {
         keyset = this.getKeyset(s.id);
       } catch (e) {
         throw new CTSError(
-          `Cannot reconstruct melt change: keyset ${s.id} is not loaded in this wallet (it may have been pruned after rotation). The mint has already paid the invoice and signed the change; if the wallet is seeded, try restoring (NUT-09) to recover.`,
+          `Cannot reconstruct melt change: keyset ${s.id} is not loaded in this wallet (may be inactive after rotation). If the wallet is seeded, try restoring (NUT-09) to recover.`,
           { cause: e },
         );
       }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1829,7 +1829,7 @@ class Wallet {
       );
       this.failIf(
         signatures[i].id !== outputData[i].blindedMessage.id,
-        `Mint signature keyset id at index ${i} does not match output: expected ${outputData[i].blindedMessage.id}, got ${signatures[i].id}.`,
+        `Mint signature keyset id at index ${i} does not match output: expected ${outputData[i].blindedMessage.id}, got ${signatures[i].id}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
       this.failIf(
         checkAmounts && !signatures[i].amount.equals(outputData[i].blindedMessage.amount),

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2646,7 +2646,7 @@ class Wallet {
     );
 
     // Create any change Proofs
-    const change = this.hydrateMeltChange(meltPreview.outputData, meltResponse.change ?? []);
+    const change = this.createMeltChangeProofs(meltPreview.outputData, meltResponse.change ?? []);
 
     if (preferAsync) {
       this._logger.debug('ASYNC MELT REQUESTED', meltResponse);
@@ -2662,22 +2662,25 @@ class Wallet {
   }
 
   /**
-   * Constructs melt change proofs from a melt response and prepared output data. Called internally
-   * by `completeMelt`; also exposed for NUT-06 async melts and any other path that defers change
-   * construction (crash recovery, process hand-off).
+   * Constructs melt change proofs from a melt response's change signatures and the prepared output
+   * data. Called internally by `completeMelt`; also exposed for NUT-06 async melts and any other
+   * path that defers change construction (crash recovery, process hand-off).
    *
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted output data.
-   * @param change The optional `change` signatures from the melt response or paid quote.
+   * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).
    * @throws {@link CTSError} If signature count exceeds output count, output data mixes keysets, or
    *   signatures cannot be verified.
    * @see {@link OutputData.serialize} for the persist/restore lifecycle example.
    */
-  hydrateMeltChange(outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[] {
+  createMeltChangeProofs(
+    outputData: OutputDataLike[],
+    changeSigs: SerializedBlindedSignature[],
+  ): Proof[] {
     // Change may not use all outputs (shorter is ok)
     this.failIf(
-      change.length > outputData.length,
-      `Mint returned ${change.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
+      changeSigs.length > outputData.length,
+      `Mint returned ${changeSigs.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
     if (outputData.length === 0) return [];
     const keysetId = outputData[0].blindedMessage.id;
@@ -2686,10 +2689,10 @@ class Wallet {
       'Mixed keyset ids in melt outputData; expected all outputs to share a single keyset',
     );
     const keyset = this.getKeyset(keysetId);
-    this.validateReturnedSignatures(change, outputData, {
+    this.validateReturnedSignatures(changeSigs, outputData, {
       checkAmounts: false, // change outputs are blank
     });
-    return change.map((s, i) => outputData[i].toProof(s, keyset));
+    return changeSigs.map((s, i) => outputData[i].toProof(s, keyset));
   }
 
   // -----------------------------------------------------------------

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -81,6 +81,7 @@ import {
   type SendResponse,
   type RestoreConfig,
   type SecretsPolicy,
+  type SerializedMeltChangeData,
   type SwapPreview,
   type MintPreview,
   type BatchMintPreview,
@@ -2622,7 +2623,6 @@ class Wallet {
     let inputs = meltPreview.inputs;
     const outputs = meltPreview.outputData.map((d) => d.blindedMessage);
     const quote = meltPreview.quote.quote;
-    const keyset = this.getKeyset(meltPreview.keysetId);
 
     // Sign proofs if needed
     if (privkey) {
@@ -2645,20 +2645,13 @@ class Wallet {
       meltPreview.method,
       meltPayload,
     );
-    if (meltResponse.change) {
-      // Change may not use all outputs (shorter is ok)
-      this.failIf(
-        meltResponse.change.length > meltPreview.outputData.length,
-        `Mint returned ${meltResponse.change.length} signatures, but only ${meltPreview.outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
-      );
-      this.validateReturnedSignatures(meltResponse.change, meltPreview.outputData, {
-        checkAmounts: false, // change outputs are blank
-      });
-    }
 
-    // Construct change
-    const change =
-      meltResponse.change?.map((s, i) => meltPreview.outputData[i].toProof(s, keyset)) ?? [];
+    // Create any change Proofs
+    const change = this.hydrateMeltChange(
+      meltPreview.keysetId,
+      meltPreview.outputData,
+      meltResponse.change ?? [],
+    );
 
     if (preferAsync) {
       this._logger.debug('ASYNC MELT REQUESTED', meltResponse);
@@ -2671,6 +2664,75 @@ class Wallet {
     // Merge preview quote with response to protect against incomplete response.
     const mergedQuote = { ...meltPreview.quote, ...meltResponse } as TQuote;
     return { quote: mergedQuote, change };
+  }
+
+  /**
+   * Constructs melt change proofs from a melt response and prepared change data.
+   *
+   * @remarks
+   * This is useful for NUT-06 asynchronous melts. Call `completeMelt(preview, privkey, true)` to
+   * request async processing, keep the original preview, then pass the later paid quote response
+   * from `checkMeltQuote*()` or `wallet.on.onceMeltPaid()` here to hydrate any returned NUT-08
+   * change signatures into spendable proofs.
+   * @param keysetId Keyset ID used to prepare the outputs.
+   * @param outputData Outputs from prepareMelt(), or deserialized persisted output data.
+   * @param change The response containing optional `change` signatures.
+   * @returns Spendable change proofs.
+   * @throws If signatures don't match output count or cannot be verified.
+   */
+  hydrateMeltChange(
+    keysetId: string,
+    outputData: OutputDataLike[],
+    change: SerializedBlindedSignature[],
+  ): Proof[] {
+    const keyset = this.getKeyset(keysetId);
+    // Change may not use all outputs (shorter is ok)
+    this.failIf(
+      change.length > outputData.length,
+      `Mint returned ${change.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
+    );
+    this.validateReturnedSignatures(change, outputData, {
+      checkAmounts: false, // change outputs are blank
+    });
+    return change.map((s, i) => outputData[i].toProof(s, keyset));
+  }
+
+  /**
+   * Produces a JSON-safe envelope of the change-recovery data from a melt preview.
+   *
+   * @remarks
+   * Use this alongside `completeMelt(preview, privkey, true)` (NUT-06 async melt) to persist the
+   * prepared change outputs across the pending window. When the quote is later paid, call
+   * `importMeltChangeData(blob)` and pass its result to `hydrateMeltChange` along with the `change`
+   * signatures from the paid quote response.
+   * @param preview The MeltPreview returned by `prepareMelt()`.
+   * @returns A JSON-safe `{ keysetId, outputData }` envelope.
+   */
+  exportMeltChangeData(preview: MeltPreview): SerializedMeltChangeData {
+    return {
+      keysetId: preview.keysetId,
+      outputData: preview.outputData.map((o) => OutputData.serialize(o)),
+    };
+  }
+
+  /**
+   * Reconstructs concrete `OutputData` from a persisted melt change-data envelope, ready to pass to
+   * `hydrateMeltChange` once the paid quote response is available.
+   *
+   * @param blob The envelope produced by `exportMeltChangeData`.
+   * @returns The keyset id and reconstructed output data.
+   * @throws {@link CTSError} If the keyset is unknown to this wallet, or any output entry is
+   *   malformed.
+   */
+  importMeltChangeData(blob: SerializedMeltChangeData): {
+    keysetId: string;
+    outputData: OutputData[];
+  } {
+    this.getKeyset(blob.keysetId);
+    return {
+      keysetId: blob.keysetId,
+      outputData: blob.outputData.map((s) => OutputData.deserialize(s)),
+    };
   }
 
   // -----------------------------------------------------------------

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1828,6 +1828,10 @@ class Wallet {
         `Mint response is missing a signature at index ${i}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
       this.failIf(
+        signatures[i].id !== outputData[i].blindedMessage.id,
+        `Mint signature keyset id at index ${i} does not match output: expected ${outputData[i].blindedMessage.id}, got ${signatures[i].id}.`,
+      );
+      this.failIf(
         checkAmounts && !signatures[i].amount.equals(outputData[i].blindedMessage.amount),
         `Mint returned signature with wrong amount at index ${i}: expected ${outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
@@ -2666,12 +2670,13 @@ class Wallet {
    *
    * @remarks
    * Called internally by `completeMelt`; also useful for NUT-06 async melts and any other path that
-   * defers change construction (crash recovery, process hand-off).
+   * defers change construction (crash recovery, process hand-off). Keyset lookup is per-signature
+   * so multi-keyset responses (e.g. a permissive CDK mint) work transparently.
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted OutputData.
    * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).
-   * @throws {@link CTSError} If signature count exceeds output count, output data mixes keysets, or
-   *   signatures cannot be verified.
+   * @throws {@link CTSError} If signature count exceeds output count, any signature's keyset id
+   *   does not match its paired output, or signatures cannot be verified.
    * @see {@link OutputData.serialize} for the persist/restore lifecycle example.
    */
   createMeltChangeProofs(
@@ -2683,17 +2688,10 @@ class Wallet {
       changeSigs.length > outputData.length,
       `Mint returned ${changeSigs.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
-    if (outputData.length === 0) return [];
-    const keysetId = outputData[0].blindedMessage.id;
-    this.failIf(
-      outputData.some((o) => o.blindedMessage.id !== keysetId),
-      'Mixed keyset ids in melt outputData; expected all outputs to share a single keyset',
-    );
-    const keyset = this.getKeyset(keysetId);
     this.validateReturnedSignatures(changeSigs, outputData, {
       checkAmounts: false, // change outputs are blank
     });
-    return changeSigs.map((s, i) => outputData[i].toProof(s, keyset));
+    return changeSigs.map((s, i) => outputData[i].toProof(s, this.getKeyset(s.id)));
   }
 
   // -----------------------------------------------------------------

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2662,20 +2662,16 @@ class Wallet {
   }
 
   /**
-   * Constructs melt change proofs from a melt response and prepared output data.
+   * Constructs melt change proofs from a melt response and prepared output data. Called internally
+   * by `completeMelt`; also exposed for NUT-06 async melts and any other path that defers change
+   * construction (crash recovery, process hand-off).
    *
-   * @remarks
-   * Called internally by `completeMelt`. Also exposed for NUT-06 async melts: call
-   * `completeMelt(preview, privkey, true)` to request async processing, persist
-   * `preview.outputData` via {@link OutputData.serialize}, then once the quote is paid (via
-   * `checkMeltQuote*()` or `wallet.on.onceMeltPaid()`) reconstruct the output data with
-   * {@link OutputData.deserialize} and pass it here alongside the response's `change` signatures to
-   * obtain spendable proofs. See {@link OutputData.serialize} for the full lifecycle example.
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted output data.
    * @param change The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).
-   * @throws {@link CTSError} If signature count exceeds output count or signatures cannot be
-   *   verified.
+   * @throws {@link CTSError} If signature count exceeds output count, output data mixes keysets, or
+   *   signatures cannot be verified.
+   * @see {@link OutputData.serialize} for the persist/restore lifecycle example.
    */
   hydrateMeltChange(outputData: OutputDataLike[], change: SerializedBlindedSignature[]): Proof[] {
     // Change may not use all outputs (shorter is ok)
@@ -2684,7 +2680,12 @@ class Wallet {
       `Mint returned ${change.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
     if (outputData.length === 0) return [];
-    const keyset = this.getKeyset(outputData[0].blindedMessage.id);
+    const keysetId = outputData[0].blindedMessage.id;
+    this.failIf(
+      outputData.some((o) => o.blindedMessage.id !== keysetId),
+      'Mixed keyset ids in melt outputData; expected all outputs to share a single keyset',
+    );
+    const keyset = this.getKeyset(keysetId);
     this.validateReturnedSignatures(change, outputData, {
       checkAmounts: false, // change outputs are blank
     });

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2691,7 +2691,18 @@ class Wallet {
     this.validateReturnedSignatures(changeSigs, outputData, {
       checkAmounts: false, // change outputs are blank
     });
-    return changeSigs.map((s, i) => outputData[i].toProof(s, this.getKeyset(s.id)));
+    return changeSigs.map((s, i) => {
+      let keyset: Keyset;
+      try {
+        keyset = this.getKeyset(s.id);
+      } catch (e) {
+        throw new CTSError(
+          `Cannot reconstruct melt change: keyset ${s.id} is not loaded in this wallet (it may have been pruned after rotation). The mint has already paid the invoice and signed the change; if the wallet is seeded, try restoring (NUT-09) to recover.`,
+          { cause: e },
+        );
+      }
+      return outputData[i].toProof(s, keyset);
+    });
   }
 
   // -----------------------------------------------------------------

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2662,11 +2662,12 @@ class Wallet {
   }
 
   /**
-   * Constructs melt change proofs from a melt response's change signatures and the prepared output
-   * data. Called internally by `completeMelt`; also exposed for NUT-06 async melts and any other
-   * path that defers change construction (crash recovery, process hand-off).
+   * Constructs melt change proofs from prepared OutputData and mint returned Change Signatures.
    *
-   * @param outputData Outputs from `prepareMelt()`, or deserialised persisted output data.
+   * @remarks
+   * Called internally by `completeMelt`; also useful for NUT-06 async melts and any other path that
+   * defers change construction (crash recovery, process hand-off).
+   * @param outputData Outputs from `prepareMelt()`, or deserialised persisted OutputData.
    * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).
    * @throws {@link CTSError} If signature count exceeds output count, output data mixes keysets, or

--- a/src/wallet/types/payloads.ts
+++ b/src/wallet/types/payloads.ts
@@ -1,5 +1,5 @@
 import { type Amount } from '../../model/Amount';
-import { type OutputDataLike, type SerializedOutputData } from '../../model/OutputData';
+import { type OutputDataLike } from '../../model/OutputData';
 import {
   type MeltQuoteBaseResponse,
   type MintQuoteBaseResponse,
@@ -92,16 +92,6 @@ export interface MeltPreview<
    */
   quote: TQuote;
 }
-
-/**
- * JSON-safe envelope for the change-recovery data produced by `prepareMelt`. Persist this across an
- * async melt's pending window, then pass it to `wallet.importMeltChangeData` +
- * `wallet.hydrateMeltChange` once the quote is paid.
- */
-export type SerializedMeltChangeData = {
-  keysetId: string;
-  outputData: SerializedOutputData[];
-};
 
 /**
  * Includes all data required to swap inputs for outputs and construct proofs from them.

--- a/src/wallet/types/payloads.ts
+++ b/src/wallet/types/payloads.ts
@@ -1,5 +1,5 @@
 import { type Amount } from '../../model/Amount';
-import { type OutputDataLike } from '../../model/OutputData';
+import { type OutputDataLike, type SerializedOutputData } from '../../model/OutputData';
 import {
   type MeltQuoteBaseResponse,
   type MintQuoteBaseResponse,
@@ -92,6 +92,16 @@ export interface MeltPreview<
    */
   quote: TQuote;
 }
+
+/**
+ * JSON-safe envelope for the change-recovery data produced by `prepareMelt`. Persist this across an
+ * async melt's pending window, then pass it to `wallet.importMeltChangeData` +
+ * `wallet.hydrateMeltChange` once the quote is paid.
+ */
+export type SerializedMeltChangeData = {
+  keysetId: string;
+  outputData: SerializedOutputData[];
+};
 
 /**
  * Includes all data required to swap inputs for outputs and construct proofs from them.

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -69,6 +69,52 @@ describe('OutputData helpers', () => {
     expect(isOutputDataFactory([])).toBe(false);
   });
 
+  test('serializes and deserializes output data', () => {
+    const output = OutputData.createSingleRandomData(21, '009a1f293253e41e');
+    const serialized = OutputData.serialize(output);
+    const deserialized = OutputData.deserialize(serialized);
+
+    expect(serialized.blindingFactor).toMatch(/^(0|[1-9]\d*)$/);
+    expect(OutputData.serialize(deserialized)).toEqual(serialized);
+  });
+
+  test('rejects invalid serialized blinding factors', () => {
+    const serialized = OutputData.serialize(
+      OutputData.createSingleRandomData(21, '009a1f293253e41e'),
+    );
+
+    expect(() => OutputData.deserialize({ ...serialized, blindingFactor: '0x01' })).toThrow(
+      /Invalid SerializedOutputData: .*blindingFactor/,
+    );
+  });
+
+  test('rejects malformed serialized secret hex', () => {
+    const serialized = OutputData.serialize(
+      OutputData.createSingleRandomData(21, '009a1f293253e41e'),
+    );
+
+    expect(() => OutputData.deserialize({ ...serialized, secret: 'zz' })).toThrow(
+      /Invalid SerializedOutputData:/,
+    );
+  });
+
+  test('preserves ephemeral P2PK blinding data when serializing output data', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const output = OutputData.createSingleP2PKData(
+      {
+        pubkey,
+        blindKeys: true,
+      },
+      1,
+      '009a1f293253e41e',
+    );
+
+    const deserialized = OutputData.deserialize(OutputData.serialize(output));
+
+    expect(deserialized.ephemeralE).toBe(output.ephemeralE);
+  });
+
   test('keeps blinded HTLC lock keys in pubkeys tags', () => {
     const privkey = Bytes.fromHex('01'.repeat(32));
     const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -516,15 +516,15 @@ describe('Wallet (BOLT12) – wrappers', () => {
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks as any);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
-        blindedMessage: { amount: 16n, B_: 'B1' },
+        blindedMessage: { amount: 16n, B_: 'B1', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 16, secret: 'secret1', C: 'C1' }),
       },
       {
-        blindedMessage: { amount: 4n, B_: 'B2' },
+        blindedMessage: { amount: 4n, B_: 'B2', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 4, secret: 'secret2', C: 'C2' }),
       },
       {
-        blindedMessage: { amount: 1n, B_: 'B3' },
+        blindedMessage: { amount: 1n, B_: 'B3', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 1, secret: 'secret3', C: 'C3' }),
       },
     ]);
@@ -576,15 +576,15 @@ describe('Wallet (BOLT12) – wrappers', () => {
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks as any);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
-        blindedMessage: { amount: 16n, B_: 'B1' },
+        blindedMessage: { amount: 16n, B_: 'B1', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 16, secret: 'secret1', C: 'C1' }),
       },
       {
-        blindedMessage: { amount: 4n, B_: 'B2' },
+        blindedMessage: { amount: 4n, B_: 'B2', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 4, secret: 'secret2', C: 'C2' }),
       },
       {
-        blindedMessage: { amount: 1n, B_: 'B3' },
+        blindedMessage: { amount: 1n, B_: 'B3', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 1, secret: 'secret3', C: 'C3' }),
       },
     ]);

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -715,7 +715,7 @@ describe('async melt preference body', () => {
     const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
       OutputData.deserialize(s),
     );
-    const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
+    const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
     expect(change).toHaveLength(2);
     expect(change[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
     expect(change[1]).toMatchObject({ amount: Amount.from(2), id: '00bd033559de27d0' });
@@ -723,14 +723,14 @@ describe('async melt preference body', () => {
     expect(/[0-9a-f]{64}/.test(change[0].secret)).toBe(true);
   });
 
-  test('hydrateMeltChange rejects outputData with mixed keyset ids', async () => {
+  test('createMeltChangeProofs rejects outputData with mixed keyset ids', async () => {
     const wallet = new Wallet(mint, { unit, logger });
     await wallet.loadMint();
 
     const o1 = OutputData.createSingleRandomData(0, '00bd033559de27d0');
     const o2 = OutputData.createSingleRandomData(0, '009a1f293253e41e');
 
-    expect(() => wallet.hydrateMeltChange([o1, o2], [])).toThrow(/Mixed keyset ids/);
+    expect(() => wallet.createMeltChangeProofs([o1, o2], [])).toThrow(/Mixed keyset ids/);
   });
 
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -661,6 +661,69 @@ describe('melt proofs', () => {
 });
 
 describe('async melt preference body', () => {
+  test('hydrates async melt change from a later paid quote response', async () => {
+    const wallet = new Wallet(mint, { unit, logger });
+    await wallet.loadMint();
+
+    const meltQuote: MeltQuoteBolt11Response = {
+      quote: 'q-async-hydrate',
+      amount: Amount.from(10),
+      fee_reserve: Amount.from(3),
+      request: invoice,
+      state: MeltQuoteState.PENDING,
+      expiry: 1234567890,
+      payment_preimage: null,
+      unit: 'sat',
+    };
+    const proofsToSend: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(8),
+        secret: 'secret1',
+        C: 'C1',
+      },
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(5),
+        secret: 'secret2',
+        C: 'C2',
+      },
+    ];
+    const preview = await wallet.prepareMelt('bolt11', meltQuote, proofsToSend);
+    // Simulate storing the change metadata
+    const storedChangeData = JSON.stringify(wallet.exportMeltChangeData(preview));
+
+    const paidQuote: MeltQuoteBolt11Response = {
+      ...meltQuote,
+      state: MeltQuoteState.PAID,
+      payment_preimage: 'preimage',
+      change: [
+        {
+          id: '00bd033559de27d0',
+          amount: Amount.from(1),
+          C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+        },
+        {
+          id: '00bd033559de27d0',
+          amount: Amount.from(2),
+          C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+        },
+      ],
+    };
+    // Simulate restoring the change metadata
+    const restored = wallet.importMeltChangeData(JSON.parse(storedChangeData));
+    const change = wallet.hydrateMeltChange(
+      restored.keysetId,
+      restored.outputData,
+      paidQuote.change ?? [],
+    );
+    expect(change).toHaveLength(2);
+    expect(change[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+    expect(change[1]).toMatchObject({ amount: Amount.from(2), id: '00bd033559de27d0' });
+    expect(/[0-9a-f]{64}/.test(change[0].C)).toBe(true);
+    expect(/[0-9a-f]{64}/.test(change[0].secret)).toBe(true);
+  });
+
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {
     const meltQuote = {
       quote: 'q-async-1b',

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -8,6 +8,7 @@ import {
   type MeltQuoteBolt11Response,
   MeltQuoteState,
   OutputData,
+  type SerializedOutputData,
   MeltQuoteBolt12Response,
   AuthProvider,
   OutputType,
@@ -690,8 +691,8 @@ describe('async melt preference body', () => {
       },
     ];
     const preview = await wallet.prepareMelt('bolt11', meltQuote, proofsToSend);
-    // Simulate storing the change metadata
-    const storedChangeData = JSON.stringify(wallet.exportMeltChangeData(preview));
+    // Simulate storing the prepared output data while the melt is pending
+    const stored = JSON.stringify(preview.outputData.map((o) => OutputData.serialize(o)));
 
     const paidQuote: MeltQuoteBolt11Response = {
       ...meltQuote,
@@ -710,13 +711,11 @@ describe('async melt preference body', () => {
         },
       ],
     };
-    // Simulate restoring the change metadata
-    const restored = wallet.importMeltChangeData(JSON.parse(storedChangeData));
-    const change = wallet.hydrateMeltChange(
-      restored.keysetId,
-      restored.outputData,
-      paidQuote.change ?? [],
+    // Restore and hydrate change once the quote pays
+    const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
+      OutputData.deserialize(s),
     );
+    const change = wallet.hydrateMeltChange(restored, paidQuote.change ?? []);
     expect(change).toHaveLength(2);
     expect(change[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
     expect(change[1]).toMatchObject({ amount: Amount.from(2), id: '00bd033559de27d0' });

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -723,6 +723,16 @@ describe('async melt preference body', () => {
     expect(/[0-9a-f]{64}/.test(change[0].secret)).toBe(true);
   });
 
+  test('hydrateMeltChange rejects outputData with mixed keyset ids', async () => {
+    const wallet = new Wallet(mint, { unit, logger });
+    await wallet.loadMint();
+
+    const o1 = OutputData.createSingleRandomData(0, '00bd033559de27d0');
+    const o2 = OutputData.createSingleRandomData(0, '009a1f293253e41e');
+
+    expect(() => wallet.hydrateMeltChange([o1, o2], [])).toThrow(/Mixed keyset ids/);
+  });
+
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {
     const meltQuote = {
       quote: 'q-async-1b',

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -9,6 +9,7 @@ import {
   MeltQuoteState,
   OutputData,
   type SerializedOutputData,
+  type SerializedBlindedSignature,
   MeltQuoteBolt12Response,
   AuthProvider,
   OutputType,
@@ -723,14 +724,20 @@ describe('async melt preference body', () => {
     expect(/[0-9a-f]{64}/.test(change[0].secret)).toBe(true);
   });
 
-  test('createMeltChangeProofs rejects outputData with mixed keyset ids', async () => {
+  test('createMeltChangeProofs rejects signature/output keyset id mismatch', async () => {
     const wallet = new Wallet(mint, { unit, logger });
     await wallet.loadMint();
 
-    const o1 = OutputData.createSingleRandomData(0, '00bd033559de27d0');
-    const o2 = OutputData.createSingleRandomData(0, '009a1f293253e41e');
+    const output = OutputData.createSingleRandomData(0, '00bd033559de27d0');
+    const mismatchedSig: SerializedBlindedSignature = {
+      id: '009a1f293253e41e', // different keyset id from the output
+      amount: Amount.from(1),
+      C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+    };
 
-    expect(() => wallet.createMeltChangeProofs([o1, o2], [])).toThrow(/Mixed keyset ids/);
+    expect(() => wallet.createMeltChangeProofs([output], [mismatchedSig])).toThrow(
+      /signature keyset id at index 0 does not match output/i,
+    );
   });
 
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -740,6 +740,23 @@ describe('async melt preference body', () => {
     );
   });
 
+  test('createMeltChangeProofs surfaces NUT-09 recovery hint when keyset is unknown', async () => {
+    const wallet = new Wallet(mint, { unit, logger });
+    await wallet.loadMint();
+
+    const unknownKeysetId = 'aaaaaaaaaaaaaaaa'; // not loaded by the test mint
+    const output = OutputData.createSingleRandomData(0, unknownKeysetId);
+    const sig: SerializedBlindedSignature = {
+      id: unknownKeysetId, // matches the output, so pair check passes
+      amount: Amount.from(1),
+      C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+    };
+
+    expect(() => wallet.createMeltChangeProofs([output], [sig])).toThrow(
+      /is not loaded in this wallet.*restoring \(NUT-09\)/is,
+    );
+  });
+
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {
     const meltQuote = {
       quote: 'q-async-1b',

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -206,7 +206,7 @@ describe('receive', () => {
         return HttpResponse.json({
           signatures: [
             {
-              id: 'z32vUtKgNCm1',
+              id: '00bd033559de27d0', // wallet's active keyset, matching the swap outputs
               amount: 1,
               C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
             },
@@ -221,7 +221,7 @@ describe('receive', () => {
     const proofs = await wallet.receive(decodedInput);
 
     expect(proofs).toHaveLength(1);
-    expect(proofs).toMatchObject([{ amount: Amount.from(1), id: 'z32vUtKgNCm1' }]);
+    expect(proofs).toMatchObject([{ amount: Amount.from(1), id: '00bd033559de27d0' }]);
     expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
   });


### PR DESCRIPTION
## Summary

Makes it straightforward for NUT-06 `prefer_async` consumers to persist prepared change data while a melt is pending and reconstruct spendable change proofs once the quote is paid..

Uses `OutputData.serialize` / `OutputData.deserialize` for the round-trip and `Wallet.createMeltChangeProofs` to build the proofs.

## Detailed Changes

- add `OutputData.serialize` / `OutputData.deserialize`, JSON-safe leaf primitives
- add `Wallet.createMeltChangeProofs(outputData, changeSigs)`, turns change signatures (from a melt response, a later `checkMeltQuote*` / `onceMeltPaid` response, or any persisted recovery path) into spendable proofs; per-signature keyset lookup transparently supports multi-keyset melt responses (CDK allows them; Nutshell forbids them — our wallet handles either)
- harden `validateReturnedSignatures` (shared by swap / mint / melt-change paths) to assert per-index `signature.id === outputData[i].blindedMessage.id` pairing. This catches mint responses with mismatched keyset ids at the validation layer, regardless of whether DLEQ is present.
- `completeMelt` is refactored to use `createMeltChangeProofs` internally so synchronous and deferred paths share the same construction code
- add docs sections: `docs-src/usage/melt_token.md` § 3 (full annotated lifecycle) and a brief WalletOps recipe in `docs-src/wallet_ops/melt.md` § 4
- add tests for the async lifecycle (`prepareMelt` → serialise + JSON round-trip → deserialise → hydrate change proofs from a paid quote response) and for the signature/output keyset mismatch guard
- Fixes tests that are broken under the stricter signature checks.

## Notes

`createMeltChangeProofs` is mechanism-agnostic (also usable for crash recovery or process hand-off); `prefer_async` is the only motivating consumer today.

Public API additions:
- `OutputData.serialize` / `OutputData.deserialize` (static) + `SerializedOutputData` type
- `Wallet.createMeltChangeProofs`