### PR TITLE
refactor(p2pk)!: model P2PK/HTLC locks as kind+data spending conditions

### DIFF
--- a/docs-src/usage/create_p2pk.md
+++ b/docs-src/usage/create_p2pk.md
@@ -8,7 +8,7 @@ import { getEncodedToken } from '@cashu/cashu-ts';
 // or you fetched existing proofs from your app database
 const proofs = [...]; // array of proofs
 const pubkey = '02...'; // Your public key
-const { keep, send } = await wallet.ops.send(32, proofs).asP2PK({pubkey}).run();
+const { keep, send } = await wallet.ops.send(32, proofs).asP2PK({ kind: 'P2PK', data: pubkey }).run();
 const token = getEncodedToken({ mint: mintUrl, proofs: send });
 console.log(token);
 

--- a/docs-src/wallet_ops/p2pk_builder.md
+++ b/docs-src/wallet_ops/p2pk_builder.md
@@ -2,7 +2,7 @@
 
 # P2PKBuilder API
 
-Small helper that only shapes `P2PKOptions`, it does not create secrets.
+Small helper that shapes a `P2PKOptions` lock, it does not create secrets.
 
 ```ts
 new P2PKBuilder()
@@ -14,7 +14,7 @@ new P2PKBuilder()
   .addTag(key: string, values?: string[] | string) // add single tag (eg: NutZap 'e')
   .addTags(tags: P2PKTag[]) // add multiple tags at once
   .addHashlock(hashlock: string) // for NUT-14 "HTLC" kind secrets
-  .toOptions(): P2PKOptions;
+  .toOptions(): P2PKOptions; // { kind, data, ...tags }
 
 P2PKBuilder.fromOptions(opts: P2PKOptions): P2PKBuilder
 ```
@@ -30,5 +30,6 @@ import { P2PKBuilder } from '@cashu/cashu-ts';
 
 const p2pk = new P2PKBuilder().addLockPubkey('02abc...').lockUntil(1_712_345_678).toOptions();
 
+// `p2pk` already carries its `kind`, so pass it to `asP2PK`:
 await wallet.ops.send(5, proofs).asP2PK(p2pk).run();
 ```

--- a/docs-src/wallet_ops/receive.md
+++ b/docs-src/wallet_ops/receive.md
@@ -38,7 +38,7 @@ const proofs = await wallet.ops
 ```ts
 const proofs = await wallet.ops
   .receive(token)
-  .asP2PK({ pubkey, locktime }) // NUT-11 options for new proofs
+  .asP2PK({ kind: 'P2PK', data: pubkey, locktime }) // NUT-11 options for new proofs
   .privkey(['k1', 'k2', 'k3']) // sign incoming P2PK proofs
   .proofsWeHave(myExistingProofs) // helps denomination selection
   .run();

--- a/docs-src/wallet_ops/send.md
+++ b/docs-src/wallet_ops/send.md
@@ -33,7 +33,7 @@ const { keep, send } = await wallet.ops
 ```ts
 const { keep, send } = await wallet.ops
   .send(10, myProofs)
-  .asP2PK({ pubkey, locktime: 1712345678 })
+  .asP2PK({ kind: 'P2PK', data: pubkey, locktime: 1712345678 })
   .includeFees(true) // sender covers receiver’s future spend fee
   .run();
 ```

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -774,6 +774,18 @@ export type KeysetPair = {
     privKeys: RawMintKeys;
 };
 
+// @public
+export type LockConditions = {
+    pubkeys?: string[];
+    locktime?: number;
+    refundKeys?: string[];
+    requiredSignatures?: number;
+    requiredRefundSignatures?: number;
+    additionalTags?: P2PKTag[];
+    blindKeys?: boolean;
+    sigFlag?: SigFlag;
+};
+
 // @public (undocumented)
 export type LockState = 'PERMANENT' | 'ACTIVE' | 'EXPIRED';
 
