### PR TITLE
refactor!: remove v4-deprecated APIs

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -391,9 +391,6 @@ export type CurvePoint = {
 // @public
 export function decodePaymentRequest(paymentRequest: string): PaymentRequest_2;
 
-// @public @deprecated (undocumented)
-export const deriveBlindingFactor: (seed: Uint8Array, keysetId: string, counter: number) => Uint8Array;
-
 // @public
 export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): string;
 
@@ -417,9 +414,6 @@ export function deriveP2BKSecretKey(privkey: string | bigint, rBlind: string | b
 
 // @public
 export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[]): string[];
-
-// @public @deprecated (undocumented)
-export const deriveSecret: (seed: Uint8Array, keysetId: string, counter: number) => Uint8Array;
 
 // @public
 export function deriveSecretAndBlindingFactor(seed: Uint8Array, keysetId: string, counter: number): {
@@ -2151,8 +2145,6 @@ export class Wallet {
     checkProofsStates(proofs: Array<Pick<ProofLike, 'secret' | 'id'>>): Promise<ProofState[]>;
     completeBatchMint(batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>): Promise<Proof[]>;
     completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(meltPreview: MeltPreview<TQuote>, privkey?: string | string[], options?: CompleteMeltOptions): Promise<MeltProofsResponse<TQuote>>;
-    // @deprecated (undocumented)
-    completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(meltPreview: MeltPreview<TQuote>, privkey?: string | string[], preferAsync?: boolean): Promise<MeltProofsResponse<TQuote>>;
     completeMint(mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>): Promise<Proof[]>;
     completeSwap(swapPreview: SwapPreview, privkey?: string | string[]): Promise<SendResponse>;
     readonly counters: WalletCounters;

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -114,3 +114,44 @@ try {
 ```
 
 If your consumer was already wrapping the loop in `try/catch` (e.g. to handle abort), no change is required beyond not assuming silent completion means all expected updates arrived.
+
+---
+
+## `deriveSecret` and `deriveBlindingFactor` removed
+
+The single-value NUT-13 derivation helpers `deriveSecret` and `deriveBlindingFactor` are removed. Use `deriveSecretAndBlindingFactor`, which derives both values for a counter in one call (and, for legacy BIP-32 keysets, avoids repeating the shared path derivation).
+
+### Migration
+
+```ts
+// Before
+import { deriveSecret, deriveBlindingFactor } from '@cashu/cashu-ts';
+
+const secret = deriveSecret(seed, keysetId, counter);
+const blindingFactor = deriveBlindingFactor(seed, keysetId, counter);
+
+// After
+import { deriveSecretAndBlindingFactor } from '@cashu/cashu-ts';
+
+const { secret, blindingFactor } = deriveSecretAndBlindingFactor(seed, keysetId, counter);
+```
+
+If you only need one of the two values, destructure just that field — `const { secret } = deriveSecretAndBlindingFactor(seed, keysetId, counter)`.
+
+---
+
+## `completeMelt` no longer accepts a boolean third argument
+
+`Wallet.completeMelt`'s deprecated boolean `preferAsync` parameter is removed. Pass the option on the `CompleteMeltOptions` object instead.
+
+### Migration
+
+```ts
+// Before
+await wallet.completeMelt(meltPreview, privkey, true);
+
+// After
+await wallet.completeMelt(meltPreview, privkey, { preferAsync: true });
+```
+
+Calls that already pass a `CompleteMeltOptions` object (or omit the third argument) need no change.

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -22,24 +22,6 @@ type DerivedSecretAndBlindingFactor = { blindingFactor: Uint8Array; secret: Uint
 type SecretAndBlindingFactorDeriver = (counter: number) => DerivedSecretAndBlindingFactor;
 
 /**
- * @deprecated Use {@link deriveSecretAndBlindingFactor} to derive both values together.
- */
-export const deriveSecret = (seed: Uint8Array, keysetId: string, counter: number): Uint8Array => {
-  return deriveSecretAndBlindingFactor(seed, keysetId, counter).secret;
-};
-
-/**
- * @deprecated Use {@link deriveSecretAndBlindingFactor} to derive both values together.
- */
-export const deriveBlindingFactor = (
-  seed: Uint8Array,
-  keysetId: string,
-  counter: number,
-): Uint8Array => {
-  return deriveSecretAndBlindingFactor(seed, keysetId, counter).blindingFactor;
-};
-
-/**
  * Derives the deterministic secret and blinding factor for one counter.
  *
  * @remarks

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2809,22 +2809,8 @@ class Wallet {
     meltPreview: MeltPreview<TQuote>,
     privkey?: string | string[],
     options?: CompleteMeltOptions,
-  ): Promise<MeltProofsResponse<TQuote>>;
-  /**
-   * @deprecated Pass `{ preferAsync: true }` as the third param, instead of `true`.
-   */
-  async completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(
-    meltPreview: MeltPreview<TQuote>,
-    privkey?: string | string[],
-    preferAsync?: boolean,
-  ): Promise<MeltProofsResponse<TQuote>>;
-  async completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(
-    meltPreview: MeltPreview<TQuote>,
-    privkey?: string | string[],
-    options?: boolean | CompleteMeltOptions,
   ): Promise<MeltProofsResponse<TQuote>> {
-    const completeOptions: CompleteMeltOptions =
-      typeof options === 'boolean' ? { preferAsync: options } : (options ?? {});
+    const completeOptions: CompleteMeltOptions = options ?? {};
 
     // Extract vars from MeltPreview
     let inputs = meltPreview.inputs;

--- a/test/crypto/NUT09.test.ts
+++ b/test/crypto/NUT09.test.ts
@@ -1,8 +1,12 @@
 import { bytesToHex } from '@noble/curves/utils.js';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
-import { deriveSecret, getKeysetIdInt } from '../../src/crypto';
+import { deriveSecretAndBlindingFactor, getKeysetIdInt } from '../../src/crypto';
 import { Bytes } from '../../src/utils';
+
+// The standalone deriveSecret() helper was removed in v5; derive it locally for these tests.
+const deriveSecret = (seed: Uint8Array, keysetId: string, counter: number): Uint8Array =>
+  deriveSecretAndBlindingFactor(seed, keysetId, counter).secret;
 
 const seed = Uint8Array.from(
   Bytes.fromHex(

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -1,11 +1,11 @@
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
-import {
-  BLS_FR_ORDER,
-  deriveBlindingFactor,
-  deriveSecretAndBlindingFactor,
-} from '../../src/crypto';
+import { BLS_FR_ORDER, deriveSecretAndBlindingFactor } from '../../src/crypto';
 import { Bytes } from '../../src/utils';
+
+// The standalone deriveBlindingFactor() helper was removed in v5; derive it locally for these tests.
+const deriveBlindingFactor = (seed: Uint8Array, keysetId: string, counter: number): Uint8Array =>
+  deriveSecretAndBlindingFactor(seed, keysetId, counter).blindingFactor;
 
 describe('deriveBlindingFactor', () => {
   test('preserves 32-byte encoding when reduced scalar has leading zeros', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -549,7 +549,7 @@ describe('mint api', () => {
     expect(fee.greaterThan(0)).toBeTruthy();
     const melt = await wallet.prepareMelt('bolt11', meltRequest, proofs);
     // complete melt async
-    const response = await wallet.completeMelt(melt, undefined, true);
+    const response = await wallet.completeMelt(melt, undefined, { preferAsync: true });
     // console.log('melt response', response);
     expect(response).toBeDefined();
     if (response.quote.state === MeltQuoteState.PAID) {

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -821,7 +821,7 @@ describe('async melt preference body', () => {
       /is not loaded in this wallet.*restoring \(NUT-09\)/is,
     );
   });
-  test('completeMelt supports deprecated boolean preferAsync argument', async () => {
+  test('completeMelt sends prefer_async when { preferAsync: true } is passed', async () => {
     const meltQuote = {
       quote: 'q-async-boolean',
       amount: Amount.from(1),


### PR DESCRIPTION
Closed as duplicate of #676, which already merged the same `refactor!: remove v4-deprecated APIs` commit.

Original validation before closing:

- `npm test -- test/crypto/NUT09.test.ts test/crypto/NUT13.test.ts test/wallet/wallet-melt.node.test.ts`
- pre-push `npm run check-lint`