### PR TITLE
fix(wallet): allow melt on inactive keyset when no change is created

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2786,7 +2786,10 @@ class Wallet {
     this.validateMeltQuote(meltQuote);
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
     const { keysetId, onCountersReserved, nut08Change = true } = config || {};
-    const keyset = this.getOutputKeyset(keysetId); // specified or wallet keyset
+    // Plain getKeyset: melting needs no new outputs, so an inactive/legacy keyset must not
+    // block withdrawal. A mint unwinding liabilities deactivates keysets but
+    // keeps melt open; gate output creation below, not the melt itself.
+    let keyset = this.getKeyset(keysetId); // specified or wallet keyset
     const normalizedProofs = normalizeProofAmounts(proofsToSend);
     const sendAmount = sumProofs(normalizedProofs);
     let outputData: OutputDataLike[] = [];
@@ -2813,6 +2816,13 @@ class Wallet {
     // Create NUT-08 blanks for return of melt change (if supported)
     // Note: zero amount + zero denomination passes splitAmount validation
     else if (nut08Change && feeReserve.greaterThan(0)) {
+      // Now we actually create outputs the mint must sign: enforce the output policy.
+      this.failIf(
+        !keyset.isActive,
+        'Melt change keyset is inactive. Use an active keyset or set nut08Change: false to forfeit it',
+        { keyset: keyset.id },
+      );
+      keyset = this.getOutputKeyset(keysetId);
       let count = Math.ceil(Math.log2(feeReserve.toNumberUnsafe())) || 1;
       if (count < 0) count = 0; // Prevents: -Infinity
       const denominations: number[] = count ? new Array<number>(count).fill(0) : [];

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -413,6 +413,41 @@ describe('melt proofs', () => {
     expect(meltTxn.quote.quote).toBe('test_melt_quote');
   });
 
+  test('prepareMelt works on an inactive keyset when no change is created', async () => {
+    // A mint unwinding liabilities deactivates keysets but keeps melt open. Withdrawing with
+    // no NUT-08 change creates no outputs, so an inactive keyset must not block the melt.
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    (wallet.getKeyset() as unknown as { _active: boolean })._active = false;
+
+    const meltQuote: MeltQuoteBolt11Response = {
+      quote: 'test_melt_quote',
+      amount: Amount.from(10),
+      fee_reserve: Amount.from(3),
+      request: 'bolt11request',
+      state: MeltQuoteState.UNPAID,
+      expiry: 1234567890,
+      payment_preimage: null,
+      unit: 'sat',
+    };
+    const proofsToSend: Proof[] = [
+      { id: '00bd033559de27d0', amount: Amount.from(8), secret: 'secret1', C: 'C1' },
+      { id: '00bd033559de27d0', amount: Amount.from(5), secret: 'secret2', C: 'C2' },
+    ];
+
+    // No change requested: must not throw on the inactive keyset
+    const meltTxn = await wallet.prepareMelt('bolt11', meltQuote, proofsToSend, {
+      nut08Change: false,
+    });
+    expect(meltTxn.outputData).toHaveLength(0);
+    expect(meltTxn.inputs).toHaveLength(2);
+
+    // Change requested with a non-zero fee reserve: the output gate still applies
+    await expect(
+      wallet.prepareMelt('bolt11', meltQuote, proofsToSend, { nut08Change: true }),
+    ).rejects.toThrow('Melt change keyset is inactive');
+  });
+
   test('prepareMelt uses one NUT-08 blank for a 1-sat fee reserve', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();


### PR DESCRIPTION
## Summary

`prepareMelt` resolved its keyset via `getOutputKeyset`, which rejects inactive (and legacy) keysets. But melting only needs new outputs when NUT-08 change is generated. With `nut08Change: false`, or when the selected proofs exactly cover the quote amount (zero fee reserve), no outputs are created and the melt is valid with inputs only — yet the check threw locally before any network call.

This change resolves the keyset with plain `getKeyset` and moves the active/hex-id gate into the NUT-08 blanks branch, where outputs are actually created. When change *is* requested on an inactive keyset, it fails with an actionable message instead of the generic one:

> Melt change keyset is inactive. Use an active keyset or set nut08Change: false to forfeit it

## Motivation

A mint that is unwinding its liabilities deactivates its keysets to stop new minting while keeping the melt endpoint open so users can withdraw. The wallet already anticipates this state in `finishInit` (it leaves the wallet unbound rather than throwing). The unconditional `getOutputKeyset` check in `prepareMelt` contradicted that: a user holding funds on a now-inactive keyset could not withdraw, because the client refused to send a perfectly valid inputs-only melt.

Note this is not a claim that melt always succeeds against a fully shut-down mint: NUT-08 change requires the mint to sign blank outputs on an active keyset, so a melt that requests change still (correctly) cannot complete if no keyset is active. The fix unblocks the no-change path and makes the change-requested path fail clearly.

This is the v4-dev counterpart of the same fix on main (#705).

## Test plan

- New test: `prepareMelt` succeeds on an inactive keyset when no change is created, and still rejects with the actionable error when change is requested.
- Full melt suite passes (22/22).