### PR TITLE
fix(dleq): use rejection sampling for deterministic DLEQ nonce (v4 backport)

### DIFF
--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -11,7 +11,6 @@ import { Bytes } from '../utils';
 import { type DLEQ, hash_e, hashToCurve } from './core';
 
 const DST_R = utf8ToBytes('Cashu_DLEQ_R_v1');
-const SECP256K1_N = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141');
 
 function deriveDLEQNonce(
   a: Uint8Array,
@@ -22,12 +21,10 @@ function deriveDLEQNonce(
   const base = concatBytes(DST_R, A.toBytes(false), B_.toBytes(false), C_.toBytes(false));
   for (let ctr = 0; ctr < 256; ctr++) {
     const h = hmac(sha256, a, concatBytes(base, new Uint8Array([ctr])));
-    const x = bytesToNumberBE(h);
-    // Reduce modulo curve order. Single subtraction suffices since HMAC output
-    // is 256 bits and SECP256K1_N is ~2^256, so x can exceed N by at most once.
-    const r = x >= SECP256K1_N ? x - SECP256K1_N : x;
+    const r = bytesToNumberBE(h);
+    // Rejection sampling: accept r only if it is a valid scalar in [1, n-1].
     /* c8 ignore next */
-    if (r !== 0n) return r;
+    if (r > 0n && r < secp256k1.Point.CURVE().n) return r;
   }
   /* c8 ignore next */
   throw new CTSError('DLEQ nonce derivation failed');


### PR DESCRIPTION
# NUT https://github.com/cashubtc/nuts/pull/368

## Summary

Backport of #696 to `v4-dev`. Replaces the single-subtraction modular reduction in `deriveDLEQNonce` (NUT-12) with rejection sampling, accepting the HMAC output only when it falls in `[1, n-1]`.

