### PR TITLE
Add conditional token primitives for NUT-CTF

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -278,6 +278,75 @@ export function computeMessageDigest(message: string, asHex: false): Uint8Array;
 // @public (undocumented)
 export function computeMessageDigest(message: string, asHex: true): string;
 
+// @public (undocumented)
+export interface ConditionalKeysetInfo {
+    // (undocumented)
+    active: boolean;
+    // (undocumented)
+    condition_id: string;
+    // (undocumented)
+    final_expiry?: number;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    input_fee_ppk?: number;
+    // (undocumented)
+    outcome_collection: string;
+    // (undocumented)
+    outcome_collection_id: string;
+    // (undocumented)
+    registered_at?: number;
+    // (undocumented)
+    unit: string;
+}
+
+// @public (undocumented)
+export interface ConditionalKeysetMetadata {
+    conditionId: string;
+    outcomeCollection: string;
+    outcomeCollectionId: string;
+    registeredAt?: number;
+}
+
+// @public (undocumented)
+export interface ConditionalKeysetsResponse {
+    // (undocumented)
+    keysets: ConditionalKeysetInfo[];
+}
+
+// @public (undocumented)
+export interface ConditionalSwapOptions {
+    // (undocumented)
+    inputs: ProofLike[];
+    keysetId?: string;
+    // (undocumented)
+    outputs: ConditionalSwapOutputGroup[];
+}
+
+// @public (undocumented)
+export interface ConditionalSwapOutputGroup {
+    // (undocumented)
+    amount: AmountLike;
+    // (undocumented)
+    customSplit?: AmountLike[];
+    // (undocumented)
+    kind: 'random' | 'p2pk';
+    // (undocumented)
+    label: string;
+    // (undocumented)
+    p2pk?: P2PKOptions;
+}
+
+// @public (undocumented)
+export interface ConditionalSwapPreview {
+    // (undocumented)
+    inputs: Proof[];
+    // (undocumented)
+    keysetId: string;
+    // (undocumented)
+    outputDataByLabel: Record<string, OutputData[]>;
+}
+
 // @public
 export class ConsoleLogger implements Logger {
     constructor(minLevel?: LogLevel);
@@ -372,6 +441,68 @@ export function createRandomSecretKey(): Uint8Array<ArrayBufferLike>;
 // @public
 export function createSecret(kind: SecretKind, data: string, tags?: string[][]): string;
 
+// @public (undocumented)
+export interface CtfConditionInfo {
+    // (undocumented)
+    announcements?: string[];
+    // (undocumented)
+    attestation?: {
+        status: string;
+        winning_outcome?: string | null;
+        attested_at?: number | null;
+    };
+    // (undocumented)
+    condition_id: string;
+    // (undocumented)
+    condition_type?: string;
+    // (undocumented)
+    hi_bound?: number;
+    // (undocumented)
+    lo_bound?: number;
+    // (undocumented)
+    partitions: CtfConditionPartition[];
+    // (undocumented)
+    precision?: number;
+    // (undocumented)
+    registered_at?: number;
+    // (undocumented)
+    tags?: string[][];
+    // (undocumented)
+    threshold?: number;
+}
+
+// @public (undocumented)
+export interface CtfConditionPartition {
+    // (undocumented)
+    collateral: string;
+    // (undocumented)
+    keysets: Record<string, string>;
+    // (undocumented)
+    parent_collection_id: string;
+    // (undocumented)
+    partition?: string[];
+    // (undocumented)
+    registered_at?: number;
+}
+
+// @public (undocumented)
+export interface CtfConvertRequest {
+    // (undocumented)
+    condition_id: string;
+    // (undocumented)
+    inputs: Record<string, Proof[]>;
+    // (undocumented)
+    outputs: Record<string, SerializedBlindedMessage[]>;
+    // (undocumented)
+    parent_collection_id?: string;
+}
+
+// @public (undocumented)
+export interface CtfConvertResponse {
+    // (undocumented)
+    signatures: Record<string, SerializedBlindedSignature[]>;
+}
+
 // @public
 export class CTSError extends Error {
     constructor(message: string, options?: {
@@ -392,6 +523,25 @@ export type CurvePoint = {
 
 // @public
 export function decodePaymentRequest(paymentRequest: string): PaymentRequest_2;
+
+// @public
+export function deriveConditionalKeysetId(input: DeriveConditionalKeysetIdInput): string;
+
+// @public (undocumented)
+export interface DeriveConditionalKeysetIdInput {
+    // (undocumented)
+    conditionId: string;
+    // (undocumented)
+    final_expiry?: number;
+    // (undocumented)
+    input_fee_ppk?: number;
+    // (undocumented)
+    keys: Keys;
+    // (undocumented)
+    outcomeCollectionId: string;
+    // (undocumented)
+    unit: string;
+}
 
 // @public
 export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): string;
@@ -460,6 +610,32 @@ export type G1Point = WeierstrassPoint<bigint>;
 
 // @public (undocumented)
 export type G2Point = WeierstrassPoint<Fp2>;
+
+// @public (undocumented)
+export interface GetConditionalKeysetsQuery {
+    // (undocumented)
+    active?: boolean;
+    // (undocumented)
+    limit?: number;
+    // (undocumented)
+    since?: number;
+}
+
+// @public (undocumented)
+export interface GetConditionsQuery {
+    // (undocumented)
+    limit?: number;
+    // (undocumented)
+    since?: number;
+    // (undocumented)
+    status?: string[];
+}
+
+// @public (undocumented)
+export interface GetConditionsResponse {
+    // (undocumented)
+    conditions: CtfConditionInfo[];
+}
 
 // @public
 export function getDataField(secret: Secret | string): string;
@@ -707,11 +883,20 @@ export class KeyChain {
     getAllKeys(): MintKeys[];
     getAllKeysetIds(): string[];
     getCheapestKeyset(): Keyset;
+    // (undocumented)
+    getConditionalKeyset(id: string): Keyset;
     getKeyset(id?: string): Keyset;
     getKeysets(): Keyset[];
+    // (undocumented)
+    hasConditionalKeyset(id: string): boolean;
     init(forceRefresh?: boolean): Promise<void>;
+    // (undocumented)
+    loadConditionalKeyset(id: string): Promise<Keyset>;
     loadFromCache(cache: KeyChainCache): void;
     static mintToCacheDTO(mintUrl: string, allKeysets: MintKeyset[], allKeys: MintKeys[]): KeyChainCache;
+    registerConditionalKeyset(meta: MintKeyset & {
+        conditional: ConditionalKeysetMetadata;
+    }, keys?: MintKeys): Keyset;
 }
 
 // @public
@@ -728,7 +913,9 @@ export type Keys = {
 
 // @public (undocumented)
 export class Keyset {
-    constructor(id: string, unit: string, active: boolean, input_fee_ppk?: number, final_expiry?: number);
+    constructor(id: string, unit: string, active: boolean, input_fee_ppk?: number, final_expiry?: number, conditional?: ConditionalKeysetMetadata);
+    // (undocumented)
+    get conditional(): ConditionalKeysetMetadata | undefined;
     // (undocumented)
     get expiry(): number | undefined;
     // (undocumented)
@@ -743,6 +930,8 @@ export class Keyset {
     // (undocumented)
     get isActive(): boolean;
     // (undocumented)
+    get isConditional(): boolean;
+    // (undocumented)
     get keys(): Record<number, string>;
     set keys(keys: Record<number, string>);
     toMintKeys(): MintKeys | null;
@@ -750,6 +939,7 @@ export class Keyset {
     // (undocumented)
     get unit(): string;
     verify(): boolean;
+    static verifyConditionalKeysetId(keys: MintKeys, conditional: ConditionalKeysetMetadata): boolean;
     static verifyKeysetId(keys: MintKeys): boolean;
 }
 
@@ -964,7 +1154,12 @@ export class Mint {
     createMintQuoteBolt11(mintQuotePayload: MintQuoteBolt11Request, customRequest?: RequestFn): Promise<MintQuoteBolt11Response>;
     createMintQuoteBolt12(mintQuotePayload: MintQuoteBolt12Request, customRequest?: RequestFn): Promise<MintQuoteBolt12Response>;
     createMintQuoteOnchain(mintQuotePayload: MintQuoteOnchainRequest, customRequest?: RequestFn): Promise<MintQuoteOnchainResponse>;
+    ctfConvert(convertPayload: CtfConvertRequest, customRequest?: RequestFn): Promise<CtfConvertResponse>;
     disconnectWebSocket(): void;
+    getConditionalKeysets(query?: GetConditionalKeysetsQuery, customRequest?: RequestFn): Promise<ConditionalKeysetsResponse>;
+    // (undocumented)
+    getConditions(query?: GetConditionsQuery, customRequest?: RequestFn): Promise<GetConditionsResponse>;
+    getCtfCondition(conditionId: string, customRequest?: RequestFn): Promise<CtfConditionInfo>;
     getInfo(customRequest?: RequestFn): Promise<GetInfoResponse>;
     getKeys(keysetId?: string, mintUrl?: string, customRequest?: RequestFn): Promise<GetKeysResponse>;
     getKeySets(customRequest?: RequestFn): Promise<GetKeysetsResponse>;
@@ -999,6 +1194,11 @@ export class Mint {
     // (undocumented)
     get mintUrl(): string;
     oidcAuth(opts?: OIDCAuthOptions): Promise<OIDCAuth>;
+    redeemOutcome(redeemPayload: RedeemOutcomeRequest, customRequest?: RequestFn): Promise<RedeemOutcomeResponse>;
+    // (undocumented)
+    registerCondition(payload: RegisterConditionRequest, customRequest?: RequestFn): Promise<RegisterConditionResponse>;
+    // (undocumented)
+    registerPartition(conditionId: string, payload: RegisterPartitionRequest, customRequest?: RequestFn): Promise<RegisterPartitionResponse>;
     restore(restorePayload: PostRestorePayload, customRequest?: RequestFn): Promise<PostRestoreResponse>;
     setMintInfo(mintInfo: MintInfo | GetInfoResponse): void;
     swap(swapPayload: SwapRequest, customRequest?: RequestFn): Promise<SwapResponse>;
@@ -1161,6 +1361,7 @@ export type MintKeys = {
     input_fee_ppk?: number;
     final_expiry?: number;
     keys: Keys;
+    conditional?: ConditionalKeysetMetadata;
 };
 
 // @public
@@ -1170,6 +1371,7 @@ export type MintKeyset = {
     active: boolean;
     input_fee_ppk?: number;
     final_expiry?: number;
+    conditional?: ConditionalKeysetMetadata;
 };
 
 // @public (undocumented)
@@ -1750,6 +1952,66 @@ export type ReceiveConfig = {
 };
 
 // @public (undocumented)
+export interface RedeemOutcomeProofsOptions {
+    inputs: ProofLike[];
+    outputs: OutputDataLike[];
+}
+
+// @public (undocumented)
+export interface RedeemOutcomeRequest {
+    // (undocumented)
+    inputs: Proof[];
+    // (undocumented)
+    outputs: SerializedBlindedMessage[];
+}
+
+// @public (undocumented)
+export interface RedeemOutcomeResponse {
+    // (undocumented)
+    signatures: SerializedBlindedSignature[];
+}
+
+// @public (undocumented)
+export interface RegisterConditionRequest {
+    // (undocumented)
+    announcements: string[];
+    // (undocumented)
+    condition_type?: string;
+    // (undocumented)
+    hi_bound?: number;
+    // (undocumented)
+    lo_bound?: number;
+    // (undocumented)
+    precision?: number;
+    // (undocumented)
+    tags?: string[][];
+    // (undocumented)
+    threshold?: number;
+}
+
+// @public (undocumented)
+export interface RegisterConditionResponse {
+    // (undocumented)
+    condition_id: string;
+}
+
+// @public (undocumented)
+export interface RegisterPartitionRequest {
+    // (undocumented)
+    collateral: string;
+    // (undocumented)
+    parent_collection_id?: string;
+    // (undocumented)
+    partition?: string[];
+}
+
+// @public (undocumented)
+export interface RegisterPartitionResponse {
+    // (undocumented)
+    keysets: Record<string, string>;
+}
+
+// @public (undocumented)
 export type RequestArgs = {
     endpoint: string;
     requestBody?: Record<string, unknown>;
@@ -2137,6 +2399,7 @@ export class Wallet {
         requireSigDleq?: boolean;
         customRequest?: RequestFn;
         requestFetch?: RequestFetch;
+        enableCtf?: boolean;
         logger?: Logger;
     });
     batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{
@@ -2150,6 +2413,8 @@ export class Wallet {
     checkMeltQuoteBolt11(quote: string | MeltQuoteBolt11Response): Promise<MeltQuoteBolt11Response>;
     checkMeltQuoteBolt12(quote: string): Promise<MeltQuoteBolt12Response>;
     checkMeltQuoteOnchain(quote: string): Promise<MeltQuoteOnchainResponse>;
+    checkMintQuote(quote: string | MintQuoteBolt11Response): Promise<MintQuoteBolt11Response>;
+    // (undocumented)
     checkMintQuote<TRes extends MintQuoteBaseResponse = MintQuoteBaseResponse>(method: string, quote: string | Pick<TRes, 'quote'>, options?: {
         normalize?: (raw: Record<string, unknown>) => TRes;
     }): Promise<TRes>;
@@ -2158,18 +2423,24 @@ export class Wallet {
     checkMintQuoteOnchain(quote: string): Promise<MintQuoteOnchainResponse>;
     checkProofsStates(proofs: Array<Pick<ProofLike, 'secret' | 'id'>>): Promise<ProofState[]>;
     completeBatchMint(batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>): Promise<Proof[]>;
+    // (undocumented)
+    completeConditionalSwap(preview: ConditionalSwapPreview): Promise<Record<string, Proof[]>>;
     completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(meltPreview: MeltPreview<TQuote>, privkey?: string | string[], options?: CompleteMeltOptions): Promise<MeltProofsResponse<TQuote>>;
     completeMint(mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>): Promise<Proof[]>;
     completeSwap(swapPreview: SwapPreview, privkey?: string | string[]): Promise<SendResponse>;
     readonly counters: WalletCounters;
     createLockedMintQuote(amount: AmountLike, pubkey: string, description?: string): Promise<MintQuoteBolt11Response>;
     createMeltChangeProofs(outputData: OutputDataLike[], changeSigs: SerializedBlindedSignature[]): Proof[];
+    createMeltQuote(invoice: string, amountMsat?: AmountLike): Promise<MeltQuoteBolt11Response>;
+    // (undocumented)
     createMeltQuote<TRes extends MeltQuoteBaseResponse = MeltQuoteBaseResponse>(method: string, payload: Record<string, unknown>, options?: {
         normalize?: (raw: Record<string, unknown>) => TRes;
     }): Promise<TRes>;
     createMeltQuoteBolt11(invoice: string, amountMsat?: AmountLike): Promise<MeltQuoteBolt11Response>;
     createMeltQuoteBolt12(offer: string, amountMsat?: AmountLike): Promise<MeltQuoteBolt12Response>;
     createMeltQuoteOnchain(address: string, amount: AmountLike): Promise<MeltQuoteOnchainResponse>;
+    createMintQuote(amount: AmountLike, description?: string): Promise<MintQuoteBolt11Response>;
+    // (undocumented)
     createMintQuote<TRes extends MintQuoteBaseResponse = MintQuoteBaseResponse>(method: string, payload: Record<string, unknown>, options?: {
         normalize?: (raw: Record<string, unknown>) => TRes;
     }): Promise<TRes>;
@@ -2180,6 +2451,7 @@ export class Wallet {
     }): Promise<MintQuoteBolt12Response>;
     createMintQuoteOnchain(pubkey: string): Promise<MintQuoteOnchainResponse>;
     createMultiPathMeltQuote(invoice: string, millisatPartialAmount: AmountLike): Promise<MeltQuoteBolt11Response>;
+    readonly ctf: WalletCtf | undefined;
     decodeToken(token: string): Token;
     defaultOutputType(): OutputType;
     getFeesForKeyset(nInputs: number, keysetId: string): Amount;
@@ -2198,11 +2470,15 @@ export class Wallet {
     // (undocumented)
     get logger(): Logger;
     maxSpendableAfterFees(proofs: ProofLike[], feeReserve?: AmountLike): Amount;
+    meltProofs(meltQuote: MeltQuoteBolt11Response, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<MeltQuoteBolt11Response>>;
+    // (undocumented)
     meltProofs<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(method: string, meltQuote: TQuote, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<TQuote>>;
     meltProofsBolt11(meltQuote: MeltQuoteBolt11Response, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<MeltQuoteBolt11Response>>;
     meltProofsBolt12(meltQuote: MeltQuoteBolt12Response, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltProofsResponse<MeltQuoteBolt12Response>>;
     meltProofsOnchain(meltQuote: MeltQuoteOnchainResponse, proofsToSend: ProofLike[], feeIndex: number, config?: MeltProofsConfig): Promise<MeltProofsResponse<MeltQuoteOnchainResponse>>;
     readonly mint: Mint;
+    mintProofs(amount: AmountLike, quote: string | MintQuoteBolt11Response, config?: MintProofsConfig, outputType?: OutputType): Promise<Proof[]>;
+    // (undocumented)
     mintProofs<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>>(method: string, amount: AmountLike, quote: TQuote, config?: MintProofsConfig, outputType?: OutputType): Promise<Proof[]>;
     mintProofsBolt11(amount: AmountLike, quote: string | MintQuoteBolt11Response, config?: MintProofsConfig, outputType?: OutputType): Promise<Proof[]>;
     mintProofsBolt12(amount: AmountLike, quote: MintQuoteBolt12Response, privkey: string, config?: {
@@ -2217,11 +2493,14 @@ export class Wallet {
         amount: AmountLike;
         quote: TQuote;
     }>, config?: MintProofsConfig, outputType?: OutputType): Promise<BatchMintPreview<TQuote>>;
+    prepareConditionalSwap(options: ConditionalSwapOptions): Promise<ConditionalSwapPreview>;
     prepareMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(method: string, meltQuote: TQuote, proofsToSend: ProofLike[], config?: PrepareMeltConfig, outputType?: OutputType): Promise<MeltPreview<TQuote>>;
     prepareMint<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>>(method: string, amount: AmountLike, quote: TQuote, config?: MintProofsConfig, outputType?: OutputType): Promise<MintPreview<TQuote>>;
     prepareSwapToReceive(token: Token | string | ProofLike[], config?: ReceiveConfig, outputType?: OutputType): Promise<SwapPreview>;
     prepareSwapToSend(amount: AmountLike, proofs: ProofLike[], config?: SendConfig, outputConfig?: OutputConfig): Promise<SwapPreview>;
     receive(token: Token | string | ProofLike[], config?: ReceiveConfig, outputType?: OutputType): Promise<Proof[]>;
+    // (undocumented)
+    redeemOutcomeProofs(options: RedeemOutcomeProofsOptions): Promise<Proof[]>;
     restore(start: number, count: number, config?: RestoreConfig): Promise<{
         proofs: Proof[];
         lastCounterWithSignature?: number;
@@ -2230,6 +2509,8 @@ export class Wallet {
     send(amount: AmountLike, proofs: ProofLike[], config?: SendConfig, outputConfig?: OutputConfig): Promise<SendResponse>;
     sendOffline(amount: AmountLike, proofs: ProofLike[], config?: SendOfflineConfig): SendResponse;
     signP2PKProofs(proofs: ProofLike[], privkey: string | string[], outputData?: OutputDataLike[], quoteId?: string): Proof[];
+    // (undocumented)
+    swapConditional(options: ConditionalSwapOptions): Promise<Record<string, Proof[]>>;
     get unit(): string;
     withKeyset(id: string, opts?: {
         counterSource?: CounterSource;
@@ -2243,6 +2524,18 @@ export class WalletCounters {
     peekNext(keysetId: string): Promise<number>;
     setNext(keysetId: string, next: number): Promise<void>;
     snapshot(): Promise<Record<string, number>>;
+}
+
+// @public (undocumented)
+export interface WalletCtf {
+    // (undocumented)
+    completeConditionalSwap(preview: ConditionalSwapPreview): Promise<Record<string, Proof[]>>;
+    // (undocumented)
+    prepareConditionalSwap(options: ConditionalSwapOptions): Promise<ConditionalSwapPreview>;
+    // (undocumented)
+    redeemOutcomeProofs(options: RedeemOutcomeProofsOptions): Promise<Proof[]>;
+    // (undocumented)
+    swapConditional(options: ConditionalSwapOptions): Promise<Record<string, Proof[]>>;
 }
 
 // @public (undocumented)

--- a/src/crypto/CTF.ts
+++ b/src/crypto/CTF.ts
@@ -1,0 +1,52 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import { Amount } from '../model/Amount';
+import { CTSError } from '../model/Errors';
+import type { Keys } from '../model/types/keyset';
+import { Bytes } from '../utils';
+
+export interface DeriveConditionalKeysetIdInput {
+  keys: Keys;
+  input_fee_ppk?: number;
+  final_expiry?: number;
+  unit: string;
+  conditionId: string;
+  outcomeCollectionId: string;
+}
+
+/**
+ * Derives a NUT-CTF conditional keyset id.
+ *
+ * Mirrors CDK's `Id::v2_from_data_conditional`: build the NUT-02 V2 preimage, append
+ * `|condition_id:<hex>|outcome_collection_id:<hex>`, SHA-256 it, and prefix the 32-byte digest with
+ * the NUT-02 V2 version byte `01`.
+ */
+export function deriveConditionalKeysetId(input: DeriveConditionalKeysetIdInput): string {
+  validateHex32(input.conditionId, 'conditionId');
+  validateHex32(input.outcomeCollectionId, 'outcomeCollectionId');
+  if (!input.unit) {
+    throw new CTSError('Cannot compute conditional keyset ID: unit is required.');
+  }
+
+  let preimage = Object.entries(input.keys)
+    .sort(([amountA], [amountB]) => Amount.from(amountA).compareTo(amountB))
+    .map(([amount, pubkey]) => `${amount}:${pubkey.toLowerCase()}`)
+    .join(',');
+  preimage += `|unit:${input.unit.toLowerCase()}`;
+  if (input.input_fee_ppk) {
+    preimage += `|input_fee_ppk:${input.input_fee_ppk}`;
+  }
+  if (input.final_expiry) {
+    preimage += `|final_expiry:${input.final_expiry}`;
+  }
+  preimage += `|condition_id:${input.conditionId.toLowerCase()}`;
+  preimage += `|outcome_collection_id:${input.outcomeCollectionId.toLowerCase()}`;
+
+  return '01' + Bytes.toHex(sha256(Bytes.fromString(preimage)));
+}
+
+function validateHex32(value: string, name: string): void {
+  if (!/^[0-9a-fA-F]{64}$/.test(value)) {
+    throw new CTSError(`${name} must be a 64-character hex string`);
+  }
+}

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,4 +1,5 @@
 export * from './core';
+export * from './CTF';
 export * from './curve_bls';
 export * from './curve_secp';
 export * from './curves';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,13 @@ export { Keyset } from './wallet/Keyset';
 export { P2PKBuilder } from './wallet/P2PKBuilder';
 export { type SelectProofs, selectProofsRGLI } from './wallet/SelectProofs';
 export { Wallet } from './wallet/Wallet';
+export type {
+  ConditionalSwapOptions,
+  ConditionalSwapOutputGroup,
+  ConditionalSwapPreview,
+  RedeemOutcomeProofsOptions,
+  WalletCtf,
+} from './wallet/Wallet';
 export { WalletCounters } from './wallet/WalletCounters';
 export { WalletEvents } from './wallet/WalletEvents';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export type * from './wallet/types/payloads';
 export type * from './wallet/types/responses';
 export type * from './mint/types/payloads';
 export type * from './mint/types/responses';
+export type * from './mint/types/ctf';
 
 // Shared models & primitives
 export type * from './model/types/blinded';

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -9,7 +9,7 @@ import type { AuthProvider } from '../auth/AuthProvider';
 import { OIDCAuth, type OIDCAuthOptions } from '../auth/OIDCAuth';
 import { type Logger, NULL_LOGGER, failIf } from '../logger';
 import { Amount, type AmountLike } from '../model/Amount';
-import { CTSError } from '../model/Errors';
+import { CTSError, MintOperationError } from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import {
   type MintQuoteBaseResponse,
@@ -61,6 +61,21 @@ import type {
   SwapResponse,
   CheckStatePayload,
   PostRestorePayload,
+  CtfConditionInfo,
+  CtfSplitRequest,
+  CtfSplitResponse,
+  RedeemOutcomeRequest,
+  RedeemOutcomeResponse,
+  ConditionalKeysetsResponse,
+  GetConditionalKeysetsQuery,
+  GetConditionsQuery,
+  GetConditionsResponse,
+  RegisterConditionRequest,
+  RegisterConditionResponse,
+  RegisterPartitionRequest,
+  RegisterPartitionResponse,
+  CtfMergeRequest,
+  CtfMergeResponse,
 } from './types';
 
 /**
@@ -958,6 +973,266 @@ class Mint {
     return data;
   }
 
+  /**
+   * Lists conditional keysets exposed by a NUT-CTF-aware mint.
+   *
+   * Conditional keysets are intentionally excluded from regular NUT-02 `/v1/keysets` discovery.
+   * Wallets use this endpoint to bind condition metadata before verifying condition-derived keyset
+   * ids.
+   */
+  async getConditionalKeysets(
+    query: GetConditionalKeysetsQuery = {},
+    customRequest?: RequestFn,
+  ): Promise<ConditionalKeysetsResponse> {
+    const params = new URLSearchParams();
+    if (query.since !== undefined) params.set('since', String(query.since));
+    if (query.limit !== undefined) params.set('limit', String(query.limit));
+    if (query.active !== undefined) params.set('active', String(query.active));
+    const suffix = params.toString();
+    const path = suffix ? `/v1/conditional_keysets?${suffix}` : '/v1/conditional_keysets';
+    const data = await this.requestWithAuth<ConditionalKeysetsResponse>(
+      'GET',
+      path,
+      {},
+      customRequest,
+    );
+    if (!isObj(data) || !Array.isArray(data.keysets)) {
+      this._logger.error('Invalid response from mint...', { data, op: 'getConditionalKeysets' });
+      throw new CTSError('Invalid response from mint');
+    }
+    return {
+      keysets: data.keysets.map((keyset) => ({
+        ...keyset,
+        input_fee_ppk: normalizeSafeIntegerMetadata(
+          keyset.input_fee_ppk,
+          'conditional_keyset.input_fee_ppk',
+          undefined,
+        ),
+        final_expiry: normalizeSafeIntegerMetadata(
+          keyset.final_expiry,
+          'conditional_keyset.final_expiry',
+          undefined,
+        ),
+        registered_at: normalizeSafeIntegerMetadata(
+          keyset.registered_at,
+          'conditional_keyset.registered_at',
+          undefined,
+        ),
+      })),
+    };
+  }
+
+  async getConditions(
+    query: GetConditionsQuery = {},
+    customRequest?: RequestFn,
+  ): Promise<GetConditionsResponse> {
+    const params = new URLSearchParams();
+    if (query.since !== undefined) params.set('since', String(query.since));
+    if (query.limit !== undefined) params.set('limit', String(query.limit));
+    for (const status of query.status ?? []) params.append('status', status);
+    const suffix = params.toString();
+    const path = suffix ? `/v1/conditions?${suffix}` : '/v1/conditions';
+    const data = await this.requestWithAuth<GetConditionsResponse>('GET', path, {}, customRequest);
+    if (!isObj(data) || !Array.isArray(data.conditions)) {
+      this._logger.error('Invalid response from mint...', { data, op: 'getConditions' });
+      throw new CTSError('Invalid response from mint');
+    }
+    return data;
+  }
+
+  async registerCondition(
+    payload: RegisterConditionRequest,
+    customRequest?: RequestFn,
+  ): Promise<RegisterConditionResponse> {
+    const data = await this.requestWithAuth<RegisterConditionResponse>(
+      'POST',
+      '/v1/conditions',
+      { requestBody: payload as unknown as Record<string, unknown> },
+      customRequest,
+    );
+    if (!isObj(data) || typeof data.condition_id !== 'string') {
+      this._logger.error('Invalid response from mint...', { data, op: 'registerCondition' });
+      throw new CTSError('Invalid response from mint');
+    }
+    return data;
+  }
+
+  async registerPartition(
+    conditionId: string,
+    payload: RegisterPartitionRequest,
+    customRequest?: RequestFn,
+  ): Promise<RegisterPartitionResponse> {
+    if (!/^[0-9a-fA-F]{64}$/.test(conditionId)) {
+      throw new CTSError(
+        'conditionId must be a 64-character hex string for CTF partition registration',
+      );
+    }
+    const data = await this.requestWithAuth<RegisterPartitionResponse>(
+      'POST',
+      `/v1/conditions/${conditionId.toLowerCase()}/partitions`,
+      { requestBody: payload as unknown as Record<string, unknown> },
+      customRequest,
+    );
+    if (!isObj(data) || !isObj(data.keysets)) {
+      this._logger.error('Invalid response from mint...', { data, op: 'registerPartition' });
+      throw new CTSError('Invalid response from mint');
+    }
+    return data;
+  }
+
+  /**
+   * Fetches one conditional-token condition from a CTF-aware mint.
+   *
+   * The CTF extension keeps condition partition metadata outside NUT-02 keyset discovery; callers
+   * use this to resolve root outcome collection keysets before building complete-set split
+   * outputs.
+   */
+  async getCtfCondition(conditionId: string, customRequest?: RequestFn): Promise<CtfConditionInfo> {
+    if (!/^[0-9a-fA-F]{64}$/.test(conditionId)) {
+      throw new CTSError('conditionId must be a 64-character hex string for CTF condition lookup');
+    }
+    const normalizedConditionId = conditionId.toLowerCase();
+    const data = await this.getCtfConditionResponse(normalizedConditionId, customRequest);
+    const dataObject = data as Record<string, unknown>;
+    const condition = isObj(dataObject.condition)
+      ? (dataObject.condition as CtfConditionInfo)
+      : (data as CtfConditionInfo);
+    if (
+      !isObj(condition) ||
+      condition.condition_id?.toLowerCase() !== normalizedConditionId ||
+      !Array.isArray(condition.partitions)
+    ) {
+      this._logger.error('Invalid response from mint...', { data, op: 'getCtfCondition' });
+      throw new CTSError(`Mint did not return condition ${normalizedConditionId}`);
+    }
+    return condition;
+  }
+
+  private async getCtfConditionResponse(
+    normalizedConditionId: string,
+    customRequest?: RequestFn,
+  ): Promise<CtfConditionInfo | { condition?: CtfConditionInfo }> {
+    try {
+      return await this.requestWithAuth<CtfConditionInfo | { condition?: CtfConditionInfo }>(
+        'GET',
+        `/v1/conditions/${normalizedConditionId}`,
+        {},
+        customRequest,
+      );
+    } catch (e) {
+      if (!this.isConditionNotFound(e)) throw e;
+      const data = await this.requestWithAuth<
+        CtfConditionInfo[] | { conditions?: CtfConditionInfo[] }
+      >('GET', '/v1/conditions', {}, customRequest);
+      const conditions = Array.isArray(data)
+        ? data
+        : isObj(data) && Array.isArray(data.conditions)
+          ? data.conditions
+          : [];
+      const condition = conditions.find(
+        (candidate) => candidate.condition_id?.toLowerCase() === normalizedConditionId,
+      );
+      if (!condition) throw e;
+      return condition;
+    }
+  }
+
+  private isConditionNotFound(e: unknown): boolean {
+    if (e instanceof MintOperationError && e.code === 13021) return true;
+    if (e instanceof CTSError && /condition not found/i.test(e.message)) return true;
+    return false;
+  }
+
+  /**
+   * Performs a CTF complete-set split.
+   *
+   * Inputs are regular collateral proofs and outputs are grouped by outcome collection. The mint
+   * returns one signature array per requested collection.
+   */
+  async ctfSplit(
+    splitPayload: CtfSplitRequest,
+    customRequest?: RequestFn,
+  ): Promise<CtfSplitResponse> {
+    const requestPayload = {
+      ...splitPayload,
+      outputs: Object.fromEntries(
+        Object.entries(splitPayload.outputs).map(([collection, outputs]) => [
+          collection,
+          this.toWireBlindedMessages(outputs),
+        ]),
+      ),
+    };
+    const data = await this.requestWithAuth<CtfSplitResponse>(
+      'POST',
+      '/v1/ctf/split',
+      { requestBody: requestPayload as unknown as Record<string, unknown> },
+      customRequest,
+    );
+    if (!isObj(data) || !isObj(data.signatures)) {
+      this._logger.error('Invalid response from mint...', { data, op: 'ctfSplit' });
+      throw new CTSError('Invalid response from mint');
+    }
+    for (const [collection, signatures] of Object.entries(data.signatures)) {
+      if (!Array.isArray(signatures)) {
+        this._logger.error('Invalid response from mint...', { data, op: 'ctfSplit' });
+        throw new CTSError(`Mint returned invalid CTF split signatures for ${collection}`);
+      }
+      data.signatures[collection] = this.normalizeSignatureAmounts(signatures);
+    }
+    return data;
+  }
+
+  async ctfMerge(
+    mergePayload: CtfMergeRequest,
+    customRequest?: RequestFn,
+  ): Promise<CtfMergeResponse> {
+    const requestPayload = {
+      ...mergePayload,
+      outputs: this.toWireBlindedMessages(mergePayload.outputs),
+    };
+    const data = await this.requestWithAuth<CtfMergeResponse>(
+      'POST',
+      '/v1/ctf/merge',
+      { requestBody: requestPayload as unknown as Record<string, unknown> },
+      customRequest,
+    );
+    if (!isObj(data) || !Array.isArray(data.signatures)) {
+      this._logger.error('Invalid response from mint...', { data, op: 'ctfMerge' });
+      throw new CTSError('Invalid response from mint');
+    }
+    data.signatures = this.normalizeSignatureAmounts(data.signatures);
+    return data;
+  }
+
+  /**
+   * Redeems witnessed conditional outcome proofs into regular mint proofs.
+   *
+   * Callers must attach the oracle witness to each conditional input proof before invoking this
+   * method. Output blinded messages are normalized to the mint's numeric wire shape so CTF redeem
+   * follows the same request encoding as regular swaps.
+   */
+  async redeemOutcome(
+    redeemPayload: RedeemOutcomeRequest,
+    customRequest?: RequestFn,
+  ): Promise<RedeemOutcomeResponse> {
+    const requestPayload = {
+      ...redeemPayload,
+      outputs: this.toWireBlindedMessages(redeemPayload.outputs),
+    };
+    const data = await this.requestWithAuth<RedeemOutcomeResponse>(
+      'POST',
+      '/v1/redeem_outcome',
+      { requestBody: requestPayload as unknown as Record<string, unknown> },
+      customRequest,
+    );
+    if (!isObj(data) || !Array.isArray(data.signatures)) {
+      this._logger.error('Invalid response from mint...', { data, op: 'redeemOutcome' });
+      throw new CTSError('Invalid response from mint');
+    }
+    data.signatures = this.normalizeSignatureAmounts(data.signatures);
+    return data;
+  }
+
   // -----------------------------------------------------------------
   // Section: Websockets
   // -----------------------------------------------------------------
@@ -1140,6 +1415,15 @@ class Mint {
     return messages.map((message) => ({
       ...message,
       amount: Amount.from(message.amount),
+    }));
+  }
+
+  private toWireBlindedMessages(
+    messages: SerializedBlindedMessage[],
+  ): Array<Omit<SerializedBlindedMessage, 'amount'> & { amount: number }> {
+    return messages.map((message) => ({
+      ...message,
+      amount: Amount.from(message.amount).toNumber(),
     }));
   }
 

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -62,8 +62,8 @@ import type {
   CheckStatePayload,
   PostRestorePayload,
   CtfConditionInfo,
-  CtfSplitRequest,
-  CtfSplitResponse,
+  CtfConvertRequest,
+  CtfConvertResponse,
   RedeemOutcomeRequest,
   RedeemOutcomeResponse,
   ConditionalKeysetsResponse,
@@ -74,8 +74,6 @@ import type {
   RegisterConditionResponse,
   RegisterPartitionRequest,
   RegisterPartitionResponse,
-  CtfMergeRequest,
-  CtfMergeResponse,
 } from './types';
 
 /**
@@ -1144,63 +1142,38 @@ class Mint {
   }
 
   /**
-   * Performs a CTF complete-set split.
-   *
-   * Inputs are regular collateral proofs and outputs are grouped by outcome collection. The mint
-   * returns one signature array per requested collection.
+   * Performs a CTF payoff-preserving convert.
    */
-  async ctfSplit(
-    splitPayload: CtfSplitRequest,
+  async ctfConvert(
+    convertPayload: CtfConvertRequest,
     customRequest?: RequestFn,
-  ): Promise<CtfSplitResponse> {
+  ): Promise<CtfConvertResponse> {
     const requestPayload = {
-      ...splitPayload,
+      ...convertPayload,
       outputs: Object.fromEntries(
-        Object.entries(splitPayload.outputs).map(([collection, outputs]) => [
+        Object.entries(convertPayload.outputs).map(([collection, outputs]) => [
           collection,
           this.toWireBlindedMessages(outputs),
         ]),
       ),
     };
-    const data = await this.requestWithAuth<CtfSplitResponse>(
+    const data = await this.requestWithAuth<CtfConvertResponse>(
       'POST',
-      '/v1/ctf/split',
+      '/v1/ctf/convert',
       { requestBody: requestPayload as unknown as Record<string, unknown> },
       customRequest,
     );
     if (!isObj(data) || !isObj(data.signatures)) {
-      this._logger.error('Invalid response from mint...', { data, op: 'ctfSplit' });
+      this._logger.error('Invalid response from mint...', { data, op: 'ctfConvert' });
       throw new CTSError('Invalid response from mint');
     }
     for (const [collection, signatures] of Object.entries(data.signatures)) {
       if (!Array.isArray(signatures)) {
-        this._logger.error('Invalid response from mint...', { data, op: 'ctfSplit' });
-        throw new CTSError(`Mint returned invalid CTF split signatures for ${collection}`);
+        this._logger.error('Invalid response from mint...', { data, op: 'ctfConvert' });
+        throw new CTSError(`Mint returned invalid CTF convert signatures for ${collection}`);
       }
       data.signatures[collection] = this.normalizeSignatureAmounts(signatures);
     }
-    return data;
-  }
-
-  async ctfMerge(
-    mergePayload: CtfMergeRequest,
-    customRequest?: RequestFn,
-  ): Promise<CtfMergeResponse> {
-    const requestPayload = {
-      ...mergePayload,
-      outputs: this.toWireBlindedMessages(mergePayload.outputs),
-    };
-    const data = await this.requestWithAuth<CtfMergeResponse>(
-      'POST',
-      '/v1/ctf/merge',
-      { requestBody: requestPayload as unknown as Record<string, unknown> },
-      customRequest,
-    );
-    if (!isObj(data) || !Array.isArray(data.signatures)) {
-      this._logger.error('Invalid response from mint...', { data, op: 'ctfMerge' });
-      throw new CTSError('Invalid response from mint');
-    }
-    data.signatures = this.normalizeSignatureAmounts(data.signatures);
     return data;
   }
 

--- a/src/mint/types/ctf.ts
+++ b/src/mint/types/ctf.ts
@@ -1,0 +1,116 @@
+import type {
+  Proof,
+  SerializedBlindedMessage,
+  SerializedBlindedSignature,
+} from '../../model/types';
+
+export interface CtfConditionPartition {
+  partition?: string[];
+  collateral: string;
+  parent_collection_id: string;
+  keysets: Record<string, string>;
+  registered_at?: number;
+}
+
+export interface CtfConditionInfo {
+  condition_id: string;
+  threshold?: number;
+  tags?: string[][];
+  announcements?: string[];
+  partitions: CtfConditionPartition[];
+  registered_at?: number;
+  condition_type?: string;
+  lo_bound?: number;
+  hi_bound?: number;
+  precision?: number;
+  attestation?: {
+    status: string;
+    winning_outcome?: string | null;
+    attested_at?: number | null;
+  };
+}
+
+export interface ConditionalKeysetInfo {
+  id: string;
+  unit: string;
+  active: boolean;
+  input_fee_ppk?: number;
+  final_expiry?: number;
+  condition_id: string;
+  outcome_collection: string;
+  outcome_collection_id: string;
+  registered_at?: number;
+}
+
+export interface GetConditionalKeysetsQuery {
+  since?: number;
+  limit?: number;
+  active?: boolean;
+}
+
+export interface ConditionalKeysetsResponse {
+  keysets: ConditionalKeysetInfo[];
+}
+
+export interface GetConditionsQuery {
+  since?: number;
+  limit?: number;
+  status?: string[];
+}
+
+export interface GetConditionsResponse {
+  conditions: CtfConditionInfo[];
+}
+
+export interface RegisterConditionRequest {
+  threshold?: number;
+  tags?: string[][];
+  announcements: string[];
+  condition_type?: string;
+  lo_bound?: number;
+  hi_bound?: number;
+  precision?: number;
+}
+
+export interface RegisterConditionResponse {
+  condition_id: string;
+}
+
+export interface RegisterPartitionRequest {
+  collateral: string;
+  partition?: string[];
+  parent_collection_id?: string;
+}
+
+export interface RegisterPartitionResponse {
+  keysets: Record<string, string>;
+}
+
+export interface CtfSplitRequest {
+  condition_id: string;
+  inputs: Proof[];
+  outputs: Record<string, SerializedBlindedMessage[]>;
+}
+
+export interface CtfSplitResponse {
+  signatures: Record<string, SerializedBlindedSignature[]>;
+}
+
+export interface CtfMergeRequest {
+  condition_id: string;
+  inputs: Record<string, Proof[]>;
+  outputs: SerializedBlindedMessage[];
+}
+
+export interface CtfMergeResponse {
+  signatures: SerializedBlindedSignature[];
+}
+
+export interface RedeemOutcomeRequest {
+  inputs: Proof[];
+  outputs: SerializedBlindedMessage[];
+}
+
+export interface RedeemOutcomeResponse {
+  signatures: SerializedBlindedSignature[];
+}

--- a/src/mint/types/ctf.ts
+++ b/src/mint/types/ctf.ts
@@ -86,24 +86,15 @@ export interface RegisterPartitionResponse {
   keysets: Record<string, string>;
 }
 
-export interface CtfSplitRequest {
+export interface CtfConvertRequest {
   condition_id: string;
-  inputs: Proof[];
+  parent_collection_id?: string;
+  inputs: Record<string, Proof[]>;
   outputs: Record<string, SerializedBlindedMessage[]>;
 }
 
-export interface CtfSplitResponse {
+export interface CtfConvertResponse {
   signatures: Record<string, SerializedBlindedSignature[]>;
-}
-
-export interface CtfMergeRequest {
-  condition_id: string;
-  inputs: Record<string, Proof[]>;
-  outputs: SerializedBlindedMessage[];
-}
-
-export interface CtfMergeResponse {
-  signatures: SerializedBlindedSignature[];
 }
 
 export interface RedeemOutcomeRequest {

--- a/src/mint/types/index.ts
+++ b/src/mint/types/index.ts
@@ -1,2 +1,3 @@
 export type * from './responses';
 export type * from './payloads';
+export type * from './ctf';

--- a/src/model/types/keyset.ts
+++ b/src/model/types/keyset.ts
@@ -24,6 +24,25 @@ export type HasKeysetId = { id: string };
  */
 export type HasKeysetKeys = { id: string; keys: Keys };
 
+export interface ConditionalKeysetMetadata {
+  /**
+   * 32-byte condition id as a 64-character hex string.
+   */
+  conditionId: string;
+  /**
+   * Outcome collection label, e.g. "YES" or "ALICE|BOB".
+   */
+  outcomeCollection: string;
+  /**
+   * 32-byte outcome collection id as a 64-character hex string.
+   */
+  outcomeCollectionId: string;
+  /**
+   * Unix timestamp from the mint's conditional-keyset registry, when known.
+   */
+  registeredAt?: number;
+}
+
 /**
  * NUT-01 Keys API response (/v1/keys)
  */
@@ -73,6 +92,10 @@ export type MintKeys = {
    * key signs for.
    */
   keys: Keys;
+  /**
+   * NUT-CTF conditional keyset metadata. Present only for conditional keysets.
+   */
+  conditional?: ConditionalKeysetMetadata;
 };
 
 /**
@@ -99,6 +122,10 @@ export type MintKeyset = {
    * Expiry of the keyset.
    */
   final_expiry?: number;
+  /**
+   * NUT-CTF conditional keyset metadata. Present only for conditional keysets.
+   */
+  conditional?: ConditionalKeysetMetadata;
 };
 
 /**

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -1,6 +1,7 @@
 import { Mint } from '../mint';
 import { CTSError } from '../model/Errors';
 import type {
+  ConditionalKeysetMetadata,
   MintKeyset,
   MintKeys,
   GetKeysetsResponse,
@@ -102,6 +103,7 @@ export class KeyChain {
       active: k.active,
       input_fee_ppk: k.input_fee_ppk,
       final_expiry: k.final_expiry,
+      conditional: k.conditional,
     }));
 
     const keys: MintKeys[] = cache.keysets
@@ -112,6 +114,7 @@ export class KeyChain {
         active: k.active,
         input_fee_ppk: k.input_fee_ppk,
         final_expiry: k.final_expiry,
+        conditional: k.conditional,
         keys: k.keys,
       }));
 
@@ -213,7 +216,7 @@ export class KeyChain {
       throw new CTSError('KeyChain not initialized');
     }
     const activeKeysets = Object.values(this.keysets).filter(
-      (k) => k.unit === this.unit && k.isActive && k.hasHexId && k.hasKeys,
+      (k) => !k.isConditional && k.unit === this.unit && k.isActive && k.hasHexId && k.hasKeys,
     );
     if (activeKeysets.length === 0) {
       throw new CTSError(`No active keyset found for unit: ${this.unit}`);
@@ -276,6 +279,84 @@ export class KeyChain {
   }
 
   /**
+   * Registers a conditional keyset that was discovered through NUT-CTF metadata.
+   *
+   * Conditional keysets are addressable by id but excluded from regular wallet keyset selection
+   * (`getCheapestKeyset` / `getKeysets`).
+   */
+  registerConditionalKeyset(
+    meta: MintKeyset & { conditional: ConditionalKeysetMetadata },
+    keys?: MintKeys,
+  ): Keyset {
+    const keyset = keys ? Keyset.fromMintApi(meta, keys) : Keyset.fromMintApi(meta);
+    if (keyset.hasKeys && !keyset.verify()) {
+      throw new CTSError(`Conditional keyset verification failed for ID ${meta.id}`);
+    }
+    this.keysets[keyset.id] = keyset;
+    return keyset;
+  }
+
+  async loadConditionalKeyset(id: string): Promise<Keyset> {
+    const existing = this.keysets[id];
+    if (existing?.isConditional && existing.hasKeys) {
+      return existing;
+    }
+
+    const pending = this.pendingKeyFetches.get(id);
+    if (pending) {
+      return await pending;
+    }
+
+    const promise = (async () => {
+      const registry = await this.mint.getConditionalKeysets();
+      const info = registry.keysets.find((keyset) => keyset.id === id);
+      if (!info) {
+        throw new CTSError(`Conditional keyset '${id}' not found`);
+      }
+
+      const conditional: ConditionalKeysetMetadata = {
+        conditionId: info.condition_id,
+        outcomeCollection: info.outcome_collection,
+        outcomeCollectionId: info.outcome_collection_id,
+        registeredAt: info.registered_at,
+      };
+      const meta: MintKeyset & { conditional: ConditionalKeysetMetadata } = {
+        id: info.id,
+        unit: info.unit,
+        active: info.active,
+        input_fee_ppk: info.input_fee_ppk,
+        final_expiry: info.final_expiry,
+        conditional,
+      };
+      const res = await this.mint.getKeys(id);
+      const keys = res.keysets.find((keyset) => keyset.id === id);
+      if (!keys || !keys.keys || Object.keys(keys.keys).length === 0) {
+        throw new CTSError(`Mint returned no keys for conditional keyset '${id}'`);
+      }
+      return this.registerConditionalKeyset(meta, { ...keys, conditional });
+    })();
+
+    this.pendingKeyFetches.set(id, promise);
+    try {
+      return await promise;
+    } finally {
+      this.pendingKeyFetches.delete(id);
+    }
+  }
+
+  getConditionalKeyset(id: string): Keyset {
+    const keyset = this.keysets[id];
+    if (!keyset || !keyset.isConditional) {
+      throw new CTSError(`Conditional keyset '${id}' not found`);
+    }
+    return keyset;
+  }
+
+  hasConditionalKeyset(id: string): boolean {
+    return !!this.keysets[id]?.isConditional;
+  }
+
+  /**
    * Get list of all keysets for the wallet's unit.
    *
    * @returns Array of Keysets for `this.unit`.
@@ -283,7 +364,9 @@ export class KeyChain {
    */
   getKeysets(): Keyset[] {
     this.assertInitialized();
-    const unitKeysets = Object.values(this.keysets).filter((k) => k.unit === this.unit);
+    const unitKeysets = Object.values(this.keysets).filter(
+      (k) => !k.isConditional && k.unit === this.unit,
+    );
     if (unitKeysets.length === 0) {
       throw new CTSError(`No keysets found for unit: ${this.unit}`);
     }

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -1,7 +1,8 @@
 import { hexToBytes } from '@noble/curves/utils.js';
 
+import { deriveConditionalKeysetId } from '../crypto';
 import { CTSError } from '../model/Errors';
-import { type MintKeyset, type MintKeys } from '../model/types';
+import { type ConditionalKeysetMetadata, type MintKeyset, type MintKeys } from '../model/types';
 import { isValidHex, deriveKeysetId, isBase64String } from '../utils';
 import { normalizeMintKeyset, normalizeMintKeys } from '../utils/normalizeNumbers';
 
@@ -12,6 +13,7 @@ export class Keyset {
   private _keys: Record<number, string> = {};
   private _input_fee_ppk?: number;
   private _final_expiry?: number;
+  private _conditional?: ConditionalKeysetMetadata;
 
   constructor(
     id: string,
@@ -19,12 +21,14 @@ export class Keyset {
     active: boolean,
     input_fee_ppk?: number,
     final_expiry?: number,
+    conditional?: ConditionalKeysetMetadata,
   ) {
     this._id = id;
     this._unit = unit;
     this._active = active;
     this._input_fee_ppk = input_fee_ppk;
     this._final_expiry = final_expiry;
+    this._conditional = conditional;
   }
 
   get id(): string {
@@ -51,6 +55,14 @@ export class Keyset {
     return Object.keys(this._keys).length > 0;
   }
 
+  get conditional(): ConditionalKeysetMetadata | undefined {
+    return this._conditional;
+  }
+
+  get isConditional(): boolean {
+    return !!this._conditional;
+  }
+
   get hasHexId(): boolean {
     return isValidHex(this._id);
   }
@@ -75,6 +87,7 @@ export class Keyset {
       active: this._active,
       input_fee_ppk: this._input_fee_ppk,
       final_expiry: this._final_expiry,
+      conditional: this._conditional,
     };
   }
 
@@ -93,6 +106,7 @@ export class Keyset {
       active: this._active,
       input_fee_ppk: this._input_fee_ppk,
       final_expiry: this._final_expiry,
+      conditional: this._conditional,
       keys: this._keys,
     };
   }
@@ -105,6 +119,9 @@ export class Keyset {
   verify(): boolean {
     if (!this.hasKeys) {
       return false;
+    }
+    if (this._conditional) {
+      return Keyset.verifyConditionalKeysetId(this.toMintKeys()!, this._conditional);
     }
     return Keyset.verifyKeysetId(this.toMintKeys()!);
   }
@@ -135,6 +152,29 @@ export class Keyset {
   }
 
   /**
+   * Verifies a NUT-CTF conditional keyset id against its keys and condition metadata.
+   */
+  static verifyConditionalKeysetId(
+    keys: MintKeys,
+    conditional: ConditionalKeysetMetadata,
+  ): boolean {
+    try {
+      if (!keys.keys || Object.keys(keys.keys).length === 0) return false;
+      const derivedId = deriveConditionalKeysetId({
+        keys: keys.keys,
+        input_fee_ppk: keys.input_fee_ppk,
+        final_expiry: keys.final_expiry,
+        unit: keys.unit,
+        conditionId: conditional.conditionId,
+        outcomeCollectionId: conditional.outcomeCollectionId,
+      });
+      return derivedId === keys.id;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Create a Keyset from Mint API DTOs.
    *
    * @param meta The MintKeyset metadata from GetKeysetsResponse.
@@ -150,6 +190,7 @@ export class Keyset {
       nMeta.active,
       nMeta.input_fee_ppk,
       nMeta.final_expiry,
+      nMeta.conditional,
     );
 
     // Sanity checks

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -18,6 +18,7 @@ import {
   assertSigAllInputs,
   buildLegacyP2PKSigAllMessage,
   parseSecret,
+  type P2PKOptions,
 } from '../crypto';
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';
@@ -99,6 +100,49 @@ import { WalletOps } from './WalletOps';
 
 const PENDING_KEYSET_ID = '__PENDING__';
 
+export interface ConditionalSwapOutputGroup {
+  label: string;
+  kind: 'random' | 'p2pk';
+  amount: AmountLike;
+  p2pk?: P2PKOptions;
+  customSplit?: AmountLike[];
+}
+
+export interface ConditionalSwapOptions {
+  /**
+   * Conditional keyset to preserve. If omitted, every input proof must share one keyset id and that
+   * id is used.
+   */
+  keysetId?: string;
+  inputs: ProofLike[];
+  outputs: ConditionalSwapOutputGroup[];
+}
+
+export interface ConditionalSwapPreview {
+  keysetId: string;
+  inputs: Proof[];
+  outputDataByLabel: Record<string, OutputData[]>;
+}
+
+export interface RedeemOutcomeProofsOptions {
+  /**
+   * Conditional proofs carrying the oracle witness required by the mint.
+   */
+  inputs: ProofLike[];
+  /**
+   * Regular-output blinded messages that will receive the redeemed sats. Persist these before
+   * calling the mint when the caller needs crash recovery.
+   */
+  outputs: OutputDataLike[];
+}
+
+export interface WalletCtf {
+  prepareConditionalSwap(options: ConditionalSwapOptions): Promise<ConditionalSwapPreview>;
+  completeConditionalSwap(preview: ConditionalSwapPreview): Promise<Record<string, Proof[]>>;
+  swapConditional(options: ConditionalSwapOptions): Promise<Record<string, Proof[]>>;
+  redeemOutcomeProofs(options: RedeemOutcomeProofsOptions): Promise<Proof[]>;
+}
+
 /**
  * Class that represents a Cashu wallet.
  *
@@ -148,6 +192,10 @@ class Wallet {
    * Developer-friendly counters API.
    */
   public readonly counters: WalletCounters;
+  /**
+   * Optional NUT-CTF wallet facade. Enabled with `new Wallet(mint, { enableCtf: true })`.
+   */
+  public readonly ctf: WalletCtf | undefined;
   private _keyChain: KeyChain;
   private _seed: Uint8Array | undefined = undefined;
   private _unit = 'sat';
@@ -204,6 +252,7 @@ class Wallet {
    * @param options.requestFetch Custom fetch-compatible transport for mint HTTP requests. Use this
    *   for per-wallet OHTTP, Tor, native HTTP clients, or proxies while preserving the default
    *   request pipeline. Ignored when `customRequest` is supplied.
+   * @param options.enableCtf Enables the optional NUT-CTF facade at `wallet.ctf`.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -222,6 +271,7 @@ class Wallet {
       requireSigDleq?: boolean;
       customRequest?: RequestFn;
       requestFetch?: RequestFetch;
+      enableCtf?: boolean;
       logger?: Logger;
     },
   ) {
@@ -261,6 +311,16 @@ class Wallet {
     this._keyChain = new KeyChain(this.mint, this._unit);
     this._denominationTarget = options?.denominationTarget ?? this._denominationTarget;
     this._requireSigDleq = options?.requireSigDleq ?? this._requireSigDleq;
+    this.ctf = options?.enableCtf ? this.createCtfFacade() : undefined;
+  }
+
+  private createCtfFacade(): WalletCtf {
+    return {
+      prepareConditionalSwap: (options) => this.prepareConditionalSwap(options),
+      completeConditionalSwap: (preview) => this.completeConditionalSwap(preview),
+      swapConditional: (options) => this.swapConditional(options),
+      redeemOutcomeProofs: (options) => this.redeemOutcomeProofs(options),
+    };
   }
 
   // Convenience wrappers for "log and throw"
@@ -1343,6 +1403,162 @@ class Wallet {
     };
   }
 
+  /**
+   * Swap proofs within one conditional keyset.
+   *
+   * CTF conditional keysets are condition-derived and are not listed as regular NUT-02 keysets.
+   * This method loads the conditional keyset through the KeyChain's conditional registry so the
+   * condition-derived keyset id is verified before any blinded output is built.
+   */
+  async prepareConditionalSwap(options: ConditionalSwapOptions): Promise<ConditionalSwapPreview> {
+    const inputs = normalizeProofAmounts(options.inputs);
+    if (inputs.length === 0) {
+      throw new CTSError('prepareConditionalSwap requires at least one input proof');
+    }
+    if (options.outputs.length === 0) {
+      throw new CTSError('prepareConditionalSwap requires at least one output group');
+    }
+
+    const keysetId = options.keysetId ?? inputs[0].id;
+    if (!keysetId) {
+      throw new CTSError('prepareConditionalSwap requires a conditional keyset id');
+    }
+    const mismatched = inputs.find((proof) => proof.id !== keysetId);
+    if (mismatched) {
+      throw new CTSError(
+        `prepareConditionalSwap inputs must use one keyset: expected ${keysetId}, got ${mismatched.id}`,
+      );
+    }
+
+    const keyset = await this._keyChain.loadConditionalKeyset(keysetId);
+
+    const seenLabels = new Set<string>();
+    let outputTotal = Amount.zero();
+    const built = options.outputs.map((group) => {
+      if (seenLabels.has(group.label)) {
+        throw new CTSError(`prepareConditionalSwap output label is duplicated: ${group.label}`);
+      }
+      seenLabels.add(group.label);
+      const amount = Amount.from(group.amount);
+      if (amount.isZero()) {
+        throw new CTSError(`prepareConditionalSwap output ${group.label} amount must be positive`);
+      }
+      outputTotal = outputTotal.add(amount);
+      if (group.kind === 'p2pk') {
+        if (!group.p2pk) {
+          throw new CTSError(
+            `prepareConditionalSwap output ${group.label} is missing P2PK options`,
+          );
+        }
+        return {
+          label: group.label,
+          data: OutputData.createP2PKData(group.p2pk, amount, keyset, group.customSplit),
+        };
+      }
+      return {
+        label: group.label,
+        data: OutputData.createRandomData(amount, keyset, group.customSplit),
+      };
+    });
+
+    const fee = Amount.from(Math.ceil((inputs.length * keyset.fee) / 1000));
+    const expectedOutputTotal = sumProofs(inputs).subtract(fee);
+    if (!outputTotal.equals(expectedOutputTotal)) {
+      throw new CTSError(
+        `prepareConditionalSwap output total ${outputTotal.toString()} does not match input total ` +
+          `${expectedOutputTotal.toString()} after fees`,
+      );
+    }
+
+    return {
+      keysetId,
+      inputs,
+      outputDataByLabel: Object.fromEntries(built.map((group) => [group.label, group.data])),
+    };
+  }
+
+  async completeConditionalSwap(preview: ConditionalSwapPreview): Promise<Record<string, Proof[]>> {
+    const flatOutputs = Object.values(preview.outputDataByLabel).flat();
+    const wireOutputs = flatOutputs.map((output) => ({
+      ...output.blindedMessage,
+      amount: output.blindedMessage.amount.toNumber(),
+    })) as unknown as SwapRequest['outputs'];
+    const { signatures } = await this.mint.swap({
+      inputs: preview.inputs,
+      outputs: wireOutputs,
+    });
+    this.failIf(
+      signatures.length !== flatOutputs.length,
+      `Mint returned ${signatures.length} signatures, expected ${flatOutputs.length}. ` +
+        'Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',
+    );
+    this.validateReturnedSignatures(signatures, flatOutputs);
+
+    const keyset = this._keyChain.getConditionalKeyset(preview.keysetId);
+
+    const result: Record<string, Proof[]> = {};
+    let cursor = 0;
+    for (const [label, outputData] of Object.entries(preview.outputDataByLabel)) {
+      result[label] = [];
+      for (const output of outputData) {
+        const signature = signatures[cursor];
+        cursor += 1;
+        if (signature.id !== preview.keysetId) {
+          throw new CTSError(
+            `Mint signed conditional swap output with keyset ${signature.id}; expected ${preview.keysetId}`,
+          );
+        }
+        result[label].push(output.toProof(signature, keyset));
+      }
+    }
+    return result;
+  }
+
+  async swapConditional(options: ConditionalSwapOptions): Promise<Record<string, Proof[]>> {
+    return this.completeConditionalSwap(await this.prepareConditionalSwap(options));
+  }
+
+  async redeemOutcomeProofs(options: RedeemOutcomeProofsOptions): Promise<Proof[]> {
+    const inputs = normalizeProofAmounts(options.inputs);
+    const outputData = [...options.outputs];
+    if (inputs.length === 0) {
+      throw new CTSError('redeemOutcomeProofs requires at least one input proof');
+    }
+    if (outputData.length === 0) {
+      throw new CTSError('redeemOutcomeProofs requires at least one output');
+    }
+
+    const keysetId = outputData[0].blindedMessage.id;
+    if (!keysetId) {
+      throw new CTSError('redeemOutcomeProofs requires output keyset ids');
+    }
+    const mismatched = outputData.find((output) => output.blindedMessage.id !== keysetId);
+    if (mismatched) {
+      throw new CTSError(
+        `redeemOutcomeProofs outputs must use one keyset: expected ${keysetId}, got ${mismatched.blindedMessage.id}`,
+      );
+    }
+
+    const { signatures } = await this.mint.redeemOutcome({
+      inputs,
+      outputs: outputData.map((output) => output.blindedMessage),
+    });
+    this.failIf(
+      signatures.length !== outputData.length,
+      `Mint returned ${signatures.length} signatures, expected ${outputData.length}. ` +
+        'Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',
+    );
+    this.validateReturnedSignatures(signatures, outputData);
+
+    const keysetResponse = await this.mint.getKeys(keysetId);
+    const keyset = keysetResponse.keysets.find((candidate) => candidate.id === keysetId);
+    if (!keyset || Object.keys(keyset.keys).length === 0) {
+      throw new CTSError(`Mint returned no keys for redeem output keyset ${keysetId}`);
+    }
+
+    return outputData.map((output, index) => output.toProof(signatures[index], keyset));
+  }
+
   // -----------------------------------------------------------------
   // Section: Transaction Helpers
   // -----------------------------------------------------------------
@@ -1666,13 +1882,23 @@ class Wallet {
    * @param options.normalize Optional callback to normalize method-specific response fields.
    * @returns The mint quote response.
    */
+  async createMintQuote(amount: AmountLike, description?: string): Promise<MintQuoteBolt11Response>;
   async createMintQuote<TRes extends MintQuoteBaseResponse = MintQuoteBaseResponse>(
     method: string,
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
-  ): Promise<TRes> {
-    const body = { ...payload, unit: this._unit };
-    const res = await this.mint.createMintQuote<TRes>(method, body, {
+  ): Promise<TRes>;
+  async createMintQuote<TRes extends MintQuoteBaseResponse = MintQuoteBaseResponse>(
+    methodOrAmount: string | AmountLike,
+    payloadOrDescription?: Record<string, unknown> | string,
+    options?: { normalize?: (raw: Record<string, unknown>) => TRes },
+  ): Promise<TRes | MintQuoteBolt11Response> {
+    if (typeof methodOrAmount !== 'string' || typeof payloadOrDescription === 'string') {
+      return this.createMintQuoteBolt11(methodOrAmount, payloadOrDescription as string | undefined);
+    }
+
+    const body = { ...(payloadOrDescription as Record<string, unknown>), unit: this._unit };
+    const res = await this.mint.createMintQuote<TRes>(methodOrAmount, body, {
       normalize: options?.normalize,
     });
     return { ...res, unit: res.unit || this._unit };
@@ -1813,13 +2039,23 @@ class Wallet {
    * @param options.normalize Optional callback to normalize method-specific response fields.
    * @returns The mint quote response.
    */
+  async checkMintQuote(quote: string | MintQuoteBolt11Response): Promise<MintQuoteBolt11Response>;
   async checkMintQuote<TRes extends MintQuoteBaseResponse = MintQuoteBaseResponse>(
     method: string,
     quote: string | Pick<TRes, 'quote'>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
-  ): Promise<TRes> {
+  ): Promise<TRes>;
+  async checkMintQuote<TRes extends MintQuoteBaseResponse = MintQuoteBaseResponse>(
+    methodOrQuote: string | MintQuoteBolt11Response,
+    quote?: string | Pick<TRes, 'quote'>,
+    options?: { normalize?: (raw: Record<string, unknown>) => TRes },
+  ): Promise<TRes | MintQuoteBolt11Response> {
+    if (quote === undefined) {
+      return this.checkMintQuoteBolt11(methodOrQuote);
+    }
+
     const quoteId = typeof quote === 'string' ? quote : (quote as { quote: string }).quote;
-    return this.mint.checkMintQuote<TRes>(method, quoteId, {
+    return this.mint.checkMintQuote<TRes>(methodOrQuote as string, quoteId, {
       normalize: options?.normalize,
     });
   }
@@ -1965,14 +2201,42 @@ class Wallet {
    * @param outputType Configuration for proof generation. Defaults to wallet.defaultOutputType().
    * @returns Minted proofs.
    */
+  async mintProofs(
+    amount: AmountLike,
+    quote: string | MintQuoteBolt11Response,
+    config?: MintProofsConfig,
+    outputType?: OutputType,
+  ): Promise<Proof[]>;
   async mintProofs<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>>(
     method: string,
     amount: AmountLike,
     quote: TQuote,
     config?: MintProofsConfig,
     outputType?: OutputType,
+  ): Promise<Proof[]>;
+  async mintProofs<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>>(
+    methodOrAmount: string | AmountLike,
+    amountOrQuote: AmountLike | string | MintQuoteBolt11Response,
+    quoteOrConfig?: TQuote | MintProofsConfig,
+    configOrOutputType?: MintProofsConfig | OutputType,
+    outputType?: OutputType,
   ): Promise<Proof[]> {
-    const preview = await this.prepareMint(method, amount, quote, config, outputType);
+    if (typeof methodOrAmount !== 'string') {
+      return this.mintProofsBolt11(
+        methodOrAmount,
+        amountOrQuote as string | MintQuoteBolt11Response,
+        quoteOrConfig as MintProofsConfig | undefined,
+        configOrOutputType as OutputType | undefined,
+      );
+    }
+
+    const preview = await this.prepareMint(
+      methodOrAmount,
+      amountOrQuote as AmountLike,
+      quoteOrConfig as TQuote,
+      configOrOutputType as MintProofsConfig | undefined,
+      outputType,
+    );
     return this.completeMint(preview);
   }
 
@@ -2378,13 +2642,31 @@ class Wallet {
    * @param options.normalize Optional callback to normalize method-specific response fields.
    * @returns The melt quote response.
    */
+  async createMeltQuote(invoice: string, amountMsat?: AmountLike): Promise<MeltQuoteBolt11Response>;
   async createMeltQuote<TRes extends MeltQuoteBaseResponse = MeltQuoteBaseResponse>(
     method: string,
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
-  ): Promise<TRes> {
-    const body = { ...payload, unit: this._unit };
-    const res = await this.mint.createMeltQuote<TRes>(method, body, {
+  ): Promise<TRes>;
+  async createMeltQuote<TRes extends MeltQuoteBaseResponse = MeltQuoteBaseResponse>(
+    methodOrInvoice: string,
+    payloadOrAmountMsat?: Record<string, unknown> | AmountLike,
+    options?: { normalize?: (raw: Record<string, unknown>) => TRes },
+  ): Promise<TRes | MeltQuoteBolt11Response> {
+    if (
+      payloadOrAmountMsat === undefined ||
+      typeof payloadOrAmountMsat === 'number' ||
+      typeof payloadOrAmountMsat === 'bigint' ||
+      (typeof payloadOrAmountMsat === 'object' && 'toNumber' in payloadOrAmountMsat)
+    ) {
+      return this.createMeltQuoteBolt11(
+        methodOrInvoice,
+        payloadOrAmountMsat as AmountLike | undefined,
+      );
+    }
+
+    const body = { ...(payloadOrAmountMsat as Record<string, unknown>), unit: this._unit };
+    const res = await this.mint.createMeltQuote<TRes>(methodOrInvoice, body, {
       normalize: options?.normalize,
     });
     return { ...res, unit: res.unit || this._unit };
@@ -2608,15 +2890,46 @@ class Wallet {
    * @param outputType Configuration for proof generation. Defaults to wallet.defaultOutputType().
    * @returns MeltProofsResponse with quote and change proofs.
    */
+  async meltProofs(
+    meltQuote: MeltQuoteBolt11Response,
+    proofsToSend: ProofLike[],
+    config?: MeltProofsConfig,
+    outputType?: OutputType,
+  ): Promise<MeltProofsResponse<MeltQuoteBolt11Response>>;
   async meltProofs<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(
     method: string,
     meltQuote: TQuote,
     proofsToSend: ProofLike[],
     config?: MeltProofsConfig,
     outputType?: OutputType,
-  ): Promise<MeltProofsResponse<TQuote>> {
-    const meltTxn = await this.prepareMelt(method, meltQuote, proofsToSend, config, outputType);
-    return this.completeMelt<TQuote>(meltTxn, config?.privkey);
+  ): Promise<MeltProofsResponse<TQuote>>;
+  async meltProofs<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(
+    methodOrQuote: string | MeltQuoteBolt11Response,
+    meltQuoteOrProofs: TQuote | ProofLike[],
+    proofsOrConfig?: ProofLike[] | MeltProofsConfig,
+    configOrOutputType?: MeltProofsConfig | OutputType,
+    outputType?: OutputType,
+  ): Promise<MeltProofsResponse<TQuote> | MeltProofsResponse<MeltQuoteBolt11Response>> {
+    if (typeof methodOrQuote !== 'string') {
+      return this.meltProofsBolt11(
+        methodOrQuote,
+        meltQuoteOrProofs as ProofLike[],
+        proofsOrConfig as MeltProofsConfig | undefined,
+        configOrOutputType as OutputType | undefined,
+      );
+    }
+
+    const meltTxn = await this.prepareMelt(
+      methodOrQuote,
+      meltQuoteOrProofs as TQuote,
+      proofsOrConfig as ProofLike[],
+      configOrOutputType as MeltProofsConfig | undefined,
+      outputType,
+    );
+    return this.completeMelt<TQuote>(
+      meltTxn,
+      (configOrOutputType as MeltProofsConfig | undefined)?.privkey,
+    );
   }
 
   /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1469,6 +1469,15 @@ class Wallet {
           `${expectedOutputTotal.toString()} after fees`,
       );
     }
+    for (const group of built) {
+      const mismatchedOutput = group.data.find((output) => output.blindedMessage.id !== keysetId);
+      if (mismatchedOutput) {
+        throw new CTSError(
+          `prepareConditionalSwap output ${group.label} uses keyset ` +
+            `${mismatchedOutput.blindedMessage.id}; expected ${keysetId}`,
+        );
+      }
+    }
 
     return {
       keysetId,

--- a/test/crypto/CTF.test.ts
+++ b/test/crypto/CTF.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+
+import { deriveConditionalKeysetId } from '../../src';
+import { DUMMY_TEST_KEYS, NUT02_V1_VECTOR1_KEYS } from '../consts';
+
+describe('NUT-CTF conditional keyset id derivation', () => {
+  test('matches CDK v2_from_data_conditional vectors', () => {
+    const conditionId = '11'.repeat(32);
+    expect(
+      deriveConditionalKeysetId({
+        keys: NUT02_V1_VECTOR1_KEYS.keys,
+        input_fee_ppk: 250,
+        final_expiry: 1754296607,
+        unit: 'sat',
+        conditionId,
+        outcomeCollectionId: '22'.repeat(32),
+      }),
+    ).toBe('01ef86b29fae7779271737d657c127f51ecf2b5672251d4e9bacc590607927dfaa');
+
+    expect(
+      deriveConditionalKeysetId({
+        keys: NUT02_V1_VECTOR1_KEYS.keys,
+        unit: 'sat',
+        conditionId,
+        outcomeCollectionId: 'bb'.repeat(32),
+      }),
+    ).toBe('01109feab5f222e4f16a3b5805fa95fdf73c22224482feb4e6e0185cce5c28fdb6');
+
+    expect(
+      deriveConditionalKeysetId({
+        keys: DUMMY_TEST_KEYS.keys,
+        final_expiry: 1754296607,
+        unit: 'sat',
+        conditionId: 'aa'.repeat(32),
+        outcomeCollectionId: 'cc'.repeat(32),
+      }),
+    ).toBe('0170110f06b9bb85565a6746ca5715f877b99db14d87219f6e9030cb529f61e6ea');
+  });
+
+  test('rejects malformed condition identifiers', () => {
+    expect(() =>
+      deriveConditionalKeysetId({
+        keys: DUMMY_TEST_KEYS.keys,
+        unit: 'sat',
+        conditionId: 'not-hex',
+        outcomeCollectionId: 'cc'.repeat(32),
+      }),
+    ).toThrow(/conditionId/);
+  });
+});

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -1060,34 +1060,42 @@ describe('Mint normalization', () => {
     expect(seen).toHaveLength(2);
   });
 
-  it('ctfMerge posts grouped conditional inputs and normalizes signatures', async () => {
+  it('ctfConvert posts grouped inputs and outputs and normalizes signatures', async () => {
     const requestSpy = vi.fn(async (options: ReqArgs) => {
-      expect(options.endpoint).toBe(`${mintUrl}/v1/ctf/merge`);
+      expect(options.endpoint).toBe(`${mintUrl}/v1/ctf/convert`);
       expect(options.method).toBe('POST');
       expect(options.requestBody).toEqual({
         condition_id: 'e'.repeat(64),
+        parent_collection_id: '0'.repeat(64),
         inputs: { YES: [] },
-        outputs: [{ id: '00bd033559de27d0', amount: 100, B_: '02'.padEnd(66, 'a') }],
+        outputs: {
+          '*': [{ id: '00bd033559de27d0', amount: 100, B_: '02'.padEnd(66, 'a') }],
+        },
       });
       return {
-        signatures: [
-          {
-            id: '00bd033559de27d0',
-            amount: 100,
-            C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
-          },
-        ],
+        signatures: {
+          '*': [
+            {
+              id: '00bd033559de27d0',
+              amount: 100,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        },
       };
     }) as RequestFn;
     const mint = new Mint(mintUrl, { customRequest: requestSpy });
 
-    const response = await mint.ctfMerge({
+    const response = await mint.ctfConvert({
       condition_id: 'e'.repeat(64),
+      parent_collection_id: '0'.repeat(64),
       inputs: { YES: [] },
-      outputs: [{ id: '00bd033559de27d0', amount: Amount.from(100), B_: '02'.padEnd(66, 'a') }],
+      outputs: {
+        '*': [{ id: '00bd033559de27d0', amount: Amount.from(100), B_: '02'.padEnd(66, 'a') }],
+      },
     });
 
-    expect(response.signatures[0].amount).toEqual(Amount.from(100));
+    expect(response.signatures['*'][0].amount).toEqual(Amount.from(100));
   });
 
   it('throws on invalid minted signatures responses', async () => {

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -8,6 +8,7 @@ import {
   injectWebSocketImpl,
   RateLimitError,
   Amount,
+  MintOperationError,
 } from '../../src';
 import type { AuthProvider, Logger, RequestFn } from '../../src';
 import { HttpResponse, http } from 'msw';
@@ -957,6 +958,136 @@ describe('Mint normalization', () => {
       data: { signatures: {} },
       op: 'mintBatch.bolt11',
     });
+  });
+
+  it('getCtfCondition falls back to the conditions list when direct lookup is unsupported', async () => {
+    const conditionId = 'a'.repeat(64);
+    const requestSpy = vi.fn(async (options: ReqArgs) => {
+      if (options.endpoint === `${mintUrl}/v1/conditions/${conditionId}`) {
+        throw new MintOperationError(13021, 'Condition not found');
+      }
+      expect(options.endpoint).toBe(`${mintUrl}/v1/conditions`);
+      return {
+        conditions: [
+          {
+            condition_id: conditionId,
+            partitions: [
+              {
+                collateral: 'sat',
+                parent_collection_id: '0'.repeat(64),
+                keysets: { YES: 'keyset-yes', NO: 'keyset-no' },
+              },
+            ],
+          },
+        ],
+      };
+    }) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    const condition = await mint.getCtfCondition(conditionId);
+
+    expect(condition.condition_id).toBe(conditionId);
+    expect(condition.partitions[0].keysets).toEqual({
+      YES: 'keyset-yes',
+      NO: 'keyset-no',
+    });
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('lists conditional keysets with query parameters and normalizes metadata numbers', async () => {
+    const requestSpy = vi.fn(async (options: ReqArgs) => {
+      expect(options.endpoint).toBe(
+        `${mintUrl}/v1/conditional_keysets?since=1700000000&limit=5&active=true`,
+      );
+      expect(options.method).toBe('GET');
+      return {
+        keysets: [
+          {
+            id: '01' + 'a'.repeat(64),
+            unit: 'sat',
+            active: true,
+            input_fee_ppk: '250',
+            final_expiry: '1754296607',
+            condition_id: 'b'.repeat(64),
+            outcome_collection: 'YES',
+            outcome_collection_id: 'c'.repeat(64),
+            registered_at: '1700000001',
+          },
+        ],
+      };
+    }) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    const response = await mint.getConditionalKeysets({
+      since: 1_700_000_000,
+      limit: 5,
+      active: true,
+    });
+
+    expect(response.keysets[0].input_fee_ppk).toBe(250);
+    expect(response.keysets[0].final_expiry).toBe(1_754_296_607);
+    expect(response.keysets[0].registered_at).toBe(1_700_000_001);
+  });
+
+  it('wraps condition registration and partition endpoints', async () => {
+    const conditionId = 'd'.repeat(64);
+    const seen: ReqArgs[] = [];
+    const requestSpy = vi.fn(async (options: ReqArgs) => {
+      seen.push(options);
+      if (options.endpoint === `${mintUrl}/v1/conditions`) {
+        expect(options.method).toBe('POST');
+        return { condition_id: conditionId };
+      }
+      expect(options.endpoint).toBe(`${mintUrl}/v1/conditions/${conditionId}/partitions`);
+      expect(options.method).toBe('POST');
+      return { keysets: { YES: 'keyset-yes', NO: 'keyset-no' } };
+    }) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    await expect(
+      mint.registerCondition({
+        threshold: 1,
+        tags: [['description', 'question']],
+        announcements: ['abcd'],
+      }),
+    ).resolves.toEqual({ condition_id: conditionId });
+    await expect(
+      mint.registerPartition(conditionId, {
+        collateral: 'sat',
+        partition: ['YES', 'NO'],
+      }),
+    ).resolves.toEqual({ keysets: { YES: 'keyset-yes', NO: 'keyset-no' } });
+    expect(seen).toHaveLength(2);
+  });
+
+  it('ctfMerge posts grouped conditional inputs and normalizes signatures', async () => {
+    const requestSpy = vi.fn(async (options: ReqArgs) => {
+      expect(options.endpoint).toBe(`${mintUrl}/v1/ctf/merge`);
+      expect(options.method).toBe('POST');
+      expect(options.requestBody).toEqual({
+        condition_id: 'e'.repeat(64),
+        inputs: { YES: [] },
+        outputs: [{ id: '00bd033559de27d0', amount: 100, B_: '02'.padEnd(66, 'a') }],
+      });
+      return {
+        signatures: [
+          {
+            id: '00bd033559de27d0',
+            amount: 100,
+            C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+          },
+        ],
+      };
+    }) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    const response = await mint.ctfMerge({
+      condition_id: 'e'.repeat(64),
+      inputs: { YES: [] },
+      outputs: [{ id: '00bd033559de27d0', amount: Amount.from(100), B_: '02'.padEnd(66, 'a') }],
+    });
+
+    expect(response.signatures[0].amount).toEqual(Amount.from(100));
   });
 
   it('throws on invalid minted signatures responses', async () => {

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -9,6 +9,9 @@ import { DUMMY_TEST_KEYS, DUMMY_TEST_KEYSET, PUBKEYS } from '../consts';
 const mintUrl = 'http://localhost:3338';
 const mint = new Mint(mintUrl);
 const unit = 'sat';
+const CTF_CONDITION_ID = 'aa'.repeat(32);
+const CTF_OUTCOME_COLLECTION_ID = 'cc'.repeat(32);
+const CTF_KEYSET_ID = '0170110f06b9bb85565a6746ca5715f877b99db14d87219f6e9030cb529f61e6ea';
 
 const dummyKeysResp: { keysets: MintKeys[] } = {
   keysets: [
@@ -182,6 +185,75 @@ describe('KeyChain initialization', () => {
     expect(() => keyChain.getCheapestKeyset()).toThrow('No active keyset found for unit: sat');
   });
 
+  test('should not use a registered conditional keyset as the cheapest regular keyset', () => {
+    const keyChain = new KeyChain(mint, unit);
+    keyChain.registerConditionalKeyset(
+      {
+        id: CTF_KEYSET_ID,
+        unit,
+        active: true,
+        input_fee_ppk: 0,
+        final_expiry: 1754296607,
+        conditional: {
+          conditionId: CTF_CONDITION_ID,
+          outcomeCollection: 'YES',
+          outcomeCollectionId: CTF_OUTCOME_COLLECTION_ID,
+        },
+      },
+      {
+        ...DUMMY_TEST_KEYS,
+        id: CTF_KEYSET_ID,
+        conditional: {
+          conditionId: CTF_CONDITION_ID,
+          outcomeCollection: 'YES',
+          outcomeCollectionId: CTF_OUTCOME_COLLECTION_ID,
+        },
+      },
+    );
+
+    expect(() => keyChain.getCheapestKeyset()).toThrow('No active keyset found for unit: sat');
+  });
+
+  test('should reject tampered keys for a discovered conditional keyset', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/conditional_keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              id: CTF_KEYSET_ID,
+              unit,
+              active: true,
+              input_fee_ppk: 0,
+              condition_id: CTF_CONDITION_ID,
+              outcome_collection: 'YES',
+              outcome_collection_id: CTF_OUTCOME_COLLECTION_ID,
+              registered_at: 1_700_000_000,
+            },
+          ],
+        }),
+      ),
+      http.get(mintUrl + '/v1/keys/' + CTF_KEYSET_ID, () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              ...DUMMY_TEST_KEYS,
+              id: CTF_KEYSET_ID,
+              keys: {
+                ...DUMMY_TEST_KEYS.keys,
+                1: PUBKEYS['2'],
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    const keyChain = new KeyChain(mint, unit);
+    await expect(keyChain.loadConditionalKeyset(CTF_KEYSET_ID)).rejects.toThrow(
+      'Conditional keyset verification failed',
+    );
+  });
+
   test('should remove keys if verification fails', async () => {
     // Create mismatched data by changing ID but keeping keys the same (derived ID won't match)
     const mismatchedKeysetResp = JSON.parse(JSON.stringify(dummyKeysetResp));
@@ -273,6 +345,74 @@ describe('KeyChain initialization', () => {
     expect(cachedActive.id).toBe(singleKeys[0].id);
     expect(cachedChain.getKeysets().length).toBe(1);
   });
+
+  test('loads conditional keysets through the conditional registry', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/conditional_keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              id: CTF_KEYSET_ID,
+              unit: 'sat',
+              active: true,
+              input_fee_ppk: 0,
+              final_expiry: 1754296607,
+              condition_id: CTF_CONDITION_ID,
+              outcome_collection: 'YES',
+              outcome_collection_id: CTF_OUTCOME_COLLECTION_ID,
+              registered_at: 1_700_000_000,
+            },
+          ],
+        }),
+      ),
+      http.get(mintUrl + '/v1/keys/' + CTF_KEYSET_ID, () =>
+        HttpResponse.json({
+          keysets: [{ ...DUMMY_TEST_KEYS, id: CTF_KEYSET_ID }],
+        }),
+      ),
+    );
+
+    const keyChain = new KeyChain(mint, unit);
+    const conditional = await keyChain.loadConditionalKeyset(CTF_KEYSET_ID);
+
+    expect(conditional.id).toBe(CTF_KEYSET_ID);
+    expect(conditional.isConditional).toBe(true);
+    expect(conditional.verify()).toBe(true);
+    expect(keyChain.getConditionalKeyset(CTF_KEYSET_ID)).toBe(conditional);
+    expect(keyChain.hasConditionalKeyset(CTF_KEYSET_ID)).toBe(true);
+    expect(() => keyChain.getCheapestKeyset()).toThrow(/No active keyset found/);
+  });
+
+  test('rejects conditional keysets whose keys do not match their condition-derived id', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/conditional_keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              id: CTF_KEYSET_ID,
+              unit: 'sat',
+              active: true,
+              input_fee_ppk: 0,
+              final_expiry: 1754296607,
+              condition_id: 'bb'.repeat(32),
+              outcome_collection: 'YES',
+              outcome_collection_id: CTF_OUTCOME_COLLECTION_ID,
+            },
+          ],
+        }),
+      ),
+      http.get(mintUrl + '/v1/keys/' + CTF_KEYSET_ID, () =>
+        HttpResponse.json({
+          keysets: [{ ...DUMMY_TEST_KEYS, id: CTF_KEYSET_ID }],
+        }),
+      ),
+    );
+
+    const keyChain = new KeyChain(mint, unit);
+    await expect(keyChain.loadConditionalKeyset(CTF_KEYSET_ID)).rejects.toThrow(
+      /Conditional keyset verification failed/,
+    );
+  });
 });
 
 describe('KeyChain getters', () => {
@@ -326,6 +466,31 @@ describe('KeyChain getters', () => {
     const list = keyChain.getKeysets();
     expect(list).toHaveLength(4);
     expect(list.map((k) => k.id).sort()).toEqual(dummyKeysetResp.keysets.map((ks) => ks.id).sort());
+  });
+
+  test('regular keyset selectors exclude registered conditional keysets', async () => {
+    const keyChain = new KeyChain(mint, unit);
+    await keyChain.init();
+    keyChain.registerConditionalKeyset(
+      {
+        id: CTF_KEYSET_ID,
+        unit: 'sat',
+        active: true,
+        input_fee_ppk: 0,
+        final_expiry: 1754296607,
+        conditional: {
+          conditionId: CTF_CONDITION_ID,
+          outcomeCollection: 'YES',
+          outcomeCollectionId: CTF_OUTCOME_COLLECTION_ID,
+          registeredAt: 1_700_000_000,
+        },
+      },
+      { ...DUMMY_TEST_KEYS, id: CTF_KEYSET_ID },
+    );
+
+    expect(keyChain.getKeysets().map((keyset) => keyset.id)).not.toContain(CTF_KEYSET_ID);
+    expect(keyChain.getCheapestKeyset().id).not.toBe(CTF_KEYSET_ID);
+    expect(keyChain.getAllKeysetIds()).toContain(CTF_KEYSET_ID);
   });
 
   test('should get keyset IDs', () => {
@@ -386,6 +551,33 @@ describe('Keyset', () => {
   test('fromMintApi should load if keys / meta match', () => {
     const keyset = Keyset.fromMintApi(dummyKeysetResp.keysets[0], dummyKeysResp.keysets[0]);
     expect(keyset.id).toBe(dummyKeysetResp.keysets[0].id);
+  });
+  test('conditional verify should pass valid condition metadata and reject tampering', () => {
+    const conditionalMeta = {
+      conditionId: CTF_CONDITION_ID,
+      outcomeCollection: 'YES',
+      outcomeCollectionId: CTF_OUTCOME_COLLECTION_ID,
+      registeredAt: 1_700_000_000,
+    };
+    const keyset = Keyset.fromMintApi(
+      {
+        id: CTF_KEYSET_ID,
+        unit: 'sat',
+        active: true,
+        input_fee_ppk: 0,
+        final_expiry: 1754296607,
+        conditional: conditionalMeta,
+      },
+      { ...DUMMY_TEST_KEYS, id: CTF_KEYSET_ID, conditional: conditionalMeta },
+    );
+    expect(keyset.isConditional).toBe(true);
+    expect(keyset.verify()).toBe(true);
+    expect(
+      Keyset.verifyConditionalKeysetId(
+        { ...DUMMY_TEST_KEYS, id: CTF_KEYSET_ID },
+        { ...conditionalMeta, outcomeCollectionId: 'dd'.repeat(32) },
+      ),
+    ).toBe(false);
   });
   test('fromMintApi should throw if keys / meta mismatched unit', () => {
     const badKeys = { ...dummyKeysResp.keysets[0], unit: 'usd' };

--- a/test/wallet/wallet-ctf.node.test.ts
+++ b/test/wallet/wallet-ctf.node.test.ts
@@ -1,0 +1,268 @@
+import { HttpResponse, http } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { Amount, Mint, OutputData, Wallet, type Proof } from '../../src';
+import { DUMMY_TEST_KEYS } from '../consts';
+
+import { mint, mintUrl, useTestServer } from './_setup';
+
+const server = useTestServer();
+
+const CONDITION_ID = 'aa'.repeat(32);
+const OUTCOME_COLLECTION_ID = 'cc'.repeat(32);
+const CONDITIONAL_KEYSET_ID = '0170110f06b9bb85565a6746ca5715f877b99db14d87219f6e9030cb529f61e6ea';
+const REDEEM_SIGNATURE = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
+
+function conditionalProof(amount: number, secret: string): Proof {
+  return {
+    id: CONDITIONAL_KEYSET_ID,
+    amount: Amount.from(amount),
+    secret,
+    C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+  };
+}
+
+function conditionalKeys(inputFeePpk = 0) {
+  return {
+    ...DUMMY_TEST_KEYS,
+    id: CONDITIONAL_KEYSET_ID,
+    input_fee_ppk: inputFeePpk,
+  };
+}
+
+describe('Wallet.swapConditional', () => {
+  test('exposes the optional wallet.ctf facade only when CTF is enabled', () => {
+    expect(new Wallet(mint).ctf).toBeUndefined();
+
+    const wallet = new Wallet(mint, { enableCtf: true });
+
+    expect(wallet.ctf).toBeDefined();
+    expect(typeof wallet.ctf?.swapConditional).toBe('function');
+  });
+
+  test('pins every output to the source conditional keyset instead of the wallet regular keyset', async () => {
+    const seenOutputs: Array<{ amount: string | number; id: string }> = [];
+    server.use(
+      http.get(mintUrl + '/v1/conditional_keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              id: CONDITIONAL_KEYSET_ID,
+              unit: 'sat',
+              active: true,
+              input_fee_ppk: 0,
+              final_expiry: 1754296607,
+              condition_id: CONDITION_ID,
+              outcome_collection: 'YES',
+              outcome_collection_id: OUTCOME_COLLECTION_ID,
+              registered_at: 1_700_000_000,
+            },
+          ],
+        }),
+      ),
+      http.get(mintUrl + '/v1/keys/' + CONDITIONAL_KEYSET_ID, () =>
+        HttpResponse.json({ keysets: [conditionalKeys()] }),
+      ),
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        const body = (await request.json()) as {
+          outputs: Array<{ amount: string | number; id: string }>;
+        };
+        seenOutputs.push(...body.outputs);
+        return HttpResponse.json({
+          signatures: body.outputs.map((output) => ({
+            id: output.id,
+            amount: output.amount,
+            C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint);
+
+    const result = await wallet.swapConditional({
+      inputs: [conditionalProof(136, 'conditional-input')],
+      outputs: [
+        { label: 'lock', kind: 'random', amount: 100 },
+        { label: 'change', kind: 'random', amount: 36 },
+      ],
+    });
+
+    expect(seenOutputs.length).toBeGreaterThan(2);
+    expect(seenOutputs.every((output) => output.id === CONDITIONAL_KEYSET_ID)).toBe(true);
+    expect(seenOutputs.every((output) => typeof output.amount === 'number')).toBe(true);
+    expect(result.lock.every((proof) => proof.id === CONDITIONAL_KEYSET_ID)).toBe(true);
+    expect(result.change.every((proof) => proof.id === CONDITIONAL_KEYSET_ID)).toBe(true);
+    expect(Amount.sum(result.lock.map((proof) => proof.amount))).toEqual(Amount.from(100));
+    expect(Amount.sum(result.change.map((proof) => proof.amount))).toEqual(Amount.from(36));
+  });
+
+  test('rejects mixed input keysets before preparing conditional outputs', async () => {
+    const wallet = new Wallet(mint);
+
+    await expect(
+      wallet.swapConditional({
+        inputs: [
+          conditionalProof(100, 'conditional-input-a'),
+          { ...conditionalProof(36, 'conditional-input-b'), id: '01' + 'bb'.repeat(32) },
+        ],
+        outputs: [{ label: 'lock', kind: 'random', amount: 136 }],
+      }),
+    ).rejects.toThrow(/inputs must use one keyset/);
+  });
+
+  test('can create P2PK-locked conditional outputs and unlocked same-keyset change', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/conditional_keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            {
+              id: CONDITIONAL_KEYSET_ID,
+              unit: 'sat',
+              active: true,
+              input_fee_ppk: 0,
+              final_expiry: 1754296607,
+              condition_id: CONDITION_ID,
+              outcome_collection: 'YES',
+              outcome_collection_id: OUTCOME_COLLECTION_ID,
+              registered_at: 1_700_000_000,
+            },
+          ],
+        }),
+      ),
+      http.get(mintUrl + '/v1/keys/' + CONDITIONAL_KEYSET_ID, () =>
+        HttpResponse.json({ keysets: [conditionalKeys()] }),
+      ),
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        const body = (await request.json()) as {
+          outputs: Array<{ amount: string | number; id: string }>;
+        };
+        return HttpResponse.json({
+          signatures: body.outputs.map((output) => ({
+            id: output.id,
+            amount: output.amount,
+            C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint);
+    const pubkeyA = '02' + 'aa'.repeat(32);
+    const pubkeyB = '02' + 'bb'.repeat(32);
+
+    const result = await wallet.swapConditional({
+      inputs: [conditionalProof(136, 'conditional-input')],
+      outputs: [
+        {
+          label: 'lock',
+          kind: 'p2pk',
+          amount: 100,
+          p2pk: {
+            pubkey: [pubkeyA, pubkeyB],
+            requiredSignatures: 2,
+            locktime: 1_700_000_100,
+            refundKeys: [pubkeyA],
+          },
+        },
+        { label: 'change', kind: 'random', amount: 36 },
+      ],
+    });
+
+    expect(JSON.parse(result.lock[0].secret)).toEqual([
+      'P2PK',
+      expect.objectContaining({
+        data: pubkeyA,
+        tags: expect.arrayContaining([
+          ['pubkeys', pubkeyB],
+          ['n_sigs', '2'],
+          ['locktime', '1700000100'],
+          ['refund', pubkeyA],
+        ]),
+      }),
+    ]);
+    expect(result.change[0].id).toBe(CONDITIONAL_KEYSET_ID);
+  });
+});
+
+describe('CTF outcome redemption', () => {
+  test('Mint.redeemOutcome posts to the CTF redeem endpoint and normalizes signatures', async () => {
+    const seenBodies: unknown[] = [];
+    const mintClient = new Mint(mintUrl, {
+      customRequest: (async (options: {
+        endpoint: string;
+        method?: string;
+        requestBody?: unknown;
+      }) => {
+        expect(options.endpoint).toBe(mintUrl + '/v1/redeem_outcome');
+        expect(options.method).toBe('POST');
+        seenBodies.push(options.requestBody);
+        return {
+          signatures: [{ id: DUMMY_TEST_KEYS.id, amount: 100, C_: REDEEM_SIGNATURE }],
+        };
+      }) as never,
+    });
+
+    const response = await mintClient.redeemOutcome({
+      inputs: [{ ...conditionalProof(100, 'conditional-input'), witness: '{"sig":"ok"}' }],
+      outputs: [
+        {
+          id: DUMMY_TEST_KEYS.id,
+          amount: Amount.from(100),
+          B_: '02'.padEnd(66, 'a'),
+        },
+      ],
+    });
+
+    expect(response.signatures[0].amount).toEqual(Amount.from(100));
+    expect(seenBodies).toEqual([
+      {
+        inputs: [{ ...conditionalProof(100, 'conditional-input'), witness: '{"sig":"ok"}' }],
+        outputs: [
+          {
+            id: DUMMY_TEST_KEYS.id,
+            amount: 100,
+            B_: '02'.padEnd(66, 'a'),
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('Wallet.redeemOutcomeProofs converts witnessed CTF proofs into regular proofs', async () => {
+    const seenRedeemBodies: Array<{
+      inputs: Array<Proof & { witness?: string }>;
+      outputs: Array<{ id: string; amount: number }>;
+    }> = [];
+    server.use(
+      http.get(mintUrl + '/v1/keys/' + DUMMY_TEST_KEYS.id, () =>
+        HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] }),
+      ),
+      http.post(mintUrl + '/v1/redeem_outcome', async ({ request }) => {
+        const body = (await request.json()) as {
+          inputs: Array<Proof & { witness?: string }>;
+          outputs: Array<{ id: string; amount: number }>;
+        };
+        seenRedeemBodies.push(body);
+        expect(body.inputs[0].witness).toBe('{"sig":"ok"}');
+        expect(body.outputs.every((output) => typeof output.amount === 'number')).toBe(true);
+        return HttpResponse.json({
+          signatures: body.outputs.map((output) => ({
+            id: output.id,
+            amount: output.amount,
+            C_: REDEEM_SIGNATURE,
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint);
+    const outputData = OutputData.createRandomData(100, DUMMY_TEST_KEYS);
+
+    const result = await wallet.redeemOutcomeProofs({
+      inputs: [{ ...conditionalProof(100, 'conditional-input'), witness: '{"sig":"ok"}' }],
+      outputs: outputData,
+    });
+
+    expect(seenRedeemBodies).toHaveLength(1);
+    expect(Amount.sum(result.map((proof) => proof.amount))).toEqual(Amount.from(100));
+    expect(result.every((proof) => proof.id === DUMMY_TEST_KEYS.id)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Draft implementation of client-side primitives for the conditional token / prediction-market NUT proposal in https://github.com/cashubtc/nuts/pull/337.

This is intentionally opened as a draft because the NUT text is still under review and the API shape may need to change with maintainer feedback. The branch is based on current upstream `main` and excludes generated `lib/` output.

## What Is Included

- CTF condition-id and conditional-keyset helpers
- typed mint payloads/responses for conditional keyset discovery, condition registration, split/merge, and outcome redemption
- `Mint` methods for the proposed CTF endpoints
- optional `wallet.ctf` facade behind `new Wallet(mint, { enableCtf: true })`
- wallet/keychain validation that keeps conditional swaps within one conditional keyset and rejects mixed regular/conditional inputs
- node tests for CTF crypto helpers, mint payload handling, conditional keychain lookup, conditional swap, and redemption flows

## Review Notes

The implementation is meant to exercise the shape proposed in cashubtc/nuts#337 and provide concrete feedback from a TypeScript wallet implementation. In particular, it keeps conditional keysets out of regular NUT-02 keyset selection and treats condition-derived keysets as an explicit registry loaded through CTF endpoints.

This PR does not make CTF behavior default wallet behavior. Callers must opt into the facade with `enableCtf: true`.

Related reference implementation context from the NUT PR: https://github.com/cashubtc/cdk/pull/1666

## Validation

- `npm run compile`
- `npx vitest run --project node test/crypto/CTF.test.ts test/mint/Mint.node.test.ts test/wallet/keychain.node.test.ts test/wallet/wallet-ctf.node.test.ts`
