### PR TITLE
fix(payment-request): forward and harden nut10 on creqB decode

### DIFF
--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -101,13 +101,11 @@ export class PaymentRequest {
       description: this.description,
       transports: this.transport,
       nut10: this.nut10
-        ? [
-            {
-              kind: this.nut10.kind,
-              data: this.nut10.data,
-              tags: this.nut10.tags,
-            },
-          ]
+        ? {
+            kind: this.nut10.kind,
+            data: this.nut10.data,
+            tags: this.nut10.tags,
+          }
         : undefined,
     };
 
@@ -214,11 +212,11 @@ export class PaymentRequest {
     if (lowerRequest.startsWith('creqb')) {
       const data = decodeBech32mToBytes(lowerRequest);
       const decoded = decodeTLV(data);
-      const nut10 = decoded.nut10?.[0]
+      const nut10 = decoded.nut10
         ? {
-            kind: decoded.nut10[0].kind,
-            data: decoded.nut10[0].data,
-            tags: decoded.nut10[0].tags ?? [],
+            kind: decoded.nut10.kind,
+            data: decoded.nut10.data,
+            tags: decoded.nut10.tags ?? [],
           }
         : undefined;
       return new PaymentRequest(

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -1,6 +1,6 @@
-import { parseSecret, getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
+import { getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
 import type { P2PKOptions, P2PKTag } from '../crypto/NUT11';
-import { P2PK_KNOWN_TAG_KEYS } from '../crypto/NUT11';
+import { P2PK_KNOWN_TAG_KEYS, parseP2PKSecret } from '../crypto/NUT11';
 import { encodeBase64toUint8, decodeCBOR, encodeCBOR, Bytes } from '../utils';
 import { decodeBech32mToBytes, encodeBech32m } from '../utils/bech32m';
 import { decodeTLV, encodeTLV } from '../utils/tlv';
@@ -138,9 +138,10 @@ export class PaymentRequest {
       throw new CTSError(`NUT-10 ${nut10.kind} option is missing its data field`);
     }
 
-    // Use the NUT-10/11 accessors the verifier uses. parseSecret rejects malformed
-    // tags (e.g. empty values), so a bad lock condition fails instead of being dropped.
-    const secret = parseSecret([
+    // Use parseP2PKSecret (the parser the verifier uses): it rejects malformed
+    // tags, duplicate tag keys and bad sigflags — all of which NUT-11 says make a
+    // proof unspendable — so a bad lock fails loudly instead of silently first-winning.
+    const secret = parseP2PKSecret([
       nut10.kind,
       { nonce: '', data: nut10.data, tags: nut10.tags ?? [] },
     ]);

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -214,6 +214,13 @@ export class PaymentRequest {
     if (lowerRequest.startsWith('creqb')) {
       const data = decodeBech32mToBytes(lowerRequest);
       const decoded = decodeTLV(data);
+      const nut10 = decoded.nut10?.[0]
+        ? {
+            kind: decoded.nut10[0].kind,
+            data: decoded.nut10[0].data,
+            tags: decoded.nut10[0].tags ?? [],
+          }
+        : undefined;
       return new PaymentRequest(
         decoded.transports,
         decoded.id,
@@ -222,7 +229,7 @@ export class PaymentRequest {
         decoded.mints,
         decoded.description,
         decoded.singleUse ?? false,
-        undefined,
+        nut10,
       );
     }
 

--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -132,10 +132,12 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         result.transports.push(parseTransport(part.value));
         break;
       case TAG_NUT10:
-        if (!result.nut10) {
-          result.nut10 = [];
+        // NUT-26 tag 0x08 is not repeatable (unlike mint/transport). A second
+        // nut10 makes the requested lock ambiguous, so reject rather than guess.
+        if (result.nut10) {
+          throw new CTSError('invalid pr: multiple nut10 spending conditions');
         }
-        result.nut10.push(parseNut10(part.value));
+        result.nut10 = [parseNut10(part.value)];
         break;
       default:
         // Ignore unknown tags for forward compatibility

--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -301,9 +301,17 @@ function parseNut10(value: Uint8Array): Nut10SpendingCondition {
   for (const part of parts) {
     switch (part.tag) {
       case NUT10_TAG_KIND:
+        // kind/data are singular; a duplicate makes the lock ambiguous (last
+        // value silently won before), so reject rather than guess.
+        if (kindNum !== undefined) {
+          throw new CTSError('invalid pr: multiple nut10 kind fields');
+        }
         kindNum = parseU8(part.value);
         break;
       case NUT10_TAG_DATA:
+        if (data !== undefined) {
+          throw new CTSError('invalid pr: multiple nut10 data fields');
+        }
         data = parseString(part.value);
         break;
       case NUT10_TAG_TAG_TUPLE:

--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -24,7 +24,7 @@ export type DecodedTLVPaymentRequest = {
   mints?: string[];
   description?: string;
   transports?: PaymentRequestTransport[];
-  nut10?: Nut10SpendingCondition[];
+  nut10?: Nut10SpendingCondition;
 };
 
 /**
@@ -137,7 +137,7 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         if (result.nut10) {
           throw new CTSError('invalid pr: multiple nut10 spending conditions');
         }
-        result.nut10 = [parseNut10(part.value)];
+        result.nut10 = parseNut10(part.value);
         break;
       default:
         // Ignore unknown tags for forward compatibility
@@ -417,11 +417,9 @@ export function encodeTLV(request: DecodedTLVPaymentRequest): Uint8Array {
     }
   }
 
-  // Repeatable: nut10
-  if (request.nut10 && request.nut10.length > 0) {
-    for (const nut10 of request.nut10) {
-      parts.push(encodeTLVPart(TAG_NUT10, encodeNut10(nut10)));
-    }
+  // Not repeatable: single nut10 spending condition (NUT-26 tag 0x08)
+  if (request.nut10) {
+    parts.push(encodeTLVPart(TAG_NUT10, encodeNut10(request.nut10)));
   }
 
   // Concatenate all parts

--- a/test/utils/bech32m.test.ts
+++ b/test/utils/bech32m.test.ts
@@ -136,10 +136,9 @@ describe('NUT-26 Test Vectors', () => {
       expect(decoded.amount).toBe(BigInt(expected.a));
       expect(decoded.mints).toEqual(expected.m);
       expect(decoded.nut10).toBeDefined();
-      expect(decoded.nut10).toHaveLength(1);
-      expect(decoded.nut10![0].kind).toBe(expected.nut10.k);
-      expect(decoded.nut10![0].data).toBe(expected.nut10.d);
-      expect(decoded.nut10![0].tags).toEqual(expected.nut10.t);
+      expect(decoded.nut10!.kind).toBe(expected.nut10.k);
+      expect(decoded.nut10!.data).toBe(expected.nut10.d);
+      expect(decoded.nut10!.tags).toEqual(expected.nut10.t);
     });
   });
 
@@ -432,10 +431,9 @@ describe('NUT-26 Test Vectors', () => {
       expect(decoded.amount).toBe(BigInt(expected.a));
       expect(decoded.mints).toEqual(expected.m);
       expect(decoded.nut10).toBeDefined();
-      expect(decoded.nut10).toHaveLength(1);
-      expect(decoded.nut10![0].kind).toBe(expected.nut10.k);
-      expect(decoded.nut10![0].data).toBe(expected.nut10.d);
-      expect(decoded.nut10![0].tags).toEqual(expected.nut10.t);
+      expect(decoded.nut10!.kind).toBe(expected.nut10.k);
+      expect(decoded.nut10!.data).toBe(expected.nut10.d);
+      expect(decoded.nut10!.tags).toEqual(expected.nut10.t);
     });
   });
 
@@ -539,13 +537,11 @@ describe('NUT-26 Encoding Test Vectors', () => {
         amount: BigInt(500),
         unit: 'sat',
         mints: ['https://mint.example.com'],
-        nut10: [
-          {
-            kind: 'P2PK',
-            data: '02c3b5bb27e361457c92d93d78dd73d3d53732110b2cfe8b50fbc0abc615e9c331',
-            tags: [['timeout', '3600']],
-          },
-        ],
+        nut10: {
+          kind: 'P2PK',
+          data: '02c3b5bb27e361457c92d93d78dd73d3d53732110b2cfe8b50fbc0abc615e9c331',
+          tags: [['timeout', '3600']],
+        },
       };
 
       const encoded = encodeTLV(request);

--- a/test/utils/tlv-roundtrip.test.ts
+++ b/test/utils/tlv-roundtrip.test.ts
@@ -114,6 +114,18 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
 
       expect(finalDecoded.nut10).toEqual(decoded.nut10);
     });
+
+    test('rejects multiple nut10 spending conditions', () => {
+      // NUT-26 tag 0x08 is not repeatable; a second nut10 is malformed.
+      const req: DecodedTLVPaymentRequest = {
+        id: 'test',
+        nut10: [
+          { kind: 'HTLC', data: 'htlcdata' },
+          { kind: 'P2PK', data: 'p2pkdata' },
+        ],
+      };
+      expect(() => decodeTLV(encodeTLV(req))).toThrow(/multiple nut10/);
+    });
   });
 
   describe('HTTP POST Transport (kind=0x01)', () => {

--- a/test/utils/tlv-roundtrip.test.ts
+++ b/test/utils/tlv-roundtrip.test.ts
@@ -121,6 +121,35 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
       const twoParts = new Uint8Array([...onePart, ...onePart]);
       expect(() => decodeTLV(twoParts)).toThrow(/multiple nut10/);
     });
+
+    test('rejects duplicate nut10 data field', () => {
+      // A single nut10 with two NUT10_TAG_DATA tags previously last-wins. Wire
+      // format per part: tag(1) + length(2, big-endian) + value.
+      const malformed = new Uint8Array([
+        0x08,
+        0x00,
+        18, // TAG_NUT10, length 18
+        0x01,
+        0x00,
+        0x01,
+        0x00, // NUT10_TAG_KIND = 0 (P2PK)
+        0x02,
+        0x00,
+        0x05,
+        97,
+        108,
+        105,
+        99,
+        101, // NUT10_TAG_DATA = "alice"
+        0x02,
+        0x00,
+        0x03,
+        98,
+        111,
+        98, // NUT10_TAG_DATA = "bob"
+      ]);
+      expect(() => decodeTLV(malformed)).toThrow(/multiple nut10 data/);
+    });
   });
 
   describe('HTTP POST Transport (kind=0x01)', () => {

--- a/test/utils/tlv-roundtrip.test.ts
+++ b/test/utils/tlv-roundtrip.test.ts
@@ -150,6 +150,29 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
       ]);
       expect(() => decodeTLV(malformed)).toThrow(/multiple nut10 data/);
     });
+
+    test('rejects duplicate nut10 kind field', () => {
+      const malformed = new Uint8Array([
+        0x08,
+        0x00,
+        14, // TAG_NUT10, length 14
+        0x01,
+        0x00,
+        0x01,
+        0x00, // NUT10_TAG_KIND = 0 (P2PK)
+        0x01,
+        0x00,
+        0x01,
+        0x01, // NUT10_TAG_KIND = 1 (HTLC)
+        0x02,
+        0x00,
+        0x03,
+        98,
+        111,
+        98, // NUT10_TAG_DATA = "bob"
+      ]);
+      expect(() => decodeTLV(malformed)).toThrow(/multiple nut10 kind/);
+    });
   });
 
   describe('HTTP POST Transport (kind=0x01)', () => {

--- a/test/utils/tlv-roundtrip.test.ts
+++ b/test/utils/tlv-roundtrip.test.ts
@@ -102,12 +102,11 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
       const decoded = decodeTLV(bytes);
 
       expect(decoded.nut10).toBeDefined();
-      expect(decoded.nut10).toHaveLength(1);
-      expect(decoded.nut10![0].kind).toBe('P2PK');
-      expect(decoded.nut10![0].data).toBe(
+      expect(decoded.nut10!.kind).toBe('P2PK');
+      expect(decoded.nut10!.data).toBe(
         '02c3b5bb27e361457c92d93d78dd73d3d53732110b2cfe8b50fbc0abc615e9c331',
       );
-      expect(decoded.nut10![0].tags).toEqual([['timeout', '3600']]);
+      expect(decoded.nut10!.tags).toEqual([['timeout', '3600']]);
 
       const reEncoded = encodeTLV(decoded);
       const finalDecoded = decodeTLV(reEncoded);
@@ -116,15 +115,11 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
     });
 
     test('rejects multiple nut10 spending conditions', () => {
-      // NUT-26 tag 0x08 is not repeatable; a second nut10 is malformed.
-      const req: DecodedTLVPaymentRequest = {
-        id: 'test',
-        nut10: [
-          { kind: 'HTLC', data: 'htlcdata' },
-          { kind: 'P2PK', data: 'p2pkdata' },
-        ],
-      };
-      expect(() => decodeTLV(encodeTLV(req))).toThrow(/multiple nut10/);
+      // NUT-26 tag 0x08 is not repeatable. encodeTLV emits a single nut10, so
+      // hand-build a malformed payload by concatenating two nut10-only streams.
+      const onePart = encodeTLV({ nut10: { kind: 'HTLC', data: 'htlcdata' } });
+      const twoParts = new Uint8Array([...onePart, ...onePart]);
+      expect(() => decodeTLV(twoParts)).toThrow(/multiple nut10/);
     });
   });
 
@@ -298,15 +293,15 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
       const decoded = decodeTLV(bytes);
 
       expect(decoded.nut10).toBeDefined();
-      expect(decoded.nut10![0].kind).toBe('HTLC');
-      expect(decoded.nut10![0].tags).toHaveLength(2);
+      expect(decoded.nut10!.kind).toBe('HTLC');
+      expect(decoded.nut10!.tags).toHaveLength(2);
 
       const reEncoded = encodeTLV(decoded);
       const finalDecoded = decodeTLV(reEncoded);
 
-      expect(finalDecoded.nut10![0].kind).toBe(decoded.nut10![0].kind);
-      expect(finalDecoded.nut10![0].data).toBe(decoded.nut10![0].data);
-      expect(finalDecoded.nut10![0].tags).toEqual(decoded.nut10![0].tags);
+      expect(finalDecoded.nut10!.kind).toBe(decoded.nut10!.kind);
+      expect(finalDecoded.nut10!.data).toBe(decoded.nut10!.data);
+      expect(finalDecoded.nut10!.tags).toEqual(decoded.nut10!.tags);
     });
   });
 
@@ -390,16 +385,14 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
         amount: BigInt(250),
         unit: 'sat',
         mints: ['https://mint.com'],
-        nut10: [
-          {
-            kind: 'P2PK',
-            data: '02abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
-            tags: [
-              ['timeout', '7200'],
-              ['refund', '03abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890cd'],
-            ],
-          },
-        ],
+        nut10: {
+          kind: 'P2PK',
+          data: '02abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
+          tags: [
+            ['timeout', '7200'],
+            ['refund', '03abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890cd'],
+          ],
+        },
       };
 
       const encoded = encodeTLV(request);
@@ -414,7 +407,6 @@ describe('TLV Encoding/Decoding Roundtrip Tests', () => {
         unit: 'sat',
         mints: ['https://mint.com'],
         transports: [], // Empty array should be omitted
-        nut10: [], // Empty array should be omitted
       };
 
       const encoded = encodeTLV(request);

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -329,6 +329,20 @@ describe('payment requests', () => {
       expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(/Invalid NUT-10 tag/);
     });
 
+    test('rejects duplicate tag keys (NUT-11 unspendable lock)', () => {
+      // A repeated tag key makes the proof unspendable per NUT-11, so building
+      // the lock must fail rather than silently first-winning one value.
+      const nut10: NUT10Option = {
+        kind: 'P2PK',
+        data: PUBKEY,
+        tags: [
+          ['locktime', '100'],
+          ['locktime', '200'],
+        ],
+      };
+      expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(/Duplicate P2PK tag "locktime"/);
+    });
+
     test('maps an HTLC option to a hashlock with signing keys', () => {
       const nut10: NUT10Option = {
         kind: 'HTLC',

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -220,7 +220,15 @@ describe('payment requests', () => {
       expect(decoded.amount?.equals(1000)).toBeTruthy();
       expect(decoded.unit).toBe('sat');
       expect(decoded.description).toBe('Locked payment');
-      // Note: nut10 is decoded from creqB format, but only first entry is stored
+      // nut10 roundtrips on creqB decode (only the first entry is stored)
+      expect(decoded.nut10?.kind).toBe('P2PK');
+      expect(decoded.nut10?.data).toBe(
+        '02abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
+      );
+      expect(decoded.nut10?.tags).toStrictEqual([
+        ['timeout', '7200'],
+        ['refund', '03abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890cd'],
+      ]);
     });
 
     test('roundtrip from creqB test vector', () => {

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -231,6 +231,29 @@ describe('payment requests', () => {
       ]);
     });
 
+    test('encode and decode payment request with tagless NUT-10', () => {
+      const pr = new PaymentRequest(
+        undefined,
+        'p2pk_test',
+        1000,
+        'sat',
+        undefined,
+        undefined,
+        false,
+        {
+          kind: 'P2PK',
+          data: '02abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
+          tags: [],
+        } as NUT10Option,
+      );
+
+      const decoded = PaymentRequest.fromEncodedRequest(pr.toEncodedCreqB());
+
+      // Empty tags decode to undefined and fall back to [] on construction.
+      expect(decoded.nut10?.kind).toBe('P2PK');
+      expect(decoded.nut10?.tags).toStrictEqual([]);
+    });
+
     test('roundtrip from creqB test vector', () => {
       // Use an existing test vector
       const originalEncoded =


### PR DESCRIPTION
## Summary

Fixes a bug where `PaymentRequest.fromEncodedRequest` dropped the `nut10` spending condition when decoding a `creqB` request, and hardens the surrounding TLV parsing so a malformed request can no longer decode to an ambiguous lock.

Changes:
- **Forward `nut10` on `creqB` decode.** The decode branch hard-coded `undefined` for the constructor's `nut10` argument, discarding the condition that TLV decode had already parsed. `creqA` was unaffected (it goes through `fromRawRequest`). A `creqB` request built with a lock now roundtrips it.
- **Model `nut10` as a single condition, not an array.** `DecodedTLVPaymentRequest.nut10` was typed `Nut10SpendingCondition[]` and `encodeTLV` emitted one TLV tag per element, but NUT-26 tag `0x08` is not repeatable. A type-valid multi-condition request could encode into bytes the same library then refused to decode. Modelling it as a single optional condition makes that state unrepresentable. (Internal type — not exported, not in the API report.)
- **Reject ambiguous duplicates on decode.** A second `nut10` sub-TLV (`0x08`), or a repeated `kind`/`data` tag within one condition, previously won silently (last value kept). Both are singular per spec, so decode now throws rather than guess which lock the payee meant. Repeatable inner `tag_tuple` (`0x03`) is unaffected.

## Motivation

`creqB` lock conditions silently vanishing is a correctness bug for payers applying payee-requested locks. The parsing-ambiguity hardening fails closed: when a request encodes a lock more than one way, a wallet should reject it rather than pick one and risk locking funds to the wrong condition.