### PR TITLE
docs(nut19): include proof id in checkProofsStates example

### DIFF
--- a/docs-src/usage/nut19.md
+++ b/docs-src/usage/nut19.md
@@ -46,7 +46,9 @@ await wallet.loadMint();
 
 // If the mint advertises this endpoint in NUT-19, timed out attempts are retried
 // until the NUT-19 TTL window is exhausted.
-const states = await wallet.checkProofsStates([{ secret: 'my-proof-secret' }]);
+const states = await wallet.checkProofsStates([
+  { id: '00bd033559de27d0', secret: 'my-proof-secret' },
+]);
 
 // Reset if you only wanted this policy temporarily.
 setGlobalRequestOptions({});


### PR DESCRIPTION
The NUT-19 usage example still called `checkProofsStates([{ secret }])` without `id`. Since v5, `id` is required alongside `secret` — it selects the hash-to-curve variant for the NUT-07 lookup point (see the `checkProofsStates` section of migration-5.0.0.md), so the example as written throws.

Docs-only; no code changes.