### PR TITLE
feat: add scoped request fetch hooks

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -30,6 +30,41 @@ After `loadMint()`, use `wallet.getMintInfo()` to inspect what the mint supports
 
 > ⚠️ **Server-side usage:** If you construct a `Wallet` (or `Mint`) using a URL from untrusted input (e.g. a received token), validate the mint URL against your own trusted-mint allowlist **before** passing it in. The library validates URL structure but cannot know which mints your application trusts.
 
+## Custom mint transport
+
+Pass `requestFetch` when one wallet or mint needs a runtime-specific transport, for example OHTTP, Tor, a native mobile HTTP client, or an application proxy. This keeps the default cashu-ts request behavior for JSON parsing, timeouts, errors, and NUT-19 retries while replacing only the network primitive.
+
+```typescript
+import { Wallet, type RequestFetch } from '@cashu/cashu-ts';
+
+const ohttpFetch: RequestFetch = async (input, init) => {
+  return fetchThroughOhttp(input, init); // your OHTTP relay client
+};
+
+const wallet = new Wallet('http://localhost:3338', {
+  unit: 'sat',
+  requestFetch: ohttpFetch,
+});
+await wallet.loadMint();
+```
+
+Use `setGlobalRequestOptions({ fetch })` when your whole app uses the same mint transport policy.
+
+Use `customRequest` when you need to replace the entire request pipeline instead of only the fetch-compatible transport.
+
+`requestFetch` only applies to Cashu mint HTTP requests. OIDC discovery and token requests use `oidc.fetch` because they target the identity provider and use OAuth/OIDC request and error semantics.
+
+```typescript
+import { createAuthWallet } from '@cashu/cashu-ts';
+
+const { wallet, oidc } = await createAuthWallet('http://localhost:3338', {
+  requestFetch: ohttpFetch,
+  oidc: {
+    fetch: ohttpFetch,
+  },
+});
+```
+
 ## Custom output generation
 
 Pass `outputDataCreator` when you need to replace the default output generation logic, for

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -321,6 +321,8 @@ export interface CounterSource {
 export function createAuthWallet(mintUrl: string, options?: {
     authPool?: number;
     oidc?: OIDCAuthOptions;
+    customRequest?: RequestFn;
+    requestFetch?: RequestFetch;
     logger?: Logger;
 }): Promise<{
     mint: Mint;
@@ -928,6 +930,7 @@ export type MeltRequest = {
 export class Mint {
     constructor(mintUrl: string, options?: {
         customRequest?: RequestFn;
+        requestFetch?: RequestFetch;
         authProvider?: AuthProvider;
         logger?: Logger;
     });
@@ -1364,6 +1367,7 @@ export type OIDCAuthOptions = {
     clientId?: string;
     scope?: string;
     logger?: Logger;
+    fetch?: OIDCFetch;
     onTokens?: (t: TokenResponse) => void | Promise<void>;
 };
 
@@ -1374,6 +1378,9 @@ export type OIDCConfig = {
     token_endpoint: string;
     device_authorization_endpoint?: string;
 };
+
+// @public
+export type OIDCFetch = typeof fetch;
 
 // @public (undocumented)
 export type OnCountersReserved = (info: OperationCounters) => void;
@@ -1750,6 +1757,9 @@ export type RequestArgs = {
     logger?: Logger;
 };
 
+// @public
+export type RequestFetch = typeof fetch;
+
 // @public (undocumented)
 export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 
@@ -1757,6 +1767,7 @@ export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 export type RequestOptions = RequestArgs & Omit<RequestInit, 'body' | 'headers'> & Partial<Nut19Policy> & {
     requestTimeout?: number;
     onResponseMeta?: (meta: ResponseMeta) => void;
+    fetch?: RequestFetch;
 };
 
 // @public
@@ -2123,6 +2134,8 @@ export class Wallet {
         selectProofs?: SelectProofs;
         outputDataCreator?: OutputDataCreator;
         requireSigDleq?: boolean;
+        customRequest?: RequestFn;
+        requestFetch?: RequestFetch;
         logger?: Logger;
     });
     batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -33,16 +33,29 @@ export type DeviceStartResponse = {
   expires_in?: number;
 };
 
+/**
+ * Fetch-compatible function used by OIDC auth helpers.
+ */
+export type OIDCFetch = typeof fetch;
+
 export type OIDCAuthOptions = {
   clientId?: string;
   scope?: string;
   logger?: Logger;
+  /**
+   * Custom fetch implementation for OIDC discovery and token endpoint requests.
+   *
+   * Use this to apply the same transport privacy policy as mint requests when the auth provider
+   * should also be reached through OHTTP, Tor, native HTTP clients, or a proxy.
+   */
+  fetch?: OIDCFetch;
   onTokens?: (t: TokenResponse) => void | Promise<void>;
 };
 
 export class OIDCAuth {
   private readonly discoveryUrl: string;
   private readonly logger: Logger;
+  private readonly fetch: OIDCFetch;
 
   private clientId: string;
   private scope: string;
@@ -66,6 +79,7 @@ export class OIDCAuth {
     this.logger = opts?.logger ?? NULL_LOGGER;
     this.clientId = opts?.clientId ?? 'cashu-client';
     this.scope = opts?.scope ?? 'openid';
+    this.fetch = opts?.fetch ?? fetch;
     this.onTokens = opts?.onTokens;
   }
 
@@ -88,7 +102,7 @@ export class OIDCAuth {
 
   async loadConfig(): Promise<OIDCConfig> {
     if (this.config) return this.config;
-    const res = await fetch(this.discoveryUrl, {
+    const res = await this.fetch(this.discoveryUrl, {
       method: 'GET',
       headers: { Accept: 'application/json' },
     });
@@ -337,7 +351,7 @@ export class OIDCAuth {
   ): Promise<TSuccess> {
     try {
       this.logger.debug('OIDCAuth Request', { formBody });
-      const res = await fetch(endpoint, {
+      const res = await this.fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -374,7 +388,7 @@ export class OIDCAuth {
   ): Promise<T | TokenResponse> {
     try {
       this.logger.debug('OIDCAuth Request', { formBody });
-      const res = await fetch(endpoint, {
+      const res = await this.fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/auth/createAuthWallet.ts
+++ b/src/auth/createAuthWallet.ts
@@ -1,5 +1,6 @@
 import { type Logger } from '../logger';
 import { Mint } from '../mint/Mint';
+import request, { type RequestFetch, type RequestFn, type RequestOptions } from '../transport';
 import { Wallet } from '../wallet/Wallet';
 
 import { AuthManager } from './AuthManager';
@@ -15,6 +16,9 @@ import type { OIDCAuth, OIDCAuthOptions } from './OIDCAuth';
  * @param options.authPool Optional. Desired BAT pool size and per-request mint cap. Both
  *   desiredPoolSize and maxPerMint on the AuthManager will be set to this value. Defaults to 10.
  * @param options.oidc Optional. Options for OIDCAuth (scope, clientId, logger, etc.)
+ * @param options.customRequest Optional request function for mint HTTP calls.
+ * @param options.requestFetch Optional fetch-compatible transport for mint HTTP calls. Ignored when
+ *   `customRequest` is supplied.
  * @returns {mint, auth, oidc, wallet} — hydrated, ready to use.
  * @throws If mint does not require authentication.
  */
@@ -23,18 +27,33 @@ export async function createAuthWallet(
   options?: {
     authPool?: number;
     oidc?: OIDCAuthOptions;
+    customRequest?: RequestFn;
+    requestFetch?: RequestFetch;
     logger?: Logger;
   },
 ): Promise<{ mint: Mint; auth: AuthManager; oidc: OIDCAuth; wallet: Wallet }> {
+  let requestInstance: RequestFn | undefined = options?.customRequest;
+  if (!requestInstance && options?.requestFetch) {
+    const requestFetch = options.requestFetch;
+    requestInstance = <T>(args: RequestOptions): Promise<T> =>
+      request<T>({ ...args, fetch: requestFetch });
+  }
+
   // 1. Create an AuthManager for both BAT and CAT handling
   const auth = new AuthManager(mintUrl, {
     desiredPoolSize: options?.authPool ?? 10,
     maxPerMint: options?.authPool ?? 10,
+    request: requestInstance,
     logger: options?.logger,
   });
 
   // 2. Create a Mint instance using the AuthManager
-  const mint = new Mint(mintUrl, { authProvider: auth, logger: options?.logger });
+  const mint = new Mint(mintUrl, {
+    authProvider: auth,
+    customRequest: options?.customRequest,
+    requestFetch: options?.requestFetch,
+    logger: options?.logger,
+  });
 
   // 3. Discover and configure OIDCAuth from the mint
   const oidc = await mint.oidcAuth({

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export {
   type TokenResponse,
   type DeviceStartResponse,
   type OIDCConfig,
+  type OIDCFetch,
   type OIDCAuthOptions,
 } from './auth';
 
@@ -110,7 +111,13 @@ export type { OutputDataLike, OutputDataFactory, SerializedOutputData } from './
 export type { OutputDataCreator } from './model/OutputDataCreator';
 export { MintInfo } from './model/MintInfo';
 export { WSConnection, injectWebSocketImpl, setGlobalRequestOptions } from './transport';
-export type { RequestFn, RequestArgs, RequestOptions, ResponseMeta } from './transport';
+export type {
+  RequestFn,
+  RequestFetch,
+  RequestArgs,
+  RequestOptions,
+  ResponseMeta,
+} from './transport';
 export {
   SigAll,
   type SigAllApi,

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -42,6 +42,7 @@ import request, {
   WSConnection,
   setRequestLogger,
   type RequestFn,
+  type RequestFetch,
   type RequestOptions,
   type ResponseMeta,
 } from '../transport';
@@ -83,6 +84,8 @@ class Mint {
   /**
    * @param mintUrl Requires mint URL to create this object.
    * @param customRequest Optional, for custom network communication with the mint.
+   * @param requestFetch Optional fetch-compatible transport for the default mint request pipeline.
+   *   Ignored when `customRequest` is supplied.
    * @param authTokenGetter Optional. Function to obtain a NUT-22 BlindedAuthToken (e.g. from a
    *   database or localstorage)
    */
@@ -90,12 +93,21 @@ class Mint {
     mintUrl: string,
     options?: {
       customRequest?: RequestFn;
+      requestFetch?: RequestFetch;
       authProvider?: AuthProvider;
       logger?: Logger;
     },
   ) {
     this._mintUrl = normalizeUrl(mintUrl);
-    this._request = options?.customRequest ?? request;
+    if (options?.customRequest) {
+      this._request = options.customRequest;
+    } else if (options?.requestFetch) {
+      const requestFetch = options.requestFetch;
+      this._request = <T>(args: RequestOptions): Promise<T> =>
+        request<T>({ ...args, fetch: requestFetch });
+    } else {
+      this._request = request;
+    }
     this._authProvider = options?.authProvider;
     this._logger = options?.logger ?? NULL_LOGGER;
     setRequestLogger(this._logger);

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -1,6 +1,6 @@
 export { default } from './request';
 export { setGlobalRequestOptions, setRequestLogger } from './request';
-export type { RequestFn, RequestArgs, RequestOptions, ResponseMeta } from './request';
+export type { RequestFn, RequestFetch, RequestArgs, RequestOptions, ResponseMeta } from './request';
 
 export { injectWebSocketImpl } from './ws';
 

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -13,6 +13,11 @@ import { JSONInt } from '../utils/JSONInt';
 export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 
 /**
+ * Fetch-compatible function used by the default request implementation.
+ */
+export type RequestFetch = typeof fetch;
+
+/**
  * Subset of globalThis used by {@link detectBrowserLike}; loosened for unit tests.
  *
  * @internal
@@ -132,6 +137,12 @@ export type RequestOptions = RequestArgs &
      * metadata even when the request fails.
      */
     onResponseMeta?: (meta: ResponseMeta) => void;
+    /**
+     * Optional fetch-compatible transport for the default request implementation. Use this to route
+     * mint HTTP requests through transports such as OHTTP, Tor, native HTTP clients, or proxies
+     * while preserving cashu-ts JSON parsing, timeout handling, errors, and NUT-19 retry logic.
+     */
+    fetch?: RequestFetch;
   };
 
 /**
@@ -351,6 +362,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
     headers: requestHeaders,
     requestTimeout,
     onResponseMeta,
+    fetch: fetchImpl,
     // consumed by requestWithRetry, excluded from raw fetch options
     cached_endpoints,
     ttl,
@@ -363,6 +375,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
   void ttl;
   void logger;
 
+  const requestFetch = fetchImpl ?? fetch;
   const body = requestBody ? JSONInt.stringify(requestBody) : undefined;
   const headers = buildRequestHeaders(body, requestHeaders);
   const callerSignal = options.signal ?? undefined;
@@ -396,7 +409,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
 
   let response: Response;
   try {
-    response = await fetch(endpoint, {
+    response = await requestFetch(endpoint, {
       body,
       headers,
       // Anti-fingerprinting fetch options.
@@ -525,6 +538,9 @@ export default async function request<T>(options: RequestOptions): Promise<T> {
   const perRequest = options.onResponseMeta;
   const globalMeta = globalRequestOptions.onResponseMeta;
   const merged: RequestOptions = { ...options, ...globalRequestOptions };
+
+  // Scoped transports should override the process-wide default.
+  if (options.fetch) merged.fetch = options.fetch;
 
   // Default: per-request callback only
   if (perRequest) merged.onResponseMeta = perRequest;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -49,6 +49,7 @@ import { CheckStateEnum, type ProofState } from '../model/types/NUT07';
 import { type BatchMintRequest } from '../model/types/NUT29';
 import type { Proof, ProofLike } from '../model/types/proof';
 import type { Token } from '../model/types/token';
+import type { RequestFetch, RequestFn } from '../transport';
 import {
   getDecodedToken,
   invoiceHasAmountInHRP,
@@ -196,6 +197,13 @@ class Wallet {
    * @param options.requireSigDleq Fail mint/swap/melt responses when the mint advertises NUT-12
    *   support but omits DLEQ proofs on returned blinded signatures. This is a fail-fast consistency
    *   check, not protection against a malicious mint already consuming inputs or payments.
+   * @param options.customRequest Custom mint request function. Use this to route all mint HTTP
+   *   requests through runtime-specific transports such as OHTTP, Tor, native HTTP clients, or
+   *   proxies. Only used when `mint` is passed as a URL string; pass a configured `Mint` instance
+   *   when you need full control.
+   * @param options.requestFetch Custom fetch-compatible transport for mint HTTP requests. Use this
+   *   for per-wallet OHTTP, Tor, native HTTP clients, or proxies while preserving the default
+   *   request pipeline. Ignored when `customRequest` is supplied.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -212,6 +220,8 @@ class Wallet {
       selectProofs?: SelectProofs; // optional override
       outputDataCreator?: OutputDataCreator;
       requireSigDleq?: boolean;
+      customRequest?: RequestFn;
+      requestFetch?: RequestFetch;
       logger?: Logger;
     },
   ) {
@@ -222,7 +232,12 @@ class Wallet {
     this._outputDataCreator = options?.outputDataCreator ?? new DefaultOutputDataCreator();
     this.mint =
       typeof mint === 'string'
-        ? new Mint(mint, { authProvider: options?.authProvider, logger: this._logger })
+        ? new Mint(mint, {
+            authProvider: options?.authProvider,
+            customRequest: options?.customRequest,
+            requestFetch: options?.requestFetch,
+            logger: this._logger,
+          })
         : mint;
     this._unit = options?.unit ?? this._unit;
     this._boundKeysetId = options?.keysetId ?? this._boundKeysetId;

--- a/test/auth/OIDCAuth.node.test.ts
+++ b/test/auth/OIDCAuth.node.test.ts
@@ -53,6 +53,23 @@ describe('OIDCAuth: discovery & caching', () => {
     expect(calls).toBe(1);
   });
 
+  test('loadConfig uses the injected fetch implementation', async () => {
+    const calls: string[] = [];
+    const customFetch = (async (input: Parameters<typeof fetch>[0]) => {
+      calls.push(String(input));
+      return new Response(JSON.stringify(goodDiscovery), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const oidc = new OIDCAuth(DISCOVERY, { fetch: customFetch });
+    const cfg = await oidc.loadConfig();
+
+    expect(cfg.token_endpoint).toBe(TOKEN_EP);
+    expect(calls).toEqual([DISCOVERY]);
+  });
+
   test('loadConfig throws on invalid discovery (no token_endpoint)', async () => {
     server.use(http.get(DISCOVERY, () => HttpResponse.json({ issuer: ISSUER })));
     const oidc = new OIDCAuth(DISCOVERY);
@@ -136,6 +153,39 @@ describe('OIDCAuth: PKCE + auth code', () => {
         '&client_id=cashu-client' +
         '&code_verifier=verifier_123',
     );
+  });
+
+  test('token requests use the injected fetch implementation', async () => {
+    const calls: Array<{ endpoint: string; body?: string }> = [];
+    const customFetch = (async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      const endpoint = String(input);
+      calls.push({ endpoint, body: init?.body?.toString() });
+      if (endpoint === DISCOVERY) {
+        return new Response(JSON.stringify(goodDiscovery), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify(accessOk), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client', fetch: customFetch });
+    const tok = await oidc.passwordGrant('user', 'pass');
+
+    expect(tok.access_token).toBe('access.ok');
+    expect(calls).toEqual([
+      { endpoint: DISCOVERY, body: undefined },
+      {
+        endpoint: TOKEN_EP,
+        body: 'grant_type=password&client_id=cashu-client&username=user&password=pass&scope=openid',
+      },
+    ]);
   });
 
   test('exchangeAuthCode throws if provider returns 400 (strict)', async () => {

--- a/test/auth/createAuthWallet.node.test.ts
+++ b/test/auth/createAuthWallet.node.test.ts
@@ -3,6 +3,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { beforeAll, beforeEach, afterEach, afterAll, test, describe, expect } from 'vitest';
 import { createAuthWallet } from '../../src/auth/createAuthWallet';
+import type { RequestFetch, RequestFn } from '../../src';
 
 // ---- Constants
 const mintUrl = 'http://localhost:3338';
@@ -125,6 +126,66 @@ describe('createAuthWallet wiring', () => {
     expect(auth.poolTarget).toBe(7);
     // KeyChain and wallet should be initialized by helper
     expect(wallet.mint).toBe(mint);
+  });
+
+  test('wires customRequest through mint and wallet hydration', async () => {
+    const endpoints: string[] = [];
+    const customRequest = (async <T>({ endpoint }: Parameters<RequestFn>[0]): Promise<T> => {
+      endpoints.push(endpoint);
+      let payload: unknown;
+      if (endpoint.endsWith('/v1/info')) {
+        payload = infoResp;
+      } else if (endpoint.endsWith('/v1/keysets')) {
+        payload = dummyKeysetResp;
+      } else if (endpoint.endsWith('/v1/keys')) {
+        payload = dummyKeysResp;
+      } else {
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
+      return payload as T;
+    }) as RequestFn;
+
+    const { wallet } = await createAuthWallet(mintUrl, { customRequest });
+
+    expect(wallet.mint.mintUrl).toBe(mintUrl);
+    expect(endpoints).toEqual([
+      `${mintUrl}/v1/info`,
+      `${mintUrl}/v1/info`,
+      `${mintUrl}/v1/keysets`,
+      `${mintUrl}/v1/keys`,
+    ]);
+  });
+
+  test('wires requestFetch through mint and wallet hydration', async () => {
+    const endpoints: string[] = [];
+    const requestFetch = (async (input: Parameters<RequestFetch>[0]) => {
+      const endpoint = String(input);
+      endpoints.push(endpoint);
+      let payload: unknown;
+      if (endpoint.endsWith('/v1/info')) {
+        payload = infoResp;
+      } else if (endpoint.endsWith('/v1/keysets')) {
+        payload = dummyKeysetResp;
+      } else if (endpoint.endsWith('/v1/keys')) {
+        payload = dummyKeysResp;
+      } else {
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    const { wallet } = await createAuthWallet(mintUrl, { requestFetch });
+
+    expect(wallet.mint.mintUrl).toBe(mintUrl);
+    expect(endpoints).toEqual([
+      `${mintUrl}/v1/info`,
+      `${mintUrl}/v1/info`,
+      `${mintUrl}/v1/keysets`,
+      `${mintUrl}/v1/keys`,
+    ]);
   });
 
   test('authPool sets both desiredPoolSize and maxPerMint', async () => {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -6,6 +6,7 @@ import {
   MintOperationError,
   RateLimitError,
   type ResponseMeta,
+  type RequestFetch,
 } from '../../src';
 import { HttpResponse, http, delay } from 'msw';
 import { setupServer } from 'msw/node';
@@ -104,6 +105,73 @@ describe('requests', { timeout: 7500 }, () => {
 
       expect(headers!).toBeDefined();
       expect(headers!.get('x-cashu')).toContain('xyz-123-abc');
+    } finally {
+      setGlobalRequestOptions({});
+    }
+  });
+
+  test('global custom fetch can be set', async () => {
+    const fetchCalls: Array<{ endpoint: string; method?: string }> = [];
+    const customFetch = (async (
+      input: Parameters<RequestFetch>[0],
+      init?: Parameters<RequestFetch>[1],
+    ) => {
+      fetchCalls.push({ endpoint: String(input), method: init?.method });
+      return new Response(
+        JSON.stringify({
+          quote: 'test_melt_quote_id',
+          amount: 2000,
+          fee_reserve: 20,
+          payment_preimage: null,
+          state: 'UNPAID',
+          unit: 'sat',
+          expiry: 9999999999,
+          request: 'bolt11invoice...',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as RequestFetch;
+
+    try {
+      const wallet = new Wallet(mintUrl);
+      wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
+      setGlobalRequestOptions({ fetch: customFetch });
+
+      await wallet.checkMeltQuoteBolt11('test');
+
+      expect(fetchCalls).toEqual([
+        { endpoint: `${mintUrl}/v1/melt/quote/bolt11/test`, method: 'GET' },
+      ]);
+    } finally {
+      setGlobalRequestOptions({});
+    }
+  });
+
+  test('request fetch overrides global custom fetch', async () => {
+    const globalFetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: 'global fetch should not run' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+    const localFetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    try {
+      setGlobalRequestOptions({ fetch: globalFetch });
+
+      const result = await request<{ ok: true }>({
+        endpoint: `${mintUrl}/v1/info`,
+        fetch: localFetch,
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(localFetch).toHaveBeenCalledTimes(1);
+      expect(globalFetch).not.toHaveBeenCalled();
     } finally {
       setGlobalRequestOptions({});
     }

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -11,6 +11,8 @@ import {
   MintInfo,
   Amount,
   setGlobalRequestOptions,
+  type RequestFetch,
+  type RequestFn,
 } from '../../src';
 
 import { NULL_LOGGER } from '../../src/logger';
@@ -103,6 +105,66 @@ describe('test wallet init', () => {
     // Verify specific keyset retrieval
     const specificKeys = wallet.keyChain.getKeyset('00bd033559de27d0').keys;
     expect(specificKeys).toEqual(dummyKeysResp.keysets[0].keys);
+  });
+
+  test('should pass customRequest from wallet URL options to the mint', async () => {
+    const endpoints: string[] = [];
+    const customRequest = (async <T>({ endpoint }: Parameters<RequestFn>[0]): Promise<T> => {
+      endpoints.push(endpoint);
+      let payload: unknown;
+      if (endpoint.endsWith('/v1/info')) {
+        payload = mintInfoResp;
+      } else if (endpoint.endsWith('/v1/keysets')) {
+        payload = dummyKeysetResp;
+      } else if (endpoint.endsWith('/v1/keys')) {
+        payload = dummyKeysResp;
+      } else {
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
+      return payload as T;
+    }) as RequestFn;
+
+    const wallet = new Wallet(mintUrl, { unit, customRequest });
+    await wallet.loadMint();
+
+    expect(wallet.mint.mintUrl).toBe(mintUrl);
+    expect(endpoints).toEqual([
+      `${mintUrl}/v1/info`,
+      `${mintUrl}/v1/keysets`,
+      `${mintUrl}/v1/keys`,
+    ]);
+  });
+
+  test('should pass requestFetch from wallet URL options through the default request pipeline', async () => {
+    const endpoints: string[] = [];
+    const requestFetch = (async (input: Parameters<RequestFetch>[0]) => {
+      const endpoint = String(input);
+      endpoints.push(endpoint);
+      let payload: unknown;
+      if (endpoint.endsWith('/v1/info')) {
+        payload = mintInfoResp;
+      } else if (endpoint.endsWith('/v1/keysets')) {
+        payload = dummyKeysetResp;
+      } else if (endpoint.endsWith('/v1/keys')) {
+        payload = dummyKeysResp;
+      } else {
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    const wallet = new Wallet(mintUrl, { unit, requestFetch });
+    await wallet.loadMint();
+
+    expect(wallet.mint.mintUrl).toBe(mintUrl);
+    expect(endpoints).toEqual([
+      `${mintUrl}/v1/info`,
+      `${mintUrl}/v1/keysets`,
+      `${mintUrl}/v1/keys`,
+    ]);
   });
 
   test('should resolve NUT-19 support lazily from mint info when unsupported', async () => {


### PR DESCRIPTION
## Summary

- add fetch-compatible transport hooks for mint requests at global, wallet, mint, and authenticated-wallet scopes
- add OIDC fetch injection for discovery and token requests, with docs clarifying the separate auth network boundary
- update API Extractor output and focused coverage for transport precedence and scoped request wiring

## Notes

`requestFetch` is the preferred hook when consumers only need to swap the network primitive, such as OHTTP, Tor, native mobile HTTP, or a proxy, while keeping cashu-ts request parsing, timeout, error, and NUT-19 retry behavior. `customRequest` remains the full request-pipeline replacement escape hatch.

## Validation

- `npm test -- test/transport/request.node.test.ts test/auth/OIDCAuth.node.test.ts test/auth/createAuthWallet.node.test.ts test/wallet/wallet-init.node.test.ts`
- pre-push `npm run check-lint`