### PR TITLE
feat: add NUT-27 Nostr mint backup helpers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ We are also tracking the project [here](https://github.com/orgs/cashubtc/project
 - [!] [NUT-24](https://github.com/cashubtc/nuts/blob/main/24.md) | HTTP 402 Payment Required |
 - [x] [NUT-25](https://github.com/cashubtc/nuts/blob/main/25.md) | BOLT12 |
 - [x] [NUT-26](https://github.com/cashubtc/nuts/blob/main/26.md) | Bech32m Encoding |
-- [ ] [NUT-27](https://github.com/cashubtc/nuts/blob/main/27.md) | Nostr Mint Backup |
+- [x] [NUT-27](https://github.com/cashubtc/nuts/blob/main/27.md) | Nostr Mint Backup |
 - [x] [NUT-28](https://github.com/cashubtc/nuts/blob/main/28.md) | Pay-to-Blinded-Key (P2BK) |
 - [x] [NUT-29](https://github.com/cashubtc/nuts/blob/main/29.md) | Batched Minting |
+- [x] [NUT-30](https://github.com/cashubtc/nuts/blob/main/30.md) | Onchain |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ We are also tracking the project [here](https://github.com/orgs/cashubtc/project
 - [x] [NUT-12](https://github.com/cashubtc/nuts/blob/main/12.md) | Offline ecash signature validation |
 - [x] [NUT-13](https://github.com/cashubtc/nuts/blob/main/13.md) | Deterministic Secrets |
 - [x] [NUT-14](https://github.com/cashubtc/nuts/blob/main/14.md) | Hashed Timelock Contracts (HTLCs) |
-- [!] [NUT-15](https://github.com/cashubtc/nuts/blob/main/15.md) | Partial multi-path payments |
+- [x] [NUT-15](https://github.com/cashubtc/nuts/blob/main/15.md) | Partial multi-path payments |
 - [!] [NUT-16](https://github.com/cashubtc/nuts/blob/main/16.md) | Animated QR codes |
 - [x] [NUT-17](https://github.com/cashubtc/nuts/blob/main/17.md) | WebSockets |
 - [x] [NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md) | Payment Requests |

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -240,6 +240,9 @@ export const BLS_G2_GENERATOR: WeierstrassPoint<Fp2>;
 // @public
 export const BLS_HASH_TO_CURVE_DST = "CASHU_BLS12_381_G1_XMD:SHA-256_SSWU_RO_";
 
+// @public
+export function buildMintBackupPayload(mints: string[], timestamp: number): string;
+
 // @public (undocumented)
 export type CancellerLike = SubscriptionCanceller | Promise<SubscriptionCanceller>;
 
@@ -403,6 +406,12 @@ export type DeriveKeysetIdOptions = {
     unit?: string;
     versionByte?: number;
     isDeprecatedBase64?: boolean;
+};
+
+// @public
+export function deriveMintBackupKeys(seed: Uint8Array): {
+    privkey: string;
+    pubkey: string;
 };
 
 // @public
@@ -1007,6 +1016,20 @@ export class Mint {
 }
 
 // @public
+export const MINT_BACKUP_D_TAG = "mint-list";
+
+// @public
+export const MINT_BACKUP_KIND = 30078;
+
+// @public
+export interface MintBackupPayload {
+    // (undocumented)
+    mints: string[];
+    // (undocumented)
+    timestamp: number;
+}
+
+// @public
 export class MintBuilder<M extends MintMethod, HasPrivKey extends boolean = M extends 'bolt12' | 'onchain' ? false : true> {
     constructor(wallet: Wallet, method: M, amount: AmountLike, quote: MintQuoteFor<M>);
     asCustom(data: OutputDataLike[]): this;
@@ -1554,6 +1577,9 @@ export type P2PKWitness = {
 
 // @public
 export function parseHTLCSecret(secret: string | Secret): Secret;
+
+// @public
+export function parseMintBackupPayload(json: string): MintBackupPayload;
 
 // @public
 export function parseP2PKSecret(secret: string | Secret): Secret;

--- a/src/crypto/NUT27.ts
+++ b/src/crypto/NUT27.ts
@@ -1,0 +1,90 @@
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
+
+import { CTSError } from '../model/Errors';
+import { Bytes } from '../utils';
+
+/**
+ * NIP-78 addressable event kind used for the mint-list backup (NUT-27).
+ */
+export const MINT_BACKUP_KIND = 30078;
+
+/**
+ * Addressable-event `d` tag identifying the mint-list backup.
+ */
+export const MINT_BACKUP_D_TAG = 'mint-list';
+
+const BACKUP_DOMAIN_SEPARATOR = utf8ToBytes('cashu-mint-backup');
+
+/**
+ * Plaintext shape that gets NIP-44-encrypted into the event `content`.
+ */
+export interface MintBackupPayload {
+  mints: string[];
+  timestamp: number;
+}
+
+/**
+ * Derive the deterministic NUT-27 mint-backup keypair from a BIP-39 seed.
+ *
+ * @remarks
+ * `privkey = SHA256(seed ‖ "cashu-mint-backup")`; `pubkey` is the 32-byte x-only Nostr public key.
+ * Takes the 64-byte seed (not a mnemonic) to match the rest of cashu-ts, which never handles
+ * mnemonics. Returns hex strings, the form nostr-tools/NDK consume. The same keypair encrypts and
+ * decrypts (self-addressed conversation key).
+ * @param seed BIP-39 seed, e.g. from `mnemonicToSeedSync(mnemonic)`.
+ * @returns `{ privkey, pubkey }` as lowercase hex strings.
+ */
+export function deriveMintBackupKeys(seed: Uint8Array): { privkey: string; pubkey: string } {
+  if (!(seed instanceof Uint8Array) || seed.length === 0) {
+    throw new CTSError('seed must be a non-empty Uint8Array');
+  }
+  const privkey = sha256(Bytes.concat(seed, BACKUP_DOMAIN_SEPARATOR));
+  const pubkey = schnorr.getPublicKey(privkey); // 32-byte x-only
+  return { privkey: bytesToHex(privkey), pubkey: bytesToHex(pubkey) };
+}
+
+/**
+ * Build the canonical backup payload JSON (the plaintext to NIP-44-encrypt).
+ *
+ * @param mints Mint URLs to back up.
+ * @param timestamp Unix seconds; reuse as the event `created_at`.
+ */
+export function buildMintBackupPayload(mints: string[], timestamp: number): string {
+  if (!Array.isArray(mints) || !mints.every((m) => typeof m === 'string')) {
+    throw new CTSError('mints must be an array of strings');
+  }
+  if (!Number.isInteger(timestamp)) {
+    throw new CTSError('timestamp must be an integer (unix seconds)');
+  }
+  const payload: MintBackupPayload = { mints, timestamp };
+  return JSON.stringify(payload);
+}
+
+/**
+ * Parse and validate decrypted backup content.
+ *
+ * @remarks
+ * Defensive decode of untrusted relay data — verifies `mints` is a `string[]` and `timestamp` an
+ * integer, rather than trusting the JSON shape.
+ */
+export function parseMintBackupPayload(json: string): MintBackupPayload {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch (cause) {
+    throw new CTSError('backup content is not valid JSON', { cause });
+  }
+  if (typeof data !== 'object' || data === null) {
+    throw new CTSError('backup payload must be an object');
+  }
+  const { mints, timestamp } = data as Record<string, unknown>;
+  if (!Array.isArray(mints) || !mints.every((m) => typeof m === 'string')) {
+    throw new CTSError('backup payload `mints` must be an array of strings');
+  }
+  if (!Number.isInteger(timestamp)) {
+    throw new CTSError('backup payload `timestamp` must be an integer');
+  }
+  return { mints: mints, timestamp: timestamp as number };
+}

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -9,4 +9,5 @@ export * from './NUT12';
 export * from './NUT13';
 export * from './NUT14';
 export * from './NUT20';
+export * from './NUT27';
 export * from './NUT28';

--- a/test/crypto/NUT27.test.ts
+++ b/test/crypto/NUT27.test.ts
@@ -1,0 +1,80 @@
+import { test, describe, expect } from 'vitest';
+import { hexToBytes } from '@noble/hashes/utils.js';
+import {
+  deriveMintBackupKeys,
+  buildMintBackupPayload,
+  parseMintBackupPayload,
+  MINT_BACKUP_KIND,
+  MINT_BACKUP_D_TAG,
+} from '../../src/crypto';
+
+// Deterministic 64-byte test seed (bytes 0x00..0x3f). cashu-ts works in seed
+// space, so we avoid a bip39 dependency in the test.
+const SEED = hexToBytes(
+  '000102030405060708090a0b0c0d0e0f' +
+    '101112131415161718191a1b1c1d1e1f' +
+    '202122232425262728292a2b2c2d2e2f' +
+    '303132333435363738393a3b3c3d3e3f',
+);
+
+// Reference vector reproduced from CME's derivation
+// (sha256(seed || "cashu-mint-backup") -> nostr-tools getPublicKey x-only).
+// Pins drop-in compatibility: existing CME backups must still restore.
+const EXPECTED_PRIVKEY = '2cbff0a8a0037c25730cd14519aaa50eaf9364db89101ad734883fbd1fbb9099';
+const EXPECTED_PUBKEY = 'e3aba74c622b09bd1c1acbb4331fa00aedec6c410051dd7b37a5ad2fee09ec2f';
+
+describe('NUT-27 deriveMintBackupKeys', () => {
+  test('matches the CME reference vector (drop-in compatible)', () => {
+    const { privkey, pubkey } = deriveMintBackupKeys(SEED);
+    expect(privkey).toBe(EXPECTED_PRIVKEY);
+    expect(pubkey).toBe(EXPECTED_PUBKEY);
+  });
+
+  test('pubkey is 32-byte x-only (not 33-byte compressed)', () => {
+    const { pubkey } = deriveMintBackupKeys(SEED);
+    expect(pubkey).toHaveLength(64);
+  });
+
+  test('is deterministic', () => {
+    expect(deriveMintBackupKeys(SEED)).toEqual(deriveMintBackupKeys(SEED));
+  });
+
+  test('rejects an empty or non-Uint8Array seed', () => {
+    expect(() => deriveMintBackupKeys(new Uint8Array(0))).toThrow();
+    // @ts-expect-error testing runtime guard
+    expect(() => deriveMintBackupKeys('not bytes')).toThrow();
+  });
+});
+
+describe('NUT-27 payload', () => {
+  test('round-trips mints and timestamp', () => {
+    const mints = ['https://mint.example.com', 'https://another-mint.org'];
+    const json = buildMintBackupPayload(mints, 1703721600);
+    expect(parseMintBackupPayload(json)).toEqual({ mints, timestamp: 1703721600 });
+  });
+
+  test('parse rejects non-JSON', () => {
+    expect(() => parseMintBackupPayload('{not json')).toThrow();
+  });
+
+  test('parse rejects a missing or malformed mints field', () => {
+    expect(() => parseMintBackupPayload(JSON.stringify({ timestamp: 1 }))).toThrow();
+    expect(() => parseMintBackupPayload(JSON.stringify({ mints: [1, 2], timestamp: 1 }))).toThrow();
+  });
+
+  test('parse rejects a non-integer timestamp', () => {
+    expect(() => parseMintBackupPayload(JSON.stringify({ mints: [], timestamp: 1.5 }))).toThrow();
+  });
+
+  test('build rejects non-string mints', () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => buildMintBackupPayload([1, 2], 1)).toThrow();
+  });
+});
+
+describe('NUT-27 conventions', () => {
+  test('exposes the kind and d-tag constants for consumers to assemble events', () => {
+    expect(MINT_BACKUP_KIND).toBe(30078);
+    expect(MINT_BACKUP_D_TAG).toBe('mint-list');
+  });
+});

--- a/test/crypto/NUT27.test.ts
+++ b/test/crypto/NUT27.test.ts
@@ -70,6 +70,15 @@ describe('NUT-27 payload', () => {
     // @ts-expect-error testing runtime guard
     expect(() => buildMintBackupPayload([1, 2], 1)).toThrow();
   });
+
+  test('build rejects a non-integer timestamp', () => {
+    expect(() => buildMintBackupPayload([], 1.5)).toThrow();
+  });
+
+  test('parse rejects JSON that is not an object', () => {
+    expect(() => parseMintBackupPayload('42')).toThrow();
+    expect(() => parseMintBackupPayload('null')).toThrow();
+  });
 });
 
 describe('NUT-27 conventions', () => {


### PR DESCRIPTION
## Summary

Adds `crypto/NUT27` with the cashu-specific primitives for the NUT-27 Nostr mint-list backup:

- `deriveMintBackupKeys(seed)` — deterministic backup keypair from a BIP-39 seed (`SHA256(seed ‖ "cashu-mint-backup")`), returning hex `{ privkey, pubkey }` with a 32-byte x-only Nostr pubkey.
- `buildMintBackupPayload(mints, timestamp)` / `parseMintBackupPayload(json)` — the `{ mints, timestamp }` backup schema, with a defensive decode that validates shape before trusting relay data.
- `MINT_BACKUP_KIND` (30078) and `MINT_BACKUP_D_TAG` (`mint-list`) constants for consumers to assemble events/filters with their own Nostr lib.

NIP-44 encryption, event signing and relay publishing are intentionally left to the consumer's Nostr library (nostr-tools / NDK) — those are generic Nostr concerns, not cashu primitives.

## Motivation

The wallet in cashu-ts is single-mint, so a multi-mint backup can't live on the `Wallet` class — it belongs as standalone protocol primitives. The genuinely cashu-specific parts are the key derivation, the payload schema, and the event conventions; everything else is already covered by a consumer's existing Nostr stack.

Pinning these as tested primitives keeps wallets interoperable: the derivation must byte-match across implementations or restore silently fails. The derivation is verified against a reference vector so existing backups stay restorable.