### PR TITLE
feat(wallet): gate proof creation to active prefixed keysets

### DIFF
--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -12,6 +12,47 @@ Existing v0 (legacy base64), v1 (`00…`), and v2 (`01…`) keysets continue to 
 
 ---
 
+## Keyset output policy: new proofs require an active, prefixed keyset
+
+Proofs on **any** keyset can still be spent, swapped, and restored. But v5 now enforces a policy on which keysets may be used to **create new proofs**: the output keyset must be active and have a hex-prefixed id (`00…`/`01…`/`02…`).
+
+Previously this was only enforced on the automatic path (the wallet binds to the cheapest active hex keyset). An explicit `config.keysetId` bypassed both checks, so outputs could be created on a deprecated legacy (base64-id) keyset or on an inactive keyset — which the mint would then reject.
+
+- `receive`, `prepareSwap`/`send`, `prepareMint`, `prepareBatchMint`, and `prepareMelt` now throw `Legacy keyset cannot be used to create new proofs` or `Inactive keyset cannot be used to create new proofs` if the resolved output keyset (explicit `keysetId` or wallet-bound) violates the policy.
+- `completeSwap`/`completeMint`/`completeBatchMint` are **not** gated: the mint has already signed, so a persisted preview (NUT-19) still completes even if the keyset was deactivated in the meantime.
+- `restore()` is **not** gated: proofs on legacy keysets remain recoverable.
+- `bindKeyset()`/`withKeyset()` still allow binding to inactive keysets (useful for restore); the policy fires when an output operation is attempted.
+
+No migration is needed unless you deliberately created outputs on inactive or legacy keysets — those calls were already doomed to fail at the mint and now fail earlier with a clearer error.
+
+---
+
+## Mint quotes now require a usable active keyset
+
+All mint-quote creation methods (`createMintQuote`, `createMintQuoteBolt11`, `createLockedMintQuote`, `createMintQuoteBolt12`, `createMintQuoteOnchain`) now throw `no active keyset for unit '…' — a paid mint quote could not be redeemed` if the mint has no usable (active, hex-id, keyed) keyset for the wallet's unit. This prevents paying an invoice for a quote that could never be redeemed for proofs — `loadMint` deliberately tolerates keyset-less mints (e.g. a mint unwinding liabilities) by leaving the wallet unbound, so without this check the failure only surfaced after payment, at minting time.
+
+### Migration
+
+⚠️ The generic `createMintQuote()` previously worked **before** `loadMint()` — it was a thin POST wrapper with no initialization requirement. It now requires an initialized keychain (in v4 this logs a deprecation warning instead of throwing).
+
+```ts
+// Before (worked without loadMint)
+const wallet = new Wallet(mintUrl);
+const quote = await wallet.createMintQuote('bolt11', { amount: 21 });
+
+// After: load the mint first (recommended)
+const wallet = new Wallet(mintUrl);
+await wallet.loadMint();
+const quote = await wallet.createMintQuote('bolt11', { amount: 21 });
+
+// Or, for a bare HTTP call with no keyset checks, drop down to the Mint class
+const quote = await new Mint(mintUrl).createMintQuote('bolt11', { amount: 21, unit: 'sat' });
+```
+
+The typed methods (`createMintQuoteBolt11` etc.) already required `loadMint()` (they check NUT-04/NUT-06 support), so no call-order change is needed there.
+
+---
+
 ## Crypto deep imports were reorganized
 
 The internal crypto module layout changed to separate curve-specific primitives from shared

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -33,7 +33,9 @@ All mint-quote creation methods (`createMintQuote`, `createMintQuoteBolt11`, `cr
 
 ### Migration
 
-⚠️ The generic `createMintQuote()` previously worked **before** `loadMint()` — it was a thin POST wrapper with no initialization requirement. It now requires an initialized keychain (in v4 this logs a deprecation warning instead of throwing).
+⚠️ The generic `createMintQuote()` previously worked **before** `loadMint()` — it was a thin POST wrapper with no initialization requirement. It now requires an initialized wallet (in v4 the keyset check logs a deprecation warning instead of throwing).
+
+The generic `createMintQuote()` and `createMeltQuote()` also now enforce NUT-04/NUT-05 method support, like the typed helpers always did: the mint must advertise the method for the wallet's unit in its info (`nuts.4.methods` / `nuts.5.methods`), or the call throws `Mint does not support <method> mint for unit '…'`. Custom methods remain fully supported — the spec requires mints to advertise them like any other method.
 
 ```ts
 // Before (worked without loadMint)

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -483,8 +483,7 @@ class Wallet {
    * verification and `getKeyset` rejects keysets without keys.
    *
    * Only the prepare-side ops use this gate. The `complete*` ops use plain `getKeyset` as the mint
-   * has already signed, and refusing to construct proofs would strand issued ecash (e.g. a keyset
-   * rotated to inactive between prepare and complete).
+   * will have signed.
    * @param id Optional keyset id to resolve. If omitted, the wallet's bound keyset is used.
    * @returns The resolved `Keyset`.
    * @throws If the keyset fails `getKeyset` validation, has a legacy (non-hex) id, or is inactive.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1717,8 +1717,8 @@ class Wallet {
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
   ): Promise<TRes> {
-    // No requireSupport here, by design: the generic method is the escape hatch
-    // for custom methods a mint exposes without advertising in NUT-06 info.
+    // Custom methods are fine, but NUT-04 requires the mint to advertise them
+    this.requireSupport('mint', method);
     this.requireMintableKeyset('createMintQuote');
     const body = { ...payload, unit: this._unit };
     const res = await this.mint.createMintQuote<TRes>(method, body, {
@@ -2438,6 +2438,8 @@ class Wallet {
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
   ): Promise<TRes> {
+    // Custom methods are fine, but NUT-05 requires the mint to advertise them
+    this.requireSupport('melt', method);
     const body = { ...payload, unit: this._unit };
     const res = await this.mint.createMeltQuote<TRes>(method, body, {
       normalize: options?.normalize,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -473,6 +473,51 @@ class Wallet {
     return keyset;
   }
 
+  /**
+   * Resolves the keyset used to create new proofs, enforcing the output policy.
+   *
+   * @remarks
+   * Legacy (pre-v1, base64-id) keysets may be spent and restored, but never used to create new
+   * proofs. Inactive keysets are rejected per NUT-02, the mint would refuse to sign outputs on
+   * them, so fail fast here. Unknown hex versions are already excluded upstream: their keys fail
+   * verification and `getKeyset` rejects keysets without keys.
+   *
+   * Only the prepare-side ops use this gate. The `complete*` ops use plain `getKeyset` as the mint
+   * has already signed, and refusing to construct proofs would strand issued ecash (e.g. a keyset
+   * rotated to inactive between prepare and complete).
+   * @param id Optional keyset id to resolve. If omitted, the wallet's bound keyset is used.
+   * @returns The resolved `Keyset`.
+   * @throws If the keyset fails `getKeyset` validation, has a legacy (non-hex) id, or is inactive.
+   */
+  private getOutputKeyset(id?: string): Keyset {
+    const keyset = this.getKeyset(id);
+    this.failIf(!keyset.hasHexId, 'Legacy keyset cannot be used to create new proofs', {
+      keyset: keyset.id,
+    });
+    this.failIf(!keyset.isActive, 'Inactive keyset cannot be used to create new proofs', {
+      keyset: keyset.id,
+    });
+    return keyset;
+  }
+
+  /**
+   * Asserts the mint has at least one usable (active, hex-id, keyed) keyset for the wallet's unit
+   * before requesting a mint quote — a paid quote could otherwise never be redeemed for proofs.
+   *
+   * @param op Operation name for the error message.
+   * @throws If the keychain is uninitialized or has no usable active keyset for the unit.
+   */
+  private requireMintableKeyset(op: string): void {
+    try {
+      this._keyChain.getCheapestKeyset();
+    } catch (e) {
+      this.fail(
+        `${op}: no active keyset for unit '${this._unit}' — a paid mint quote could not be redeemed`,
+        { reason: (e as Error).message },
+      );
+    }
+  }
+
   public get logger(): Logger {
     return this._logger;
   }
@@ -986,7 +1031,7 @@ class Wallet {
     verifyProofsForReceive(proofs, (id) => this._keyChain.getKeyset(id), { requireDleq });
 
     // Shape receive output type and denominations
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
     const swapFee = this.getFeesForProofs(proofs);
     const receiveAmount = totalAmount.subtract(swapFee);
     let receiveOT = this.configureOutputs(
@@ -1190,7 +1235,7 @@ class Wallet {
     };
 
     // Fetch keys
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
 
     // Shape SEND output type and denominations
     let sendOT = this.configureOutputs(
@@ -1315,6 +1360,7 @@ class Wallet {
     this.validateReturnedSignatures(signatures, swapTransaction.outputData);
 
     // Construct proofs
+    // Plain getKeyset: the mint has already signed
     const keyset = this.getKeyset(swapPreview.keysetId);
     const swapProofs = swapTransaction.outputData.map((d, i) => d.toProof(signatures[i], keyset));
     const reorderedProofs = Array(swapProofs.length);
@@ -1671,6 +1717,7 @@ class Wallet {
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
   ): Promise<TRes> {
+    this.requireMintableKeyset('createMintQuote');
     const body = { ...payload, unit: this._unit };
     const res = await this.mint.createMintQuote<TRes>(method, body, {
       normalize: options?.normalize,
@@ -1693,6 +1740,7 @@ class Wallet {
     description?: string,
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
+    this.requireMintableKeyset('createMintQuoteBolt11');
     const mintAmount = this.parseAmount(amount, 'createMintQuoteBolt11');
     // Check if mint supports description for bolt11
     if (description) {
@@ -1726,6 +1774,7 @@ class Wallet {
     description?: string,
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
+    this.requireMintableKeyset('createLockedMintQuote');
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1760,6 +1809,7 @@ class Wallet {
     },
   ): Promise<MintQuoteBolt12Response> {
     this.requireSupport('mint', 'bolt12');
+    this.requireMintableKeyset('createMintQuoteBolt12');
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1791,6 +1841,7 @@ class Wallet {
    */
   async createMintQuoteOnchain(pubkey: string): Promise<MintQuoteOnchainResponse> {
     this.requireSupport('mint', 'onchain');
+    this.requireMintableKeyset('createMintQuoteOnchain');
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
     return { ...res, unit: res.unit || this._unit };
   }
@@ -2108,7 +2159,7 @@ class Wallet {
 
     // Shape output type and denominations for our proofs
     // we are receiving, so no includeFees.
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
     let mintOT = this.configureOutputs(
       requestedAmount,
       keyset,
@@ -2188,6 +2239,7 @@ class Wallet {
     );
     this.validateReturnedSignatures(signatures, outputData);
 
+    // Plain getKeyset: the mint has already signed
     const keyset = this.getKeyset(keysetId);
     this._logger.debug('MINT COMPLETED', {
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
@@ -2268,7 +2320,7 @@ class Wallet {
     }
 
     // Parse amounts and determine keyset
-    const keyset = this.getKeyset(keysetId);
+    const keyset = this.getOutputKeyset(keysetId);
     const amounts = entries.map((e) => this.parseAmount(e.amount, `prepareBatchMint: ${method}`));
     const totalAmount = Amount.sum(amounts);
 
@@ -2351,6 +2403,7 @@ class Wallet {
     );
     this.validateReturnedSignatures(sigs, outputData);
 
+    // Plain getKeyset: the mint has already signed
     const keyset = this.getKeyset(keysetId);
     this._logger.debug('BATCH MINT COMPLETED', {
       quotes: payload.quotes.length,
@@ -2744,7 +2797,7 @@ class Wallet {
     this.validateMeltQuote(meltQuote);
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
     const { keysetId, onCountersReserved, nut08Change = true } = config || {};
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
     const normalizedProofs = normalizeProofAmounts(proofsToSend);
     const sendAmount = sumProofs(normalizedProofs);
     let outputData: OutputDataLike[] = [];

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1717,6 +1717,8 @@ class Wallet {
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
   ): Promise<TRes> {
+    // No requireSupport here, by design: the generic method is the escape hatch
+    // for custom methods a mint exposes without advertising in NUT-06 info.
     this.requireMintableKeyset('createMintQuote');
     const body = { ...payload, unit: this._unit };
     const res = await this.mint.createMintQuote<TRes>(method, body, {

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -153,6 +153,18 @@ describe('Legacy (pre-v1) keyset output gating', () => {
     );
   });
 
+  test('generic quote methods refuse methods the mint does not advertise (NUT-04/05)', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuote('fancypay', { amount: 1000 })).rejects.toThrow(
+      /does not support/i,
+    );
+    await expect(wallet.createMeltQuote('fancypay', { request: 'x' })).rejects.toThrow(
+      /does not support/i,
+    );
+  });
+
   test('mint quotes still work when an active keyset exists', async () => {
     server.use(
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -1,0 +1,188 @@
+import { HttpResponse, http } from 'msw';
+import { test, describe, expect } from 'vitest';
+
+import { randomBytes } from '@noble/hashes/utils.js';
+
+import { Wallet, type MintKeys, type MintKeyset } from '../../src';
+import { deriveKeysetId, isValidHex, isBase64String } from '../../src/utils';
+import { DUMMY_TEST_KEYS, DUMMY_TEST_KEYSET, PUBKEYS } from '../consts';
+import { useTestServer, mint, mintUrl, token3sat } from './_setup';
+
+const server = useTestServer();
+
+// Legacy (pre-v1) deprecated base64 keyset whose id verifies against its keys
+const legacyId = deriveKeysetId(PUBKEYS, { isDeprecatedBase64: true });
+const legacyKeyset: MintKeyset = { id: legacyId, unit: 'sat', active: true, input_fee_ppk: 0 };
+const legacyKeys: MintKeys = { ...legacyKeyset, keys: PUBKEYS };
+
+// Inactive v2 (01-prefixed) keyset whose id verifies against its keys
+const inactiveId = deriveKeysetId(PUBKEYS, { versionByte: 1, unit: 'sat' });
+const inactiveKeyset: MintKeyset = { id: inactiveId, unit: 'sat', active: false, input_fee_ppk: 0 };
+const inactiveKeys: MintKeys = { ...inactiveKeyset, keys: PUBKEYS };
+
+// valid compressed secp point (any well-formed 33-byte point will do)
+const VALID_POINT = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
+
+function useLegacyHandlers() {
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, legacyKeyset] }),
+    ),
+    http.get(mintUrl + '/v1/keys', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYS, legacyKeys] }),
+    ),
+  );
+}
+
+function useInactiveHandlers() {
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, inactiveKeyset] }),
+    ),
+    http.get(mintUrl + '/v1/keys', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYS, inactiveKeys] }),
+    ),
+  );
+}
+
+describe('Legacy (pre-v1) keyset output gating', () => {
+  test('fixture sanity: legacy keyset id is base64, not hex, and verifies', async () => {
+    expect(isValidHex(legacyId)).toBe(false);
+    expect(isBase64String(legacyId)).toBe(true);
+
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    // Keys must survive keychain verification, or the gate test below would
+    // pass for the wrong reason ('Keyset has no keys loaded').
+    const keyset = wallet.keyChain.getKeyset(legacyId);
+    expect(keyset.hasKeys).toBe(true);
+    expect(keyset.hasHexId).toBe(false);
+  });
+
+  test('prepareMint refuses to create proofs on a legacy keyset', async () => {
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(
+      wallet.prepareMint('bolt11', 3, { quote: 'test-quote' }, { keysetId: legacyId }),
+    ).rejects.toThrow(/legacy keyset/i);
+  });
+
+  test('receive refuses to create proofs on a legacy keyset', async () => {
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(wallet.receive(token3sat, { keysetId: legacyId })).rejects.toThrow(
+      /legacy keyset/i,
+    );
+  });
+
+  test('prepareMint still works on the bound (hex) keyset', async () => {
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 3, { quote: 'test-quote' });
+    expect(preview.keysetId).toBe(DUMMY_TEST_KEYSET.id);
+  });
+
+  test('prepareMint refuses to create proofs on an inactive keyset', async () => {
+    useInactiveHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    // Fixture sanity: keys must survive verification so the gate fails for
+    // the right reason (not 'Keyset has no keys loaded').
+    const keyset = wallet.keyChain.getKeyset(inactiveId);
+    expect(keyset.hasKeys).toBe(true);
+    expect(keyset.isActive).toBe(false);
+
+    await expect(
+      wallet.prepareMint('bolt11', 3, { quote: 'test-quote' }, { keysetId: inactiveId }),
+    ).rejects.toThrow(/inactive keyset/i);
+  });
+
+  test('completeMint constructs proofs even if the keyset was deactivated after prepare', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 3, { quote: 'test-quote' });
+
+    // Keyset rotates to inactive between prepare and complete. The mint has
+    // already signed; refusing to construct proofs would strand the ecash.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({ keysets: [{ ...DUMMY_TEST_KEYSET, active: false }] }),
+      ),
+      http.get(mintUrl + '/v1/keys', () =>
+        HttpResponse.json({ keysets: [{ ...DUMMY_TEST_KEYS, active: false }] }),
+      ),
+      http.post(mintUrl + '/v1/mint/bolt11', () =>
+        HttpResponse.json({
+          signatures: preview.outputData.map((d) => ({
+            id: d.blindedMessage.id,
+            amount: Number(d.blindedMessage.amount.toString()),
+            C_: VALID_POINT,
+          })),
+        }),
+      ),
+    );
+    await wallet.loadMint(true);
+
+    const proofs = await wallet.completeMint(preview);
+    expect(proofs).toHaveLength(preview.outputData.length);
+  });
+
+  test('mint quotes are refused when the mint has no active keyset', async () => {
+    // Mint only has an inactive keyset: loadMint tolerates this (wallet
+    // remains unbound), but a paid quote could never be redeemed for proofs.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [inactiveKeyset] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [inactiveKeys] })),
+    );
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteBolt11(1000)).rejects.toThrow(/no active keyset/i);
+    await expect(wallet.createMintQuote('bolt11', { amount: 1000 })).rejects.toThrow(
+      /no active keyset/i,
+    );
+  });
+
+  test('mint quotes still work when an active keyset exists', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+        HttpResponse.json({
+          quote: 'bolt11-quote-1',
+          request: 'lnbc1000...',
+          unit: 'sat',
+          amount: 1000,
+          state: 'UNPAID',
+          expiry: 3600,
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    const quote = await wallet.createMintQuoteBolt11(1000);
+    expect(quote.quote).toBe('bolt11-quote-1');
+  });
+
+  test('restore still works on a legacy keyset', async () => {
+    useLegacyHandlers();
+    server.use(
+      http.post(mintUrl + '/v1/restore', () => HttpResponse.json({ outputs: [], signatures: [] })),
+    );
+
+    const wallet = new Wallet(mint, { bip39seed: randomBytes(32) });
+    await wallet.loadMint();
+
+    const res = await wallet.restore(0, 2, { keysetId: legacyId });
+    expect(res.proofs).toEqual([]);
+  });
+});

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -26,6 +26,29 @@ const mintInfoRespWithNut12 = {
   ...mintInfoResp,
   nuts: { ...mintInfoResp.nuts, 12: { supported: true } },
 };
+// NUT-04/05 require mints to advertise every supported method, custom ones included
+const mintInfoRespWithBacs = {
+  ...mintInfoResp,
+  nuts: {
+    ...mintInfoResp.nuts,
+    4: {
+      methods: [
+        ...mintInfoResp.nuts['4'].methods,
+        { method: 'bacs', unit: 'sat' },
+        { method: 'swift', unit: 'sat' },
+      ],
+      disabled: false,
+    },
+    5: {
+      methods: [
+        ...mintInfoResp.nuts['5'].methods,
+        { method: 'bacs', unit: 'sat' },
+        { method: 'swift', unit: 'sat' },
+      ],
+      disabled: false,
+    },
+  },
+};
 
 function normalizeProofsForTest(proofs: Parameters<Wallet['signP2PKProofs']>[0]): Proof[] {
   return proofs.map((proof) => ({ ...proof, amount: Amount.from(proof.amount) }));
@@ -733,6 +756,7 @@ describe('generic mint/melt methods', () => {
   describe('wallet.createMintQuote / checkMintQuote', () => {
     test('createMintQuote with custom method hits /v1/mint/quote/{method}', async () => {
       server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
         http.post(mintUrl + '/v1/mint/quote/bacs', () =>
           HttpResponse.json({
             quote: 'bacs-quote-1',
@@ -777,6 +801,7 @@ describe('generic mint/melt methods', () => {
 
     test('createMintQuote forces wallet unit over payload unit', async () => {
       server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
         http.post(mintUrl + '/v1/mint/quote/bacs', async ({ request }) => {
           const body = (await request.json()) as { unit: string };
           return HttpResponse.json({
@@ -1190,6 +1215,7 @@ describe('generic mint/melt methods', () => {
   describe('wallet.createMeltQuote / checkMeltQuote', () => {
     test('createMeltQuote with custom method hits /v1/melt/quote/{method}', async () => {
       server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
         http.post(mintUrl + '/v1/melt/quote/bacs', () =>
           HttpResponse.json({
             quote: 'bacs-melt-1',
@@ -1234,6 +1260,7 @@ describe('generic mint/melt methods', () => {
 
     test('createMeltQuote forces wallet unit over payload unit', async () => {
       server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
         http.post(mintUrl + '/v1/melt/quote/bacs', async ({ request }) => {
           const body = (await request.json()) as { unit: string };
           return HttpResponse.json({
@@ -1675,16 +1702,18 @@ describe('generic mint/melt methods', () => {
       const wallet = new Wallet(mint, { unit });
       await wallet.loadMint();
 
+      // Malformed methods can never be advertised, so the NUT-04/05 support
+      // gate rejects them before the Mint-level format validation is reached.
       await expect(wallet.createMintQuote('INVALID', { amount: 1n })).rejects.toThrow(
-        'Invalid mint quote method',
+        "Mint does not support INVALID mint for unit 'sat'",
       );
 
       await expect(wallet.createMintQuote('has spaces', { amount: 1n })).rejects.toThrow(
-        'Invalid mint quote method',
+        "Mint does not support has spaces mint for unit 'sat'",
       );
 
       await expect(wallet.createMeltQuote('has/slash', { request: 'x' })).rejects.toThrow(
-        'Invalid melt quote method',
+        "Mint does not support has/slash melt for unit 'sat'",
       );
     });
   });
@@ -1747,6 +1776,7 @@ describe('generic mint/melt methods', () => {
 
     test('custom normalize runs after base normalization', async () => {
       server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
         http.post(mintUrl + '/v1/melt/quote/swift', () =>
           HttpResponse.json({
             quote: 'swift-1',


### PR DESCRIPTION
## Summary

Enforces keyset output policy: **any keyset can be spent/swapped/restored, but new proofs may only be created on active, hex-prefixed (`00`/`01`/`02`) keysets.**

Previously, only auto-selection (`getCheapestKeyset`) filtered by hex id and active state. An explicit `config.keysetId` bypassed both, so a consumer could create outputs on a deprecated base64 keyset or an inactive keyset (which the mint would then reject, or worse, sign against a sunsetting keyset).

## Changes

- **New private `Wallet.getOutputKeyset(id?)`** — wraps `getKeyset()` and rejects legacy (base64-id) and inactive keysets. Used by all prepare-side ops that create blinded messages: `receive`, `prepareSwap`, `prepareMint`, `prepareBatchMint`, `prepareMelt` (NUT-08 blanks).
- **`completeSwap`/`completeMint`/`completeBatchMint` deliberately keep plain `getKeyset()`** — at completion the mint has already signed; the lookup only converts signatures into proofs. Refusing there (e.g. a persisted NUT-19 preview completed after the keyset rotated to inactive) would strand issued ecash.
- **`restore()` is exempt** so proofs on legacy keysets remain recoverable.
- **New private `Wallet.requireMintableKeyset(op)`** — `createMintQuote`, `createMintQuoteBolt11`, `createLockedMintQuote`, `createMintQuoteBolt12` and `createMintQuoteOnchain` now fail fast if the mint has no usable (active, hex-id, keyed) keyset for the wallet's unit. Without this, a user could pay an invoice for a quote that can never be redeemed for proofs (`loadMint` deliberately tolerates keyset-less mints by leaving the wallet unbound).

## Behavior notes

- The generic `createMintQuote()` previously worked before `loadMint()` (it just POSTed). It now requires an initialized keychain. Callers who want a bare HTTP helper can use `mint.createMintQuote()` directly.
- `bindKeyset()`/`withKeyset()` still allow binding to inactive keysets (needed for restore flows); the gate fires at prepare time instead.

## Tests

New `test/wallet/wallet-legacy-keysets.node.test.ts` (9 tests), including fixture-sanity checks that the legacy/inactive fixtures pass keyset verification (so gates fail for the right reason), a regression guard that `completeMint` still constructs proofs when the keyset is deactivated between prepare and complete, and positive controls for the happy paths. Full suite: 170 files / 4826 tests passing.

## Update: generic quote methods now enforce NUT-04/05 support

`createMintQuote()` and `createMeltQuote()` (the generic, method-string variants) now call `requireSupport` like the typed helpers. NUT-04/05 require mints to advertise **every** supported method — custom ones included — so an unadvertised method now fails fast with `Mint does not support <method> …` instead of surfacing as a mint-side error. The migration guide covers this alongside the keyset-policy notes.
