### PR TITLE
fix(htlc): return false for a malformed preimage instead of throwing (v4-dev backport)

### DIFF
--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -67,13 +67,18 @@ export function createHTLCHash(preimage?: string): { hash: string; preimage: str
 /**
  * Verify an HTLC hash/preimage pair.
  *
- * @param preimage - As a 64-character lowercase hexadecimal string.
+ * @param preimage - A 64-character hexadecimal string. A malformed value returns `false`.
  * @param hash - As a 64-character lowercase hexadecimal string.
  * @returns True if preimage calculates the same hash, False otherwise.
  */
 export function verifyHTLCHash(preimage: string, hash: string): boolean {
-  const { hash: valid } = createHTLCHash(preimage);
-  return hash === valid;
+  try {
+    return createHTLCHash(preimage).hash === hash;
+  } catch {
+    // A malformed preimage can't match; return false rather than letting
+    // createHTLCHash throw (it still validates input on the creation path).
+    return false;
+  }
 }
 
 /**

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -55,6 +55,13 @@ describe('NUT14 module core functions', () => {
     const pre = '00'.repeat(32);
     expect(verifyHTLCHash(pre, 'ff'.repeat(32))).toBe(false);
   });
+
+  test('verifyHTLCHash returns false for a malformed preimage (no throw)', () => {
+    // A non-hex or wrong-length preimage must return false, not throw.
+    for (const bad of ['not-hex', 'zz', '', 'abc', 'g'.repeat(64)]) {
+      expect(verifyHTLCHash(bad, 'ff'.repeat(32))).toBe(false);
+    }
+  });
 });
 
 describe('verifyHTLCSpendingConditions and isHTLCSpendAuthorised', () => {
@@ -129,6 +136,14 @@ describe('HTLC hashlock-only receiver pathway (no pubkeys)', () => {
 
   test('no preimage fails', () => {
     expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, [])))).toBe(false);
+  });
+
+  test('malformed preimage fails without throwing', () => {
+    // A keyless HTLC reaches the preimage check with no signature, so a malformed
+    // preimage must return false rather than throw.
+    for (const bad of ['not-hex', 'zz', 'abc', 'g'.repeat(64)]) {
+      expect(isHTLCSpendAuthorised(proofFor(createHTLCsecret(HASH, []), bad))).toBe(false);
+    }
   });
 
   test('receiver pathway remains available after locktime with refund keys present', () => {


### PR DESCRIPTION
v4-dev backport of #713.

## Summary

`verifyHTLCHash` delegated to `createHTLCHash`, which throws a `CTSError` on a non-hex or wrong-length preimage. Because a keyless (hashlock-only) HTLC reaches the preimage check with **no signature**, a malformed preimage in the witness made `verifyHTLCSpendingConditions` / `isHTLCSpendAuthorised` throw instead of returning `false`.

`verifyHTLCHash` now catches the validation error and returns `false`; `createHTLCHash` still throws on the creation path. Regression tests cover `verifyHTLCHash` directly and a keyless HTLC with a malformed preimage through `isHTLCSpendAuthorised`.