### PR TITLE
feat(nut06): add method_name to mint/melt method settings (NUT-04/05)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2001,6 +2001,7 @@ export function sumProofs(proofs: Array<Pick<ProofLike, 'amount'>>): Amount;
 export type SwapMethod = {
     method: string;
     unit: string;
+    method_name: string | null;
     min_amount: AmountLike | null;
     max_amount: AmountLike | null;
     description?: boolean;

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -68,13 +68,13 @@ export class MintInfo {
     };
   }
 
-  // Per NUT-04/05/25/XX, `min_amount` and `max_amount` are `<int|null>`. Mints that omit
-  // them entirely (older Nutshell, etc.) leave the field as `undefined`; coerce to null
-  // so the runtime value matches the `AmountLike | null` type.
+  // Per NUT-04/05/25/XX, `min_amount`, `max_amount`, and `method_name` are `<x|null>`. Mints that
+  // omit them entirely (older Nutshell, etc.) leave the field as `undefined`; coerce to null so the
+  // normalized response is spec-valid and matches the declared types.
   private static normalizeSwapMethods(methods: SwapMethod[]): SwapMethod[] {
     return methods.map((m) => {
       const next = { ...m } as Record<string, unknown>;
-      nullIfUndefined(next, 'min_amount', 'max_amount');
+      nullIfUndefined(next, 'min_amount', 'max_amount', 'method_name');
       return next as SwapMethod;
     });
   }

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -100,10 +100,6 @@ export type MintContactInfo = {
 export type SwapMethod = {
   method: string;
   unit: string;
-  /**
-   * Human-readable name for this method (NUT-04/05), e.g. `"Lightning"`. `<str|null>` on the wire
-   * and coerced to `null` when the mint omits it. Fall back to {@link method} for display.
-   */
   method_name: string | null;
   min_amount: AmountLike | null;
   max_amount: AmountLike | null;

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -100,6 +100,11 @@ export type MintContactInfo = {
 export type SwapMethod = {
   method: string;
   unit: string;
+  /**
+   * Human-readable name for this method (NUT-04/05), e.g. `"Lightning"`. `<str|null>` on the wire
+   * and coerced to `null` when the mint omits it. Fall back to {@link method} for display.
+   */
+  method_name: string | null;
   min_amount: AmountLike | null;
   max_amount: AmountLike | null;
   description?: boolean; //added this for Nutshell =>0.16.4 compatibility, see https://github.com/cashubtc/nutshell/pull/783

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -108,7 +108,15 @@ describe('MintInfo protected endpoint matching', () => {
       nuts: {
         4: {
           disabled: false,
-          methods: [{ method: 'bolt11', unit: 'sat', min_amount: 1n, max_amount: 2n }],
+          methods: [
+            {
+              method: 'bolt11',
+              unit: 'sat',
+              method_name: 'Lightning',
+              min_amount: 1n,
+              max_amount: 2n,
+            },
+          ],
         },
         5: {
           disabled: false,
@@ -130,6 +138,9 @@ describe('MintInfo protected endpoint matching', () => {
     expect(info.nuts['4'].methods[0].max_amount).toBe(2n);
     expect(info.nuts['5'].methods[0].min_amount).toBe(3n);
     expect(info.nuts['5'].methods[0].max_amount).toBe(4n);
+    // method_name (NUT-04/05) passes through; coerced to null on mints that omit it
+    expect(info.nuts['4'].methods[0].method_name).toBe('Lightning');
+    expect(info.nuts['5'].methods[0].method_name).toBeNull();
     // metadata integers (ttl, bat_max_mint) are still normalized to safe numbers
     expect(info.nuts['19']?.ttl).toBe(30);
     expect(info.nuts['22']?.bat_max_mint).toBe(5);

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -313,11 +313,11 @@ describe('test info', () => {
     expect(info.isSupported(5)).toEqual({
       disabled: false,
       params: [
-        { method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null },
-        { method: 'bolt11', unit: 'usd', min_amount: null, max_amount: null },
-        { method: 'bolt11', unit: 'eur', min_amount: null, max_amount: null },
-        { method: 'bolt12', unit: 'sat', min_amount: null, max_amount: null },
-        { method: 'onchain', unit: 'sat', min_amount: null, max_amount: null },
+        { method: 'bolt11', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
+        { method: 'bolt11', unit: 'usd', method_name: null, min_amount: null, max_amount: null },
+        { method: 'bolt11', unit: 'eur', method_name: null, min_amount: null, max_amount: null },
+        { method: 'bolt12', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
+        { method: 'onchain', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
       ],
     });
     expect(info.isSupported(17)).toEqual({


### PR DESCRIPTION
Implements: https://github.com/cashubtc/nuts/pull/374

## Summary

NUT-04/05 add a `method_name` field to the method-unit settings a mint advertises at `/v1/info` — a human-readable name for the method (e.g. `"Lightning"`). cashu-ts models both NUT-04 and NUT-05 settings with a single `SwapMethod` type, so one addition covers both.

```ts
export type SwapMethod = {
  method: string;
  unit: string;
  method_name: string | null; // new
  min_amount: AmountLike | null;
  max_amount: AmountLike | null;
  // …
};
```

## Modelling

Typed `string | null` (not optional) to match the existing `<x|null>` siblings `min_amount`/`max_amount`. `normalizeSwapMethods` coerces an absent field to `null`, so `MintInfo` always hands consumers a spec-valid, fully-shaped response rather than a sometimes-`undefined` field. Consumers fall back to `method` for display when it's `null`.

## Notes

- Purely additive on a response type → **non-breaking**.
- Covered by a passthrough/coercion assertion in `MintInfo.test.ts` (present → value, omitted → `null`).
- `etc/cashu-ts.api.md` regenerated.