### PR TITLE
fix(bls): rejection-sample random blinding scalar to remove modulo bias

### DIFF
--- a/src/crypto/curve_bls.ts
+++ b/src/crypto/curve_bls.ts
@@ -131,8 +131,14 @@ export function getG2PubKeyFromPrivKey(privKey: Uint8Array): Uint8Array<ArrayBuf
 }
 
 function randomScalar(): bigint {
-  // bls12_381's Fr.fromBytes accepts 32 bytes BE and reduces mod ORDER.
-  return Fr.fromBytes(randomBytes(32));
+  // Rejection-sample, not Fr.fromBytes' mod-reduction, which biases small scalars (BLS_FR_ORDER ~ 0.45·2^256).
+  for (let ctr = 0; ctr < 1 << 16; ctr++) {
+    const x = bytesToNumberBE(randomBytes(32));
+    if (x === 0n || x >= BLS_FR_ORDER) continue;
+    return x;
+  }
+  /* c8 ignore next */
+  throw new CTSError('BLS random scalar generation failed');
 }
 
 /**

--- a/test/crypto/bls_random_scalar.test.ts
+++ b/test/crypto/bls_random_scalar.test.ts
@@ -1,0 +1,32 @@
+import { numberToBytesBE } from '@noble/curves/utils.js';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { BLS_FR_ORDER, blindMessageBls } from '../../src/crypto';
+
+// randomScalar() (module-private in curve_bls.ts) feeds the no-r path of blindMessageBls — the
+// production random-output path for v3 BLS keysets. It must rejection-sample uniformly in
+// [1, BLS_FR_ORDER), like deriveBatchWeights. Fr.fromBytes mod-reduces (BLS_FR_ORDER ~ 0.45·2^256),
+// which biases scalars small; this guards against a regression back to that.
+const { randomBytesMock } = vi.hoisted(() => ({ randomBytesMock: vi.fn() }));
+
+vi.mock('@noble/curves/utils.js', async (importActual) => {
+  const actual = await importActual<typeof import('@noble/curves/utils.js')>();
+  return { ...actual, randomBytes: randomBytesMock };
+});
+
+describe('randomScalar uniform rejection sampling (no-r blinding path)', () => {
+  afterEach(() => randomBytesMock.mockReset());
+
+  test('discards an out-of-range draw instead of mod-reducing it', () => {
+    const secret = new TextEncoder().encode('unlinkability');
+    // 1st draw >= BLS_FR_ORDER: rejection sampling must discard it. 2nd draw in range: accepted.
+    randomBytesMock
+      .mockReturnValueOnce(numberToBytesBE(BLS_FR_ORDER + 7n, 32))
+      .mockReturnValueOnce(numberToBytesBE(11n, 32));
+
+    const { r } = blindMessageBls(secret);
+
+    // Rejection sampling keeps the 2nd draw = 11. Mod-reduction would consume only the 1st draw:
+    // (BLS_FR_ORDER + 7) mod BLS_FR_ORDER = 7 — never 11.
+    expect(r).toBe(11n);
+  });
+});


### PR DESCRIPTION
## Summary

`randomScalar()` in `src/crypto/curve_bls.ts` — the blinding-factor source for the no-`r` (random-output) path of `blindMessageBls`, used by every random v3 (BLS) output — drew its scalar via `Fr.fromBytes(randomBytes(32))`. noble's `bls12_381_Fr` is built with `modFromBytes: true`, so `fromBytes` silently reduces the 32-byte draw mod `ORDER` rather than rejecting out-of-range values.

This swaps it for true rejection sampling in `[1, BLS_FR_ORDER)`, matching the existing `deriveBatchWeights` path in the same file.

## Motivation

`BLS_FR_ORDER ≈ 0.45·2²⁵⁶`, so `floor(2²⁵⁶ / ORDER) = 2` and the bottom ~9.4% of the scalar range gets three preimages in `[0, 2²⁵⁶)` while the rest get two — making small blinding factors ~50% more likely. That's a non-uniform blinding factor on a privacy primitive. `deriveBatchWeights` already rejection-samples for exactly this reason; `randomScalar` was the lone CSPRNG path that didn't.

Impact is low (exploiting the skew requires solving DLP), but the fix is essentially free and removes an in-tree inconsistency.

The two remaining `Fr.fromBytes` calls (`getG2PubKeyFromPrivKey`, `createBlindSignatureBls`) are left as-is: they decode externally-supplied private keys where mod-reduction is the intended, signer-matching convention.

## Test

New `test/crypto/bls_random_scalar.test.ts` mocks `randomBytes` to feed an out-of-range draw followed by an in-range one and asserts the in-range value is the one kept (mod-reduction would consume only the first draw). Passes on node + chromium/firefox/webkit.

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).