### PR TITLE
chore(crypto): deprecate verifyDleqIfPresent ahead of v5 removal

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -515,7 +515,9 @@ export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: strin
 export function hasTag(secret: Secret | string, key: string): boolean;
 
 // @public
-export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean;
+export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys, opts?: {
+    require?: boolean;
+}): boolean;
 
 // @public
 export type HTLCWitness = {
@@ -1875,7 +1877,7 @@ export type UnblindedSignature = {
 // @public (undocumented)
 export function unblindSignature(C_: WeierstrassPoint<bigint>, r: bigint, A: WeierstrassPoint<bigint>): WeierstrassPoint<bigint>;
 
-// @public
+// @public @deprecated
 export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean;
 
 // @public (undocumented)

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1877,7 +1877,7 @@ export type UnblindedSignature = {
 // @public (undocumented)
 export function unblindSignature(C_: WeierstrassPoint<bigint>, r: bigint, A: WeierstrassPoint<bigint>): WeierstrassPoint<bigint>;
 
-// @public @deprecated
+// @public @deprecated (undocumented)
 export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean;
 
 // @public (undocumented)

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -689,12 +689,19 @@ function mapShortKeysetIds(proofs: Proof[], keysetIds: readonly string[]): Proof
  *
  * @param proof The proof subject to verification.
  * @param keyset Object containing keyset keys (eg: Keyset, MintKeys, KeysetCache)
+ * @param opts.require Default `true`. When `false`, a proof without a DLEQ payload returns `true`
+ *   (NUT-12 "MUST verify-if-present"). The default flips to `false` in v5.0.
  * @returns True if verification succeeded, false otherwise.
  * @throws Throws if the proof amount does not match any key in the provided keyset.
  */
-export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean {
+export function hasValidDleq(
+  proof: Proof,
+  keyset: HasKeysetKeys,
+  opts?: { require?: boolean },
+): boolean {
+  const require = opts?.require ?? true;
   if (proof?.dleq == undefined) {
-    return false;
+    return !require;
   }
   if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
     throw new CTSError(
@@ -721,24 +728,12 @@ export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys): boolean {
 }
 
 /**
- * NUT-12: verifies the DLEQ proof on a Proof when one is included.
+ * @deprecated Use `hasValidDleq(proof, keyset, { require: false })`.
  *
- * @remarks
- * Distinct from {@link hasValidDleq}: if the proof carries no DLEQ this returns true (nothing to
- * verify), satisfying the spec "MUST verify-if-present" rule. Use {@link hasValidDleq} when you want
- * a stricter "must be present and valid" check.
- * @param proof The proof subject to verification.
- * @param keyset Object containing keyset keys (eg: Keyset, MintKeys, KeysetCache)
- * @returns True if no DLEQ is present, or if the present DLEQ verifies; false if the present DLEQ
- *   fails to verify.
- * @throws Throws if a DLEQ is present and the proof amount does not match any key in the provided
- *   keyset.
+ *   Will be removed in v5.0.
  */
 export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean {
-  if (proof?.dleq == undefined) {
-    return true;
-  }
-  return hasValidDleq(proof, keyset);
+  return hasValidDleq(proof, keyset, { require: false });
 }
 
 /**


### PR DESCRIPTION
## Summary

- `hasValidDleq` gains optional `{ require?: boolean }`. Default `true` preserves the existing strict semantic (missing DLEQ on a v0/v1/v2 proof returns `false`); `require: false` accepts (NUT-12 "MUST verify-if-present"). Non-breaking on v4.
- `verifyDleqIfPresent` becomes a one-line wrapper around `hasValidDleq(proof, keyset, { require: false })` and carries a `@deprecated` JSDoc tag pointing at the new opt. Output identical to today's implementation for every input.
- The `hasValidDleq` JSDoc notes the v5.0 plan: default flips to `false` (NUT-12 spec semantic) and `verifyDleqIfPresent` is removed; the strict policy will be opt-in via `{ require: true }`.

The aim is to give downstream consumers an IDE strikethrough and a one-line migration target *before* the v5 BLS branch lands the actual removal.

## Test plan

- [x] Existing `hasValidDleq` and `verifyDleqIfPresent` test coverage passes unchanged (no behaviour change on the default path).
- [x] `npm run api:check` clean — `etc/cashu-ts.api.md` reflects the new optional parameter and the `@deprecated` annotation.
- [x] In an editor, hover/autocomplete on `verifyDleqIfPresent` surfaces the strikethrough and the migration hint.