### PR TITLE
fix(htlc): support hashlock-only (pubkey-less) HTLC locks

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -515,7 +515,10 @@ export function verifyP2PKSpendingConditions(
   const signatures = getP2PKWitnessSignatures(proof.witness);
   const locktime = getLocktime(secret);
   const lockState: LockState = deriveLockState(locktime);
-  const nsigs = resolveNSigs(secret, lockState, refundKeys);
+  // A path with no eligible keys requires no signatures (e.g. a keyless HTLC,
+  // spent by preimage alone). The `n_sigs` default of 1 only applies when there
+  // are main keys to satisfy it.
+  const nsigs = mainKeys.length === 0 ? 0 : resolveNSigs(secret, lockState, refundKeys);
   const nSigsRefund = resolveNSigsRefund(secret, lockState, refundKeys);
 
   // Verify signatures against both key sets

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -220,7 +220,11 @@ export function dedupeP2PKPubkeys(keys: string[]): string[] {
 export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   const pubkeys = dedupeP2PKPubkeys(Array.isArray(p2pk.pubkey) ? p2pk.pubkey : [p2pk.pubkey]);
   const refundKeys = dedupeP2PKPubkeys(p2pk.refundKeys ?? []);
-  if (pubkeys.length === 0) {
+  // HTLC (NUT-14) locks the proof to a hashlock in Secret.data, so its pubkeys
+  // list is optional: with none, possession of the preimage alone spends. P2PK
+  // has no hashlock and so always needs at least one main key.
+  const isHTLC = typeof p2pk.hashlock === 'string' && p2pk.hashlock.length > 0;
+  if (pubkeys.length === 0 && !isHTLC) {
     throw new CTSError('P2PK requires at least one pubkey');
   }
   const totalKeys = pubkeys.length + refundKeys.length;
@@ -229,7 +233,9 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
 
-  const requiredSignatures = p2pk.requiredSignatures ?? 1;
+  // With no main pubkeys (hashlock-only HTLC) there is no main-signature
+  // threshold to satisfy, so leave it undefined rather than defaulting to 1.
+  const requiredSignatures = pubkeys.length > 0 ? (p2pk.requiredSignatures ?? 1) : undefined;
   const requiredRefundSignatures = p2pk.requiredRefundSignatures;
 
   // Shared semantic validation
@@ -245,7 +251,7 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
     pubkey: pubkeys.length === 1 ? pubkeys[0] : pubkeys,
     ...(p2pk.locktime !== undefined ? { locktime: p2pk.locktime } : {}),
     ...(refundKeys.length > 0 ? { refundKeys } : {}),
-    ...(requiredSignatures > 1 ? { requiredSignatures } : {}),
+    ...(requiredSignatures !== undefined && requiredSignatures > 1 ? { requiredSignatures } : {}),
     ...(requiredRefundSignatures !== undefined && requiredRefundSignatures > 1
       ? { requiredRefundSignatures }
       : {}),

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -233,9 +233,13 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
 
-  // With no main pubkeys (hashlock-only HTLC) there is no main-signature
-  // threshold to satisfy, so leave it undefined rather than defaulting to 1.
-  const requiredSignatures = pubkeys.length > 0 ? (p2pk.requiredSignatures ?? 1) : undefined;
+  // With no main pubkeys (hashlock-only HTLC) there is no threshold to default,
+  // so skip the implicit `?? 1`. Pass through an *explicit* requiredSignatures
+  // though, so assertSpendingConditionRules rejects an impossible threshold
+  // (n_sigs with zero pubkeys) loudly rather than silently weakening the lock to
+  // preimage-only.
+  const requiredSignatures =
+    pubkeys.length > 0 ? (p2pk.requiredSignatures ?? 1) : p2pk.requiredSignatures;
   const requiredRefundSignatures = p2pk.requiredRefundSignatures;
 
   // Shared semantic validation

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -105,15 +105,33 @@ export function verifyHTLCSpendingConditions(
   let result: P2PKVerificationResult;
   message = message ?? proof.secret; // default message is proof secret
 
-  // Check P2PK locking conditions are satisfied first
-  // We are only interested in 'MAIN' pathway spends on HTLC proofs
+  // Verify the underlying P2PK conditions first. Only the hashlock (receiver)
+  // pathway is HTLC-specific; the refund and unlocked outcomes are plain P2PK
+  // verdicts and pass straight through.
   const secret = parseSecret(proof.secret); // no assert
   const p2pkResult = verifyP2PKSpendingConditions(proof, logger, message);
-  if (p2pkResult.path != 'MAIN' || getSecretKind(secret) !== 'HTLC') {
-    return p2pkResult; // not an hashlock spend
+  if (getSecretKind(secret) !== 'HTLC') {
+    return p2pkResult; // not an HTLC proof
   }
 
-  // Ensure proof has a preimage
+  // Receiver pathway (NUT-14): always available to receivers — even during an
+  // active locktime or with refund keys present — given the preimage plus, when
+  // main pubkeys exist, their signature threshold. A hashlock-only HTLC has no
+  // main keys and so no threshold, so the preimage alone authorises it.
+  const hashlockOnly = p2pkResult.main.pubkeys.length === 0;
+
+  // Keyed HTLC: the main signatures must meet the threshold (a 'MAIN' verdict).
+  if (!hashlockOnly && p2pkResult.path !== 'MAIN') {
+    return p2pkResult; // threshold not met: defer to the P2PK verdict
+  }
+  // Keyless HTLC never yields 'MAIN' (no keys to sign), so the guard above can't
+  // gate it. If another pathway already authorised the spend (e.g. expired with
+  // no refund keys = anyone-can-spend), keep that verdict; no preimage needed.
+  if (hashlockOnly && p2pkResult.success) {
+    return p2pkResult;
+  }
+
+  // From here, the spend depends solely on a valid preimage.
   const preimage = getHTLCWitnessPreimage(proof.witness);
   if (!preimage) {
     result = { ...p2pkResult, success: false, path: 'FAILED' };
@@ -121,18 +139,20 @@ export function verifyHTLCSpendingConditions(
     return result;
   }
 
-  // Check preimage and hash correspond if main pathway was used
+  // Confirm the preimage hashes to the lock in Secret.data.
   const hash = getDataField(secret);
   if (verifyHTLCHash(preimage, hash)) {
-    result = p2pkResult;
+    // Authorised via the receiver pathway. A keyless HTLC carries a FAILED P2PK
+    // verdict (no keys to meet a threshold), so stamp the successful MAIN result.
+    result = { ...p2pkResult, success: true, path: 'MAIN' };
     logger.debug('Spending condition satisfied via hashlock (receiver) pathway', { result });
-    return result; // success, MAIN pathway
+    return result;
   }
 
-  // Still here? Bad news...
+  // Preimage present but does not match the hash lock.
   result = { ...p2pkResult, success: false, path: 'FAILED' };
   logger.debug('Hashlock spend failed, wrong preimage for hash', { result });
-  return result; // failed, wrong preimage
+  return result;
 }
 
 /**

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -86,7 +86,11 @@ export class P2PKBuilder {
     const locks = this.lockKeys;
     const refunds = this.refundKeys;
 
-    if (locks.length === 0) throw new CTSError('At least one lock pubkey is required');
+    // HTLC (NUT-14) locks to a hashlock, so lock pubkeys are optional there; a
+    // plain P2PK always needs at least one.
+    if (locks.length === 0 && !this.hashlock) {
+      throw new CTSError('At least one lock pubkey is required');
+    }
 
     const pubkey: string | string[] = locks.length === 1 ? locks[0] : locks;
 

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -98,8 +98,14 @@ export class P2PKBuilder {
       pubkey,
       ...(this.locktime !== undefined ? { locktime: this.locktime } : {}),
       ...(refunds.length ? { refundKeys: refunds } : {}),
-      ...(this.nSigs && this.nSigs > 1 ? { requiredSignatures: this.nSigs } : {}),
-      ...(this.nSigsRefund && this.nSigsRefund > 1
+      // Drop a redundant default threshold of 1 (1-of-N is implied), but pass an
+      // explicit threshold through when its key set is empty — a keyless HTLC with
+      // n_sigs, or n_sigs_refund with no refund keys, is contradictory and must be
+      // rejected by the smoke test below, not silently weakened to preimage-only.
+      ...(this.nSigs !== undefined && (this.nSigs > 1 || locks.length === 0)
+        ? { requiredSignatures: this.nSigs }
+        : {}),
+      ...(this.nSigsRefund !== undefined && (this.nSigsRefund > 1 || refunds.length === 0)
         ? { requiredRefundSignatures: this.nSigsRefund }
         : {}),
       ...(this.extraTags.length ? { additionalTags: this.extraTags.slice() } : {}),

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1406,6 +1406,13 @@ describe('normalizeP2PKOptions', () => {
     );
   });
 
+  test('allows an empty pubkey array for a hashlock-only HTLC (NUT-14)', () => {
+    // An HTLC carries its lock in the hashlock, so a pubkeys list is optional.
+    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+    const normalized = normalizeP2PKOptions({ pubkey: [], hashlock });
+    expect(normalized).toEqual({ pubkey: [], hashlock });
+  });
+
   test('throws when pubkey contains an empty string', () => {
     expect(() => normalizeP2PKOptions({ pubkey: [pk, ''] })).toThrow(/invalid pubkey/i);
   });

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1413,6 +1413,18 @@ describe('normalizeP2PKOptions', () => {
     expect(normalized).toEqual({ pubkey: [], hashlock });
   });
 
+  test('rejects an explicit n_sigs on a hashlock-only HTLC (no pubkeys to sign)', () => {
+    // Skipping the *default* n_sigs is fine, but an explicit threshold with zero
+    // pubkeys is impossible and must fail loudly, not silently weaken the lock.
+    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+    expect(() => normalizeP2PKOptions({ pubkey: [], hashlock, requiredSignatures: 2 })).toThrow(
+      /exceeds available pubkeys/i,
+    );
+    expect(() => normalizeP2PKOptions({ pubkey: [], hashlock, requiredSignatures: 0 })).toThrow(
+      /positive integer/i,
+    );
+  });
+
   test('throws when pubkey contains an empty string', () => {
     expect(() => normalizeP2PKOptions({ pubkey: [pk, ''] })).toThrow(/invalid pubkey/i);
   });

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -112,6 +112,16 @@ describe('HTLC hashlock-only receiver pathway (no pubkeys)', () => {
     expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, []), PREIMAGE))).toBe(true);
   });
 
+  test('successful spend yields an internally consistent result', () => {
+    // With no main pubkeys the receiver path requires zero signatures, so the
+    // result must not claim a signer was required (requiredSigners <= received).
+    const result = verifyHTLCSpendingConditions(proofFor(createHTLCsecret(HASH, []), PREIMAGE));
+    expect(result.success).toBe(true);
+    expect(result.main.pubkeys).toEqual([]);
+    expect(result.main.requiredSigners).toBe(0);
+    expect(result.main.receivedSigners.length).toBeGreaterThanOrEqual(result.main.requiredSigners);
+  });
+
   test('wrong preimage fails', () => {
     const wrong = '1000000000000000000000000000000000000000000000000000000000000001';
     expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, []), wrong))).toBe(false);

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -8,6 +8,7 @@ import {
   parseHTLCSecret,
   signP2PKProof,
   verifyHTLCHash,
+  verifyHTLCSpendingConditions,
 } from '../../src/crypto';
 import { Amount, Proof } from '../../src';
 import { schnorr } from '@noble/curves/secp256k1.js';
@@ -128,6 +129,15 @@ describe('HTLC hashlock-only receiver pathway (no pubkeys)', () => {
       ['refund', PUBKEY],
     ]);
     expect(isHTLCSpendAuthorised(proofFor(secret, PREIMAGE))).toBe(true);
+  });
+
+  test('expired with no refund keys is anyone-can-spend, no preimage needed', () => {
+    // Keyless HTLC, locktime in the past, no refund tag: the P2PK pathway already
+    // unlocks it, so the spend succeeds as-is — the hashlock check is skipped.
+    const secret = createHTLCsecret(HASH, [['locktime', '1']]);
+    const result = verifyHTLCSpendingConditions(proofFor(secret)); // no preimage
+    expect(result.success).toBe(true);
+    expect(result.path).toBe('UNLOCKED');
   });
 });
 

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -93,6 +93,44 @@ describe('verifyHTLCSpendingConditions and isHTLCSpendAuthorised', () => {
   });
 });
 
+describe('HTLC hashlock-only receiver pathway (no pubkeys)', () => {
+  // NUT-14: with no `pubkeys` tag, possession of the preimage alone spends the
+  // proof. The receiver pathway is ALWAYS available, with no signature needed.
+  const HASH = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+  const PREIMAGE = '0000000000000000000000000000000000000000000000000000000000000001';
+
+  const proofFor = (secret: string, preimage?: string): Proof => ({
+    amount: Amount.from(2),
+    id: '00bfa73302d12ffd',
+    secret,
+    C: '03ff6567e2e6c31db5cb7189dab2b5121930086791c93899e4eff3dda61cb57273',
+    witness: preimage ? JSON.stringify({ preimage }) : undefined,
+  });
+
+  test('correct preimage authorises with no signature', () => {
+    expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, []), PREIMAGE))).toBe(true);
+  });
+
+  test('wrong preimage fails', () => {
+    const wrong = '1000000000000000000000000000000000000000000000000000000000000001';
+    expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, []), wrong))).toBe(false);
+  });
+
+  test('no preimage fails', () => {
+    expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, [])))).toBe(false);
+  });
+
+  test('receiver pathway remains available after locktime with refund keys present', () => {
+    // Expired locktime + refund key: the sender refund path opens, but the
+    // receiver can still claim with the preimage (no refund signature needed).
+    const secret = createHTLCsecret(HASH, [
+      ['locktime', '1'],
+      ['refund', PUBKEY],
+    ]);
+    expect(isHTLCSpendAuthorised(proofFor(secret, PREIMAGE))).toBe(true);
+  });
+});
+
 describe('getHTLCWitnessPreimage', () => {
   test('returns undefined when witness is undefined', () => {
     expect(getHTLCWitnessPreimage(undefined)).toBeUndefined();

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -151,6 +151,30 @@ describe('P2PKBuilder.toOptions()', () => {
     expect('requiredRefundSignatures' in o2).toBe(false);
   });
 
+  it('rejects an explicit n_sigs on a keyless HTLC (no lock keys to sign)', () => {
+    // The <=1 omission above is a redundant default *when keys back it*. With zero
+    // lock keys (hashlock-only HTLC) an explicit n_sigs=1 is contradictory and must
+    // surface, not be dropped into a spendable preimage-only lock. n_sigs>1 already
+    // survives the filter; n_sigs=1 is the value that previously slipped through.
+    expect(() =>
+      new P2PKBuilder().addHashlock('deadbeef').requireLockSignatures(1).toOptions(),
+    ).toThrow(/exceeds available pubkeys/i);
+    expect(() =>
+      new P2PKBuilder().addHashlock('deadbeef').requireLockSignatures(2).toOptions(),
+    ).toThrow(/exceeds available pubkeys/i);
+    // No explicit threshold => keyless HTLC builds fine.
+    const ok = new P2PKBuilder().addHashlock('deadbeef').toOptions();
+    expect('requiredSignatures' in ok).toBe(false);
+  });
+
+  it('rejects an explicit n_sigs_refund when there are no refund keys', () => {
+    // Same defect, refund side: n_sigs_refund=1 with zero refund keys is impossible
+    // and must throw rather than be silently dropped.
+    expect(() =>
+      new P2PKBuilder().addLockPubkey(comp('a', '02')).requireRefundSignatures(1).toOptions(),
+    ).toThrow(/requires refund keys/i);
+  });
+
   it('enforces combined lock+refund keys limit of 10', () => {
     // build 11 distinct keys
     const chars = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b'];

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -361,6 +361,19 @@ describe('payment requests', () => {
       });
     });
 
+    test('maps a pubkey-less HTLC option to a hashlock-only lock', () => {
+      // NUT-14 allows an HTLC with no `pubkeys` tag: anyone with the preimage
+      // can spend. This must produce a buildable lock, not a poison-pill option.
+      const nut10: NUT10Option = { kind: 'HTLC', data: HASH, tags: [] };
+      const options = prWithNut10(nut10).toP2PKOptions()!;
+      expect(options).toEqual({ hashlock: HASH, pubkey: [] });
+      const od = OutputData.createSingleP2PKData(options, 1, '00ad268c4d1f5826');
+      const secret = JSON.parse(new TextDecoder().decode(od.secret));
+      expect(secret[0]).toBe('HTLC');
+      expect(secret[1].data).toBe(HASH);
+      expect(secret[1].tags.find((t: string[]) => t[0] === 'pubkeys')).toBeUndefined();
+    });
+
     test('ignores unknown/future kinds by returning undefined', () => {
       const nut10: NUT10Option = { kind: 'FUTURE', data: 'abc', tags: [] };
       expect(prWithNut10(nut10).toP2PKOptions()).toBeUndefined();


### PR DESCRIPTION
## Summary

A NUT-14 HTLC may omit the `pubkeys` tag, locking the proof to a hashlock alone so that anyone holding the preimage can spend it. CTS did not support this end-to-end:

- **Creation** rejected it. `normalizeP2PKOptions` (and `P2PKBuilder.toOptions`) enforced the P2PK "at least one pubkey" rule unconditionally, so a hashlock-only option threw `P2PK requires at least one pubkey`. `PaymentRequest.toP2PKOptions()` on such a request therefore produced an options object that crashed the output builders.
- **Verification** never authorised it. `verifyHTLCSpendingConditions` only treated a `'MAIN'` P2PK verdict as a hashlock spend, but a keyless HTLC can never reach `'MAIN'` (there are no keys to meet a signature threshold), so even a correct preimage returned `false`.

This PR wires the hashlock-only case through both sides:

- `normalizeP2PKOptions` / `P2PKBuilder` allow zero pubkeys when a hashlock is present, and skip the main-signature threshold (which defaulted to 1 and would otherwise still throw downstream).
- `verifyHTLCSpendingConditions` authorises the receiver pathway on a valid preimage alone when there are no main pubkeys, while preserving the existing behaviour when pubkeys are present (preimage **and** signature threshold required).

## Motivation

Pubkey-less HTLCs are spec-valid (NUT-14) and match the reference implementation (CDK treats an empty pubkey list as a zero-signature receiver pathway). Without this, a CTS wallet cannot create or accept a compliant hashlock-only HTLC.

## Tests

- Verification: keyless HTLC authorises on correct preimage; rejects wrong/missing preimage; receiver pathway remains available after locktime with refund keys present.
- Creation: tag-less HTLC `PaymentRequest` → `toP2PKOptions` → builds a valid `["HTLC", …]` secret with no `pubkeys` tag; `normalizeP2PKOptions` accepts an empty pubkey array only when a hashlock is present.
- Regressions: HTLC **with** pubkeys still needs a signature; P2PK with no pubkey still throws.