### PR TITLE
feat(model): add AmountWithUnit value object

### DIFF
--- a/docs-src/usage/amounts.md
+++ b/docs-src/usage/amounts.md
@@ -56,8 +56,8 @@ AmountWithUnit.sum([a, b]); // 150 sat (unit inferred)
 AmountWithUnit.sum([], 'sat'); // 0 sat (empty + explicit hint)
 
 // Display: string coercion is unit-bearing (and parseInt-safe)
-`balance: ${a}`; // 'balance: sat: 100'
-String(a); // 'sat: 100'
+`balance: ${a}`; // 'balance: [sat]: 100'
+String(a); // '[sat]: 100'
 
 // Numeric coercion is blocked so the unit can't be silently stripped
 // (these throw AmountWithUnitError; use .toAmount() if you really mean it)

--- a/docs-src/usage/amounts.md
+++ b/docs-src/usage/amounts.md
@@ -55,9 +55,9 @@ Amount.from(21).withUnit('sat'); // AmountWithUnit
 AmountWithUnit.sum([a, b]); // 150 sat (unit inferred)
 AmountWithUnit.sum([], 'sat'); // 0 sat (empty + explicit hint)
 
-// Display: string coercion is unit-bearing
-`balance: ${a}`; // 'balance: 100 sat'
-String(a); // '100 sat'
+// Display: string coercion is unit-bearing (and parseInt-safe)
+`balance: ${a}`; // 'balance: sat: 100'
+String(a); // 'sat: 100'
 
 // Numeric coercion is blocked so the unit can't be silently stripped
 // (these throw AmountWithUnitError; use .toAmount() if you really mean it)

--- a/docs-src/usage/amounts.md
+++ b/docs-src/usage/amounts.md
@@ -54,6 +54,14 @@ Amount.from(21).withUnit('sat'); // AmountWithUnit
 // Aggregate a unit-tagged iterable
 AmountWithUnit.sum([a, b]); // 150 sat (unit inferred)
 AmountWithUnit.sum([], 'sat'); // 0 sat (empty + explicit hint)
+
+// Display: string coercion is unit-bearing
+`balance: ${a}`; // 'balance: 100 sat'
+String(a); // '100 sat'
+
+// Numeric coercion is blocked so the unit can't be silently stripped
+// (these throw AmountWithUnitError; use .toAmount() if you really mean it)
+// Number(a); a - 10; +a; a == 100;
 ```
 
 ## Choosing between them

--- a/docs-src/usage/amounts.md
+++ b/docs-src/usage/amounts.md
@@ -30,8 +30,6 @@ Amount.from(500).clamp(100, 1000); // 500
 Amount.from(500).inRange(100, 1000); // true
 ```
 
