### PR TITLE
feat(wallet): gate proof creation to active prefixed keysets (v4 backport)

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -457,6 +457,51 @@ class Wallet {
     return keyset;
   }
 
+  /**
+   * Resolves the keyset used to create new proofs, enforcing the output policy.
+   *
+   * @remarks
+   * Legacy (pre-v1, base64-id) keysets may be spent and restored, but never used to create new
+   * proofs. Inactive keysets are rejected per NUT-02 — the mint would refuse to sign outputs on
+   * them, so fail fast here. Unknown hex versions are already excluded upstream: their keys fail
+   * verification and `getKeyset` rejects keysets without keys.
+   *
+   * Only the prepare-side ops use this gate. The `complete*` ops use plain `getKeyset` — there the
+   * mint has already signed, and refusing to construct proofs would strand issued ecash (e.g. a
+   * keyset rotated to inactive between prepare and complete).
+   * @param id Optional keyset id to resolve. If omitted, the wallet's bound keyset is used.
+   * @returns The resolved `Keyset`.
+   * @throws If the keyset fails `getKeyset` validation, has a legacy (non-hex) id, or is inactive.
+   */
+  private getOutputKeyset(id?: string): Keyset {
+    const keyset = this.getKeyset(id);
+    this.failIf(!keyset.hasHexId, 'Legacy keyset cannot be used to create new proofs', {
+      keyset: keyset.id,
+    });
+    this.failIf(!keyset.isActive, 'Inactive keyset cannot be used to create new proofs', {
+      keyset: keyset.id,
+    });
+    return keyset;
+  }
+
+  /**
+   * Asserts the mint has at least one usable (active, hex-id, keyed) keyset for the wallet's unit
+   * before requesting a mint quote — a paid quote could otherwise never be redeemed for proofs.
+   *
+   * @param op Operation name for the error message.
+   * @throws If the keychain is uninitialized or has no usable active keyset for the unit.
+   */
+  private requireMintableKeyset(op: string): void {
+    try {
+      this._keyChain.getCheapestKeyset();
+    } catch (e) {
+      this.fail(
+        `${op}: no active keyset for unit '${this._unit}' — a paid mint quote could not be redeemed`,
+        { reason: (e as Error).message },
+      );
+    }
+  }
+
   public get logger(): Logger {
     return this._logger;
   }
