### PR TITLE
feat(payment-request): add PaymentRequest.toP2PKOptions() (backport to v4-dev)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1527,6 +1527,7 @@ class PaymentRequest_2 {
     toEncodedCreqB(): string;
     // (undocumented)
     toEncodedRequest(): string;
+    toP2PKOptions(): P2PKOptions | undefined;
     // (undocumented)
     toRawRequest(): RawPaymentRequest;
     // (undocumented)

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -114,9 +114,12 @@ type WitnessData = {
 };
 
 /**
+ * NUT-11 tag keys that map onto structured {@link P2PKOptions} fields, rather than being carried as
+ * free-form `additionalTags`.
+ *
  * @internal
  */
-const P2PK_KNOWN_TAG_KEYS = new Set([
+export const P2PK_KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',
   'n_sigs',

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -1,3 +1,6 @@
+import { parseSecret, getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
+import type { P2PKOptions, P2PKTag } from '../crypto/NUT11';
+import { P2PK_KNOWN_TAG_KEYS } from '../crypto/NUT11';
 import { encodeBase64toUint8, decodeCBOR, encodeCBOR, Bytes } from '../utils';
 import { decodeBech32mToBytes, encodeBech32m } from '../utils/bech32m';
 import { decodeTLV, encodeTLV } from '../utils/tlv';
@@ -114,6 +117,60 @@ export class PaymentRequest {
 
   getTransport(type: PaymentRequestTransportType) {
     return this.transport?.find((t: PaymentRequestTransport) => t.type === type);
+  }
+
+  /**
+   * Converts this request's `nut10` locking option into the {@link P2PKOptions} accepted by the
+   * `.asP2PK()` builder, so a payer can produce proofs locked to exactly the spending condition the
+   * payee requested.
+   *
+   * Supports `P2PK` (NUT-11) and `HTLC` (NUT-14) only. Returns `undefined` when there is no `nut10`
+   * option or its kind is not one we can build.
+   *
+   * @throws If the option is missing its `data` field, or carries malformed NUT-10 tags — invalid
+   *   lock semantics must not be silently dropped.
+   */
+  toP2PKOptions(): P2PKOptions | undefined {
+    const nut10 = this.nut10;
+    const isHTLC = nut10?.kind === 'HTLC';
+    if (!nut10 || (nut10.kind !== 'P2PK' && !isHTLC)) {
+      return undefined;
+    }
+    if (!nut10.data) {
+      throw new CTSError(`NUT-10 ${nut10.kind} option is missing its data field`);
+    }
+
+    // Use the NUT-10/11 accessors the verifier uses. parseSecret rejects malformed
+    // tags (e.g. empty values), so a bad lock condition fails instead of being dropped.
+    const secret = parseSecret([
+      nut10.kind,
+      { nonce: '', data: nut10.data, tags: nut10.tags ?? [] },
+    ]);
+    const taggedPubkeys = getTag(secret, 'pubkeys') ?? [];
+    const pubkeys = [nut10.data, ...taggedPubkeys];
+    const options: P2PKOptions = isHTLC
+      ? { hashlock: nut10.data, pubkey: taggedPubkeys }
+      : { pubkey: pubkeys.length === 1 ? pubkeys[0] : pubkeys };
+
+    // Optional fields pass straight through: the accessors return undefined when
+    // absent, and the builder ignores undefined options. getTag never yields [].
+    options.locktime = getTagInt(secret, 'locktime');
+    options.refundKeys = getTag(secret, 'refund');
+    options.requiredSignatures = getTagInt(secret, 'n_sigs');
+    options.requiredRefundSignatures = getTagInt(secret, 'n_sigs_refund');
+    if (getTagScalar(secret, 'sigflag') === 'SIG_ALL') {
+      options.sigFlag = 'SIG_ALL';
+    }
+
+    // Forward any non-standard tags verbatim.
+    const additionalTags = (nut10.tags ?? []).filter(
+      (t) => t.length > 0 && !P2PK_KNOWN_TAG_KEYS.has(t[0]),
+    ) as P2PKTag[];
+    if (additionalTags.length > 0) {
+      options.additionalTags = additionalTags;
+    }
+
+    return options;
   }
 
   /**

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -1,6 +1,7 @@
 import { test, describe, expect } from 'vitest';
 import {
   decodePaymentRequest,
+  OutputData,
   PaymentRequest,
   PaymentRequestTransport,
   PaymentRequestTransportType,
@@ -238,6 +239,105 @@ describe('payment requests', () => {
       expect(decoded.mints).toEqual(pr.mints);
       expect(decoded.transport![0].type).toBe(pr.transport![0].type);
       expect(decoded.transport![0].target).toBe(pr.transport![0].target);
+    });
+  });
+
+  describe('toP2PKOptions', () => {
+    const PUBKEY = '03a16e8557f5a4229212f4df093791c8615c864a387d66fd990e9cdca5dcb5c9aa';
+    const PUBKEY_2 = '02000000000000000000000000000000000000000000000000000000000000000a';
+    const REFUND = '020000000000000000000000000000000000000000000000000000000000000b0b';
+    const HASH = '5d3f2c1b0a99887766554433221100ffeeddccbbaa99887766554433221100ff';
+
+    const prWithNut10 = (nut10?: NUT10Option) =>
+      new PaymentRequest(undefined, 'id', 1, 'sat', undefined, undefined, false, nut10);
+
+    test('returns undefined when there is no nut10 option', () => {
+      expect(prWithNut10(undefined).toP2PKOptions()).toBeUndefined();
+    });
+
+    test('maps a bare P2PK option to a single pubkey', () => {
+      const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [] };
+      expect(prWithNut10(nut10).toP2PKOptions()).toEqual({ pubkey: PUBKEY });
+    });
+
+    test('maps standard NUT-11 tags onto structured P2PK fields', () => {
+      const nut10: NUT10Option = {
+        kind: 'P2PK',
+        data: PUBKEY,
+        tags: [
+          ['pubkeys', PUBKEY_2],
+          ['locktime', '1700000000'],
+          ['n_sigs', '2'],
+          ['refund', REFUND],
+          ['n_sigs_refund', '1'],
+          ['sigflag', 'SIG_ALL'],
+        ],
+      };
+      expect(prWithNut10(nut10).toP2PKOptions()).toEqual({
+        pubkey: [PUBKEY, PUBKEY_2],
+        locktime: 1700000000,
+        requiredSignatures: 2,
+        refundKeys: [REFUND],
+        requiredRefundSignatures: 1,
+        sigFlag: 'SIG_ALL',
+      });
+    });
+
+    test('preserves non-standard tags as additionalTags', () => {
+      const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [['custom', 'value']] };
+      expect(prWithNut10(nut10).toP2PKOptions()).toEqual({
+        pubkey: PUBKEY,
+        additionalTags: [['custom', 'value']],
+      });
+    });
+
+    test('rejects malformed tags rather than dropping invalid lock semantics', () => {
+      // An empty-string tag value is invalid per NUT-10; silently ignoring it
+      // would produce a lock weaker than the payee requested, so it must throw.
+      const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [['locktime', '']] };
+      expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(/Invalid NUT-10 tag/);
+    });
+
+    test('maps an HTLC option to a hashlock with signing keys', () => {
+      const nut10: NUT10Option = {
+        kind: 'HTLC',
+        data: HASH,
+        tags: [
+          ['pubkeys', PUBKEY],
+          ['locktime', '1700000000'],
+          ['refund', REFUND],
+        ],
+      };
+      expect(prWithNut10(nut10).toP2PKOptions()).toEqual({
+        hashlock: HASH,
+        pubkey: [PUBKEY],
+        locktime: 1700000000,
+        refundKeys: [REFUND],
+      });
+    });
+
+    test('ignores unknown/future kinds by returning undefined', () => {
+      const nut10: NUT10Option = { kind: 'FUTURE', data: 'abc', tags: [] };
+      expect(prWithNut10(nut10).toP2PKOptions()).toBeUndefined();
+    });
+
+    test('throws when a P2PK/HTLC option is missing its data field', () => {
+      expect(() => prWithNut10({ kind: 'P2PK', data: '', tags: [] }).toP2PKOptions()).toThrow(
+        /missing its data field/,
+      );
+      expect(() => prWithNut10({ kind: 'HTLC', data: '', tags: [] }).toP2PKOptions()).toThrow(
+        /missing its data field/,
+      );
+    });
+
+    test('produced options build a secret locked to exactly the requested condition', () => {
+      const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [] };
+      const options = prWithNut10(nut10).toP2PKOptions()!;
+      const od = OutputData.createSingleP2PKData(options, 1, '00ad268c4d1f5826');
+      const secret = JSON.parse(new TextDecoder().decode(od.secret));
+      expect(secret[0]).toBe('P2PK');
+      expect(secret[1].data).toBe(PUBKEY);
+      expect(secret[1].tags).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Backport of #700 to `v4-dev`.

## Summary

Adds `PaymentRequest.toP2PKOptions()`, which converts a NUT-18 payment request's `nut10` locking option into the `P2PKOptions` accepted by the `.asP2PK()` send/mint builder, so a payer can mint proofs locked to exactly the spending condition the payee requested.

- Supports **P2PK** (NUT-11) and **HTLC** (NUT-14, carried as a `hashlock`); returns `undefined` for any other/unknown kind so the caller can fall back to an unlocked send.
- Maps the standard NUT-11 tags onto structured `P2PKOptions` fields and forwards non-standard tags verbatim as `additionalTags`.

## Notes

- Reuses existing internals (`parseSecret` / `getTag` / `getTagInt` / `getTagScalar`, and the now-exported `@internal` `P2PK_KNOWN_TAG_KEYS`) instead of re-implementing tag parsing.
- Rejects malformed tags via `parseSecret` rather than silently dropping them — invalid lock semantics must not produce a weaker lock than requested.
- Single new method on `PaymentRequest`; no new top-level exports.

## Test plan

- New `toP2PKOptions` test block in `test/wallet/paymentRequests.test.ts`.
- Cherry-picked cleanly onto `v4-dev`; `npm run prtasks` (lint + format + api:update + node/browser suite) passes locally with a clean working tree.

Cherry-picked from 32011e81.