### PR TITLE
feat(wallet): accept proof id in checkProofsStates ahead of v5

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2071,6 +2071,8 @@ export class Wallet {
     checkMintQuoteBolt11(quote: string | MintQuoteBolt11Response): Promise<MintQuoteBolt11Response>;
     checkMintQuoteBolt12(quote: string): Promise<MintQuoteBolt12Response>;
     checkMintQuoteOnchain(quote: string): Promise<MintQuoteOnchainResponse>;
+    checkProofsStates(proofs: Array<Pick<ProofLike, 'secret' | 'id'>>): Promise<ProofState[]>;
+    // @deprecated (undocumented)
     checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]>;
     completeBatchMint(batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>): Promise<Proof[]>;
     completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(meltPreview: MeltPreview<TQuote>, privkey?: string | string[], options?: CompleteMeltOptions): Promise<MeltProofsResponse<TQuote>>;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2921,10 +2921,17 @@ class Wallet {
   /**
    * Get an array of the states of proofs from the mint (as an array of CheckStateEnum's)
    *
-   * @param proofs (only the `secret` field is required)
+   * @param proofs Each proof should carry both `secret` and `id`. The `id` is currently unused, but
+   *   becomes required in v5 where it selects the hash-to-curve variant (secp256k1 vs BLS12-381).
    * @returns NUT-07 state for each proof, in same order.
    */
-  async checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]> {
+  async checkProofsStates(proofs: Array<Pick<ProofLike, 'secret' | 'id'>>): Promise<ProofState[]>;
+  /**
+   * @deprecated Include `id` on each proof alongside `secret`. The keyset `id` becomes required in
+   *   v5 to select the hash-to-curve variant; `secret`-only proofs will stop working then.
+   */
+  async checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]>;
+  async checkProofsStates(proofs: Array<Pick<ProofLike, 'secret'>>): Promise<ProofState[]> {
     const enc = new TextEncoder();
     const Ys = proofs.map((p: Pick<Proof, 'secret'>) =>
       hashToCurve(enc.encode(p.secret)).toHex(true),


### PR DESCRIPTION
## What

Adds an `id`-aware overload to `Wallet.checkProofsStates()` and marks the existing `secret`-only signature `@deprecated`.

```ts
// preferred
checkProofsStates(proofs: Array<Pick<ProofLike, 'secret' | 'id'>>): Promise<ProofState[]>;
// @deprecated — secret-only
checkProofsStates(proofs: Array<Pick<Proof, 'secret'>>): Promise<ProofState[]>;
```

## Why

In v5, `checkProofsStates()` widens from `secret`-only to `{ secret, id }`, because the keyset `id` selects the hash-to-curve variant (secp256k1 vs BLS12-381). Introducing the `id`-aware signature now — and deprecating the `secret`-only one — gives callers a migration window so the v5 change is non-breaking for code written today.

## Behaviour

- Non-breaking on v4: the `id` is accepted but unused (secp256k1 only); the implementation is unchanged.
- Overload order means callers already passing full proofs resolve to the new signature and see **no** warning; only genuine `secret`-only callers get the deprecation nudge.