@@ -808,7 +820,7 @@ export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | '
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
@@ -1035,7 +1047,7 @@ export class MintBuilder<M extends MintMethod, HasPrivKey extends boolean = M ex
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
@@ -1521,7 +1533,7 @@ export class P2PKBuilder {
     // (undocumented)
     blindKeys(): this;
     // (undocumented)
-    static fromOptions(opts: P2PKOptions): P2PKBuilder;
+    static fromOptions(p2pk: P2PKOptions): P2PKBuilder;
     // (undocumented)
     lockUntil(when: Date | number): this;
     // (undocumented)
@@ -1535,16 +1547,8 @@ export class P2PKBuilder {
 }
 
 // @public
-export type P2PKOptions = {
-    pubkey: string | string[];
-    locktime?: number;
-    refundKeys?: string[];
-    requiredSignatures?: number;
-    requiredRefundSignatures?: number;
-    additionalTags?: P2PKTag[];
-    blindKeys?: boolean;
-    sigFlag?: SigFlag;
-    hashlock?: string;
+export type P2PKOptions = SpendingConditionsBase & LockConditions & {
+    kind: 'P2PK' | 'HTLC';
 };
 
 // @public
@@ -1756,7 +1760,7 @@ export class ReceiveBuilder {
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
@@ -1855,13 +1859,13 @@ export class SendBuilder {
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     includeFees(on?: boolean): this;
     keepAsCustom(data: OutputDataLike[]): this;
     keepAsDeterministic(counter?: number, denoms?: AmountLike[]): this;
     keepAsFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    keepAsP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     keepAsRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     offlineCloseMatch(requireDleq?: boolean): this;
@@ -2012,6 +2016,12 @@ export function signP2PKProofs(proofs: Proof[], privateKey: PrivKey | PrivKey[],
 
 // @public
 export function sortProofsById(proofs: Proof[]): Proof[];
+
+// @public
+export type SpendingConditionsBase = {
+    kind: SecretKind;
+    data: string;
+};
 
 // @public
 export function splitAmount(value: AmountLike, keyset: Keys, split?: AmountLike[], order?: 'desc' | 'asc'): Amount[];

--- a/examples/paymentApi_example.js
+++ b/examples/paymentApi_example.js
@@ -79,7 +79,7 @@ export const ecashPayment = onRequest(async (req, res) => {
 
   let receiveProofs;
   try {
-    receiveProofs = await wallet.ops.receive(token).asP2PK({ pubkey: p2pkLock }).run();
+    receiveProofs = await wallet.ops.receive(token).asP2PK({ kind: 'P2PK', data: p2pkLock }).run();
   } catch (error) {
     if (error.code === 11001) {
       res.json({

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -198,3 +198,33 @@ await wallet.completeMelt(meltPreview, privkey, { preferAsync: true });
 ```
 
 Calls that already pass a `CompleteMeltOptions` object (or omit the third argument) need no change.
+
+---
+
+## `P2PKOptions` is now a `kind` + `data` spending condition
+
+`P2PKOptions` drops `pubkey: string | string[]` and `hashlock?`. It is now the NUT-10 envelope (`kind` + `data`) plus the shared NUT-11 `LockConditions` tags:
+
+```ts
+type P2PKOptions = SpendingConditionsBase & LockConditions & { kind: 'P2PK' | 'HTLC' };
+```
+
+`data` is the lock pubkey (`'P2PK'`) or the hashlock (`'HTLC'`); extra signers move from the old `pubkey` array to the `pubkeys` tag. This affects every place a lock is built: `asP2PK()`, `OutputData.createP2PKData()`, and `{ type: 'p2pk', options }` output configs. `P2PKBuilder` (`addLockPubkey`/`addHashlock`) is unchanged.
+
+### Migration
+
+```ts
+// Before
+asP2PK({ pubkey: pk });
+asP2PK({ pubkey: [a, b], requiredSignatures: 2 });
+asP2PK({ hashlock: h });
+asP2PK({ hashlock: h, pubkey: [a] });
+
+// After
+asP2PK({ kind: 'P2PK', data: pk });
+asP2PK({ kind: 'P2PK', data: a, pubkeys: [b], requiredSignatures: 2 });
+asP2PK({ kind: 'HTLC', data: h });
+asP2PK({ kind: 'HTLC', data: h, pubkeys: [a] });
+```
+
+`PaymentRequest.toP2PKOptions()` already returns the new shape, so pass its result straight to `asP2PK()`.

--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -12,6 +12,24 @@ export interface SecretData {
 
 export type Secret = [SecretKind, SecretData];
 
+/**
+ * The base spending conditions for every NUT-10 well-known secret.
+ *
+ * @remarks
+ * Lock kinds extend this with tag conditions (`LockConditions` → `P2PKOptions`); a future NUT-10
+ * kind need not.
+ */
+export type SpendingConditionsBase = {
+  /**
+   * The NUT-10 secret kind (eg: `'P2PK'` / `'HTLC'`).
+   */
+  kind: SecretKind;
+  /**
+   * The NUT-10 data slot: a pubkey for P2PK, a hashlock for HTLC.
+   */
+  data: string;
+};
+
 // ------------------------------
 // NUT-10 Secrets
 // ------------------------------

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -199,6 +199,23 @@ function normalizePubkey(pk: string): string {
 }
 
 /**
+ * Validate and canonicalise an HTLC hashlock (a SHA-256 digest).
+ *
+ * @remarks
+ * Lowercases so the stored hashlock byte-matches the lowercase output of createHTLCHash() /
+ * verifyHTLCHash().
+ * @param hashlock - Expected 64-char hex string.
+ * @throws If not a 64-character hex string.
+ * @internal
+ */
+export function normalizeHashlock(hashlock: string): string {
+  if (typeof hashlock !== 'string' || !/^[0-9a-f]{64}$/i.test(hashlock)) {
+    throw new CTSError('HTLC hashlock must be a 64-character hex string (SHA-256)');
+  }
+  return hashlock.toLowerCase();
+}
+
+/**
  * Dedupes pubkeys by their x-only portion (last 64 chars).
  *
  * @remarks
@@ -247,13 +264,9 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
     data = all[0];
     pubkeys = all.slice(1);
   } else {
-    // data is a hashlock (SHA-256), not a key; only the (optional) pubkeys tag carries
-    // signers. Enforce the 64-char hex shape and lowercase it so the stored hashlock
-    // byte-matches the lowercase output of createHTLCHash() / verifyHTLCHash().
-    if (!/^[0-9a-f]{64}$/i.test(data)) {
-      throw new CTSError('HTLC hashlock must be a 64-character hex string (SHA-256)');
-    }
-    data = data.toLowerCase();
+    // data is a hashlock (SHA-256), not a key; validate + canonicalise it. Only the
+    // (optional) pubkeys tag carries signers.
+    data = normalizeHashlock(data);
     pubkeys = dedupeP2PKPubkeys(p2pk.pubkeys ?? []);
   }
 

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -16,6 +16,7 @@ import {
   assertSecretKind,
   createSecret,
   type Secret,
+  type SpendingConditionsBase,
   getSecretKind,
 } from './NUT10';
 import { deriveP2BKSecretKeys } from './NUT28';
@@ -37,10 +38,15 @@ export type P2PKSpendingPath = 'MAIN' | 'REFUND' | 'UNLOCKED' | 'FAILED';
 export type P2PKTag = [key: string, ...values: string[]];
 
 /**
- * Options for configuring P2PK (Pay-to-Public-Key) locked proofs according to NUT-11.
+ * Shared NUT-11 lock tags, reused by P2PK (NUT-11) and HTLC (NUT-14).
+ *
+ * @remarks
+ * Every field is optional and maps onto an optional NUT-11 tag. `pubkeys` (additional / receiver
+ * keys) is _always_ optional (a keyless HTLC spends by preimage alone). The mandatory lock material
+ * lives in {@link SpendingConditionsBase.data}.
  */
-export type P2PKOptions = {
-  pubkey: string | string[];
+export type LockConditions = {
+  pubkeys?: string[];
   locktime?: number;
   refundKeys?: string[];
   requiredSignatures?: number;
@@ -48,8 +54,16 @@ export type P2PKOptions = {
   additionalTags?: P2PKTag[];
   blindKeys?: boolean; // default false
   sigFlag?: SigFlag;
-  hashlock?: string; // NUT-14 (HTLC)
 };
+
+/**
+ * A complete, persistable lock for the P2PK-based family.
+ *
+ * @remarks
+ * Comprises the NUT-10 {@link SpendingConditionsBase} envelope plus NUT-11 family
+ * {@link LockConditions} tags. `data` is a pubkey for `'P2PK'`, a hashlock for `'HTLC'`.
+ */
+export type P2PKOptions = SpendingConditionsBase & LockConditions & { kind: 'P2PK' | 'HTLC' };
 
 /**
  * Signature info for a single spending path (main or refund).
@@ -114,8 +128,8 @@ type WitnessData = {
 };
 
 /**
- * NUT-11 tag keys that map onto structured {@link P2PKOptions} fields, rather than being carried as
- * free-form `additionalTags`.
+ * NUT-11 tag keys that map onto structured {@link LockConditions} fields, rather than being carried
+ * as free-form `additionalTags`.
  *
  * @internal
  */
@@ -208,43 +222,52 @@ export function dedupeP2PKPubkeys(keys: string[]): string[] {
 }
 
 /**
- * Validate and normalize P2PK/HTLC output options.
+ * Validate and normalize a {@link P2PKOptions} into a canonical, deduplicated copy (not mutated).
  *
  * @remarks
- * Normalizes and deduplicates pubkeys, then enforces that requested signature thresholds are
- * satisfiable by the resulting key sets.
- *
- * External callers use {@link P2PKBuilder}: `P2PKBuilder.fromOptions(opts).toOptions()`
+ * Dedupes keys, defaults the signature threshold, and rejects unsatisfiable thresholds. External
+ * callers use `P2PKBuilder.fromOptions(p2pk).toOptions()`.
  * @internal
  */
 export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
-  const pubkeys = dedupeP2PKPubkeys(Array.isArray(p2pk.pubkey) ? p2pk.pubkey : [p2pk.pubkey]);
-  const refundKeys = dedupeP2PKPubkeys(p2pk.refundKeys ?? []);
-  // HTLC (NUT-14) locks the proof to a hashlock in Secret.data, so its pubkeys
-  // list is optional: with none, possession of the preimage alone spends. P2PK
-  // has no hashlock and so always needs at least one main key.
-  const isHTLC = typeof p2pk.hashlock === 'string' && p2pk.hashlock.length > 0;
-  if (pubkeys.length === 0 && !isHTLC) {
-    throw new CTSError('P2PK requires at least one pubkey');
+  const { kind } = p2pk;
+  if (kind !== 'P2PK' && kind !== 'HTLC') {
+    throw new CTSError(`Unknown lock kind: ${String(kind)}`);
   }
-  const totalKeys = pubkeys.length + refundKeys.length;
+  if (typeof p2pk.data !== 'string' || p2pk.data.length === 0) {
+    throw new CTSError(`${kind} requires a ${kind === 'HTLC' ? 'hashlock' : 'pubkey'} in data`);
+  }
+  const refundKeys = dedupeP2PKPubkeys(p2pk.refundKeys ?? []);
+
+  let data = p2pk.data;
+  let pubkeys: string[];
+  if (kind === 'P2PK') {
+    // data = primary pubkey, extras ride the pubkeys tag; dedupe both, data first.
+    const all = dedupeP2PKPubkeys([p2pk.data, ...(p2pk.pubkeys ?? [])]);
+    data = all[0];
+    pubkeys = all.slice(1);
+  } else {
+    // data is a hashlock, not a key; only the (optional) pubkeys tag carries signers.
+    pubkeys = dedupeP2PKPubkeys(p2pk.pubkeys ?? []);
+  }
+
+  // Signers: P2PK - data key + pubkeys; HTLC - data is a hash, so only pubkeys.
+  const signerCount = (kind === 'P2PK' ? 1 : 0) + pubkeys.length;
+  const totalKeys = signerCount + refundKeys.length;
   if (totalKeys > 10) {
     throw new CTSError(`Too many pubkeys, ${totalKeys} provided, maximum allowed is 10 in total`);
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
 
-  // With no main pubkeys (hashlock-only HTLC) there is no threshold to default,
-  // so skip the implicit `?? 1`. Pass through an *explicit* requiredSignatures
-  // though, so assertSpendingConditionRules rejects an impossible threshold
-  // (n_sigs with zero pubkeys) loudly rather than silently weakening the lock to
-  // preimage-only.
+  // No signers (keyless HTLC) => no default threshold, but pass an explicit one through
+  // so an impossible n_sigs is rejected below, not silently dropped to preimage-only.
   const requiredSignatures =
-    pubkeys.length > 0 ? (p2pk.requiredSignatures ?? 1) : p2pk.requiredSignatures;
+    signerCount > 0 ? (p2pk.requiredSignatures ?? 1) : p2pk.requiredSignatures;
   const requiredRefundSignatures = p2pk.requiredRefundSignatures;
 
   // Shared semantic validation
   assertSpendingConditionRules({
-    mainKeyCount: pubkeys.length,
+    mainKeyCount: signerCount,
     refundKeyCount: refundKeys.length,
     nSigs: requiredSignatures,
     nSigsRefund: requiredRefundSignatures,
@@ -252,17 +275,19 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   });
 
   return {
-    pubkey: pubkeys.length === 1 ? pubkeys[0] : pubkeys,
-    ...(p2pk.locktime !== undefined ? { locktime: p2pk.locktime } : {}),
-    ...(refundKeys.length > 0 ? { refundKeys } : {}),
+    kind,
+    data,
+    ...(pubkeys.length ? { pubkeys } : {}),
+    ...(refundKeys.length ? { refundKeys } : {}),
+    // Drop a redundant default threshold of 1 (1-of-N is implied); the builder does the same.
     ...(requiredSignatures !== undefined && requiredSignatures > 1 ? { requiredSignatures } : {}),
     ...(requiredRefundSignatures !== undefined && requiredRefundSignatures > 1
       ? { requiredRefundSignatures }
       : {}),
+    ...(p2pk.locktime !== undefined ? { locktime: p2pk.locktime } : {}),
     ...(p2pk.additionalTags?.length ? { additionalTags: p2pk.additionalTags } : {}),
     ...(p2pk.blindKeys ? { blindKeys: true } : {}),
     ...(p2pk.sigFlag !== undefined ? { sigFlag: p2pk.sigFlag } : {}),
-    ...(p2pk.hashlock ? { hashlock: p2pk.hashlock } : {}),
   };
 }
 

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -247,7 +247,13 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
     data = all[0];
     pubkeys = all.slice(1);
   } else {
-    // data is a hashlock, not a key; only the (optional) pubkeys tag carries signers.
+    // data is a hashlock (SHA-256), not a key; only the (optional) pubkeys tag carries
+    // signers. Enforce the 64-char hex shape and lowercase it so the stored hashlock
+    // byte-matches the lowercase output of createHTLCHash() / verifyHTLCHash().
+    if (!/^[0-9a-f]{64}$/i.test(data)) {
+      throw new CTSError('HTLC hashlock must be a 64-character hex string (SHA-256)');
+    }
+    data = data.toLowerCase();
     pubkeys = dedupeP2PKPubkeys(p2pk.pubkeys ?? []);
   }
 

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -269,21 +269,22 @@ export class OutputData implements OutputDataLike {
   static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData {
     const amountValue = Amount.from(amount);
     const normalized = normalizeP2PKOptions(p2pk);
-    const lockKeys = Array.isArray(normalized.pubkey) ? normalized.pubkey : [normalized.pubkey];
+    const isHTLC = normalized.kind === 'HTLC';
     const refundKeys = normalized.refundKeys ?? [];
     const reqLock = normalized.requiredSignatures ?? 1;
     const reqRefund = normalized.requiredRefundSignatures ?? 1;
 
-    // Init vars
-    const hashlock = normalized.hashlock;
-    const isHTLC = typeof hashlock === 'string' && hashlock.length > 0;
-    let data = isHTLC ? hashlock : lockKeys[0];
-    let pubkeys = isHTLC ? lockKeys : lockKeys.slice(1);
+    // Canonical layout: `data` is the NUT-10 data slot (a pubkey for P2PK, a hashlock
+    // for HTLC); `pubkeys` is the optional `pubkeys` tag content.
+    let data = normalized.data;
+    let pubkeys = normalized.pubkeys ?? [];
     let refund = refundKeys;
 
-    // Optional key blinding (P2BK)
+    // Optional key blinding (P2BK). Only signing keys are blinded: for P2PK the data
+    // key signs and is blinded too; for HTLC the data is a hash, so it stays in clear.
     let Ehex: string | undefined;
-    if (p2pk.blindKeys) {
+    if (normalized.blindKeys) {
+      const lockKeys = isHTLC ? pubkeys : [data, ...pubkeys];
       const ordered = [...lockKeys, ...refundKeys];
       const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered);
       if (isHTLC) {

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -118,13 +118,12 @@ export class PaymentRequest {
   }
 
   /**
-   * Converts this request's `nut10` locking option into the {@link P2PKOptions} accepted by the
-   * `.asP2PK()` builder, so a payer can produce proofs locked to exactly the spending condition the
-   * payee requested.
+   * Converts this request's `nut10` locking option into a {@link P2PKOptions} for the wallet's
+   * `.asP2PK()` gate, so a payer can lock proofs to exactly the condition the payee requested.
    *
-   * Supports `P2PK` (NUT-11) and `HTLC` (NUT-14) only. Returns `undefined` when there is no `nut10`
-   * option or its kind is not one we can build.
-   *
+   * @remarks
+   * Supports `P2PK` (NUT-11) and `HTLC` (NUT-14) only; returns `undefined` for no `nut10` or an
+   * unbuildable kind.
    * @throws If the option is missing its `data` field, or carries malformed NUT-10 tags — invalid
    *   lock semantics must not be silently dropped.
    */
@@ -145,11 +144,14 @@ export class PaymentRequest {
       nut10.kind,
       { nonce: '', data: nut10.data, tags: nut10.tags ?? [] },
     ]);
+    // `data` is the NUT-10 data slot (hashlock for HTLC, primary pubkey for P2PK);
+    // the `pubkeys` tag carries the optional additional / receiver keys for either kind.
     const taggedPubkeys = getTag(secret, 'pubkeys') ?? [];
-    const pubkeys = [nut10.data, ...taggedPubkeys];
-    const options: P2PKOptions = isHTLC
-      ? { hashlock: nut10.data, pubkey: taggedPubkeys }
-      : { pubkey: pubkeys.length === 1 ? pubkeys[0] : pubkeys };
+    const options: P2PKOptions = {
+      kind: isHTLC ? 'HTLC' : 'P2PK',
+      data: nut10.data,
+      ...(taggedPubkeys.length ? { pubkeys: taggedPubkeys } : {}),
+    };
 
     // Optional fields pass straight through: the accessors return undefined when
     // absent, and the builder ignores undefined options. getTag never yields [].

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -1,5 +1,6 @@
 import {
   dedupeP2PKPubkeys,
+  normalizeHashlock,
   type LockConditions,
   type P2PKTag,
   type SigFlag,
@@ -82,9 +83,14 @@ export class P2PKBuilder {
 
   /**
    * Converts a `P2PK` output into a NUT-14 `HTLC` kind output.
+   *
+   * @throws If the hashlock is not a 64-character hex string (SHA-256).
    */
   addHashlock(hashlock: string) {
-    this.hashlock = hashlock;
+    // Validate at the setter (like addLockPubkey) so a bad hashlock fails here, not
+    // silently: an empty/invalid value must never be mistaken for "no hashlock" and
+    // degrade the intended HTLC into a plain P2PK lock.
+    this.hashlock = normalizeHashlock(hashlock);
     return this;
   }
 
@@ -94,14 +100,15 @@ export class P2PKBuilder {
 
     // HTLC (NUT-14) locks to a hashlock, so lock pubkeys are optional there; a
     // plain P2PK always needs at least one.
-    if (locks.length === 0 && !this.hashlock) {
+    if (locks.length === 0 && this.hashlock === undefined) {
       throw new CTSError('At least one lock pubkey is required');
     }
 
     // The first lock key is the P2PK `data` slot; the rest ride the `pubkeys` tag.
     // For an HTLC the hashlock is the `data` slot, so every lock key is a `pubkeys`
-    // (receiver) key.
-    const tagPubkeys = this.hashlock ? locks : locks.slice(1);
+    // (receiver) key. Branch on set-ness, not truthiness: addHashlock already rejects
+    // empty/invalid values, so this only distinguishes "hashlock set" from "unset".
+    const tagPubkeys = this.hashlock !== undefined ? locks : locks.slice(1);
 
     const conditions: LockConditions = {
       ...(tagPubkeys.length ? { pubkeys: tagPubkeys } : {}),
@@ -120,9 +127,10 @@ export class P2PKBuilder {
       ...(this.sigFlag == 'SIG_ALL' ? { sigFlag: 'SIG_ALL' } : {}),
     };
 
-    const p2pk: P2PKOptions = this.hashlock
-      ? { kind: 'HTLC', data: this.hashlock, ...conditions }
-      : { kind: 'P2PK', data: locks[0], ...conditions };
+    const p2pk: P2PKOptions =
+      this.hashlock !== undefined
+        ? { kind: 'HTLC', data: this.hashlock, ...conditions }
+        : { kind: 'P2PK', data: locks[0], ...conditions };
 
     // Ensure the secret is valid (not too long etc); also validates options
     const smokeTest = OutputData.createSingleP2PKData(p2pk, 1, 'deedbeef');

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -1,4 +1,10 @@
-import { dedupeP2PKPubkeys, type P2PKOptions, type P2PKTag, type SigFlag } from '../crypto';
+import {
+  dedupeP2PKPubkeys,
+  type LockConditions,
+  type P2PKTag,
+  type SigFlag,
+  type P2PKOptions,
+} from '../crypto';
 import { CTSError } from '../model/Errors';
 import { assertValidTagKey, OutputData } from '../model/OutputData';
 
@@ -92,16 +98,17 @@ export class P2PKBuilder {
       throw new CTSError('At least one lock pubkey is required');
     }
 
-    const pubkey: string | string[] = locks.length === 1 ? locks[0] : locks;
+    // The first lock key is the P2PK `data` slot; the rest ride the `pubkeys` tag.
+    // For an HTLC the hashlock is the `data` slot, so every lock key is a `pubkeys`
+    // (receiver) key.
+    const tagPubkeys = this.hashlock ? locks : locks.slice(1);
 
-    const p2pk: P2PKOptions = {
-      pubkey,
+    const conditions: LockConditions = {
+      ...(tagPubkeys.length ? { pubkeys: tagPubkeys } : {}),
       ...(this.locktime !== undefined ? { locktime: this.locktime } : {}),
       ...(refunds.length ? { refundKeys: refunds } : {}),
-      // Drop a redundant default threshold of 1 (1-of-N is implied), but pass an
-      // explicit threshold through when its key set is empty — a keyless HTLC with
-      // n_sigs, or n_sigs_refund with no refund keys, is contradictory and must be
-      // rejected by the smoke test below, not silently weakened to preimage-only.
+      // Drop a redundant default of 1, but keep an explicit threshold when its key set is
+      // empty (keyless HTLC / no refund keys) so the smoke test rejects the impossible lock.
       ...(this.nSigs !== undefined && (this.nSigs > 1 || locks.length === 0)
         ? { requiredSignatures: this.nSigs }
         : {}),
@@ -111,8 +118,11 @@ export class P2PKBuilder {
       ...(this.extraTags.length ? { additionalTags: this.extraTags.slice() } : {}),
       ...(this._blindKeys ? { blindKeys: true } : {}),
       ...(this.sigFlag == 'SIG_ALL' ? { sigFlag: 'SIG_ALL' } : {}),
-      ...(this.hashlock ? { hashlock: this.hashlock } : {}),
     };
+
+    const p2pk: P2PKOptions = this.hashlock
+      ? { kind: 'HTLC', data: this.hashlock, ...conditions }
+      : { kind: 'P2PK', data: locks[0], ...conditions };
 
     // Ensure the secret is valid (not too long etc); also validates options
     const smokeTest = OutputData.createSingleP2PKData(p2pk, 1, 'deedbeef');
@@ -121,19 +131,22 @@ export class P2PKBuilder {
     return p2pk;
   }
 
-  static fromOptions(opts: P2PKOptions): P2PKBuilder {
+  static fromOptions(p2pk: P2PKOptions): P2PKBuilder {
     const b = new P2PKBuilder();
-    const locks = Array.isArray(opts.pubkey) ? opts.pubkey : [opts.pubkey];
-    b.addLockPubkey(locks);
-    if (opts.locktime !== undefined) b.lockUntil(opts.locktime);
-    if (opts.refundKeys?.length) b.addRefundPubkey(opts.refundKeys);
-    if (opts.requiredSignatures !== undefined) b.requireLockSignatures(opts.requiredSignatures);
-    if (opts.requiredRefundSignatures !== undefined)
-      b.requireRefundSignatures(opts.requiredRefundSignatures);
-    if (opts.additionalTags?.length) b.addTags(opts.additionalTags);
-    if (opts.blindKeys) b.blindKeys();
-    if (opts.sigFlag == 'SIG_ALL') b.sigAll();
-    if (opts.hashlock) b.addHashlock(opts.hashlock);
+    if (p2pk.kind === 'HTLC') {
+      b.addHashlock(p2pk.data);
+      if (p2pk.pubkeys?.length) b.addLockPubkey(p2pk.pubkeys);
+    } else {
+      b.addLockPubkey([p2pk.data, ...(p2pk.pubkeys ?? [])]);
+    }
+    if (p2pk.locktime !== undefined) b.lockUntil(p2pk.locktime);
+    if (p2pk.refundKeys?.length) b.addRefundPubkey(p2pk.refundKeys);
+    if (p2pk.requiredSignatures !== undefined) b.requireLockSignatures(p2pk.requiredSignatures);
+    if (p2pk.requiredRefundSignatures !== undefined)
+      b.requireRefundSignatures(p2pk.requiredRefundSignatures);
+    if (p2pk.additionalTags?.length) b.addTags(p2pk.additionalTags);
+    if (p2pk.blindKeys) b.blindKeys();
+    if (p2pk.sigFlag == 'SIG_ALL') b.sigAll();
     return b;
   }
 }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1120,7 +1120,7 @@ class Wallet {
    *
    * // With Custom output configuration
    * const customConfig: OutputConfig = {
-   *   send: { type: 'p2pk', options: { pubkey: '...' } },
+   *   send: { type: 'p2pk', options: { kind: 'P2PK', data: '...' } },
    *   keep: { type: 'deterministic', counter: 0 },
    * };
    * const customResult = await wallet.send(5, proofs, { includeFees: true }, customConfig);

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -135,13 +135,14 @@ export class SendBuilder {
   }
 
   /**
-   * Use P2PK locked outputs for the sent proofs.
+   * Lock the sent proofs to a NUT-11 P2PK / NUT-14 HTLC spending condition.
    *
-   * @param options NUT 11 options like pubkey and locktime.
+   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
+   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
-    this.sendOT = { type: 'p2pk', options, denominations: denoms };
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    this.sendOT = { type: 'p2pk', options: p2pk, denominations: denoms };
     return this;
   }
 
@@ -189,13 +190,13 @@ export class SendBuilder {
   }
 
   /**
-   * Use P2PK locked change (NUT 11).
+   * Lock the change to a NUT-11 P2PK / NUT-14 HTLC spending condition.
    *
-   * @param options Locking options applied to the kept proofs.
+   * @param p2pk A complete {@link P2PKOptions} whose `kind` selects P2PK vs HTLC.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  keepAsP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
-    this.keepOT = { type: 'p2pk', options, denominations: denoms };
+  keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    this.keepOT = { type: 'p2pk', options: p2pk, denominations: denoms };
     return this;
   }
 
@@ -408,15 +409,16 @@ export class ReceiveBuilder {
   }
 
   /**
-   * Use P2PK locked outputs for the received proofs.
+   * Lock the received proofs to a NUT-11 P2PK / NUT-14 HTLC spending condition.
    *
    * @remarks
-   * If denoms specified, proofsWeHave() will have no effect.
-   * @param options NUT 11 options like pubkey and locktime.
+   * If `denoms` is specified, `proofsWeHave()` has no effect.
+   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
+   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
-    this.outputType = { type: 'p2pk', options, denominations: denoms };
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    this.outputType = { type: 'p2pk', options: p2pk, denominations: denoms };
     return this;
   }
 
@@ -581,15 +583,16 @@ export class MintBuilder<
   }
 
   /**
-   * Use P2PK locked outputs for the minted proofs.
+   * Lock the minted proofs to a NUT-11 P2PK / NUT-14 HTLC spending condition.
    *
    * @remarks
-   * If denoms specified, proofsWeHave() will have no effect.
-   * @param options NUT 11 options like pubkey and locktime.
+   * If `denoms` is specified, `proofsWeHave()` has no effect.
+   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
+   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
-    this.outputType = { type: 'p2pk', options, denominations: denoms };
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    this.outputType = { type: 'p2pk', options: p2pk, denominations: denoms };
     return this;
   }
 
@@ -801,13 +804,14 @@ export class MeltBuilder<
   }
 
   /**
-   * Use P2PK-locked change (NUT-11).
+   * Lock the change to a NUT-11 P2PK / NUT-14 HTLC spending condition.
    *
-   * @param options NUT-11 locking options (e.g., pubkey, locktime).
+   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
+   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
-    this.outputType = { type: 'p2pk', options, denominations: denoms };
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    this.outputType = { type: 'p2pk', options: p2pk, denominations: denoms };
     return this;
   }
 

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -54,7 +54,7 @@ export type OutputType =
     } & SharedOutputTypeProps)
   | ({
       /**
-       * Pay-to-public-key (P2PK) outputs.
+       * P2PK (NUT-11) or HTLC (NUT-14) locked outputs.
        *
        * @see P2PKOptions
        */

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1402,6 +1402,27 @@ describe('normalizeP2PKOptions', () => {
   const refundPk = _comp('b', '02');
   const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
 
+  test('throws on an unknown lock kind', () => {
+    expect(() => normalizeP2PKOptions({ kind: 'FOO', data: pk } as any)).toThrow(
+      /unknown lock kind: FOO/i,
+    );
+  });
+
+  test('throws when P2PK data is missing or empty', () => {
+    expect(() => normalizeP2PKOptions({ kind: 'P2PK', data: '' })).toThrow(
+      /P2PK requires a pubkey in data/i,
+    );
+    expect(() => normalizeP2PKOptions({ kind: 'P2PK', data: undefined } as any)).toThrow(
+      /P2PK requires a pubkey in data/i,
+    );
+  });
+
+  test('throws when HTLC data is empty', () => {
+    expect(() => normalizeP2PKOptions({ kind: 'HTLC', data: '' })).toThrow(
+      /HTLC requires a hashlock in data/i,
+    );
+  });
+
   test('splits a P2PK lock into canonical data slot + pubkeys tag', () => {
     // `data` is the NUT-10 data slot; extra keys ride the `pubkeys` tag. Empty key
     // sets are dropped from the canonical result.

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1398,65 +1398,77 @@ const _comp = (ch: string, prefix: '02' | '03' = '02') => `${prefix}${ch.repeat(
 
 describe('normalizeP2PKOptions', () => {
   const pk = _comp('a', '02');
+  const pk2 = _comp('c', '02');
   const refundPk = _comp('b', '02');
+  const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
 
-  test('throws when pubkey is an empty array', () => {
-    expect(() => normalizeP2PKOptions({ pubkey: [] as any })).toThrow(
-      /P2PK requires at least one pubkey/i,
-    );
+  test('splits a P2PK lock into canonical data slot + pubkeys tag', () => {
+    // `data` is the NUT-10 data slot; extra keys ride the `pubkeys` tag. Empty key
+    // sets are dropped from the canonical result.
+    expect(
+      normalizeP2PKOptions({ kind: 'P2PK', data: pk, pubkeys: [pk2], requiredSignatures: 2 }),
+    ).toEqual({
+      kind: 'P2PK',
+      data: pk,
+      pubkeys: [pk2],
+      requiredSignatures: 2,
+    });
   });
 
-  test('allows an empty pubkey array for a hashlock-only HTLC (NUT-14)', () => {
+  test('allows a hashlock-only HTLC with no pubkeys (NUT-14)', () => {
     // An HTLC carries its lock in the hashlock, so a pubkeys list is optional.
-    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
-    const normalized = normalizeP2PKOptions({ pubkey: [], hashlock });
-    expect(normalized).toEqual({ pubkey: [], hashlock });
+    expect(normalizeP2PKOptions({ kind: 'HTLC', data: hashlock })).toEqual({
+      kind: 'HTLC',
+      data: hashlock,
+    });
   });
 
-  test('rejects an explicit n_sigs on a hashlock-only HTLC (no pubkeys to sign)', () => {
+  test('rejects an explicit n_sigs on a hashlock-only HTLC (no signers)', () => {
     // Skipping the *default* n_sigs is fine, but an explicit threshold with zero
-    // pubkeys is impossible and must fail loudly, not silently weaken the lock.
-    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
-    expect(() => normalizeP2PKOptions({ pubkey: [], hashlock, requiredSignatures: 2 })).toThrow(
-      /exceeds available pubkeys/i,
-    );
-    expect(() => normalizeP2PKOptions({ pubkey: [], hashlock, requiredSignatures: 0 })).toThrow(
-      /positive integer/i,
-    );
+    // signers is impossible and must fail loudly, not silently weaken the lock.
+    expect(() =>
+      normalizeP2PKOptions({ kind: 'HTLC', data: hashlock, requiredSignatures: 2 }),
+    ).toThrow(/exceeds available pubkeys/i);
+    expect(() =>
+      normalizeP2PKOptions({ kind: 'HTLC', data: hashlock, requiredSignatures: 0 }),
+    ).toThrow(/positive integer/i);
   });
 
-  test('throws when pubkey contains an empty string', () => {
-    expect(() => normalizeP2PKOptions({ pubkey: [pk, ''] })).toThrow(/invalid pubkey/i);
+  test('throws when a pubkeys-tag entry is an empty string', () => {
+    expect(() => normalizeP2PKOptions({ kind: 'P2PK', data: pk, pubkeys: [''] })).toThrow(
+      /invalid pubkey/i,
+    );
   });
 
   test('throws when refundKeys contains an empty string', () => {
     expect(() =>
-      normalizeP2PKOptions({ pubkey: pk, locktime: 9999, refundKeys: [refundPk, ''] }),
+      normalizeP2PKOptions({ kind: 'P2PK', data: pk, locktime: 9999, refundKeys: [refundPk, ''] }),
     ).toThrow(/invalid pubkey/i);
   });
 
   test('throws when requiredSignatures is not an integer', () => {
-    expect(() => normalizeP2PKOptions({ pubkey: pk, requiredSignatures: 1.5 })).toThrow(
+    expect(() => normalizeP2PKOptions({ kind: 'P2PK', data: pk, requiredSignatures: 1.5 })).toThrow(
       /requiredSignatures \(n_sigs\) must be a positive integer/i,
     );
   });
 
   test('throws when requiredSignatures is less than 1', () => {
-    expect(() => normalizeP2PKOptions({ pubkey: pk, requiredSignatures: 0 })).toThrow(
+    expect(() => normalizeP2PKOptions({ kind: 'P2PK', data: pk, requiredSignatures: 0 })).toThrow(
       /requiredSignatures \(n_sigs\) must be a positive integer/i,
     );
   });
 
   test('throws when requiredRefundSignatures is set without refundKeys', () => {
     expect(() =>
-      normalizeP2PKOptions({ pubkey: pk, locktime: 9999, requiredRefundSignatures: 1 }),
+      normalizeP2PKOptions({ kind: 'P2PK', data: pk, locktime: 9999, requiredRefundSignatures: 1 }),
     ).toThrow(/requiredRefundSignatures \(n_sigs_refund\) requires refund keys/i);
   });
 
   test('throws when requiredRefundSignatures is not an integer', () => {
     expect(() =>
       normalizeP2PKOptions({
-        pubkey: pk,
+        kind: 'P2PK',
+        data: pk,
         locktime: 9999,
         refundKeys: [refundPk],
         requiredRefundSignatures: 1.5,
@@ -1467,7 +1479,8 @@ describe('normalizeP2PKOptions', () => {
   test('throws when requiredRefundSignatures is less than 1', () => {
     expect(() =>
       normalizeP2PKOptions({
-        pubkey: pk,
+        kind: 'P2PK',
+        data: pk,
         locktime: 9999,
         refundKeys: [refundPk],
         requiredRefundSignatures: 0,
@@ -1476,9 +1489,9 @@ describe('normalizeP2PKOptions', () => {
   });
 
   test('throws when sigFlag is not a valid SigFlag value', () => {
-    expect(() => normalizeP2PKOptions({ pubkey: pk, sigFlag: 'FOOBAR' as any })).toThrow(
-      /invalid sigflag/i,
-    );
+    expect(() =>
+      normalizeP2PKOptions({ kind: 'P2PK', data: pk, sigFlag: 'FOOBAR' as any }),
+    ).toThrow(/invalid sigflag/i);
   });
 });
 

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1423,6 +1423,31 @@ describe('normalizeP2PKOptions', () => {
     );
   });
 
+  test('throws when HTLC hashlock is not 64-char hex', () => {
+    // A malformed hashlock yields an unspendable lock (no preimage can hash to it),
+    // so reject it at construction rather than minting a dead token.
+    expect(() => normalizeP2PKOptions({ kind: 'HTLC', data: 'invalid_hashlock' })).toThrow(
+      /HTLC hashlock must be a 64-character hex string/i,
+    );
+    // Right length, non-hex char.
+    expect(() => normalizeP2PKOptions({ kind: 'HTLC', data: 'z'.repeat(64) })).toThrow(
+      /HTLC hashlock must be a 64-character hex string/i,
+    );
+    // Valid hex, wrong length (32 bytes expected).
+    expect(() => normalizeP2PKOptions({ kind: 'HTLC', data: 'ab'.repeat(20) })).toThrow(
+      /HTLC hashlock must be a 64-character hex string/i,
+    );
+  });
+
+  test('lowercases the HTLC hashlock so it matches createHTLCHash output', () => {
+    // verifyHTLCHash compares against lowercase bytesToHex(sha256(preimage)); an
+    // uppercase hashlock passes the hex check but must be canonicalised to match.
+    expect(normalizeP2PKOptions({ kind: 'HTLC', data: hashlock.toUpperCase() })).toEqual({
+      kind: 'HTLC',
+      data: hashlock,
+    });
+  });
+
   test('splits a P2PK lock into canonical data slot + pubkeys tag', () => {
     // `data` is the NUT-10 data slot; extra keys ride the `pubkeys` tag. Empty key
     // sets are dropped from the canonical result.

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -334,7 +334,10 @@ describe('mint api', () => {
     await untilMintQuotePaid(wallet, request);
     const mintedProofs = await wallet.mintProofsBolt11(128, request.quote);
     // Send them P2PK locked to Bob
-    const { send } = await wallet.ops.send(64, mintedProofs).asP2PK({ pubkey: pubKeyBob }).run();
+    const { send } = await wallet.ops
+      .send(64, mintedProofs)
+      .asP2PK({ kind: 'P2PK', data: pubKeyBob })
+      .run();
     expectNUT10SecretDataToEqual(send, pubKeyBob);
     const encoded = getEncodedToken({ mint: mintUrl, proofs: send });
     // Try and receive them with Alice's secret key (should fail)
@@ -496,7 +499,8 @@ describe('mint api', () => {
     const proofs = await wallet.ops
       .mintBolt11(3000, mintRequest.quote)
       .asP2PK({
-        pubkey: bytesToHex(pubKeyBob),
+        kind: 'P2PK',
+        data: bytesToHex(pubKeyBob),
       })
       .run();
     const meltRequest = await wallet.createMeltQuoteBolt11(invoice);
@@ -519,7 +523,8 @@ describe('mint api', () => {
     const preview = await wallet.ops
       .mintBolt11(50, mintRequest.quote)
       .asP2PK({
-        pubkey: bytesToHex(pubKeyBob),
+        kind: 'P2PK',
+        data: bytesToHex(pubKeyBob),
         sigFlag: 'SIG_ALL',
       })
       .prepare();
@@ -819,7 +824,7 @@ describe('Custom Outputs', () => {
   test('Default keepFactory', async () => {
     // First we create a keep factory, this is a function that will be used to construct all outputs that we "keep"
     function p2pkFactory(a: AmountLike, k: HasKeysetKeys) {
-      return OutputData.createSingleP2PKData({ pubkey: hexPk }, a, k.id);
+      return OutputData.createSingleP2PKData({ kind: 'P2PK', data: hexPk }, a, k.id);
     }
     const keepFactory: OutputType = { type: 'factory', factory: p2pkFactory };
     // We then construct and load the wallet
@@ -866,7 +871,7 @@ describe('Custom Outputs', () => {
     const testPk = '02' + 'ab'.repeat(32);
     const newFactory: OutputType = {
       type: 'factory',
-      factory: (a, k) => OutputData.createSingleP2PKData({ pubkey: testPk }, a, k.id),
+      factory: (a, k) => OutputData.createSingleP2PKData({ kind: 'P2PK', data: testPk }, a, k.id),
     };
     const newProofs = await wallet.receive(
       { proofs: unlockedProofs.send, mint: mintUrl, unit: wallet.unit },
@@ -879,7 +884,7 @@ describe('Custom Outputs', () => {
   test('Manual Factory Mint', async () => {
     function createFactory(pubkey: string): OutputDataFactory {
       function inner(a: AmountLike, k: HasKeysetKeys) {
-        return OutputData.createSingleP2PKData({ pubkey: pubkey }, a, k.id);
+        return OutputData.createSingleP2PKData({ kind: 'P2PK', data: pubkey }, a, k.id);
       }
       return inner;
     }
@@ -895,7 +900,7 @@ describe('Custom Outputs', () => {
   test('Manual Factory Send', async () => {
     function createFactory(pubkey: string): OutputDataFactory {
       function inner(a: AmountLike, k: HasKeysetKeys) {
-        return OutputData.createSingleP2PKData({ pubkey }, a, k.id);
+        return OutputData.createSingleP2PKData({ kind: 'P2PK', data: pubkey }, a, k.id);
       }
       return inner;
     }
@@ -928,8 +933,8 @@ describe('Custom Outputs', () => {
     const proofs = await wallet.mintProofsBolt11(40, quote.quote);
     const pk1 = '02' + 'aa'.repeat(32);
     const pk2 = '02' + 'bb'.repeat(32);
-    const data1 = OutputData.createP2PKData({ pubkey: pk1 }, 10, keys);
-    const data2 = OutputData.createP2PKData({ pubkey: pk2 }, 10, keys);
+    const data1 = OutputData.createP2PKData({ kind: 'P2PK', data: pk1 }, 10, keys);
+    const data2 = OutputData.createP2PKData({ kind: 'P2PK', data: pk2 }, 10, keys);
     const customConfig: OutputConfig = {
       keep: wallet.defaultOutputType(),
       send: { type: 'custom', data: [...data1, ...data2] },

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -103,7 +103,8 @@ describe('OutputData helpers', () => {
     const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
     const output = OutputData.createSingleP2PKData(
       {
-        pubkey,
+        kind: 'P2PK',
+        data: pubkey,
         blindKeys: true,
       },
       1,
@@ -120,8 +121,9 @@ describe('OutputData helpers', () => {
     const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
     const output = OutputData.createSingleP2PKData(
       {
-        pubkey,
-        hashlock: 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5',
+        kind: 'HTLC',
+        data: 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5',
+        pubkeys: [pubkey],
         blindKeys: true,
       },
       1,

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -4,6 +4,8 @@ import { P2PKBuilder, type P2PKOptions } from '../../src/';
 // helpers to make valid hex keys
 const xonly = (ch: string) => ch.repeat(64); // 32-byte X-only
 const comp = (ch: string, prefix: '02' | '03' = '02') => `${prefix}${ch.repeat(64)}`;
+// a valid 64-char hex hashlock (SHA-256 output shape)
+const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
 
 describe('P2PKBuilder.toOptions()', () => {
   it('returns single lock key as a string', () => {
@@ -159,13 +161,13 @@ describe('P2PKBuilder.toOptions()', () => {
     // surface, not be dropped into a spendable preimage-only lock. n_sigs>1 already
     // survives the filter; n_sigs=1 is the value that previously slipped through.
     expect(() =>
-      new P2PKBuilder().addHashlock('deadbeef').requireLockSignatures(1).toOptions(),
+      new P2PKBuilder().addHashlock(hashlock).requireLockSignatures(1).toOptions(),
     ).toThrow(/exceeds available pubkeys/i);
     expect(() =>
-      new P2PKBuilder().addHashlock('deadbeef').requireLockSignatures(2).toOptions(),
+      new P2PKBuilder().addHashlock(hashlock).requireLockSignatures(2).toOptions(),
     ).toThrow(/exceeds available pubkeys/i);
     // No explicit threshold => keyless HTLC builds fine.
-    const ok = new P2PKBuilder().addHashlock('deadbeef').toOptions();
+    const ok = new P2PKBuilder().addHashlock(hashlock).toOptions();
     expect('requiredSignatures' in ok).toBe(false);
   });
 
@@ -198,7 +200,7 @@ describe('P2PKBuilder.toOptions()', () => {
       .requireLockSignatures(2)
       .requireRefundSignatures(1)
       .sigAll()
-      .addHashlock('foo')
+      .addHashlock(hashlock)
       .toOptions();
 
     const rebuilt = P2PKBuilder.fromOptions(original).toOptions();
@@ -206,7 +208,7 @@ describe('P2PKBuilder.toOptions()', () => {
   });
 
   it('round-trips a keyless HTLC via fromOptions (no pubkeys)', () => {
-    const lock = { kind: 'HTLC', data: 'deadbeef' } as const;
+    const lock = { kind: 'HTLC', data: hashlock } as const;
     expect(P2PKBuilder.fromOptions(lock).toOptions()).toEqual(lock);
   });
 

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -8,19 +8,20 @@ const comp = (ch: string, prefix: '02' | '03' = '02') => `${prefix}${ch.repeat(6
 describe('P2PKBuilder.toOptions()', () => {
   it('returns single lock key as a string', () => {
     const opts = new P2PKBuilder().addLockPubkey(comp('a', '02')).toOptions();
-    expect(typeof opts.pubkey).toBe('string');
-    expect(opts.pubkey).toBe(comp('a', '02'));
+    expect(typeof opts.data).toBe('string');
+    expect(opts.data).toBe(comp('a', '02'));
   });
 
-  it('returns multiple lock keys as an array and preserves insertion order', () => {
+  it('splits multiple lock keys into a single data key + pubkeys tag, preserving order', () => {
     const k1 = comp('a', '02');
     const k2 = comp('b', '03');
     const k3 = comp('c', '02');
 
     const opts = new P2PKBuilder().addLockPubkey([k1, k2]).addLockPubkey(k3).toOptions();
 
-    expect(Array.isArray(opts.pubkey)).toBe(true);
-    expect(opts.pubkey).toEqual([k1, k2, k3]);
+    // First key is the NUT-10 data slot; the rest ride the optional pubkeys tag.
+    expect(opts.data).toBe(k1);
+    expect(opts.pubkeys).toEqual([k2, k3]);
   });
 
   it('normalizes x-only lock keys to 02-prefixed compressed', () => {
@@ -28,7 +29,7 @@ describe('P2PKBuilder.toOptions()', () => {
     const expected = comp('1', '02'); // normalized
 
     const opts = new P2PKBuilder().addLockPubkey(x).toOptions();
-    expect(opts.pubkey).toBe(expected);
+    expect(opts.data).toBe(expected);
   });
 
   it('normalizes x-only refund keys to 02-prefixed compressed', () => {
@@ -54,8 +55,9 @@ describe('P2PKBuilder.toOptions()', () => {
       .addRefundPubkey([kA, kA, kB])
       .toOptions();
 
-    // pubkey is array because >1
-    expect(opts.pubkey).toEqual([kA, kB]);
+    // data slot holds the first key; the deduped remainder rides the pubkeys tag.
+    expect(opts.data).toBe(kA);
+    expect(opts.pubkeys).toEqual([kB]);
     expect(opts.refundKeys).toEqual([kA, kB]);
   });
 
@@ -204,7 +206,7 @@ describe('P2PKBuilder.toOptions()', () => {
   });
 
   it('fromOptions with minimal shape leaves required* undefined', () => {
-    const minimal = { pubkey: '02' + 'b'.repeat(64) } as const;
+    const minimal = { kind: 'P2PK', data: '02' + 'b'.repeat(64) } as const;
     const round = P2PKBuilder.fromOptions(minimal).toOptions();
     expect(round).toEqual(minimal); // no extra props added
     expect('requiredSignatures' in round).toBe(false);
@@ -221,7 +223,8 @@ describe('P2PKBuilder.toOptions()', () => {
     const now = Math.floor(Date.now() / 1000) + 300;
 
     const src = {
-      pubkey: lock,
+      kind: 'P2PK',
+      data: lock,
       locktime: now,
       refundKeys: [r1, r2] as string[],
       requiredRefundSignatures: 2,
@@ -259,11 +262,11 @@ describe('P2PKBuilder, simple fuzzish case', () => {
       .sigAll()
       .toOptions();
 
-    const expLocks = ['02' + 'a'.repeat(64), '02' + 'b'.repeat(64)];
     const expRefunds = ['03' + 'c'.repeat(64)];
 
-    expect(Array.isArray(opts.pubkey)).toBe(true);
-    expect(opts.pubkey).toEqual(expLocks);
+    // Two unique lock keys: first is the data slot, second rides the pubkeys tag.
+    expect(opts.data).toBe('02' + 'a'.repeat(64));
+    expect(opts.pubkeys).toEqual(['02' + 'b'.repeat(64)]);
     expect(opts.refundKeys).toEqual(expRefunds);
     expect(opts.locktime).toBe(ms / 1000);
     expect(opts.sigFlag).toEqual('SIG_ALL');
@@ -377,7 +380,8 @@ describe('P2PKBuilder addTag and addTags', () => {
 
   it('fromOptions accepts options with additionalTags only and leaves shape untouched', () => {
     const minimalWithTags: P2PKOptions = {
-      pubkey: comp('a', '02'),
+      kind: 'P2PK',
+      data: comp('a', '02'),
       additionalTags: [['x'], ['y', '1'], ['z', 'a', 'b']],
     };
 

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -155,6 +155,26 @@ describe('P2PKBuilder.toOptions()', () => {
     expect('requiredRefundSignatures' in o2).toBe(false);
   });
 
+  it('rejects an empty or malformed hashlock at addHashlock, not silently', () => {
+    // An empty hashlock must NOT be treated as "no hashlock" and degrade the intended
+    // HTLC into a plain P2PK lock (spendable with a signature, no preimage).
+    expect(() => new P2PKBuilder().addHashlock('')).toThrow(
+      /HTLC hashlock must be a 64-character hex string/i,
+    );
+    expect(() => new P2PKBuilder().addHashlock('not-a-hash')).toThrow(
+      /HTLC hashlock must be a 64-character hex string/i,
+    );
+    // Regression: empty hashlock + a lock key previously yielded { kind: 'P2PK' }.
+    expect(() =>
+      new P2PKBuilder().addHashlock('').addLockPubkey(comp('a', '02')).toOptions(),
+    ).toThrow(/HTLC hashlock must be a 64-character hex string/i);
+  });
+
+  it('lowercases the hashlock so it matches createHTLCHash output', () => {
+    const opts = new P2PKBuilder().addHashlock(hashlock.toUpperCase()).toOptions();
+    expect(opts).toEqual({ kind: 'HTLC', data: hashlock });
+  });
+
   it('rejects an explicit n_sigs on a keyless HTLC (no lock keys to sign)', () => {
     // The <=1 omission above is a redundant default *when keys back it*. With zero
     // lock keys (hashlock-only HTLC) an explicit n_sigs=1 is contradictory and must

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -205,6 +205,11 @@ describe('P2PKBuilder.toOptions()', () => {
     expect(rebuilt).toEqual(original);
   });
 
+  it('round-trips a keyless HTLC via fromOptions (no pubkeys)', () => {
+    const lock = { kind: 'HTLC', data: 'deadbeef' } as const;
+    expect(P2PKBuilder.fromOptions(lock).toOptions()).toEqual(lock);
+  });
+
   it('fromOptions with minimal shape leaves required* undefined', () => {
     const minimal = { kind: 'P2PK', data: '02' + 'b'.repeat(64) } as const;
     const round = P2PKBuilder.fromOptions(minimal).toOptions();

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -376,16 +376,20 @@ describe('WalletOps builders', () => {
     it('supports sendP2PK and keepP2PK OutputTypes', async () => {
       await ops
         .send(7, proofs)
-        .asP2PK({ pubkey: 'pub', locktime: 123 }, [7])
-        .keepAsP2PK({ pubkey: ['a', 'b'], requiredSignatures: 2 }, [])
+        .asP2PK({ kind: 'P2PK', data: 'pub', locktime: 123 }, [7])
+        .keepAsP2PK({ kind: 'P2PK', data: 'a', pubkeys: ['b'], requiredSignatures: 2 }, [])
         .run();
 
       const [, , , outputConfig] = wallet.send.mock.calls[0];
       expect(outputConfig).toEqual({
-        send: { type: 'p2pk', options: { pubkey: 'pub', locktime: 123 }, denominations: [7] },
+        send: {
+          type: 'p2pk',
+          options: { kind: 'P2PK', data: 'pub', locktime: 123 },
+          denominations: [7],
+        },
         keep: {
           type: 'p2pk',
-          options: { pubkey: ['a', 'b'], requiredSignatures: 2 },
+          options: { kind: 'P2PK', data: 'a', pubkeys: ['b'], requiredSignatures: 2 },
           denominations: [],
         },
       });
@@ -402,16 +406,20 @@ describe('WalletOps builders', () => {
     it('supports prepareSwapToSend', async () => {
       await ops
         .send(7, proofs)
-        .asP2PK({ pubkey: 'pub', locktime: 123 }, [7])
-        .keepAsP2PK({ pubkey: ['a', 'b'], requiredSignatures: 2 }, [])
+        .asP2PK({ kind: 'P2PK', data: 'pub', locktime: 123 }, [7])
+        .keepAsP2PK({ kind: 'P2PK', data: 'a', pubkeys: ['b'], requiredSignatures: 2 }, [])
         .prepare();
 
       const [, , , outputConfig] = wallet.prepareSwapToSend.mock.calls[0];
       expect(outputConfig).toEqual({
-        send: { type: 'p2pk', options: { pubkey: 'pub', locktime: 123 }, denominations: [7] },
+        send: {
+          type: 'p2pk',
+          options: { kind: 'P2PK', data: 'pub', locktime: 123 },
+          denominations: [7],
+        },
         keep: {
           type: 'p2pk',
-          options: { pubkey: ['a', 'b'], requiredSignatures: 2 },
+          options: { kind: 'P2PK', data: 'a', pubkeys: ['b'], requiredSignatures: 2 },
           denominations: [],
         },
       });
@@ -547,12 +555,12 @@ describe('WalletOps builders', () => {
     });
 
     it('p2pk() OutputType for receive', async () => {
-      await ops.receive(token).asP2PK({ pubkey: 'PUB', locktime: 42 }, [7]).run();
+      await ops.receive(token).asP2PK({ kind: 'P2PK', data: 'PUB', locktime: 42 }, [7]).run();
 
       const [, , outputType] = wallet.receive.mock.calls[0];
       expect(outputType).toEqual({
         type: 'p2pk',
-        options: { pubkey: 'PUB', locktime: 42 },
+        options: { kind: 'P2PK', data: 'PUB', locktime: 42 },
         denominations: [7],
       });
     });
@@ -599,7 +607,7 @@ describe('WalletOps builders', () => {
     it('calls wallet.prepareMint with custom OutputType and config', async () => {
       await ops
         .mintBolt11(10, quote)
-        .asP2PK({ pubkey: 'P' }, [10])
+        .asP2PK({ kind: 'P2PK', data: 'P' }, [10])
         .privkey('sk')
         .onCountersReserved(() => {})
         .prepare();
@@ -611,7 +619,11 @@ describe('WalletOps builders', () => {
       expect(Amount.from(amount).equals(10)).toBeTruthy();
       // MintBuilder resolves string quote IDs via checkMintQuoteBolt11 before calling prepareMint
       expect(q.quote).toBe(quote);
-      expect(outputType).toEqual({ type: 'p2pk', options: { pubkey: 'P' }, denominations: [10] });
+      expect(outputType).toEqual({
+        type: 'p2pk',
+        options: { kind: 'P2PK', data: 'P' },
+        denominations: [10],
+      });
 
       expect(config).toBeDefined();
       const cfg = config!;
@@ -933,7 +945,10 @@ describe('WalletOps builders', () => {
     });
 
     it('bolt11: supports P2PK OutputType', async () => {
-      await ops.meltBolt11(melt11, proofs).asP2PK({ pubkey: 'X', locktime: 99 }, []).run();
+      await ops
+        .meltBolt11(melt11, proofs)
+        .asP2PK({ kind: 'P2PK', data: 'X', locktime: 99 }, [])
+        .run();
 
       expect(wallet.prepareMelt).toHaveBeenCalledTimes(1);
       expect(wallet.completeMelt).toHaveBeenCalledTimes(1);
@@ -941,7 +956,7 @@ describe('WalletOps builders', () => {
       const [, , , , ot] = wallet.prepareMelt.mock.calls[0];
       expect(ot).toEqual({
         type: 'p2pk',
-        options: { pubkey: 'X', locktime: 99 },
+        options: { kind: 'P2PK', data: 'X', locktime: 99 },
         denominations: [],
       });
     });

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -71,13 +71,13 @@ describe('stringifyOutputTypeForLog', () => {
   test('formats p2pk denominations as strings', () => {
     const result = stringifyOutputTypeForLog({
       type: 'p2pk',
-      options: { pubkey: '02'.padEnd(66, '1') },
+      options: { kind: 'P2PK', data: '02'.padEnd(66, '1') },
       denominations: [1, Amount.from(2)],
     });
     expect(result).toBe(
       JSON.stringify({
         type: 'p2pk',
-        options: { pubkey: '02'.padEnd(66, '1') },
+        options: { kind: 'P2PK', data: '02'.padEnd(66, '1') },
         denominations: ['1', '2'],
       }),
     );
@@ -116,12 +116,12 @@ describe('stringifyOutputTypeForLog', () => {
     expect(
       stringifyOutputTypeForLog({
         type: 'p2pk',
-        options: { pubkey: '02'.padEnd(66, '1') },
+        options: { kind: 'P2PK', data: '02'.padEnd(66, '1') },
       }),
     ).toBe(
       JSON.stringify({
         type: 'p2pk',
-        options: { pubkey: '02'.padEnd(66, '1') },
+        options: { kind: 'P2PK', data: '02'.padEnd(66, '1') },
         denominations: [],
       }),
     );

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -288,7 +288,7 @@ describe('payment requests', () => {
 
     test('maps a bare P2PK option to a single pubkey', () => {
       const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [] };
-      expect(prWithNut10(nut10).toP2PKOptions()).toEqual({ pubkey: PUBKEY });
+      expect(prWithNut10(nut10).toP2PKOptions()).toEqual({ kind: 'P2PK', data: PUBKEY });
     });
 
     test('maps standard NUT-11 tags onto structured P2PK fields', () => {
@@ -305,7 +305,9 @@ describe('payment requests', () => {
         ],
       };
       expect(prWithNut10(nut10).toP2PKOptions()).toEqual({
-        pubkey: [PUBKEY, PUBKEY_2],
+        kind: 'P2PK',
+        data: PUBKEY,
+        pubkeys: [PUBKEY_2],
         locktime: 1700000000,
         requiredSignatures: 2,
         refundKeys: [REFUND],
@@ -317,7 +319,8 @@ describe('payment requests', () => {
     test('preserves non-standard tags as additionalTags', () => {
       const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [['custom', 'value']] };
       expect(prWithNut10(nut10).toP2PKOptions()).toEqual({
-        pubkey: PUBKEY,
+        kind: 'P2PK',
+        data: PUBKEY,
         additionalTags: [['custom', 'value']],
       });
     });
@@ -354,8 +357,9 @@ describe('payment requests', () => {
         ],
       };
       expect(prWithNut10(nut10).toP2PKOptions()).toEqual({
-        hashlock: HASH,
-        pubkey: [PUBKEY],
+        kind: 'HTLC',
+        data: HASH,
+        pubkeys: [PUBKEY],
         locktime: 1700000000,
         refundKeys: [REFUND],
       });
@@ -366,7 +370,7 @@ describe('payment requests', () => {
       // can spend. This must produce a buildable lock, not a poison-pill option.
       const nut10: NUT10Option = { kind: 'HTLC', data: HASH, tags: [] };
       const options = prWithNut10(nut10).toP2PKOptions()!;
-      expect(options).toEqual({ hashlock: HASH, pubkey: [] });
+      expect(options).toEqual({ kind: 'HTLC', data: HASH });
       const od = OutputData.createSingleP2PKData(options, 1, '00ad268c4d1f5826');
       const secret = JSON.parse(new TextDecoder().decode(od.secret));
       expect(secret[0]).toBe('HTLC');

--- a/test/wallet/wallet-p2pk.node.test.ts
+++ b/test/wallet/wallet-p2pk.node.test.ts
@@ -20,7 +20,7 @@ describe('P2PK BlindingData', () => {
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
-      { pubkey: PK1, locktime: 212, refundKeys: [REFUND1] },
+      { kind: 'P2PK', data: PK1, locktime: 212, refundKeys: [REFUND1] },
       21,
       keys,
     );
@@ -38,7 +38,7 @@ describe('P2PK BlindingData', () => {
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
-      { pubkey: PK1, locktime: 212, refundKeys: [REFUND1, REFUND2] },
+      { kind: 'P2PK', data: PK1, locktime: 212, refundKeys: [REFUND1, REFUND2] },
       21,
       keys,
     );
@@ -55,7 +55,7 @@ describe('P2PK BlindingData', () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
-    const data = OutputData.createP2PKData({ pubkey: PK1 }, 21, keys);
+    const data = OutputData.createP2PKData({ kind: 'P2PK', data: PK1 }, 21, keys);
     const decoder = new TextDecoder();
     const allSecrets = data.map((d) => JSON.parse(decoder.decode(d.secret)));
     allSecrets.forEach((s) => {
@@ -69,14 +69,18 @@ describe('P2PK BlindingData', () => {
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
     expect(() =>
-      OutputData.createP2PKData({ pubkey: PK1, requiredSignatures: 5 }, 21, keys),
+      OutputData.createP2PKData({ kind: 'P2PK', data: PK1, requiredSignatures: 5 }, 21, keys),
     ).toThrow(/requiredSignatures \(n_sigs\) \(5\) exceeds available pubkeys \(1\)/i);
   });
   test('Create BlindingData locked to multiple pks with no requiredSignatures', async () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
-    const data = OutputData.createP2PKData({ pubkey: [PK1, PK2, PK3] }, 21, keys);
+    const data = OutputData.createP2PKData(
+      { kind: 'P2PK', data: PK1, pubkeys: [PK2, PK3] },
+      21,
+      keys,
+    );
     const decoder = new TextDecoder();
     const allSecrets = data.map((d) => JSON.parse(decoder.decode(d.secret)));
     allSecrets.forEach((s) => {
@@ -91,7 +95,7 @@ describe('P2PK BlindingData', () => {
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
-      { pubkey: [PK1, PK2, PK3], requiredSignatures: 2 },
+      { kind: 'P2PK', data: PK1, pubkeys: [PK2, PK3], requiredSignatures: 2 },
       21,
       keys,
     );
@@ -109,7 +113,11 @@ describe('P2PK BlindingData', () => {
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
     expect(() =>
-      OutputData.createP2PKData({ pubkey: [PK1, PK2, PK3], requiredSignatures: 5 }, 21, keys),
+      OutputData.createP2PKData(
+        { kind: 'P2PK', data: PK1, pubkeys: [PK2, PK3], requiredSignatures: 5 },
+        21,
+        keys,
+      ),
     ).toThrow(/requiredSignatures \(n_sigs\) \(5\) exceeds available pubkeys \(3\)/i);
   });
   test('Create BlindingData locked to single refund key with default requiredRefundSignatures', async () => {
@@ -118,7 +126,8 @@ describe('P2PK BlindingData', () => {
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
       {
-        pubkey: PK1,
+        kind: 'P2PK',
+        data: PK1,
         locktime: 212,
         refundKeys: [REFUND1],
         requiredRefundSignatures: 1,
@@ -141,7 +150,7 @@ describe('P2PK BlindingData', () => {
     await wallet.loadMint();
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
-      { pubkey: PK1, locktime: 212, refundKeys: [REFUND1, REFUND2] },
+      { kind: 'P2PK', data: PK1, locktime: 212, refundKeys: [REFUND1, REFUND2] },
       21,
       keys,
     );
@@ -161,7 +170,8 @@ describe('P2PK BlindingData', () => {
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
       {
-        pubkey: PK1,
+        kind: 'P2PK',
+        data: PK1,
         locktime: 212,
         refundKeys: [REFUND1, REFUND2, REFUND3],
         requiredRefundSignatures: 2,
@@ -186,7 +196,8 @@ describe('P2PK BlindingData', () => {
     expect(() =>
       OutputData.createP2PKData(
         {
-          pubkey: PK1,
+          kind: 'P2PK',
+          data: PK1,
           locktime: 212,
           refundKeys: [REFUND1, REFUND2, REFUND3],
           requiredRefundSignatures: 5,
@@ -204,7 +215,9 @@ describe('P2PK BlindingData', () => {
     const keys = wallet.keyChain.getKeyset();
     const data = OutputData.createP2PKData(
       {
-        pubkey: [PK1, PK2, PK3],
+        kind: 'P2PK',
+        data: PK1,
+        pubkeys: [PK2, PK3],
         locktime: 212,
         refundKeys: [REFUND1, REFUND2],
         requiredSignatures: 2,

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -440,7 +440,10 @@ describe('receive', () => {
       {},
       {
         type: 'p2pk',
-        options: { pubkey: '02a9acc1e594c8d2f91fbd5664973aaef2ff2b8c2f6cf5f419c17a35755a6ab5c4' },
+        options: {
+          kind: 'P2PK',
+          data: '02a9acc1e594c8d2f91fbd5664973aaef2ff2b8c2f6cf5f419c17a35755a6ab5c4',
+        },
       },
     );
     expect(proofs).toHaveLength(2);

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -458,7 +458,7 @@ describe('send', () => {
         // p2pk: { pubkey: 'pk' }
       },
       {
-        send: { type: 'p2pk', options: { pubkey: '02' + 'aa'.repeat(32) } },
+        send: { type: 'p2pk', options: { kind: 'P2PK', data: '02' + 'aa'.repeat(32) } },
       },
     );
 


### PR DESCRIPTION
## Summary

Restructures the P2PK / HTLC lock options into an explicit, kind-discriminated model.

- NUT-10 gains `SpendingConditionsBase = { kind: SecretKind; data: string }`, the envelope every well-known secret shares.
- NUT-11 gains `LockConditions` (the optional tag bag) and redefines `P2PKOptions = SpendingConditionsBase & LockConditions & { kind: 'P2PK' | 'HTLC' }`.
- The wallet locks through a single `asP2PK(p2pk)` gate per builder. HTLC extends P2PK, so one gate covers both kinds; the `kind` discriminant selects which.

Public method names are unchanged (`OutputData.createP2PKData`, `normalizeP2PKOptions`, `PaymentRequest.toP2PKOptions`, `P2PKBuilder`). The only breaking change is the shape of `P2PKOptions`.

## Motivation

The old `P2PKOptions.pubkey: string | string[]` conflated two orthogonal things (the mandatory NUT-10 `data` slot and the optional `pubkeys` tag) and bolted `hashlock?` on as a third. That made a keyless HTLC a degenerate state of a pubkey-mandatory P2PK type, so every spot assuming "1 or more main keys" became a separate runtime edge patched at each call site. Separating the NUT-10 envelope (`kind` + `data`) from the NUT-11 tags (`LockConditions`) makes the kind explicit and the data/tags split honest, so those edges live in the type instead of being whacked one by one.

## Breaking changes

`P2PKOptions` changes shape:

- P2PK: `{ pubkey: '02ab…' }` becomes `{ kind: 'P2PK', data: '02ab…' }`
- P2PK multisig: `{ pubkey: [a, b, c], requiredSignatures: 2 }` becomes `{ kind: 'P2PK', data: a, pubkeys: [b, c], requiredSignatures: 2 }`
- HTLC: `{ hashlock: 'ec49…' }` becomes `{ kind: 'HTLC', data: 'ec49…' }`
- HTLC with receivers: `{ hashlock: h, pubkey: [a] }` becomes `{ kind: 'HTLC', data: h, pubkeys: [a] }`

`P2PKBuilder`'s API is unchanged (`addLockPubkey([...])`, `addHashlock(...)`); `toOptions()` now returns the new shape.

Added: `SpendingConditionsBase` (NUT-10), `LockConditions` (NUT-11).