-See the full reference in [migration-4.0.0.md § Finance Helpers — going further with `Amount`](../../migration-4.0.0.md#finance-helpers--going-further-with-amount).
-
 ## Working with `AmountWithUnit`
 
 ```ts
@@ -54,8 +52,6 @@ Amount.from(21).withUnit('sat'); // AmountWithUnit
 AmountWithUnit.sum([a, b]); // 150 sat (unit inferred)
 AmountWithUnit.sum([], 'sat'); // 0 sat (empty + explicit hint)
 ```
-
-See the full reference in [migration-4.0.0.md § Multi-unit support: `AmountWithUnit`](../../migration-4.0.0.md#multi-unit-support-amountwithunit).
 
 ## Choosing between them
 

--- a/docs-src/usage/amounts.md
+++ b/docs-src/usage/amounts.md
@@ -23,10 +23,13 @@ a.equals(Amount.from(100)); // true
 a.greaterThan(50); // true
 
 // Finance helpers — integer arithmetic, no floats
-Amount.from(1000).ceilPercent(2); // 20
-Amount.from(1000).floorPercent(98); // 980
+Amount.from(1000).ceilPercent(2); // 20 (2% of 1000)
+Amount.from(1001).ceilPercent(1, 200); // 6 (= ceil(0.5% of 1001), fractional via larger denom)
+Amount.from(1000).floorPercent(98); // 980 (98% of 1000)
+Amount.from(1001).floorPercent(1, 200); // 5 (= floor(0.5% of 1001), fractional via larger denom)
 Amount.from(1000).scaledBy(3, 4); // 750
-Amount.from(500).clamp(100, 1000); // 500
+Amount.from(500).clamp(100, 1000); // 500 (already in range, unchanged)
+Amount.from(500).clamp(100, 400); // 400 (clamped down to max)
 Amount.from(500).inRange(100, 1000); // true
 ```
 

--- a/docs-src/usage/amounts.md
+++ b/docs-src/usage/amounts.md
@@ -1,0 +1,63 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Amounts**
+
+# Amounts
+
+cashu-ts represents monetary values with two related value objects:
+
+- **`Amount`** — immutable, bigint-backed, non-negative. Unit-agnostic. Use this for protocol-level math, fee calculations, and any operation scoped to a single keyset/wallet (which already implies a unit).
+- **`AmountWithUnit`** — wraps an `Amount` and a `unit: string`. Use this when your app aggregates or compares across units (e.g. multi-currency balances).
+
+`Amount` is what every cashu-ts API returns and accepts. `AmountWithUnit` is an opt-in for downstream consumers.
+
+## Working with `Amount`
+
+```ts
+import { Amount } from '@cashu/cashu-ts';
+
+const a = Amount.from(100); // accepts number | bigint | string | Amount
+const b = Amount.from('21');
+
+a.add(b).toBigInt(); // 121n
+a.subtract(b).toString(); // '79'
+a.equals(Amount.from(100)); // true
+a.greaterThan(50); // true
+
+// Finance helpers — integer arithmetic, no floats
+Amount.from(1000).ceilPercent(2); // 20
+Amount.from(1000).floorPercent(98); // 980
+Amount.from(1000).scaledBy(3, 4); // 750
+Amount.from(500).clamp(100, 1000); // 500
+Amount.from(500).inRange(100, 1000); // true
+```
+
+See the full reference in [migration-4.0.0.md § Finance Helpers — going further with `Amount`](../../migration-4.0.0.md#finance-helpers--going-further-with-amount).
+
+## Working with `AmountWithUnit`
+
+```ts
+import { Amount, AmountWithUnit, AmountWithUnitError } from '@cashu/cashu-ts';
+
+const a = AmountWithUnit.from(100, 'sat');
+const b = AmountWithUnit.from(50, 'sat');
+const c = AmountWithUnit.from(5, 'usd');
+
+a.add(b); // AmountWithUnit { amount: 150, unit: 'sat' }
+a.add(c); // throws AmountWithUnitError
+
+// Drop back to a unitless Amount when handing off to single-unit APIs
+const raw: Amount = a.toAmount();
+
+// Lift a unitless Amount into the unit-checked tier
+Amount.from(21).withUnit('sat'); // AmountWithUnit
+
+// Aggregate a unit-tagged iterable
+AmountWithUnit.sum([a, b]); // 150 sat (unit inferred)
+AmountWithUnit.sum([], 'sat'); // 0 sat (empty + explicit hint)
+```
+
+See the full reference in [migration-4.0.0.md § Multi-unit support: `AmountWithUnit`](../../migration-4.0.0.md#multi-unit-support-amountwithunit).
+
+## Choosing between them
+
+- One wallet, one unit per mint → `Amount` is enough. The wallet already enforces unit at the object level.
+- Aggregating across units (totals, transfers, displays) → wrap into `AmountWithUnit` at the boundary; do unit-checked math; unwrap with `.toAmount()` when handing back to single-unit APIs.

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -31,6 +31,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [Bolt12](./bolt12.md)                 | Work with reusable BOLT12 offers for minting and melting.              |
 | [NUT-19 Cached Responses](./nut19.md) | Understand cached endpoint retries and timeout behavior.               |
 | [Logging](./logging.md)               | Enable and route library logs while debugging wallet or mint behavior. |
+| [Amounts](./amounts.md)               | Work with the `Amount` and `AmountWithUnit` value objects.             |
 
 ## Related docs
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -122,7 +122,6 @@ export class AmountWithUnit {
     };
     // (undocumented)
     toNumber(): number;
-    // (undocumented)
     toString(): string;
     // (undocumented)
     readonly unit: string;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -51,6 +51,7 @@ export class Amount {
     toNumber(): number;
     toNumberUnsafe(): number;
     toString(): string;
+    withUnit(unit: string): AmountWithUnit;
     // (undocumented)
     static zero(): Amount;
 }
@@ -62,6 +63,77 @@ export class AmountError extends CTSError {
 
 // @public
 export type AmountLike = number | bigint | string | Amount;
+
+// @public
+export class AmountWithUnit {
+    constructor(amount: Amount, unit: string);
+    // (undocumented)
+    add(other: AmountWithUnit): AmountWithUnit;
+    // (undocumented)
+    ceilPercent(numerator: number, denominator?: number): AmountWithUnit;
+    // (undocumented)
+    clamp(min: AmountWithUnit, max: AmountWithUnit): AmountWithUnit;
+    // (undocumented)
+    compareTo(other: AmountWithUnit): -1 | 0 | 1;
+    // (undocumented)
+    divideBy(divisor: AmountLike): AmountWithUnit;
+    // (undocumented)
+    equals(other: AmountWithUnit): boolean;
+    // (undocumented)
+    floorPercent(numerator: number, denominator?: number): AmountWithUnit;
+    // (undocumented)
+    static from(value: AmountLike, unit: string): AmountWithUnit;
+    // (undocumented)
+    greaterThan(other: AmountWithUnit): boolean;
+    // (undocumented)
+    greaterThanOrEqual(other: AmountWithUnit): boolean;
+    // (undocumented)
+    inRange(min: AmountWithUnit, max: AmountWithUnit): boolean;
+    // (undocumented)
+    isSafeNumber(): boolean;
+    // (undocumented)
+    isZero(): boolean;
+    // (undocumented)
+    lessThan(other: AmountWithUnit): boolean;
+    // (undocumented)
+    lessThanOrEqual(other: AmountWithUnit): boolean;
+    // (undocumented)
+    static max(a: AmountWithUnit, b: AmountWithUnit): AmountWithUnit;
+    // (undocumented)
+    static min(a: AmountWithUnit, b: AmountWithUnit): AmountWithUnit;
+    // (undocumented)
+    modulo(divisor: AmountLike): AmountWithUnit;
+    // (undocumented)
+    multiplyBy(factor: AmountLike): AmountWithUnit;
+    // (undocumented)
+    static one(unit: string): AmountWithUnit;
+    // (undocumented)
+    scaledBy(numerator: AmountLike, denominator: AmountLike): AmountWithUnit;
+    // (undocumented)
+    subtract(other: AmountWithUnit): AmountWithUnit;
+    static sum(values: Iterable<AmountWithUnit>, unit?: string): AmountWithUnit;
+    toAmount(): Amount;
+    // (undocumented)
+    toBigInt(): bigint;
+    // (undocumented)
+    toJSON(): {
+        amount: string;
+        unit: string;
+    };
+    // (undocumented)
+    toNumber(): number;
+    // (undocumented)
+    toString(): string;
+    // (undocumented)
+    readonly unit: string;
+    // (undocumented)
+    static zero(unit: string): AmountWithUnit;
+}
+
+// @public (undocumented)
+export class AmountWithUnitError extends CTSError {
+    constructor(message: string);
+}
 
 // @public
 export function assertSecretKind(allowed: SecretKind | SecretKind[], secret: Secret | string): Secret;

--- a/migration-4.0.0.SKILL.md
+++ b/migration-4.0.0.SKILL.md
@@ -35,6 +35,8 @@ v4 introduces an immutable, bigint-backed `Amount` value object wherever the lib
 - **Finance**: `.scaledBy()`, `.ceilPercent()`, `.floorPercent()`, `.clamp()`, `.inRange()`
 - **Construction**: `Amount.from(x)` accepts `number`, `bigint`, `string`, or another `Amount`
 
+**Multi-unit apps:** If the app handles more than one currency unit (e.g. `sat` _and_ `usd`, or cross-unit balance aggregation), also see `AmountWithUnit` — the unit-aware wrapper that prevents silent unit-mixing in arithmetic. See `migration-4.0.0.md` § "Multi-unit support: AmountWithUnit". Most apps are single-unit and don't need it.
+
 **Ask the user before proceeding:**
 
 > v4 returns `Amount` objects from several APIs (see Step 3). Do you want the app to:

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -924,6 +924,14 @@ Single-unit consumers (the common case — one `Wallet` per mint+unit) don't nee
 
 `AmountWithUnit` exposes the same arithmetic, comparison, and finance helpers as `Amount`, plus `static AmountWithUnit.sum(iter, unit?)` for aggregating a unit-tagged iterable.
 
+### Implicit coercion is intentionally restricted
+
+To keep the unit guard meaningful, `AmountWithUnit` overrides JS coercion so that the unit cannot be silently stripped:
+
+- **String coercion** (`String(x)`, `` `${x}` ``, `.toString()`) returns a unit-bearing form like `"100 sat"`.
+- **Numeric / default coercion** (`+x`, `x - 1`, `x == 5`, `Number(x)`, `x + y` between two `AmountWithUnit`) **throws** `AmountWithUnitError`. Use `.toAmount()` to get the unitless `Amount` if you genuinely need raw arithmetic.
+- **JSON** is unaffected — `JSON.stringify(x)` uses `toJSON()` and emits `{"amount":"...","unit":"..."}`.
+
 ---
 
 ## New: `createEphemeralCounterSource` factory

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -928,7 +928,7 @@ Single-unit consumers (the common case — one `Wallet` per mint+unit) don't nee
 
 To keep the unit guard meaningful, `AmountWithUnit` overrides JS coercion so that the unit cannot be silently stripped:
 
-- **String coercion** (`String(x)`, `` `${x}` ``, `.toString()`) returns a unit-bearing form like `"100 sat"`.
+- **String coercion** (`String(x)`, `` `${x}` ``, `.toString()`) returns a unit-bearing form like `"sat: 100"`. The unit-first ordering is deliberate: `parseInt`/`parseFloat` on the string form return `NaN` rather than silently extracting the bare number.
 - **Numeric / default coercion** (`+x`, `x - 1`, `x == 5`, `Number(x)`, `x + y` between two `AmountWithUnit`) **throws** `AmountWithUnitError`. Use `.toAmount()` to get the unitless `Amount` if you genuinely need raw arithmetic.
 - **JSON** is unaffected — `JSON.stringify(x)` uses `toJSON()` and emits `{"amount":"...","unit":"..."}`.
 

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -899,6 +899,33 @@ if (msats.inRange(data.minSendable, data.maxSendable)) { ... }
 
 ---
 
+## Multi-unit support: `AmountWithUnit`
+
+If your application handles more than one currency unit (e.g. `sat` and `usd` from the same mint, or wallets across multiple mints with different units), `AmountWithUnit` is the unit-aware sibling of `Amount`. It refuses to silently mix units in arithmetic or comparison.
+
+`AmountWithUnit` is a thin wrapper composing an `Amount` and a `unit: string`. The two type families are deliberately distinct — `AmountWithUnit.add` accepts only `AmountWithUnit`, and there is no implicit coercion from one to the other. Lifting is always explicit.
+
+```ts
+import { Amount, AmountWithUnit, AmountWithUnitError } from '@cashu/cashu-ts';
+
+const a = AmountWithUnit.from(100, 'sat');
+const b = AmountWithUnit.from(50, 'sat');
+const c = AmountWithUnit.from(5, 'usd');
+
+a.add(b); // AmountWithUnit { amount: 150, unit: 'sat' }
+a.add(c); // throws AmountWithUnitError: unit mismatch
+a.toAmount().add(b.toAmount()); // Amount 150 — raw arithmetic, intentional escape hatch
+
+// Lift a unitless Amount when needed:
+Amount.from(21).withUnit('sat'); // AmountWithUnit
+```
+
+Single-unit consumers (the common case — one `Wallet` per mint+unit) don't need this. It exists for downstream wallets that aggregate across units (balances, transfers, multi-currency display) without reinventing the unit-equality bookkeeping.
+
+`AmountWithUnit` exposes the same arithmetic, comparison, and finance helpers as `Amount`, plus `static AmountWithUnit.sum(iter, unit?)` for aggregating a unit-tagged iterable.
+
+---
+
 ## New: `createEphemeralCounterSource` factory
 
 v4 adds a public factory for the built-in in-memory `CounterSource`:

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,13 @@ export {
 } from './model/Errors';
 
 // Low-level helpers/types that appear in public surfaces
-export { Amount, AmountError, type AmountLike } from './model/Amount';
+export {
+  Amount,
+  AmountError,
+  AmountWithUnit,
+  AmountWithUnitError,
+  type AmountLike,
+} from './model/Amount';
 export { OutputData } from './model/OutputData';
 export type { OutputDataLike, OutputDataFactory, SerializedOutputData } from './model/OutputData';
 export type { OutputDataCreator } from './model/OutputDataCreator';

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -461,12 +461,28 @@ export class AmountWithUnit {
     return this._amount.toNumber();
   }
 
+  /**
+   * Unit-bearing canonical form, e.g. `"100 sat"`. Used by `String(x)`, template literals,
+   * `console.log`, and any other string-coercion context.
+   */
   toString(): string {
-    return this._amount.toString();
+    return `${this._amount.toString()} ${this.unit}`;
   }
 
   toJSON(): { amount: string; unit: string } {
     return { amount: this._amount.toString(), unit: this.unit };
+  }
+
+  /**
+   * Coercion hook: returns the unit-bearing string for `"string"` hints (`String(x)`, template
+   * literals), throws otherwise. Prevents `+`, `-`, `*`, `==`, `Number(x)`, etc. from silently
+   * stripping the unit — use {@link AmountWithUnit.toAmount} for explicit numeric access.
+   */
+  [Symbol.toPrimitive](hint: 'number' | 'string' | 'default'): string {
+    if (hint === 'string') return this.toString();
+    throw new AmountWithUnitError(
+      `Implicit ${hint === 'number' ? 'numeric' : 'default'} coercion of AmountWithUnit is unsafe; use .toAmount() then explicit arithmetic, or .toString() for display.`,
+    );
   }
 
   isZero(): boolean {

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -362,4 +362,235 @@ export class Amount {
     }
     return new Amount(total);
   }
+
+  // -----------------------------------------------------------------
+  // Section: Unit lifting
+  // -----------------------------------------------------------------
+
+  /**
+   * Tag this {@link Amount} with a currency unit, returning an {@link AmountWithUnit}.
+   */
+  withUnit(unit: string): AmountWithUnit {
+    return new AmountWithUnit(this, unit);
+  }
+}
+
+export class AmountWithUnitError extends CTSError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AmountWithUnitError';
+    Object.setPrototypeOf(this, AmountWithUnitError.prototype);
+  }
+}
+
+/**
+ * Immutable {@link Amount} paired with a currency unit.
+ *
+ * Binary ops require matching units (throw {@link AmountWithUnitError} otherwise); scalar ops
+ * preserve the unit.
+ *
+ * Lift via {@link Amount.withUnit} / {@link AmountWithUnit.from}, drop via
+ * {@link AmountWithUnit.toAmount}.
+ *
+ * @example
+ *
+ *     AmountWithUnit.from(100, 'sat');
+ *     Amount.from(21).withUnit('sat');
+ */
+export class AmountWithUnit {
+  private readonly _amount: Amount;
+  readonly unit: string;
+
+  constructor(amount: Amount, unit: string) {
+    if (typeof unit !== 'string' || unit.length === 0) {
+      throw new AmountWithUnitError('unit required');
+    }
+    this._amount = amount;
+    this.unit = unit;
+    Object.freeze(this);
+  }
+
+  // -----------------------------------------------------------------
+  // Section: Static Factories
+  // -----------------------------------------------------------------
+
+  static from(value: AmountLike, unit: string): AmountWithUnit {
+    return new AmountWithUnit(Amount.from(value), unit);
+  }
+
+  static zero(unit: string): AmountWithUnit {
+    return new AmountWithUnit(Amount.zero(), unit);
+  }
+
+  static one(unit: string): AmountWithUnit {
+    return new AmountWithUnit(Amount.one(), unit);
+  }
+
+  // -----------------------------------------------------------------
+  // Section: Escape hatch
+  // -----------------------------------------------------------------
+
+  /**
+   * Return the underlying unitless {@link Amount}, dropping the unit guard.
+   */
+  toAmount(): Amount {
+    return this._amount;
+  }
+
+  // -----------------------------------------------------------------
+  // Section: Pass-through converters (no unit dimension)
+  // -----------------------------------------------------------------
+
+  toBigInt(): bigint {
+    return this._amount.toBigInt();
+  }
+
+  toNumber(): number {
+    return this._amount.toNumber();
+  }
+
+  toString(): string {
+    return this._amount.toString();
+  }
+
+  toJSON(): { amount: string; unit: string } {
+    return { amount: this._amount.toString(), unit: this.unit };
+  }
+
+  isZero(): boolean {
+    return this._amount.isZero();
+  }
+
+  isSafeNumber(): boolean {
+    return this._amount.isSafeNumber();
+  }
+
+  // -----------------------------------------------------------------
+  // Section: Binary ops — strict unit match
+  // -----------------------------------------------------------------
+
+  private requireSameUnit(other: AmountWithUnit): void {
+    if (this.unit !== other.unit) {
+      throw new AmountWithUnitError(`unit mismatch: ${this.unit} vs ${other.unit}`);
+    }
+  }
+
+  add(other: AmountWithUnit): AmountWithUnit {
+    this.requireSameUnit(other);
+    return new AmountWithUnit(this._amount.add(other._amount), this.unit);
+  }
+
+  subtract(other: AmountWithUnit): AmountWithUnit {
+    this.requireSameUnit(other);
+    return new AmountWithUnit(this._amount.subtract(other._amount), this.unit);
+  }
+
+  equals(other: AmountWithUnit): boolean {
+    this.requireSameUnit(other);
+    return this._amount.equals(other._amount);
+  }
+
+  compareTo(other: AmountWithUnit): -1 | 0 | 1 {
+    this.requireSameUnit(other);
+    return this._amount.compareTo(other._amount);
+  }
+
+  lessThan(other: AmountWithUnit): boolean {
+    return this.compareTo(other) < 0;
+  }
+
+  lessThanOrEqual(other: AmountWithUnit): boolean {
+    return this.compareTo(other) <= 0;
+  }
+
+  greaterThan(other: AmountWithUnit): boolean {
+    return this.compareTo(other) > 0;
+  }
+
+  greaterThanOrEqual(other: AmountWithUnit): boolean {
+    return this.compareTo(other) >= 0;
+  }
+
+  inRange(min: AmountWithUnit, max: AmountWithUnit): boolean {
+    this.requireSameUnit(min);
+    this.requireSameUnit(max);
+    return this._amount.inRange(min._amount, max._amount);
+  }
+
+  clamp(min: AmountWithUnit, max: AmountWithUnit): AmountWithUnit {
+    this.requireSameUnit(min);
+    this.requireSameUnit(max);
+    return new AmountWithUnit(this._amount.clamp(min._amount, max._amount), this.unit);
+  }
+
+  // -----------------------------------------------------------------
+  // Section: Scalar ops — second arg dimensionless, unit preserved
+  // -----------------------------------------------------------------
+
+  multiplyBy(factor: AmountLike): AmountWithUnit {
+    return new AmountWithUnit(this._amount.multiplyBy(factor), this.unit);
+  }
+
+  divideBy(divisor: AmountLike): AmountWithUnit {
+    return new AmountWithUnit(this._amount.divideBy(divisor), this.unit);
+  }
+
+  modulo(divisor: AmountLike): AmountWithUnit {
+    return new AmountWithUnit(this._amount.modulo(divisor), this.unit);
+  }
+
+  ceilPercent(numerator: number, denominator?: number): AmountWithUnit {
+    return new AmountWithUnit(this._amount.ceilPercent(numerator, denominator), this.unit);
+  }
+
+  floorPercent(numerator: number, denominator?: number): AmountWithUnit {
+    return new AmountWithUnit(this._amount.floorPercent(numerator, denominator), this.unit);
+  }
+
+  scaledBy(numerator: AmountLike, denominator: AmountLike): AmountWithUnit {
+    return new AmountWithUnit(this._amount.scaledBy(numerator, denominator), this.unit);
+  }
+
+  // -----------------------------------------------------------------
+  // Section: Statics
+  // -----------------------------------------------------------------
+
+  static min(a: AmountWithUnit, b: AmountWithUnit): AmountWithUnit {
+    a.requireSameUnit(b);
+    return a.compareTo(b) <= 0 ? a : b;
+  }
+
+  static max(a: AmountWithUnit, b: AmountWithUnit): AmountWithUnit {
+    a.requireSameUnit(b);
+    return a.compareTo(b) >= 0 ? a : b;
+  }
+
+  /**
+   * Sum a unit-tagged iterable.
+   *
+   * - If `unit` is provided, every element must match it; the result has that unit. An empty iterable
+   *   returns `AmountWithUnit.zero(unit)`.
+   * - If `unit` is omitted, the iterable must be non-empty; the unit is inferred from the first
+   *   element and every subsequent element must match. An empty iterable throws.
+   *
+   * @throws {AmountWithUnitError} On unit mismatch, or on empty iterable when `unit` is omitted.
+   */
+  static sum(values: Iterable<AmountWithUnit>, unit?: string): AmountWithUnit {
+    let expected = unit;
+    let total = 0n;
+    let seen = false;
+    for (const v of values) {
+      if (expected === undefined) {
+        expected = v.unit;
+      } else if (v.unit !== expected) {
+        throw new AmountWithUnitError(`unit mismatch: ${expected} vs ${v.unit}`);
+      }
+      total += v._amount.toBigInt();
+      seen = true;
+    }
+    if (expected === undefined) {
+      throw new AmountWithUnitError('cannot infer unit from empty sum');
+    }
+    return new AmountWithUnit(seen ? Amount.from(total) : Amount.zero(), expected);
+  }
 }

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -187,8 +187,11 @@ export class Amount {
    * The default denominator of 100 makes common percentage calculations natural. Use a larger
    * denominator to express fractional percentages without floats.
    *
-   * @example Amount.ceilPercent(2) // ceil(2% of amount) amount.ceilPercent(1, 200) // ceil(0.5% of
-   * amount) amount.ceilPercent(15, 10) // ceil(1.5% of amount)
+   * @example
+   *
+   *     amount.ceilPercent(2); // ceil(2% of amount)
+   *     amount.ceilPercent(1, 200); // ceil(0.5% of amount)
+   *     amount.ceilPercent(15, 10); // ceil(1.5% of amount)
    *
    * @throws If numerator or denominator are not positive integers.
    */
@@ -213,8 +216,10 @@ export class Amount {
    * The natural complement to {@link Amount.ceilPercent} — use when you need the conservative lower
    * bound, e.g. "maximum spendable after reserving fees".
    *
-   * @example Amount.floorPercent(98) // floor(98% of amount) amount.floorPercent(1, 200) //
-   * floor(0.5% of amount)
+   * @example
+   *
+   *     amount.floorPercent(98); // floor(98% of amount)
+   *     amount.floorPercent(1, 200); // floor(0.5% of amount)
    *
    * @throws If numerator or denominator are not positive integers.
    */
@@ -233,7 +238,9 @@ export class Amount {
   /**
    * Returns true if this amount is within the inclusive range [min, max].
    *
-   * @example Msats.inRange(data.minSendable, data.maxSendable)
+   * @example
+   *
+   *     msats.inRange(data.minSendable, data.maxSendable);
    *
    * @throws If min > max.
    */
@@ -249,8 +256,10 @@ export class Amount {
   /**
    * Clamps this amount to the inclusive range [min, max].
    *
-   * @example Fee.clamp(MIN_FEE, tokenAmount) invoiceAmount.clamp(Amount.from(minSendable),
-   * Amount.from(maxSendable))
+   * @example
+   *
+   *     fee.clamp(MIN_FEE, tokenAmount);
+   *     invoiceAmount.clamp(Amount.from(minSendable), Amount.from(maxSendable));
    *
    * @throws If min > max.
    */
@@ -271,7 +280,10 @@ export class Amount {
    *
    * Uses the identity: `round(a × b / c) = floor((2 × a × b + c) / (2 × c))`
    *
-   * @example // Scale a 1000-sat amount down by a 3/4 ratio → 750 Amount.from(1000).scaledBy(3, 4)
+   * @example
+   *
+   *     // Scale a 1000-sat amount down by a 3/4 ratio → 750
+   *     Amount.from(1000).scaledBy(3, 4);
    *
    *     // Proportional rescale: if neededAmount is too high, shrink estInvAmount to fit
    *     estInvAmount.scaledBy(tokenAmount, neededAmount).subtract(1);

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -462,11 +462,14 @@ export class AmountWithUnit {
   }
 
   /**
-   * Unit-bearing canonical form, e.g. `"100 sat"`. Used by `String(x)`, template literals,
+   * Unit-bearing canonical form, e.g. `"sat: 100"`. Used by `String(x)`, template literals,
    * `console.log`, and any other string-coercion context.
+   *
+   * Unit comes first so that `parseInt(String(x))` / `parseFloat(String(x))` return `NaN` rather
+   * than silently extracting the bare number and dropping the unit.
    */
   toString(): string {
-    return `${this._amount.toString()} ${this.unit}`;
+    return `${this.unit}: ${this._amount.toString()}`;
   }
 
   toJSON(): { amount: string; unit: string } {

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -462,14 +462,16 @@ export class AmountWithUnit {
   }
 
   /**
-   * Unit-bearing canonical form, e.g. `"sat: 100"`. Used by `String(x)`, template literals,
+   * Unit-bearing canonical form, e.g. `"[sat]: 100"`. Used by `String(x)`, template literals,
    * `console.log`, and any other string-coercion context.
    *
-   * Unit comes first so that `parseInt(String(x))` / `parseFloat(String(x))` return `NaN` rather
-   * than silently extracting the bare number and dropping the unit.
+   * Leads with `[` (never a digit, sign, or decimal point) so that `parseInt(String(x))` /
+   * `parseFloat(String(x))` return `NaN` even if the unit itself starts with digits — otherwise a
+   * unit like `"9999sat"` would let `parseInt` silently extract `9999` from the unit and drop the
+   * real amount.
    */
   toString(): string {
-    return `${this.unit}: ${this._amount.toString()}`;
+    return `[${this.unit}]: ${this._amount.toString()}`;
   }
 
   toJSON(): { amount: string; unit: string } {

--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -477,6 +477,8 @@ export class AmountWithUnit {
    * Coercion hook: returns the unit-bearing string for `"string"` hints (`String(x)`, template
    * literals), throws otherwise. Prevents `+`, `-`, `*`, `==`, `Number(x)`, etc. from silently
    * stripping the unit — use {@link AmountWithUnit.toAmount} for explicit numeric access.
+   *
+   * @internal
    */
   [Symbol.toPrimitive](hint: 'number' | 'string' | 'default'): string {
     if (hint === 'string') return this.toString();

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -10,6 +10,16 @@ describe('Amount.from validation', () => {
     expect(() => Amount.from(-1)).toThrow('Amount must be >= 0');
   });
 
+  it('rejects non-finite or non-integer number amounts', () => {
+    expect(() => Amount.from(Number.NaN)).toThrow('Invalid number amount');
+    expect(() => Amount.from(Number.POSITIVE_INFINITY)).toThrow('Invalid number amount');
+    expect(() => Amount.from(1.5)).toThrow('Invalid number amount');
+  });
+
+  it('rejects unsafe-integer number amounts', () => {
+    expect(() => Amount.from(Number.MAX_SAFE_INTEGER + 1)).toThrow('Unsafe integer amount');
+  });
+
   it('rejects invalid decimal strings', () => {
     expect(() => Amount.from('-1')).toThrow('Invalid amount string');
     expect(() => Amount.from('01')).toThrow('Invalid amount string');
@@ -209,10 +219,17 @@ describe('Amount arithmetic and comparisons', () => {
 
   it('handles comparison helpers', () => {
     const amount = Amount.from(5);
+    expect(amount.lessThan(6)).toBe(true);
+    expect(amount.lessThan(5)).toBe(false);
     expect(amount.lessThanOrEqual(5)).toBe(true);
     expect(amount.lessThanOrEqual(6)).toBe(true);
     expect(amount.greaterThanOrEqual(5)).toBe(true);
     expect(amount.greaterThanOrEqual(4)).toBe(true);
+  });
+
+  it('sums an iterable of AmountLike values', () => {
+    expect(Amount.sum([1, 2n, '3', Amount.from(4)]).toBigInt()).toBe(10n);
+    expect(Amount.sum([]).toBigInt()).toBe(0n);
   });
 
   it('performs arithmetic operations', () => {

--- a/test/model/AmountWithUnit.test.ts
+++ b/test/model/AmountWithUnit.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { Amount, AmountWithUnit, AmountWithUnitError } from '../../src/model/Amount';
+
+describe('AmountWithUnit construction', () => {
+  it('rejects empty unit string', () => {
+    expect(() => new AmountWithUnit(Amount.from(1), '')).toThrow(AmountWithUnitError);
+    expect(() => new AmountWithUnit(Amount.from(1), '')).toThrow('unit required');
+  });
+
+  it('rejects non-string unit', () => {
+    expect(() => new AmountWithUnit(Amount.from(1), undefined as unknown as string)).toThrow(
+      AmountWithUnitError,
+    );
+    expect(() => new AmountWithUnit(Amount.from(1), null as unknown as string)).toThrow(
+      AmountWithUnitError,
+    );
+  });
+
+  it('stores amount and unit', () => {
+    const a = AmountWithUnit.from(100, 'sat');
+    expect(a.toAmount().toBigInt()).toBe(100n);
+    expect(a.unit).toBe('sat');
+  });
+
+  it('is frozen — assignment to unit throws in strict mode', () => {
+    const a = AmountWithUnit.from(1, 'sat');
+    expect(() => {
+      (a as unknown as { unit: string }).unit = 'usd';
+    }).toThrow();
+  });
+});
+
+describe('AmountWithUnit factories', () => {
+  it('AmountWithUnit.from accepts AmountLike + unit', () => {
+    expect(AmountWithUnit.from(100, 'sat').toAmount().toBigInt()).toBe(100n);
+    expect(AmountWithUnit.from(100n, 'sat').toAmount().toBigInt()).toBe(100n);
+    expect(AmountWithUnit.from('100', 'sat').toAmount().toBigInt()).toBe(100n);
+    expect(AmountWithUnit.from(Amount.from(100), 'sat').toAmount().toBigInt()).toBe(100n);
+  });
+
+  it('AmountWithUnit.zero / one', () => {
+    expect(AmountWithUnit.zero('sat').toAmount().toBigInt()).toBe(0n);
+    expect(AmountWithUnit.one('usd').toAmount().toBigInt()).toBe(1n);
+    expect(AmountWithUnit.zero('sat').unit).toBe('sat');
+    expect(AmountWithUnit.one('usd').unit).toBe('usd');
+  });
+});
+
+describe('AmountWithUnit pass-through converters', () => {
+  it('toBigInt / toNumber / toString match underlying Amount', () => {
+    const a = AmountWithUnit.from(123, 'sat');
+    expect(a.toBigInt()).toBe(a.toAmount().toBigInt());
+    expect(a.toNumber()).toBe(a.toAmount().toNumber());
+    expect(a.toString()).toBe(a.toAmount().toString());
+  });
+
+  it('isZero / isSafeNumber match underlying Amount', () => {
+    expect(AmountWithUnit.zero('sat').isZero()).toBe(true);
+    expect(AmountWithUnit.one('sat').isZero()).toBe(false);
+    expect(AmountWithUnit.from(1, 'sat').isSafeNumber()).toBe(true);
+    expect(AmountWithUnit.from(BigInt(Number.MAX_SAFE_INTEGER) + 1n, 'sat').isSafeNumber()).toBe(
+      false,
+    );
+  });
+});
+
+describe('AmountWithUnit.toJSON', () => {
+  it('returns { amount: string, unit: string }', () => {
+    const a = AmountWithUnit.from(100, 'sat');
+    expect(a.toJSON()).toEqual({ amount: '100', unit: 'sat' });
+  });
+
+  it('round-trips through JSON.stringify', () => {
+    const a = AmountWithUnit.from(100, 'sat');
+    expect(JSON.parse(JSON.stringify(a))).toEqual({ amount: '100', unit: 'sat' });
+  });
+});
+
+describe('AmountWithUnit binary ops', () => {
+  const a = AmountWithUnit.from(100, 'sat');
+  const b = AmountWithUnit.from(40, 'sat');
+  const c = AmountWithUnit.from(5, 'usd');
+
+  it('add matches Amount.add when units agree', () => {
+    expect(a.add(b).toAmount().toBigInt()).toBe(140n);
+    expect(a.add(b).unit).toBe('sat');
+  });
+
+  it('add throws AmountWithUnitError on unit mismatch', () => {
+    expect(() => a.add(c)).toThrow(AmountWithUnitError);
+    expect(() => a.add(c)).toThrow('unit mismatch: sat vs usd');
+  });
+
+  it('subtract matches Amount.subtract when units agree', () => {
+    expect(a.subtract(b).toAmount().toBigInt()).toBe(60n);
+  });
+
+  it('subtract throws on unit mismatch', () => {
+    expect(() => a.subtract(c)).toThrow(AmountWithUnitError);
+  });
+
+  it('equals throws on unit mismatch (not silently false)', () => {
+    expect(a.equals(AmountWithUnit.from(100, 'sat'))).toBe(true);
+    expect(a.equals(b)).toBe(false);
+    expect(() => a.equals(c)).toThrow(AmountWithUnitError);
+  });
+
+  it('compareTo throws on unit mismatch', () => {
+    expect(a.compareTo(b)).toBe(1);
+    expect(b.compareTo(a)).toBe(-1);
+    expect(a.compareTo(AmountWithUnit.from(100, 'sat'))).toBe(0);
+    expect(() => a.compareTo(c)).toThrow(AmountWithUnitError);
+  });
+
+  it('comparators throw on unit mismatch', () => {
+    expect(() => a.lessThan(c)).toThrow(AmountWithUnitError);
+    expect(() => a.lessThanOrEqual(c)).toThrow(AmountWithUnitError);
+    expect(() => a.greaterThan(c)).toThrow(AmountWithUnitError);
+    expect(() => a.greaterThanOrEqual(c)).toThrow(AmountWithUnitError);
+  });
+
+  it('comparators agree with raw Amount semantics for same-unit pairs', () => {
+    expect(a.greaterThan(b)).toBe(true);
+    expect(b.lessThan(a)).toBe(true);
+    expect(a.greaterThanOrEqual(AmountWithUnit.from(100, 'sat'))).toBe(true);
+    expect(a.lessThanOrEqual(AmountWithUnit.from(100, 'sat'))).toBe(true);
+  });
+
+  it('inRange / clamp respect unit', () => {
+    const lo = AmountWithUnit.from(10, 'sat');
+    const hi = AmountWithUnit.from(200, 'sat');
+    expect(a.inRange(lo, hi)).toBe(true);
+    expect(a.clamp(lo, hi).toAmount().toBigInt()).toBe(100n);
+    expect(() => a.inRange(c, hi)).toThrow(AmountWithUnitError);
+    expect(() => a.clamp(c, hi)).toThrow(AmountWithUnitError);
+    expect(() => a.inRange(lo, c)).toThrow(AmountWithUnitError);
+    expect(() => a.clamp(lo, c)).toThrow(AmountWithUnitError);
+  });
+});
+
+describe('AmountWithUnit scalar ops preserve unit', () => {
+  const a = AmountWithUnit.from(1000, 'sat');
+
+  it('multiplyBy', () => {
+    const r = a.multiplyBy(3);
+    expect(r.toAmount().toBigInt()).toBe(3000n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('divideBy', () => {
+    const r = a.divideBy(4);
+    expect(r.toAmount().toBigInt()).toBe(250n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('modulo', () => {
+    const r = a.modulo(7);
+    expect(r.toAmount().toBigInt()).toBe(1000n % 7n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('ceilPercent', () => {
+    const r = a.ceilPercent(2);
+    expect(r.toAmount().toBigInt()).toBe(20n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('floorPercent', () => {
+    const r = a.floorPercent(2);
+    expect(r.toAmount().toBigInt()).toBe(20n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('scaledBy', () => {
+    const r = a.scaledBy(3, 4);
+    expect(r.toAmount().toBigInt()).toBe(750n);
+    expect(r.unit).toBe('sat');
+  });
+});
+
+describe('AmountWithUnit.min / max', () => {
+  it('returns the lesser/greater when units agree', () => {
+    const a = AmountWithUnit.from(3, 'sat');
+    const b = AmountWithUnit.from(5, 'sat');
+    expect(AmountWithUnit.min(a, b).toAmount().toBigInt()).toBe(3n);
+    expect(AmountWithUnit.min(b, a).toAmount().toBigInt()).toBe(3n);
+    expect(AmountWithUnit.max(a, b).toAmount().toBigInt()).toBe(5n);
+    expect(AmountWithUnit.max(b, a).toAmount().toBigInt()).toBe(5n);
+    expect(AmountWithUnit.min(a, b).unit).toBe('sat');
+  });
+
+  it('throws on unit mismatch', () => {
+    const a = AmountWithUnit.from(3, 'sat');
+    const c = AmountWithUnit.from(3, 'usd');
+    expect(() => AmountWithUnit.min(a, c)).toThrow(AmountWithUnitError);
+    expect(() => AmountWithUnit.max(a, c)).toThrow(AmountWithUnitError);
+  });
+});
+
+describe('AmountWithUnit.sum', () => {
+  it('infers unit from first element when hint omitted', () => {
+    const r = AmountWithUnit.sum([
+      AmountWithUnit.from(1, 'sat'),
+      AmountWithUnit.from(2, 'sat'),
+      AmountWithUnit.from(3, 'sat'),
+    ]);
+    expect(r.toAmount().toBigInt()).toBe(6n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('throws on empty iterable when hint omitted', () => {
+    expect(() => AmountWithUnit.sum([])).toThrow('cannot infer unit from empty sum');
+  });
+
+  it('returns zero(unit) on empty iterable when hint provided', () => {
+    const r = AmountWithUnit.sum([], 'sat');
+    expect(r.toAmount().toBigInt()).toBe(0n);
+    expect(r.unit).toBe('sat');
+  });
+
+  it('validates every element against unit hint', () => {
+    expect(() =>
+      AmountWithUnit.sum([AmountWithUnit.from(1, 'sat'), AmountWithUnit.from(2, 'usd')], 'sat'),
+    ).toThrow(AmountWithUnitError);
+  });
+
+  it('throws on mixed-unit iterable without hint', () => {
+    expect(() =>
+      AmountWithUnit.sum([AmountWithUnit.from(1, 'sat'), AmountWithUnit.from(2, 'usd')]),
+    ).toThrow(AmountWithUnitError);
+  });
+});
+
+describe('Amount.withUnit', () => {
+  it('lifts a unitless Amount and round-trips', () => {
+    const a = Amount.from(100).withUnit('sat');
+    expect(a.toAmount().equals(Amount.from(100))).toBe(true);
+    expect(a.unit).toBe('sat');
+  });
+
+  it('rejects empty unit', () => {
+    expect(() => Amount.from(1).withUnit('')).toThrow(AmountWithUnitError);
+  });
+});
+
+describe('Amount and AmountWithUnit do not silently bridge', () => {
+  it('Amount.from does not accept AmountWithUnit (compile-time, runtime rejects too)', () => {
+    const tagged = AmountWithUnit.from(100, 'sat');
+    expect(() => {
+      // @ts-expect-error AmountWithUnit is not assignable to AmountLike
+      Amount.from(tagged);
+    }).toThrow('Unsupported amount input type');
+    // .toAmount() is the explicit, safe escape hatch
+    expect(Amount.from(tagged.toAmount()).toBigInt()).toBe(100n);
+  });
+});

--- a/test/model/AmountWithUnit.test.ts
+++ b/test/model/AmountWithUnit.test.ts
@@ -47,11 +47,16 @@ describe('AmountWithUnit factories', () => {
 });
 
 describe('AmountWithUnit pass-through converters', () => {
-  it('toBigInt / toNumber / toString match underlying Amount', () => {
+  it('toBigInt / toNumber match underlying Amount', () => {
     const a = AmountWithUnit.from(123, 'sat');
     expect(a.toBigInt()).toBe(a.toAmount().toBigInt());
     expect(a.toNumber()).toBe(a.toAmount().toNumber());
-    expect(a.toString()).toBe(a.toAmount().toString());
+  });
+
+  it('toString includes the unit (does not silently drop it)', () => {
+    expect(AmountWithUnit.from(123, 'sat').toString()).toBe('123 sat');
+    expect(AmountWithUnit.from(5, 'usd').toString()).toBe('5 usd');
+    expect(AmountWithUnit.zero('msat').toString()).toBe('0 msat');
   });
 
   it('isZero / isSafeNumber match underlying Amount', () => {
@@ -240,6 +245,47 @@ describe('Amount.withUnit', () => {
 
   it('rejects empty unit', () => {
     expect(() => Amount.from(1).withUnit('')).toThrow(AmountWithUnitError);
+  });
+});
+
+describe('AmountWithUnit implicit coercion is safe', () => {
+  const a = AmountWithUnit.from(100, 'sat');
+
+  it('template literals produce unit-bearing string', () => {
+    expect(`${a}`).toBe('100 sat');
+    expect(`balance: ${a}`).toBe('balance: 100 sat');
+  });
+
+  it('String(x) produces unit-bearing string', () => {
+    expect(String(a)).toBe('100 sat');
+  });
+
+  it('Number(x) throws (does not silently strip unit)', () => {
+    expect(() => Number(a)).toThrow(AmountWithUnitError);
+    expect(() => Number(a)).toThrow(/numeric coercion .* unsafe/i);
+  });
+
+  it('unary + throws', () => {
+    expect(() => +(a as unknown as number)).toThrow(AmountWithUnitError);
+  });
+
+  it('arithmetic operators throw (a - n, n * a, etc.)', () => {
+    expect(() => (a as unknown as number) - 10).toThrow(AmountWithUnitError);
+    expect(() => 2 * (a as unknown as number)).toThrow(AmountWithUnitError);
+    expect(() => (a as unknown as number) / 5).toThrow(AmountWithUnitError);
+  });
+
+  it('loose equality with a number throws (no silent comparison on bare value)', () => {
+    expect(() => (a as unknown) == 100).toThrow(AmountWithUnitError);
+  });
+
+  it('`a + b` with two AmountWithUnit throws (no silent numeric add)', () => {
+    const b = AmountWithUnit.from(50, 'sat');
+    expect(() => (a as unknown as number) + (b as unknown as number)).toThrow(AmountWithUnitError);
+  });
+
+  it('JSON.stringify is unaffected (uses toJSON, not toString)', () => {
+    expect(JSON.stringify(a)).toBe('{"amount":"100","unit":"sat"}');
   });
 });
 

--- a/test/model/AmountWithUnit.test.ts
+++ b/test/model/AmountWithUnit.test.ts
@@ -53,10 +53,10 @@ describe('AmountWithUnit pass-through converters', () => {
     expect(a.toNumber()).toBe(a.toAmount().toNumber());
   });
 
-  it('toString includes the unit (does not silently drop it)', () => {
-    expect(AmountWithUnit.from(123, 'sat').toString()).toBe('123 sat');
-    expect(AmountWithUnit.from(5, 'usd').toString()).toBe('5 usd');
-    expect(AmountWithUnit.zero('msat').toString()).toBe('0 msat');
+  it('toString returns "<unit>: <amount>" (does not silently drop unit)', () => {
+    expect(AmountWithUnit.from(123, 'sat').toString()).toBe('sat: 123');
+    expect(AmountWithUnit.from(5, 'usd').toString()).toBe('usd: 5');
+    expect(AmountWithUnit.zero('msat').toString()).toBe('msat: 0');
   });
 
   it('isZero / isSafeNumber match underlying Amount', () => {
@@ -252,12 +252,20 @@ describe('AmountWithUnit implicit coercion is safe', () => {
   const a = AmountWithUnit.from(100, 'sat');
 
   it('template literals produce unit-bearing string', () => {
-    expect(`${a}`).toBe('100 sat');
-    expect(`balance: ${a}`).toBe('balance: 100 sat');
+    expect(`${a}`).toBe('sat: 100');
+    expect(`balance: ${a}`).toBe('balance: sat: 100');
   });
 
   it('String(x) produces unit-bearing string', () => {
-    expect(String(a)).toBe('100 sat');
+    expect(String(a)).toBe('sat: 100');
+  });
+
+  it('parseInt / parseFloat of the string form return NaN (unit cannot be stripped via parse)', () => {
+    expect(parseInt(String(a), 10)).toBeNaN();
+    expect(parseFloat(String(a))).toBeNaN();
+    // and via implicit string coercion on the object directly
+    expect(parseInt(a as unknown as string, 10)).toBeNaN();
+    expect(parseFloat(a as unknown as string)).toBeNaN();
   });
 
   it('Number(x) throws (does not silently strip unit)', () => {

--- a/test/model/AmountWithUnit.test.ts
+++ b/test/model/AmountWithUnit.test.ts
@@ -53,10 +53,10 @@ describe('AmountWithUnit pass-through converters', () => {
     expect(a.toNumber()).toBe(a.toAmount().toNumber());
   });
 
-  it('toString returns "<unit>: <amount>" (does not silently drop unit)', () => {
-    expect(AmountWithUnit.from(123, 'sat').toString()).toBe('sat: 123');
-    expect(AmountWithUnit.from(5, 'usd').toString()).toBe('usd: 5');
-    expect(AmountWithUnit.zero('msat').toString()).toBe('msat: 0');
+  it('toString returns "[<unit>]: <amount>" (does not silently drop unit)', () => {
+    expect(AmountWithUnit.from(123, 'sat').toString()).toBe('[sat]: 123');
+    expect(AmountWithUnit.from(5, 'usd').toString()).toBe('[usd]: 5');
+    expect(AmountWithUnit.zero('msat').toString()).toBe('[msat]: 0');
   });
 
   it('isZero / isSafeNumber match underlying Amount', () => {
@@ -252,12 +252,12 @@ describe('AmountWithUnit implicit coercion is safe', () => {
   const a = AmountWithUnit.from(100, 'sat');
 
   it('template literals produce unit-bearing string', () => {
-    expect(`${a}`).toBe('sat: 100');
-    expect(`balance: ${a}`).toBe('balance: sat: 100');
+    expect(`${a}`).toBe('[sat]: 100');
+    expect(`balance: ${a}`).toBe('balance: [sat]: 100');
   });
 
   it('String(x) produces unit-bearing string', () => {
-    expect(String(a)).toBe('sat: 100');
+    expect(String(a)).toBe('[sat]: 100');
   });
 
   it('parseInt / parseFloat of the string form return NaN (unit cannot be stripped via parse)', () => {
@@ -266,6 +266,13 @@ describe('AmountWithUnit implicit coercion is safe', () => {
     // and via implicit string coercion on the object directly
     expect(parseInt(a as unknown as string, 10)).toBeNaN();
     expect(parseFloat(a as unknown as string)).toBeNaN();
+  });
+
+  it('parseInt / parseFloat return NaN even when unit string itself starts with digits', () => {
+    const tricky = AmountWithUnit.from(1, '9999sat');
+    expect(String(tricky)).toBe('[9999sat]: 1');
+    expect(parseInt(String(tricky), 10)).toBeNaN();
+    expect(parseFloat(String(tricky))).toBeNaN();
   });
 
   it('Number(x) throws (does not silently strip unit)', () => {


### PR DESCRIPTION
## Summary

Adds `AmountWithUnit`, a unit-aware sibling to `Amount`, so multi-unit consumers (wallets aggregating across `sat`/`usd` or multiple mints) can do arithmetic and comparisons without silently mixing units. Binary ops require matching units and throw `AmountWithUnitError`; scalar ops preserve the unit.

`AmountWithUnit` and `Amount` are deliberately distinct types with no implicit coercion: lift with `Amount.withUnit()` or `AmountWithUnit.from()`, drop back with `.toAmount()`.

**Design Note:** Extending `AmountLike` to accept `AmountWithUnit` was rejected: that would silently strip the unit at every coercion point. CTS APIs continue to take `AmountLike ` and return `Amount`; `AmountWithUnit` is opt-in at the consumer boundary.

## Detailed Changes

- new `AmountWithUnit` class in `src/model/Amount.ts`: passes through Amount methods with unit checks as needed
- new `AmountWithUnitError extends CTSError`
- new `Amount.withUnit(unit)` lifting method
- updated documentation and migration guides
- tests bring `src/model/Amount.ts` to 100%

## Notes

No internal call sites migrated: `Wallet` / `Mint` / `SelectProofs` / `utils/core` continue using unit-agnostic `Amount`.

Public API additions:

- new exports: `AmountWithUnit`, `AmountWithUnitError`
- new method on `Amount`: `withUnit(unit: string): AmountWithUnit`