### PR TITLE
fix(nut-17): replace Math.random() subId with CSPRNG-backed UUID v7

### DIFF
--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -1,6 +1,7 @@
 import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type JsonRpcMessage, type JsonRpcReqParams, type RpcSubId } from '../model/types';
+import { generateUuidV7 } from '../utils/uuid.js';
 
 import { getWebSocketImpl } from './ws';
 
@@ -349,7 +350,7 @@ export class WSConnection {
       throw new CTSError('Socket is not open');
     }
 
-    const subId = (Math.random() + 1).toString(36).substring(7);
+    const subId = generateUuidV7();
     const rpcId = this.rpcId; // this is the id sendRequest will use next
     this.addRpcListener(
       () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './limits';
 export * from './core';
 export * from './JSONInt';
 export * from './normalizeNumbers';
+export * from './uuid';

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -28,10 +28,10 @@ export function generateUuidV7(): string {
   buf[5] = Number(tsMs & 0xffn);
 
   // Byte 6: version nibble (0x7) in the high nibble, keep low nibble random (rand_a[0:4])
-  buf[6] = (0x70 | (buf[6] & 0x0f)) >>> 0;
+  buf[6] = 0x70 | (buf[6] & 0x0f);
 
   // Byte 8: variant bits 0b10 in the two high bits, keep lower 6 bits random (rand_b[0:6])
-  buf[8] = (0x80 | (buf[8] & 0x3f)) >>> 0;
+  buf[8] = 0x80 | (buf[8] & 0x3f);
 
   const hex = Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from '@noble/hashes/utils.js';
+import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 
 /**
  * Generates a UUID v7 string.
@@ -33,6 +33,6 @@ export function generateUuidV7(): string {
   // Byte 8: variant bits 0b10 in the two high bits, keep lower 6 bits random (rand_b[0:6])
   buf[8] = 0x80 | (buf[8] & 0x3f);
 
-  const hex = Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+  const hex = bytesToHex(buf);
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,38 @@
+import { randomBytes } from '@noble/hashes/utils.js';
+
+/**
+ * Generates a UUID v7 string.
+ *
+ * Layout (RFC 9562 §5.7):
+ *
+ * - Bits 0–47: Unix timestamp in milliseconds (big-endian)
+ * - Bits 48–51: version = 0b0111 (7)
+ * - Bits 52–63: rand_a — 12 bits, CSPRNG.
+ * - Bits 64–65: variant = 0b10.
+ * - Bits 66–127: rand_b — 62 bits, CSPRNG.
+ *
+ * All 74 variable bits (rand_a + rand_b) are filled by randomBytes(), which uses the platform
+ * CSPRNG (crypto.getRandomValues / node:crypto) — no monotonic counter, no predictable suffix.
+ */
+export function generateUuidV7(): string {
+  const buf = randomBytes(16);
+
+  const tsMs = BigInt(Date.now());
+
+  // Bytes 0–5: 48-bit timestamp
+  buf[0] = Number((tsMs >> 40n) & 0xffn);
+  buf[1] = Number((tsMs >> 32n) & 0xffn);
+  buf[2] = Number((tsMs >> 24n) & 0xffn);
+  buf[3] = Number((tsMs >> 16n) & 0xffn);
+  buf[4] = Number((tsMs >> 8n) & 0xffn);
+  buf[5] = Number(tsMs & 0xffn);
+
+  // Byte 6: version nibble (0x7) in the high nibble, keep low nibble random (rand_a[0:4])
+  buf[6] = (0x70 | (buf[6] & 0x0f)) >>> 0;
+
+  // Byte 8: variant bits 0b10 in the two high bits, keep lower 6 bits random (rand_b[0:6])
+  buf[8] = (0x80 | (buf[8] & 0x3f)) >>> 0;
+
+  const hex = Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/test/utils/uuid.test.ts
+++ b/test/utils/uuid.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+
+import { generateUuidV7 } from '../../src/utils/uuid';
+
+describe('generateUuidV7', () => {
+  test('has version 7 and variant 10 bits', () => {
+    const re = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    for (let i = 0; i < 100; i++) {
+      expect(generateUuidV7()).toMatch(re);
+    }
+  });
+
+  test('encodes current timestamp into bytes 0-5 in big-endian order', () => {
+    const before = Date.now();
+    const u = generateUuidV7();
+    const after = Date.now();
+    const tsHex = u.slice(0, 8) + u.slice(9, 13);
+    const ts = Number('0x' + tsHex);
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
## Description

Implements [cashubtc/nuts#383](https://github.com/cashubtc/nuts/pull/383).

The NUT spec now recommends UUID v7 for quote IDs (NUT-04, NUT-05) and WebSocket subscription IDs (NUT-17).  ([robwoodgate](https://github.com/robwoodgate)) clarified that all 74 variable bits must be CSPRNG-generated, not filled with a monotonic counter or predictable suffix.

---

## Changes

- no changes needed on NUT-04 / NUT-05, the quote IDs are assigned by the mint and returned to the client. The wallet never generates them.
- fixed, NUT-17, the `WSConnection.createSubscription()` was generating `subId` with a weak idiom:
```ts
// before: ~30 bits of entropy, Math.random() is not cryptographically secure
const subId = (Math.random() + 1).toString(36).substring(7);
```
Replaced with a new `generateUuidV7()` helper:
```ts
// after
const subId = generateUuidV7();
```

---

## Alignment & Discussion

- Was an issue opened prior to this PR? [Spec]

---