### PR TITLE
chore(scripts): unbreak renovate by narrowing tsconfig to the CI script

### DIFF
--- a/scripts/generate-nuts-vectors.ts
+++ b/scripts/generate-nuts-vectors.ts
@@ -17,7 +17,7 @@ import {
   verifyUnblindedSignatureBls,
   type G1Point,
   type G2Point,
-} from '../src/crypto/bls';
+} from '../src/crypto/curve_bls';
 import { deriveKeysetId } from '../src/utils/core';
 
 const G2 = BLS_G2_GENERATOR;

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -7,5 +7,5 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": ["./**/*.ts"]
+  "include": ["./UpdateMakefileMintVersion.ts"]
 }


### PR DESCRIPTION
## Summary
- Fix stale `../src/crypto/bls` import in `scripts/generate-nuts-vectors.ts` (renamed to `curve_bls` in #667)
- Narrow `scripts/tsconfig.json` `include` to just `UpdateMakefileMintVersion.ts` so the renovate workflow only compiles what it runs

## Motivation
The nightly renovate workflow runs `npm run update-docker-versions`, which calls `build:scripts` (`tsc -p scripts/tsconfig.json`). The tsconfig included every `.ts` under `scripts/`, so a stale import in the one-shot `generate-nuts-vectors.ts` generator (left behind by the crypto split in #667) was enough to fail the whole step.

`UpdateMakefileMintVersion.ts` is the only script invoked from CI. The bench scripts and the nuts-vector generator are run ad-hoc via `npx tsx`. Narrowing the tsconfig include keeps CI focused on what it actually runs and prevents future dev/bench scripts from blocking renovate.

## Test plan
- [x] `npm run update-docker-versions` succeeds locally
- [x] `dist-scripts/` contains only `UpdateMakefileMintVersion.js`
- [ ] Next renovate workflow run completes