### PR TITLE
feat(mint-info): derive default method_name per NUT-04/05

### DIFF
--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -16,6 +16,17 @@ import {
 type Method = 'GET' | 'POST';
 type Endpoint = { method: Method; path: string };
 
+/**
+ * Per NUT-04/05, when `method_name` is null or omitted, wallets derive a human-readable name.
+ * Returns null for a missing/empty/non-string method so malformed entries stay null.
+ */
+function deriveMethodName(method: unknown): string | null {
+  if (typeof method !== 'string') return null;
+  const words = method.split(/[-_]/).filter((w) => w !== '');
+  if (words.length === 0) return null;
+  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
 type ProtectedIndex = {
   exact: Record<Method, Set<string>>;
   prefix: Record<Method, string[]>;
@@ -68,13 +79,17 @@ export class MintInfo {
     };
   }
 
-  // Per NUT-04/05/25/XX, `min_amount`, `max_amount`, and `method_name` are `<x|null>`. Mints that
-  // omit them entirely (older Nutshell, etc.) leave the field as `undefined`; coerce to null so the
-  // normalized response is spec-valid and matches the declared types.
+  // Per NUT-04/05/25/XX, `min_amount` and `max_amount` are `<x|null>`. Mints that omit them entirely
+  // (older Nutshell, etc.) leave the field as `undefined`; coerce to null so the normalized response
+  // is spec-valid and matches the declared types. `method_name` is `<str|null>` but per NUT-04/05 a
+  // null/omitted name is derived deterministically from `method`, so we populate it here instead.
   private static normalizeSwapMethods(methods: SwapMethod[]): SwapMethod[] {
     return methods.map((m) => {
       const next = { ...m } as Record<string, unknown>;
-      nullIfUndefined(next, 'min_amount', 'max_amount', 'method_name');
+      nullIfUndefined(next, 'min_amount', 'max_amount');
+      if (next.method_name == null) {
+        next.method_name = deriveMethodName(next.method);
+      }
       return next as SwapMethod;
     });
   }

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,6 +1,6 @@
 import { type Logger, NULL_LOGGER } from '../logger';
 import { nullIfUndefined } from '../utils/core';
-import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
+import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT, MAX_METHOD_LENGTH } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
 import { CTSError } from './Errors';
@@ -18,10 +18,11 @@ type Endpoint = { method: Method; path: string };
 
 /**
  * Per NUT-04/05, when `method_name` is null or omitted, wallets derive a human-readable name.
- * Returns null for a missing/empty/non-string method so malformed entries stay null.
+ * Returns null for a missing/empty/non-string/over-long method so malformed (or hostile) entries
+ * stay null. The length cap avoids a potential memory-exhaustion DoS vector.
  */
 function deriveMethodName(method: unknown): string | null {
-  if (typeof method !== 'string') return null;
+  if (typeof method !== 'string' || method.length > MAX_METHOD_LENGTH) return null;
   const words = method.split(/[-_]/).filter((w) => w !== '');
   if (words.length === 0) return null;
   return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -11,3 +11,11 @@ export const ABSOLUTE_MAX_PER_MINT = 100;
  * clamped.
  */
 export const ABSOLUTE_MAX_BATCH_SIZE = 100;
+
+/**
+ * NUT-04/05: Upper bound on the length of a mint-advertised payment `method` string we will derive
+ * a default `method_name` from. Real methods are short identifiers (`bolt11`, `onchain`); a value
+ * beyond this is malformed/hostile, so we skip derivation rather than run unbounded string work
+ * (split/map/join) on a multi-megabyte string, which a malicious mint could use to exhaust memory.
+ */
+export const MAX_METHOD_LENGTH = 255;

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -138,9 +138,9 @@ describe('MintInfo protected endpoint matching', () => {
     expect(info.nuts['4'].methods[0].max_amount).toBe(2n);
     expect(info.nuts['5'].methods[0].min_amount).toBe(3n);
     expect(info.nuts['5'].methods[0].max_amount).toBe(4n);
-    // method_name (NUT-04/05) passes through; coerced to null on mints that omit it
+    // method_name (NUT-04/05) passes through; derived from `method` on mints that omit it
     expect(info.nuts['4'].methods[0].method_name).toBe('Lightning');
-    expect(info.nuts['5'].methods[0].method_name).toBeNull();
+    expect(info.nuts['5'].methods[0].method_name).toBe('Bolt11');
     // metadata integers (ttl, bat_max_mint) are still normalized to safe numbers
     expect(info.nuts['19']?.ttl).toBe(30);
     expect(info.nuts['22']?.bat_max_mint).toBe(5);
@@ -151,6 +151,42 @@ describe('MintInfo protected endpoint matching', () => {
         cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
       },
     });
+  });
+
+  it('derives method_name from method per NUT-04/05 when null or omitted', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        4: {
+          disabled: false,
+          methods: [
+            // omitted -> derived
+            { method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null },
+            // explicit null -> derived, hyphen split + title-case
+            {
+              method: 'apple-pay',
+              unit: 'usd',
+              method_name: null,
+              min_amount: null,
+              max_amount: null,
+            },
+            // explicit name -> passes through untouched
+            {
+              method: 'bolt12',
+              unit: 'sat',
+              method_name: 'Lightning Offers',
+              min_amount: null,
+              max_amount: null,
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const methods = info.nuts['4'].methods;
+    expect(methods[0].method_name).toBe('Bolt11');
+    expect(methods[1].method_name).toBe('Apple Pay');
+    expect(methods[2].method_name).toBe('Lightning Offers');
   });
 
   it('supportedMethods lists usable methods and returns [] for disabled ops', () => {

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -210,6 +210,23 @@ describe('MintInfo protected endpoint matching', () => {
     expect(methods[1].method_name).toBeNull();
   });
 
+  it('skips derivation for an over-long method (memory-exhaustion guard)', () => {
+    // A hostile mint could send a multi-megabyte `method`; deriving from it would run unbounded
+    // split/map/join. The length cap short-circuits before any string work.
+    const hugeMethod = 'a-'.repeat(1_000_000); // 2M chars, well past MAX_METHOD_LENGTH
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        4: {
+          disabled: false,
+          methods: [{ method: hugeMethod, unit: 'sat', min_amount: null, max_amount: null }],
+        },
+      },
+    } as any);
+
+    expect(info.nuts['4'].methods[0].method_name).toBeNull();
+  });
+
   it('supportedMethods lists usable methods and returns [] for disabled ops', () => {
     const info = new MintInfo({
       ...MINTINFORESP,

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -189,6 +189,27 @@ describe('MintInfo protected endpoint matching', () => {
     expect(methods[2].method_name).toBe('Lightning Offers');
   });
 
+  it('leaves method_name null when method is malformed (non-string or delimiter-only)', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        4: {
+          disabled: false,
+          methods: [
+            // non-string method -> null (no bogus name)
+            { method: 123, unit: 'sat', min_amount: null, max_amount: null },
+            // delimiter-only method -> zero words -> null
+            { method: '-_-', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
+          ],
+        },
+      },
+    } as any);
+
+    const methods = info.nuts['4'].methods;
+    expect(methods[0].method_name).toBeNull();
+    expect(methods[1].method_name).toBeNull();
+  });
+
   it('supportedMethods lists usable methods and returns [] for disabled ops', () => {
     const info = new MintInfo({
       ...MINTINFORESP,

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -375,11 +375,41 @@ describe('test info', () => {
     expect(info.isSupported(5)).toEqual({
       disabled: false,
       params: [
-        { method: 'bolt11', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
-        { method: 'bolt11', unit: 'usd', method_name: null, min_amount: null, max_amount: null },
-        { method: 'bolt11', unit: 'eur', method_name: null, min_amount: null, max_amount: null },
-        { method: 'bolt12', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
-        { method: 'onchain', unit: 'sat', method_name: null, min_amount: null, max_amount: null },
+        {
+          method: 'bolt11',
+          unit: 'sat',
+          method_name: 'Bolt11',
+          min_amount: null,
+          max_amount: null,
+        },
+        {
+          method: 'bolt11',
+          unit: 'usd',
+          method_name: 'Bolt11',
+          min_amount: null,
+          max_amount: null,
+        },
+        {
+          method: 'bolt11',
+          unit: 'eur',
+          method_name: 'Bolt11',
+          min_amount: null,
+          max_amount: null,
+        },
+        {
+          method: 'bolt12',
+          unit: 'sat',
+          method_name: 'Bolt12',
+          min_amount: null,
+          max_amount: null,
+        },
+        {
+          method: 'onchain',
+          unit: 'sat',
+          method_name: 'Onchain',
+          min_amount: null,
+          max_amount: null,
+        },
       ],
     });
     expect(info.isSupported(17)).toEqual({
@@ -521,7 +551,7 @@ describe('test info', () => {
           ],
         },
       },
-    });
+    } as any);
 
     expect(info.supportsAmountless('bolt11', 'sat')).toBe(true);
 
@@ -550,7 +580,7 @@ describe('test info', () => {
           ],
         },
       },
-    });
+    } as any);
 
     expect(info2.supportsAmountless('bolt11', 'sat')).toBe(false);
   });


### PR DESCRIPTION
# NUT cashubtc/nuts#374

Fiollows on from PR https://github.com/cashubtc/cashu-ts/pull/672

## Summary

When a mint omits `method_name` (null or absent) in its NUT-04/05 method settings, derive a human-readable default from `method`: replace `_`/`-` with spaces and title-case each word (`bolt11` → `Bolt11`, `apple-pay` → `Apple Pay`). Previously such entries were coerced to `null`.

`MintInfo.normalizeSwapMethods` now populates `method_name` during normalization, so consumers reading the normalized response get a usable name for every well-formed method. Malformed entries (missing/empty/non-string `method`) still resolve to `null` rather than producing a bogus name.

## Motivation

cashubtc/nuts#374 defines a deterministic fallback for `method_name` when unspecified, letting wallets rely on predictable strings instead of requiring every mint to name each method explicitly.