@@ -976,7 +1021,7 @@ class Wallet {
     }
 
     // Shape receive output type and denominations
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
     const swapFee = this.getFeesForProofs(proofs);
     const receiveAmount = totalAmount.subtract(swapFee);
     let receiveOT = this.configureOutputs(
@@ -1177,7 +1222,7 @@ class Wallet {
     };
 
     // Fetch keys
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
 
     // Shape SEND output type and denominations
     let sendOT = this.configureOutputs(
@@ -1658,6 +1703,16 @@ class Wallet {
     payload: Record<string, unknown>,
     options?: { normalize?: (raw: Record<string, unknown>) => TRes },
   ): Promise<TRes> {
+    // Kept permissive for v4 compatibility; this becomes an error in v5.
+    // (Direct keychain probe rather than requireMintableKeyset, which logs an error.)
+    try {
+      this._keyChain.getCheapestKeyset();
+    } catch (e) {
+      this._logger.warn(
+        `createMintQuote: no active keyset for unit '${this._unit}' — a paid mint quote could not be redeemed. This will become an error in cashu-ts v5.`,
+        { reason: (e as Error).message },
+      );
+    }
     const body = { ...payload, unit: this._unit };
     const res = await this.mint.createMintQuote<TRes>(method, body, {
       normalize: options?.normalize,
@@ -1680,6 +1735,7 @@ class Wallet {
     description?: string,
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
+    this.requireMintableKeyset('createMintQuoteBolt11');
     const mintAmount = this.parseAmount(amount, 'createMintQuoteBolt11');
     // Check if mint supports description for bolt11
     if (description) {
@@ -1713,6 +1769,7 @@ class Wallet {
     description?: string,
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
+    this.requireMintableKeyset('createLockedMintQuote');
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1747,6 +1804,7 @@ class Wallet {
     },
   ): Promise<MintQuoteBolt12Response> {
     this.requireSupport('mint', 'bolt12');
+    this.requireMintableKeyset('createMintQuoteBolt12');
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1778,6 +1836,7 @@ class Wallet {
    */
   async createMintQuoteOnchain(pubkey: string): Promise<MintQuoteOnchainResponse> {
     this.requireSupport('mint', 'onchain');
+    this.requireMintableKeyset('createMintQuoteOnchain');
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
     return { ...res, unit: res.unit || this._unit };
   }
@@ -2092,7 +2151,7 @@ class Wallet {
 
     // Shape output type and denominations for our proofs
     // we are receiving, so no includeFees.
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
     let mintOT = this.configureOutputs(
       requestedAmount,
       keyset,
@@ -2252,7 +2311,7 @@ class Wallet {
     }
 
     // Parse amounts and determine keyset
-    const keyset = this.getKeyset(keysetId);
+    const keyset = this.getOutputKeyset(keysetId);
     const amounts = entries.map((e) => this.parseAmount(e.amount, `prepareBatchMint: ${method}`));
     const totalAmount = Amount.sum(amounts);
 
@@ -2728,7 +2787,7 @@ class Wallet {
     this.validateMeltQuote(meltQuote);
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
     const { keysetId, onCountersReserved, nut08Change = true } = config || {};
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
     const normalizedProofs = normalizeProofAmounts(proofsToSend);
     const sendAmount = sumProofs(normalizedProofs);
     let outputData: OutputDataLike[] = [];

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -466,9 +466,8 @@ class Wallet {
    * them, so fail fast here. Unknown hex versions are already excluded upstream: their keys fail
    * verification and `getKeyset` rejects keysets without keys.
    *
-   * Only the prepare-side ops use this gate. The `complete*` ops use plain `getKeyset` — there the
-   * mint has already signed, and refusing to construct proofs would strand issued ecash (e.g. a
-   * keyset rotated to inactive between prepare and complete).
+   * Only the prepare-side ops use this gate. The `complete*` ops use plain `getKeyset` as the mint
+   * will have signed.
    * @param id Optional keyset id to resolve. If omitted, the wallet's bound keyset is used.
    * @returns The resolved `Keyset`.
    * @throws If the keyset fails `getKeyset` validation, has a legacy (non-hex) id, or is inactive.

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -1,0 +1,225 @@
+import { HttpResponse, http } from 'msw';
+import { test, describe, expect, vi } from 'vitest';
+
+import { randomBytes } from '@noble/hashes/utils.js';
+
+import { Wallet, type Logger, type MintKeys, type MintKeyset } from '../../src';
+import { deriveKeysetId, isValidHex, isBase64String } from '../../src/utils';
+import { DUMMY_TEST_KEYS, DUMMY_TEST_KEYSET, PUBKEYS } from '../consts';
+import { useTestServer, mint, mintUrl, token3sat } from './_setup';
+
+const server = useTestServer();
+
+// Legacy (pre-v1) deprecated base64 keyset whose id verifies against its keys
+const legacyId = deriveKeysetId(PUBKEYS, { isDeprecatedBase64: true });
+const legacyKeyset: MintKeyset = { id: legacyId, unit: 'sat', active: true, input_fee_ppk: 0 };
+const legacyKeys: MintKeys = { ...legacyKeyset, keys: PUBKEYS };
+
+// Inactive v2 (01-prefixed) keyset whose id verifies against its keys
+const inactiveId = deriveKeysetId(PUBKEYS, { versionByte: 1, unit: 'sat' });
+const inactiveKeyset: MintKeyset = { id: inactiveId, unit: 'sat', active: false, input_fee_ppk: 0 };
+const inactiveKeys: MintKeys = { ...inactiveKeyset, keys: PUBKEYS };
+
+// valid compressed secp point (any well-formed 33-byte point will do)
+const VALID_POINT = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
+
+function makeSpyLogger(): Logger {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    log: vi.fn(),
+  };
+}
+
+function useLegacyHandlers() {
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, legacyKeyset] }),
+    ),
+    http.get(mintUrl + '/v1/keys', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYS, legacyKeys] }),
+    ),
+  );
+}
+
+function useInactiveHandlers() {
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, inactiveKeyset] }),
+    ),
+    http.get(mintUrl + '/v1/keys', () =>
+      HttpResponse.json({ keysets: [DUMMY_TEST_KEYS, inactiveKeys] }),
+    ),
+  );
+}
+
+describe('Legacy (pre-v1) keyset output gating', () => {
+  test('fixture sanity: legacy keyset id is base64, not hex, and verifies', async () => {
+    expect(isValidHex(legacyId)).toBe(false);
+    expect(isBase64String(legacyId)).toBe(true);
+
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    // Keys must survive keychain verification, or the gate test below would
+    // pass for the wrong reason ('Keyset has no keys loaded').
+    const keyset = wallet.keyChain.getKeyset(legacyId);
+    expect(keyset.hasKeys).toBe(true);
+    expect(keyset.hasHexId).toBe(false);
+  });
+
+  test('prepareMint refuses to create proofs on a legacy keyset', async () => {
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(
+      wallet.prepareMint('bolt11', 3, { quote: 'test-quote' }, { keysetId: legacyId }),
+    ).rejects.toThrow(/legacy keyset/i);
+  });
+
+  test('receive refuses to create proofs on a legacy keyset', async () => {
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(wallet.receive(token3sat, { keysetId: legacyId })).rejects.toThrow(
+      /legacy keyset/i,
+    );
+  });
+
+  test('prepareMint still works on the bound (hex) keyset', async () => {
+    useLegacyHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 3, { quote: 'test-quote' });
+    expect(preview.keysetId).toBe(DUMMY_TEST_KEYSET.id);
+  });
+
+  test('prepareMint refuses to create proofs on an inactive keyset', async () => {
+    useInactiveHandlers();
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    // Fixture sanity: keys must survive verification so the gate fails for
+    // the right reason (not 'Keyset has no keys loaded').
+    const keyset = wallet.keyChain.getKeyset(inactiveId);
+    expect(keyset.hasKeys).toBe(true);
+    expect(keyset.isActive).toBe(false);
+
+    await expect(
+      wallet.prepareMint('bolt11', 3, { quote: 'test-quote' }, { keysetId: inactiveId }),
+    ).rejects.toThrow(/inactive keyset/i);
+  });
+
+  test('completeMint constructs proofs even if the keyset was deactivated after prepare', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 3, { quote: 'test-quote' });
+
+    // Keyset rotates to inactive between prepare and complete. The mint has
+    // already signed; refusing to construct proofs would strand the ecash.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({ keysets: [{ ...DUMMY_TEST_KEYSET, active: false }] }),
+      ),
+      http.get(mintUrl + '/v1/keys', () =>
+        HttpResponse.json({ keysets: [{ ...DUMMY_TEST_KEYS, active: false }] }),
+      ),
+      http.post(mintUrl + '/v1/mint/bolt11', () =>
+        HttpResponse.json({
+          signatures: preview.outputData.map((d) => ({
+            id: d.blindedMessage.id,
+            amount: Number(d.blindedMessage.amount.toString()),
+            C_: VALID_POINT,
+          })),
+        }),
+      ),
+    );
+    await wallet.loadMint(true);
+
+    const proofs = await wallet.completeMint(preview);
+    expect(proofs).toHaveLength(preview.outputData.length);
+  });
+
+  test('typed mint quotes are refused when the mint has no active keyset', async () => {
+    // Mint only has an inactive keyset: loadMint tolerates this (wallet
+    // remains unbound), but a paid quote could never be redeemed for proofs.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [inactiveKeyset] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [inactiveKeys] })),
+    );
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteBolt11(1000)).rejects.toThrow(/no active keyset/i);
+  });
+
+  test('generic createMintQuote warns (but proceeds) when the mint has no active keyset', async () => {
+    // v4 keeps the old generic semantics for compatibility; the keyset
+    // requirement becomes an error in v5.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [inactiveKeyset] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [inactiveKeys] })),
+      http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+        HttpResponse.json({
+          quote: 'bolt11-quote-1',
+          request: 'lnbc1000...',
+          unit: 'sat',
+          amount: 1000,
+          state: 'UNPAID',
+          expiry: 3600,
+        }),
+      ),
+    );
+    const logger = makeSpyLogger();
+    const wallet = new Wallet(mint, { logger });
+    await wallet.loadMint();
+
+    const quote = await wallet.createMintQuote('bolt11', { amount: 1000 });
+    expect(quote.quote).toBe('bolt11-quote-1');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/no active keyset.*will become an error/i),
+      expect.anything(),
+    );
+  });
+
+  test('mint quotes still work when an active keyset exists', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+        HttpResponse.json({
+          quote: 'bolt11-quote-1',
+          request: 'lnbc1000...',
+          unit: 'sat',
+          amount: 1000,
+          state: 'UNPAID',
+          expiry: 3600,
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+
+    const quote = await wallet.createMintQuoteBolt11(1000);
+    expect(quote.quote).toBe('bolt11-quote-1');
+  });
+
+  test('restore still works on a legacy keyset', async () => {
+    useLegacyHandlers();
+    server.use(
+      http.post(mintUrl + '/v1/restore', () => HttpResponse.json({ outputs: [], signatures: [] })),
+    );
+
+    const wallet = new Wallet(mint, { bip39seed: randomBytes(32) });
+    await wallet.loadMint();
+
+    const res = await wallet.restore(0, 2, { keysetId: legacyId });
+    expect(res.proofs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Backport of cashubtc/cashu-ts#691 to the v4 LTS line: **any keyset can be spent/swapped/restored, but new proofs may only be created on active, hex-prefixed keysets.**

Previously, only auto-selection (`getCheapestKeyset`) filtered by hex id and active state — an explicit `config.keysetId` bypassed both, so a consumer could create outputs on a deprecated base64 keyset or an inactive keyset.

## Changes

- **New private `Wallet.getOutputKeyset(id?)`** — wraps `getKeyset()` and rejects legacy (base64-id) and inactive keysets. Used by all prepare-side ops that create blinded messages: `receive`, `prepareSwap`, `prepareMint`, `prepareBatchMint`, `prepareMelt` (NUT-08 blanks).
- **`completeSwap`/`completeMint`/`completeBatchMint` keep plain `getKeyset()`** — at completion the mint has already signed; refusing there (e.g. a persisted NUT-19 preview completed after a keyset rotation) would strand issued ecash.
- **`restore()` is exempt** so proofs on legacy keysets remain recoverable.
- **New private `Wallet.requireMintableKeyset(op)`** — the typed quote methods (`createMintQuoteBolt11`, `createLockedMintQuote`, `createMintQuoteBolt12`, `createMintQuoteOnchain`) now fail fast if the mint has no usable (active, hex-id, keyed) keyset for the wallet's unit. Without this, a user could pay an invoice for a quote that can never be redeemed for proofs.

## Differences from the v5 PR (LTS compatibility)

The generic `createMintQuote()` keeps its existing semantics: when no usable keyset exists it only emits a `logger.warn` noting that this **becomes an error in cashu-ts v5**, then proceeds. This avoids changing call-order requirements for v4 consumers who use the generic method before `loadMint()`.

## Tests

New `test/wallet/wallet-legacy-keysets.node.test.ts` (10 tests), including the warn-but-proceed behavior of the generic quote method. Full suite: 162 files / 4409 tests passing.