### PR TITLE
feat(mintinfo): add supportedMethods(op) to list usable mint/melt methods

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -26,6 +26,8 @@ wallet2.loadMintFromCache(mintInfoCache, keychainCache);
 // wallet2 is now ready to use
 ```
 
+After `loadMint()`, use `wallet.getMintInfo()` to inspect what the mint supports — see [Inspect Mint Capabilities](./mint_capabilities.md).
+
 > ⚠️ **Server-side usage:** If you construct a `Wallet` (or `Mint`) using a URL from untrusted input (e.g. a received token), validate the mint URL against your own trusted-mint allowlist **before** passing it in. The library validates URL structure but cannot know which mints your application trusts.
 
 ## Custom output generation

--- a/docs-src/usage/mint_capabilities.md
+++ b/docs-src/usage/mint_capabilities.md
@@ -1,0 +1,76 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Inspect Mint Capabilities**
+
+# Inspect mint capabilities
+
+After `loadMint()`, the mint's `/v1/info` response is available through `wallet.getMintInfo()`, which exposes helpers for discovering what the mint supports — the methods you can mint and melt with, and which NUTs it advertises.
+
+```ts
+import { Wallet } from '@cashu/cashu-ts';
+
+const wallet = new Wallet('http://localhost:3338');
+await wallet.loadMint();
+
+const info = wallet.getMintInfo();
+```
+
+Three helpers cover the common questions:
+
+| I want to…                               | Use                                             | Returns        |
+| :--------------------------------------- | :---------------------------------------------- | :------------- |
+| list the methods I can mint or melt with | `info.supportedMethods(op)`                     | `SwapMethod[]` |
+| check one method/unit pair               | `info.supportsMintMeltMethod(op, method, unit)` | `boolean`      |
+| inspect raw support for any NUT          | `info.isSupported(num)`                         | varies by NUT  |
+
+## List supported methods
+
+`supportedMethods('mint' | 'melt')` returns the method-unit settings the mint advertises for that operation, or an empty array when the operation is **disabled** - so a non-empty result means the methods are usable.
+
+```ts
+const mintMethods = info.supportedMethods('mint');
+// e.g. [{ method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null }, ...]
+
+for (const m of mintMethods) {
+  console.log(`can mint ${m.unit} via ${m.method}`);
+}
+
+const meltMethods = info.supportedMethods('melt');
+if (meltMethods.length === 0) {
+  console.log('This mint cannot melt (no methods, or melting is disabled)');
+}
+```
+
+Each entry is a `SwapMethod` carrying `method`, `unit`, and the optional `min_amount` / `max_amount` limits (`null` when the mint advertises no bound).
+
+## Check a specific method and unit
+
+When you already know the pair you want, `supportsMintMeltMethod` is a direct boolean check. It accounts for the disabled flag.
+
+```ts
+if (info.supportsMintMeltMethod('melt', 'bolt11', 'sat')) {
+  // safe to prepare a bolt11 melt in sats
+}
+```
+
+## Inspect raw NUT support
+
+`isSupported(num)` reports the mint's advertised support for a given NUT.
+
+For NUT-4 (mint) and NUT-5 (melt) it returns the `disabled` flag and the raw method list:
+
+```ts
+const melt = info.isSupported(5);
+console.log('melt disabled?', melt.disabled);
+console.log('advertised melt methods:', melt.params);
+```
+
+> `isSupported(4 | 5).params` returns the advertised methods **even when the operation is disabled**. Prefer `supportedMethods(op)` when you want only the methods you can actually use — it returns `[]` for a disabled operation.
+
+For other NUTs it reports a boolean, and some include params:
+
+```ts
+info.isSupported(20); // { supported: boolean }           — locked mint quotes (NUT-20)
+info.isSupported(15); // { supported: boolean; params? }  — MPP methods (NUT-15)
+info.isSupported(19); // { supported: boolean; params? }  — cached endpoints (NUT-19)
+```
+
+See [NUT-19 Cached Responses](./nut19.md) for a worked example of the `isSupported(19)` shape.

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -20,18 +20,19 @@ If you are building a wallet integration from scratch, read these in order:
 
 ## Recipes
 
-| Recipe                                | Use it for                                                             |
-| :------------------------------------ | :--------------------------------------------------------------------- |
-| [Create Wallet](./create_wallet.md)   | Initialize a wallet from a mint URL or cached mint state.              |
-| [Mint Token](./mint_token.md)         | Create proofs from a paid quote, including two-step mint flows.        |
-| [Create Token](./create_token.md)     | Send standard Cashu tokens to another wallet.                          |
-| [Create P2PK](./create_p2pk.md)       | Send tokens locked to a public key.                                    |
-| [Get Token](./get_token.md)           | Inspect token metadata before wallet creation or decode it after load. |
-| [Melt Token](./melt_token.md)         | Pay BOLT11 invoices or other payment methods with wallet proofs.       |
-| [Bolt12](./bolt12.md)                 | Work with reusable BOLT12 offers for minting and melting.              |
-| [NUT-19 Cached Responses](./nut19.md) | Understand cached endpoint retries and timeout behavior.               |
-| [Logging](./logging.md)               | Enable and route library logs while debugging wallet or mint behavior. |
-| [Amounts](./amounts.md)               | Work with the `Amount` and `AmountWithUnit` value objects.             |
+| Recipe                                              | Use it for                                                                      |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------ |
+| [Create Wallet](./create_wallet.md)                 | Initialize a wallet from a mint URL or cached mint state.                       |
+| [Inspect Mint Capabilities](./mint_capabilities.md) | Discover which methods you can mint/melt with and which NUTs the mint supports. |
+| [Mint Token](./mint_token.md)                       | Create proofs from a paid quote, including two-step mint flows.                 |
+| [Create Token](./create_token.md)                   | Send standard Cashu tokens to another wallet.                                   |
+| [Create P2PK](./create_p2pk.md)                     | Send tokens locked to a public key.                                             |
+| [Get Token](./get_token.md)                         | Inspect token metadata before wallet creation or decode it after load.          |
+| [Melt Token](./melt_token.md)                       | Pay BOLT11 invoices or other payment methods with wallet proofs.                |
+| [Bolt12](./bolt12.md)                               | Work with reusable BOLT12 offers for minting and melting.                       |
+| [NUT-19 Cached Responses](./nut19.md)               | Understand cached endpoint retries and timeout behavior.                        |
+| [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |
+| [Amounts](./amounts.md)                             | Work with the `Amount` and `AmountWithUnit` value objects.                      |
 
 ## Related docs
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1147,6 +1147,7 @@ export class MintInfo {
     requiresBlindAuthToken(method: 'GET' | 'POST', path: string): boolean;
     // (undocumented)
     requiresClearAuthToken(method: 'GET' | 'POST', path: string): boolean;
+    supportedMethods(op: 'mint' | 'melt'): SwapMethod[];
     // (undocumented)
     supportsAmountless(method?: string, unit?: string): boolean;
     supportsMintMeltMethod(op: 'mint' | 'melt', method: string, unit: string): boolean;

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -384,6 +384,16 @@ export class MintInfo {
   }
 
   /**
+   * Lists the method-unit settings the mint advertises for an operation (`'mint'` → NUT-4, `'melt'`
+   * → NUT-5), or `[]` when that operation is disabled. Use this to discover what a consumer can
+   * mint or melt with; to test a single pair use `supportsMintMeltMethod`.
+   */
+  supportedMethods(op: 'mint' | 'melt'): SwapMethod[] {
+    const { disabled, params } = this.isSupported(op === 'mint' ? 4 : 5);
+    return disabled ? [] : params;
+  }
+
+  /**
    * Checks if the mint advertises the given (method, unit) pair for the given operation (`'mint'` →
    * NUT-4, `'melt'` → NUT-5).
    */

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -142,6 +142,28 @@ describe('MintInfo protected endpoint matching', () => {
     });
   });
 
+  it('supportedMethods lists usable methods and returns [] for disabled ops', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        4: {
+          disabled: false,
+          methods: [
+            { method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null },
+            { method: 'bolt12', unit: 'sat', min_amount: null, max_amount: null },
+          ],
+        },
+        5: {
+          disabled: true,
+          methods: [{ method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null }],
+        },
+      },
+    } as any);
+
+    expect(info.supportedMethods('mint').map((m) => m.method)).toEqual(['bolt11', 'bolt12']);
+    expect(info.supportedMethods('melt')).toEqual([]);
+  });
+
   it('rejects out-of-range bigint info metadata at construction', () => {
     expect(
       () =>


### PR DESCRIPTION
## Summary

Adds a discovery convenience to `MintInfo`:

```ts
supportedMethods(op: 'mint' | 'melt'): SwapMethod[]   // [] when the op is disabled
```

Returns the method-unit settings the mint advertises for minting (NUT-04) or melting (NUT-05), so a consumer can enumerate what they can actually use (e.g. to build a method picker).

## Motivation

It's the discovery counterpart to the existing point-check `supportsMintMeltMethod(op, method, unit)`. Compared to the lower-level `isSupported(4 | 5).params`, it is:
- **operation-named** (no need to remember NUT-4 = mint, NUT-5 = melt), and
- **disabled-filtered** — `isSupported(4).params` returns methods even when the op is disabled; `supportedMethods` returns `[]`, so "supported" means *usable*.

