### PR TITLE
chore: ignore .claude directory in eslint and prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.claude
 package-lock.json
 temp
 etc

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ export default tseslint.config(
   {
     ignores: [
       'node_modules/**',
+      '.claude/**',
       'dist/**',
       'dist-scripts/**',
       'scripts/**',


### PR DESCRIPTION
Two one-liners: add `.claude/**` to the eslint `ignores` and `.claude` to `.prettierignore`.
