### PR TITLE
feat: allow ProofLike in WalletEvent proof state updates

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2043,14 +2043,18 @@ export class WalletEvents {
         signal?: AbortSignal;
         timeoutMs?: number;
     }): Promise<MintQuoteBolt11Response>;
-    proofStatesStream<T = unknown>(proofs: Proof[], opts?: {
+    proofStatesStream<P extends ProofLike = Proof>(proofs: P[], opts?: {
         signal?: AbortSignal;
         maxBuffer?: number;
         drop?: 'oldest' | 'newest';
-        onDrop?: (payload: T) => void;
-    }): AsyncIterable<T>;
-    proofStateUpdates(proofs: Proof[], cb: (payload: ProofState & {
-        proof: Proof;
+        onDrop?: (payload: ProofState & {
+            proof: P;
+        }) => void;
+    }): AsyncIterable<ProofState & {
+        proof: P;
+    }>;
+    proofStateUpdates<T extends ProofLike = Proof>(proofs: T[], cb: (payload: ProofState & {
+        proof: T;
     }) => void, err: (e: Error) => void, opts?: SubscribeOpts): Promise<SubscriptionCanceller>;
 }
 

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -4,6 +4,7 @@ import { CTSError } from '../model/Errors';
 import { MintQuoteState, MeltQuoteState } from '../model/types';
 import type {
   Proof,
+  ProofLike,
   ProofState,
   MeltQuoteBolt11Response,
   MintQuoteBolt11Response,
@@ -289,14 +290,19 @@ export class WalletEvents {
   /**
    * Register a callback to be called whenever a subscribed proof state changes.
    *
+   * Only `secret` is read from each proof to derive the subscription filter; any `ProofLike`-shaped
+   * object (e.g. proofs loaded from storage where `amount` has not yet been normalized to `Amount`)
+   * may be passed without conversion. The original proof object is echoed back on the callback
+   * payload as the inferred input type.
+   *
    * @param proofs List of proofs that should be subscribed to.
    * @param callback Callback function that will be called whenever a proof's state changes.
    * @param errorCallback
    * @returns
    */
-  async proofStateUpdates(
-    proofs: Proof[],
-    cb: (payload: ProofState & { proof: Proof }) => void,
+  async proofStateUpdates<T extends ProofLike = Proof>(
+    proofs: T[],
+    cb: (payload: ProofState & { proof: T }) => void,
     err: (e: Error) => void,
     opts?: SubscribeOpts,
   ): Promise<SubscriptionCanceller> {
@@ -305,7 +311,7 @@ export class WalletEvents {
     if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const enc = new TextEncoder();
-    const proofMap: Record<string, Proof> = {};
+    const proofMap: Record<string, T> = {};
     for (const p of proofs) {
       const y = hashToCurve(enc.encode(p.secret)).toHex(true);
       proofMap[y] = p;
@@ -555,26 +561,29 @@ export class WalletEvents {
    * }
    * ```
    *
-   * @param proofs The proofs to subscribe to. Only `secret` is required.
+   * @param proofs The proofs to subscribe to. Only `secret` is required, so any `ProofLike`-shaped
+   *   object may be passed without first normalizing `amount` to `Amount`.
    * @param opts Optional controls.
    * @param opts.signal AbortSignal that stops the stream when aborted.
    * @param opts.maxBuffer Maximum number of queued items before applying the drop strategy.
    * @param opts.drop Overflow strategy when `maxBuffer` is reached, 'oldest' | 'newest'. Default
    *   'oldest'.
    * @param opts.onDrop Callback invoked with the payload that was dropped.
-   * @returns An async iterable of update payloads.
+   * @returns An async iterable of update payloads. The `proof` field on each payload preserves the
+   *   input proof type.
    */
-  proofStatesStream<T = unknown>(
-    proofs: Proof[],
+  proofStatesStream<P extends ProofLike = Proof>(
+    proofs: P[],
     opts?: {
       signal?: AbortSignal;
       maxBuffer?: number;
       drop?: 'oldest' | 'newest';
-      onDrop?: (payload: T) => void;
+      onDrop?: (payload: ProofState & { proof: P }) => void;
     },
-  ): AsyncIterable<T> {
+  ): AsyncIterable<ProofState & { proof: P }> {
+    type Payload = ProofState & { proof: P };
     return async function* (this: WalletEvents) {
-      const queue: T[] = [];
+      const queue: Payload[] = [];
       let done = false;
       let notify: (() => void) | null = null;
 
@@ -587,7 +596,7 @@ export class WalletEvents {
         if (n) n();
       };
 
-      const push = (payload: T) => {
+      const push = (payload: Payload) => {
         if (queue.length >= max) {
           if (dropMode === 'oldest') {
             const dropped = queue.shift();
@@ -613,12 +622,9 @@ export class WalletEvents {
         wake();
       };
 
-      const cancelP: Promise<SubscriptionCanceller> = this.proofStateUpdates(
+      const cancelP: Promise<SubscriptionCanceller> = this.proofStateUpdates<P>(
         proofs,
-        (payload: ProofState & { proof: Proof }) => {
-          // Accept wallet payload type and expose as generic T to consumer
-          push(payload as unknown as T);
-        },
+        push,
         () => {
           done = true;
           wake();

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -311,7 +311,10 @@ export class WalletEvents {
     if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const enc = new TextEncoder();
-    const proofMap: Record<string, T> = {};
+    // Object.create(null) avoids prototype-key collisions: a mint sending
+    // payload.Y === '__proto__' (or 'constructor', etc.) would otherwise
+    // resolve to an inherited property and bypass the unknown-Y guard below.
+    const proofMap = Object.create(null) as Record<string, T>;
     for (const p of proofs) {
       const y = hashToCurve(enc.encode(p.secret)).toHex(true);
       if (proofMap[y]) {
@@ -627,6 +630,7 @@ export class WalletEvents {
         wake();
       };
 
+      let setupErr: Error | null = null;
       const cancelP: Promise<SubscriptionCanceller> = this.proofStateUpdates<P>(
         proofs,
         push,
@@ -636,6 +640,14 @@ export class WalletEvents {
         },
         { signal: opts?.signal },
       );
+      // Attach a catch handler in the same tick so a synchronous setup
+      // failure (e.g. duplicate proof secrets) cannot escape as an
+      // unhandled rejection. The error is surfaced once the loop drains.
+      cancelP.catch((e: unknown) => {
+        setupErr = normalizeError(e);
+        done = true;
+        wake();
+      });
 
       const onAbort = () => {
         done = true;
@@ -651,6 +663,13 @@ export class WalletEvents {
           while (queue.length) yield queue.shift()!;
           if (done) break;
           await new Promise<void>((resolve) => (notify = resolve));
+        }
+        // Check after the loop, not inside. The catch handler sets done=true
+        // before waking the awaited notify, so the next loop iteration exits
+        // immediately and an in-loop throw would never be reached.
+        if (setupErr) {
+          const err: Error = setupErr;
+          throw err;
         }
       } finally {
         cancelSafely(cancelP);

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -314,12 +314,17 @@ export class WalletEvents {
     const proofMap: Record<string, T> = {};
     for (const p of proofs) {
       const y = hashToCurve(enc.encode(p.secret)).toHex(true);
+      if (proofMap[y]) {
+        throw new CTSError('Duplicate proof secret in proofStateUpdates input');
+      }
       proofMap[y] = p;
     }
     const ys = Object.keys(proofMap);
 
     const handler = (payload: ProofState) => {
-      cb({ ...payload, proof: proofMap[payload.Y] });
+      const proof = proofMap[payload.Y];
+      if (!proof) return; // ignore unsolicited Y from a misbehaving mint
+      cb({ ...payload, proof });
     };
     const subId = ws.createSubscription({ kind: 'proof_state', filters: ys }, handler, err);
     const cancel = () => ws.cancelSubscription(subId, handler);

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -55,6 +55,17 @@ class MockWS {
   }
 
   /**
+   * Deliver a proof_state payload to every proof_state subscriber unconditionally, simulating a
+   * misbehaving mint that sends a Y outside the subscribed filters.
+   */
+  emitProofRaw(payload: { Y: string; [k: string]: any }) {
+    for (const { kind: k, cb } of this.subs.values()) {
+      if (k !== 'proof_state') continue;
+      cb(payload);
+    }
+  }
+
+  /**
    * Invoke error callbacks for a kind.
    */
   fail(kind: string, error: any) {
@@ -210,6 +221,32 @@ describe('WalletEvents', () => {
       // input shape (number amount, reserved field) is preserved
       expect(seen[0].proof.reserved).toBe(false);
       expect(typeof seen[0].proof.amount).toBe('number');
+    });
+
+    it('proofStateUpdates throws on duplicate proof secrets', async () => {
+      const proofs: Proof[] = [
+        { amount: Amount.from(2), id: '00bd033559de27d0', secret: 'same', C: 'a' },
+        { amount: Amount.from(2), id: '00bd033559de27d0', secret: 'same', C: 'b' },
+      ];
+      await expect(events.proofStateUpdates(proofs, vi.fn(), vi.fn())).rejects.toThrow(
+        /Duplicate proof secret/,
+      );
+    });
+
+    it('proofStateUpdates ignores updates for an unsubscribed Y', async () => {
+      const cb = vi.fn();
+      const err = vi.fn();
+      const proofs: Proof[] = [
+        { amount: Amount.from(2), id: '00bd033559de27d0', secret: 's1', C: 'test' },
+      ];
+      await events.proofStateUpdates(proofs, cb, err);
+
+      const ws = mock.mint.webSocketConnection!;
+      // Simulate a misbehaving mint sending a Y the wallet never subscribed to.
+      ws.emitProofRaw({ Y: 'bogus_Y_from_malicious_mint', state: 0 });
+
+      expect(cb).not.toHaveBeenCalled();
+      expect(err).not.toHaveBeenCalled();
     });
   });
 

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -248,6 +248,26 @@ describe('WalletEvents', () => {
       expect(cb).not.toHaveBeenCalled();
       expect(err).not.toHaveBeenCalled();
     });
+
+    it('proofStateUpdates ignores prototype-key Ys (no pollution lookup)', async () => {
+      const cb = vi.fn();
+      const err = vi.fn();
+      const proofs: Proof[] = [
+        { amount: Amount.from(2), id: '00bd033559de27d0', secret: 's1', C: 'test' },
+      ];
+      await events.proofStateUpdates(proofs, cb, err);
+
+      const ws = mock.mint.webSocketConnection!;
+      // A plain-object proofMap would resolve these to inherited values
+      // (Object.prototype, the constructor, etc.) and bypass the unknown-Y guard.
+      ws.emitProofRaw({ Y: '__proto__', state: 0 });
+      ws.emitProofRaw({ Y: 'constructor', state: 0 });
+      ws.emitProofRaw({ Y: 'hasOwnProperty', state: 0 });
+      ws.emitProofRaw({ Y: 'toString', state: 0 });
+
+      expect(cb).not.toHaveBeenCalled();
+      expect(err).not.toHaveBeenCalled();
+    });
   });
 
   describe('onceMintPaid', () => {
@@ -447,6 +467,23 @@ describe('WalletEvents', () => {
   });
 
   describe('proofStatesStream', () => {
+    it('surfaces setup errors via the consumer (no hang, no unhandled rejection)', async () => {
+      // Vitest fails the test on any unhandled rejection, so reaching the
+      // explicit rejection assertion below also proves cancelP did not leak.
+      const proofs: Proof[] = [
+        { amount: Amount.from(2), id: '00bd033559de27d0', secret: 'dup', C: 'a' },
+        { amount: Amount.from(2), id: '00bd033559de27d0', secret: 'dup', C: 'b' },
+      ];
+      const iter = events.proofStatesStream(proofs);
+      await expect(
+        (async () => {
+          for await (const _ of iter) {
+            // should never yield
+          }
+        })(),
+      ).rejects.toThrow(/Duplicate proof secret/);
+    });
+
     it('yields payloads until error completes the stream, then cancels', async () => {
       const proofs: Proof[] = [
         { amount: Amount.from(2), id: '00bd033559de27d0', secret: 's1', C: 'test' },

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -185,6 +185,32 @@ describe('WalletEvents', () => {
 
       expect(cb).toHaveBeenCalledWith(expect.objectContaining({ Y, state: 0 }));
     });
+
+    it('proofStateUpdates accepts ProofLike-shaped input and preserves its type', async () => {
+      type StoredProof = {
+        id: string;
+        amount: number;
+        secret: string;
+        C: string;
+        reserved: boolean;
+      };
+      const stored: StoredProof[] = [
+        { amount: 2, id: '00bd033559de27d0', secret: 's1', C: 'test', reserved: false },
+      ];
+      const seen: Array<{ proof: StoredProof }> = [];
+      const err = vi.fn();
+      await events.proofStateUpdates<StoredProof>(stored, (p) => seen.push(p), err);
+
+      const ws = mock.mint.webSocketConnection!;
+      const [Y] = ws.firstFilters('proof_state');
+      ws.emitProof({ Y, state: 0 });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0].proof).toBe(stored[0]);
+      // input shape (number amount, reserved field) is preserved
+      expect(seen[0].proof.reserved).toBe(false);
+      expect(typeof seen[0].proof.amount).toBe('number');
+    });
   });
 
   describe('onceMintPaid', () => {


### PR DESCRIPTION
## Description

`proofStateUpdates` and `proofStatesStream` only read `secret` from each proof to derive the subscription filter — no `amount` normalization is needed. This PR widens both to accept any `ProofLike` shaped input.

Motivation: app-local proof shapes (e.g. wallet rows loaded from storage with `amount: number` and extra metadata) can be subscribed directly, without first round-tripping through `Amount.from(...)`. The original proof object is echoed back on the callback/yield payload with its inferred input type.

## Changes

- `proofStateUpdates` is now generic `<T extends ProofLike = Proof>`. The proof object echoed on the callback payload preserves the caller's input type.
- `proofStatesStream` is now generic `<P extends ProofLike = Proof>` and yields `ProofState & { proof: P }` directly. The previous `<T = unknown>` output generic and the internal `payload as unknown as T` cast are removed — default-typed consumers now get a useful payload type for free.
- Added a test confirming a non-`Proof` `ProofLike` input flows through and is preserved on the callback payload.

## Reviewer Notes

- **Runtime behaviour is unchanged.** This is a type-surface refinement.
- **`proofStateUpdates` is fully backward-compatible** — default `T = Proof` keeps existing call sites identical at the type level.
- **`proofStatesStream` has a minor type-level break** for callers who supplied an explicit non-`ProofLike` `<T>` (which only worked previously by virtue of the internal `as unknown as T` cast). Such callers should drop the type arg or replace it with a `ProofLike`-extending one. The runtime contract is unchanged.
- Tests pass on node + chromium + webkit + firefox.