### PR TITLE
Add @experimental dist-tag + tooling for testing unmerged NUTs

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -44,7 +44,7 @@ jobs:
           MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
           if echo "$VERSION" | grep -qE '[-](beta|alpha)'; then
             # experimental / unstable — off the release path; may change or be withdrawn
-            echo "tag=beta" >> $GITHUB_OUTPUT
+            echo "tag=experimental" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
           elif echo "$VERSION" | grep -qE '[-]rc'; then
             # release candidate — the only pre-release we ship from main; becomes GA

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -42,7 +42,12 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
-          if echo "$VERSION" | grep -qE '[-](rc|alpha|beta)'; then
+          if echo "$VERSION" | grep -qE '[-](beta|alpha)'; then
+            # experimental / unstable — off the release path; may change or be withdrawn
+            echo "tag=beta" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          elif echo "$VERSION" | grep -qE '[-]rc'; then
+            # release candidate — the only pre-release we ship from main; becomes GA
             echo "tag=next" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
           elif [ "$MAJOR_VERSION" = "$LATEST_MAJOR" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test-results
 .claude
 .githooks
 .husky/_
+
+# local beta-bundle PR list (see scripts/make-experimental.sh)
+scripts/.experimental-prs

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -333,9 +333,14 @@ Releases on `main` are automated with [release-please](https://github.com/google
 
 > **Major bumps:** when breaking changes (`feat!` / `fix!`) land on `main`, release-please proposes the next major automatically. To control the pre-release cadence, add a `Release-As: X.0.0-rc.1` footer to a commit so the Release PR targets that version (it publishes to `next`).
 
-### Pre-releases / release candidates
+### Pre-releases: `next` (RC) vs `beta` (unstable)
 
-Any version containing `-rc`, `-beta`, or `-alpha` publishes to the `next` dist-tag, regardless of branch. Cut these either from `main` (via a `Release-As` footer) or from a short-lived branch off `main` (bump `package.json`, tag, and publish a GitHub **pre-release**).
+Two distinct pre-release channels — don't conflate them:
+
+- **`next` — release candidates.** `-rc` versions only. The one pre-release we ship from `main`: finalized work that _will_ become GA barring a blocker. Cut from `main` (via a `Release-As: X.Y.Z-rc.1` footer) or a short-lived branch off `main`. `npm i @cashu/cashu-ts@next`.
+- **`beta` — experimental / unstable.** `-beta` / `-alpha` versions. Off the release path: speculative bundles of _unmerged_ PRs for real-world testing; may change or be withdrawn and are **not** guaranteed to ship. Produced by [`scripts/make-experimental.sh`](#experimental-beta-line), published under `@beta`. `npm i @cashu/cashu-ts@beta`.
+
+From `main` we only ever ship `-rc` (→ `next`) or full GA (→ `latest`); anything `-alpha`/`-beta` is unstable and lives on `beta`. Rule of thumb: `@next` = "trust it, it's coming"; `@beta` = "kick the tires, no promises".
 
 ### LTS releases on `vN-dev` (manual)
 
@@ -356,19 +361,21 @@ release-please only watches `main`, so prior-major maintenance releases are cut 
 
 ### npm dist-tags
 
-`version.yml` derives the dist-tag from the version being published:
+`version.yml` derives the dist-tag from the version being published (checked in this order):
 
-- Prerelease (`-rc` / `-beta` / `-alpha`) → `next`
+- `-beta` / `-alpha` → `beta` (experimental / unstable)
+- `-rc` → `next` (release candidate)
 - Major equal to `LATEST_MAJOR` (a workflow-level env var) → `latest`
 - Any other major → `vN-lts`
 
-| Version       | Tag      | Install                              |
-| ------------- | -------- | ------------------------------------ |
-| Current major | `latest` | `npm install @cashu/cashu-ts`        |
-| Prerelease    | `next`   | `npm install @cashu/cashu-ts@next`   |
-| LTS           | `vN-lts` | `npm install @cashu/cashu-ts@v3-lts` |
+| Version            | Tag      | Stability                     | Install                              |
+| ------------------ | -------- | ----------------------------- | ------------------------------------ |
+| Current major (GA) | `latest` | stable                        | `npm install @cashu/cashu-ts`        |
+| `-rc`              | `next`   | release candidate — will ship | `npm install @cashu/cashu-ts@next`   |
+| `-beta` / `-alpha` | `beta`   | unstable — may change/vanish  | `npm install @cashu/cashu-ts@beta`   |
+| Prior major        | `vN-lts` | maintenance                   | `npm install @cashu/cashu-ts@v3-lts` |
 
-> `latest` is governed **solely** by `LATEST_MAJOR` in `version.yml`. Any major that is not `LATEST_MAJOR` (and is not a prerelease) falls through to `vN-lts` and can never accidentally become `latest`.
+> `latest` is governed **solely** by `LATEST_MAJOR` in `version.yml`. Any major that is not `LATEST_MAJOR` (and is not a prerelease) falls through to `vN-lts` and can never accidentally become `latest`. `beta` and `next` are separate channels: a `-beta` never lands on `next`, and neither ever becomes `latest`.
 
 ### Major transitions
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -40,6 +40,17 @@ Notes:
 - `npm ci` requires a package-lock.json and produces a reproducible node_modules tree.
 - Node requirement: see `package.json` (engine: `node >=22.4.0`). Use `nvm`, `volta`, or `asdf` to pin your local Node version.
 
+#### Experimental `@beta` line
+
+Speculative work tied to **unmerged NUTs** (specs that may still change) is **not** merged into `main`, where it would become a compatibility promise we can't walk back. Instead those PRs stay open against `main` and are bundled onto a disposable `experimental` branch, published to npm under the `@beta` dist-tag for real-world testing:
+
+```bash
+./scripts/make-experimental.sh 698 712    # rebuild from main + these PRs
+PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag beta
+```
+
+The branch is throwaway, rebuilt from scratch each run, never promoted from and never merged back. Work graduates by merging its individual PR into `main` the normal way. The bundle is passed as PR-number args (or kept in the gitignored `scripts/.experimental-prs`), so changing the mix is a local operation — no PR required. See the script header for the full rationale.
+
 ### ⚠️ Important — run `npm ci` after switching major branches
 
 When switching between major branches (for example `main` and a `vN-dev` branch) the lockfile and installed dependencies can differ. This frequently causes confusing failures when compiling or running `api-extractor`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -40,13 +40,13 @@ Notes:
 - `npm ci` requires a package-lock.json and produces a reproducible node_modules tree.
 - Node requirement: see `package.json` (engine: `node >=22.4.0`). Use `nvm`, `volta`, or `asdf` to pin your local Node version.
 
-#### Experimental `@beta` line
+#### The `@experimental` line
 
-Speculative work tied to **unmerged NUTs** (specs that may still change) is **not** merged into `main`, where it would become a compatibility promise we can't walk back. Instead those PRs stay open against `main` and are bundled onto a disposable `experimental` branch, published to npm under the `@beta` dist-tag for real-world testing:
+Speculative work tied to **unmerged NUTs** (specs that may still change) is **not** merged into `main`, where it would become a compatibility promise we can't walk back. Instead those PRs stay open against `main` and are bundled onto a disposable `experimental` branch, published to npm under the `@experimental` dist-tag for real-world testing:
 
 ```bash
 ./scripts/make-experimental.sh 698 712    # rebuild from main + these PRs
-PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag beta
+PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag experimental
 ```
 
 The branch is throwaway, rebuilt from scratch each run, never promoted from and never merged back. Work graduates by merging its individual PR into `main` the normal way. The bundle is passed as PR-number args (or kept in the gitignored `scripts/.experimental-prs`), so changing the mix is a local operation — no PR required. See the script header for the full rationale.
@@ -333,14 +333,14 @@ Releases on `main` are automated with [release-please](https://github.com/google
 
 > **Major bumps:** when breaking changes (`feat!` / `fix!`) land on `main`, release-please proposes the next major automatically. To control the pre-release cadence, add a `Release-As: X.0.0-rc.1` footer to a commit so the Release PR targets that version (it publishes to `next`).
 
-### Pre-releases: `next` (RC) vs `beta` (unstable)
+### Pre-releases: `next` (RC) vs `experimental` (unstable)
 
 Two distinct pre-release channels — don't conflate them:
 
 - **`next` — release candidates.** `-rc` versions only. The one pre-release we ship from `main`: finalized work that _will_ become GA barring a blocker. Cut from `main` (via a `Release-As: X.Y.Z-rc.1` footer) or a short-lived branch off `main`. `npm i @cashu/cashu-ts@next`.
-- **`beta` — experimental / unstable.** `-beta` / `-alpha` versions. Off the release path: speculative bundles of _unmerged_ PRs for real-world testing; may change or be withdrawn and are **not** guaranteed to ship. Produced by [`scripts/make-experimental.sh`](#experimental-beta-line), published under `@beta`. `npm i @cashu/cashu-ts@beta`.
+- **`experimental` — unstable.** `-beta` / `-alpha` versions. Off the release path: speculative bundles of _unmerged_ PRs for real-world testing; may change or be withdrawn and are **not** guaranteed to ship. Produced by [`scripts/make-experimental.sh`](#the-experimental-line), published under `@experimental`. `npm i @cashu/cashu-ts@experimental`.
 
-From `main` we only ever ship `-rc` (→ `next`) or full GA (→ `latest`); anything `-alpha`/`-beta` is unstable and lives on `beta`. Rule of thumb: `@next` = "trust it, it's coming"; `@beta` = "kick the tires, no promises".
+From `main` we only ever ship `-rc` (→ `next`) or full GA (→ `latest`); anything `-alpha`/`-beta` is unstable and lives on `experimental`. Rule of thumb: `@next` = "trust it, it's coming"; `@experimental` = "kick the tires, no promises".
 
 ### LTS releases on `vN-dev` (manual)
 
@@ -363,19 +363,19 @@ release-please only watches `main`, so prior-major maintenance releases are cut 
 
 `version.yml` derives the dist-tag from the version being published (checked in this order):
 
-- `-beta` / `-alpha` → `beta` (experimental / unstable)
+- `-beta` / `-alpha` → `experimental` (unstable)
 - `-rc` → `next` (release candidate)
 - Major equal to `LATEST_MAJOR` (a workflow-level env var) → `latest`
 - Any other major → `vN-lts`
 
-| Version            | Tag      | Stability                     | Install                              |
-| ------------------ | -------- | ----------------------------- | ------------------------------------ |
-| Current major (GA) | `latest` | stable                        | `npm install @cashu/cashu-ts`        |
-| `-rc`              | `next`   | release candidate — will ship | `npm install @cashu/cashu-ts@next`   |
-| `-beta` / `-alpha` | `beta`   | unstable — may change/vanish  | `npm install @cashu/cashu-ts@beta`   |
-| Prior major        | `vN-lts` | maintenance                   | `npm install @cashu/cashu-ts@v3-lts` |
+| Version            | Tag            | Stability                     | Install                                    |
+| ------------------ | -------------- | ----------------------------- | ------------------------------------------ |
+| Current major (GA) | `latest`       | stable                        | `npm install @cashu/cashu-ts`              |
+| `-rc`              | `next`         | release candidate — will ship | `npm install @cashu/cashu-ts@next`         |
+| `-beta` / `-alpha` | `experimental` | unstable — may change/vanish  | `npm install @cashu/cashu-ts@experimental` |
+| Prior major        | `vN-lts`       | maintenance                   | `npm install @cashu/cashu-ts@v3-lts`       |
 
-> `latest` is governed **solely** by `LATEST_MAJOR` in `version.yml`. Any major that is not `LATEST_MAJOR` (and is not a prerelease) falls through to `vN-lts` and can never accidentally become `latest`. `beta` and `next` are separate channels: a `-beta` never lands on `next`, and neither ever becomes `latest`.
+> `latest` is governed **solely** by `LATEST_MAJOR` in `version.yml`. Any major that is not `LATEST_MAJOR` (and is not a prerelease) falls through to `vN-lts` and can never accidentally become `latest`. `experimental` and `next` are separate channels: a `-beta`/`-alpha` never lands on `next`, and neither ever becomes `latest`.
 
 ### Major transitions
 

--- a/scripts/make-experimental.sh
+++ b/scripts/make-experimental.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ============================================================================
+# make-experimental.sh — rebuild the disposable beta line
+# ============================================================================
+#
+# WHY THIS EXISTS (read this later when you've forgotten):
+#
+#   The branch/dist-tag layout, whatever the current major happens to be:
+#     vN-dev (LTS)  -> @lts      prior major, manual security-only cuts (no RP)
+#     main          -> @latest   current major in dev, FINALIZED work, release-please
+#     experimental  -> @beta     main + speculative PRs, THIS SCRIPT, disposable
+#
+#   (During a pre-GA window @latest may still sit on the previous major on its
+#   vN-dev branch and main sits on @next; once the current major ships, @latest
+#   moves to main. The roles above don't change — only which major fills each slot.)
+#
+#   Speculative work tied to unmerged specs (NUTs that might still change) must
+#   NOT touch main — once on main it's a compatibility promise you can't walk
+#   back. So it rides a throwaway branch published as @beta for real-world
+#   testing, while the PRs stay OPEN against main.
+#
+# THE RULES:
+#   * The experimental branch is THROWAWAY. Rebuilt from scratch every run.
+#   * NEVER promote from it. NEVER merge it back to main.
+#   * Promote approved work by merging the individual PR into main (normal PR
+#     flow, one at a time onto clean main). Then delete it from PRS below and
+#     rebuild — @latest gains it, @beta drops it.
+#   * Order into beta is irrelevant to main: you promote branches individually,
+#     so speculative-vs-speculative conflicts here never recur on main.
+#   * git rerere banks your conflict fixes and replays them on the next rebuild,
+#     so this is usually hands-off.
+#
+# USAGE:
+#   ./scripts/make-experimental.sh 698 712        # rebuild with these PRs
+#   PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag beta
+#   ./scripts/make-experimental.sh                 # no args → read the local list
+#   REMOTE=fork ./scripts/make-experimental.sh 698 # PRs live on a non-default remote
+#
+# REMOTE defaults to `origin` (the canonical cashubtc repo). GitHub mirrors
+# every PR — yours and contributors' forks alike — as pull/<N>/head on the base
+# repo, so fetching PR heads from `origin` Just Works regardless of fork.
+#
+# TO CHANGE THE BUNDLE: pass PR numbers as args, or keep them (one per line) in
+# scripts/.experimental-prs — a gitignored LOCAL file. Either is the memory,
+# not your head. Changing the mix is a local edit, NOT a repo change: no PR
+# needed. Only edits to this script's logic go through a PR.
+# ============================================================================
+set -euo pipefail
+
+# --- config ------------------------------------------------------------------
+REMOTE="${REMOTE:-origin}"          # remote hosting the canonical repo + PRs (cashubtc)
+BASE="${BASE:-main}"                # curated line the beta sits on top of
+BRANCH="${BRANCH:-experimental}"    # version-neutral; survives major bumps
+
+# PR list (merge order): CLI args win; else scripts/.experimental-prs, one PR
+# number per line ('#' comments ok). Both are LOCAL — changing the mix is not
+# a repo change, so no PR needed. Portable to bash 3.2 (macOS).
+PRS=("$@")
+if [[ ${#PRS[@]} -eq 0 && -f scripts/.experimental-prs ]]; then
+  while read -r n _; do [[ $n =~ ^[0-9]+$ ]] && PRS+=("$n"); done < scripts/.experimental-prs
+fi
+if [[ ${#PRS[@]} -eq 0 ]]; then
+  echo "no PRs given — pass numbers as args, or list them in scripts/.experimental-prs" >&2
+  exit 1
+fi
+# -----------------------------------------------------------------------------
+
+git config rerere.enabled true      # bank conflict resolutions, replay on rebuild
+git config rerere.autoupdate true   # AND stage the replay, so rebuilds conclude hands-off
+
+if ! git diff-index --quiet HEAD --; then
+  echo "working tree dirty — commit or stash first" >&2; exit 1
+fi
+
+echo ">> refreshing $BASE from $REMOTE"
+git fetch "$REMOTE" "$BASE"
+git branch -D "$BRANCH" 2>/dev/null || true
+# Base off FETCH_HEAD (the commit we JUST fetched), not "$REMOTE/$BASE": the
+# tracking-ref namespace need not match the remote name — e.g. crossed fetch
+# refspecs where `origin/*` actually tracks a fork — which would silently build
+# on a stale base. FETCH_HEAD is exactly what we just pulled, refspec-agnostic.
+git checkout -B "$BRANCH" FETCH_HEAD
+BASE_SHA=$(git rev-parse --short HEAD)   # the $BASE commit this beta sits on
+
+for pr in "${PRS[@]}"; do
+  echo ">> merging PR #$pr"
+  git fetch "$REMOTE" "pull/$pr/head:pr-$pr" --force
+  if ! git merge --no-edit "pr-$pr"; then
+    if [[ -n "$(git ls-files --unmerged)" ]]; then
+      echo "" >&2
+      echo "!! unresolved conflict merging PR #$pr — fix the files, then:" >&2
+      echo "     git add -A && git commit --no-edit --no-verify" >&2
+      echo "   then re-run; rerere replays the fix automatically next time." >&2
+      exit 1
+    fi
+    # rerere replayed a known resolution and staged it — just conclude the merge
+    git commit --no-edit --no-verify
+    echo ">> rerere auto-resolved PR #$pr"
+  fi
+done
+
+echo ">> $BRANCH rebuilt: $BASE + ${PRS[*]}"
+
+if [[ "${PUBLISH:-}" == "1" ]]; then
+  # Beta version = main's core version + this bundle's commit sha, e.g.
+  # 5.0.0-beta.a1b2c3d. Unique per bundle (sha changes when PRs change), no
+  # state to track, and re-publishing an identical bundle is a harmless no-op
+  # (npm rejects the duplicate version). Prerelease version + the @beta tag mean
+  # plain `npm i cashu-ts` never picks this up — @latest is unaffected.
+  # compile (nothing else triggers it on publish) + unit tests on the MERGED
+  # tree — each PR passed CI alone, but this catches breakage from combining
+  # them, which is the whole point of the beta. Not full `prtasks`: lint/format/
+  # api-report are repo hygiene that don't affect the published lib/, and
+  # api:update mutates files mid-publish. Skip tests with SKIP_TEST=1 to iterate.
+  echo ">> building + testing merged tree"
+  npm run compile
+  # node project only: fast, no Playwright browser dep, no coverage report —
+  # enough to catch breakage from combining the PRs. SKIP_TEST=1 to skip.
+  [[ "${SKIP_TEST:-}" == "1" ]] || npx vitest run --project node
+  ver=$(node -p "require('./package.json').version")
+  core=${ver%%-*}
+  betaver="${core}-beta.$(git rev-parse --short HEAD)"
+
+  # Record what's in this beta so testers know what they're testing against.
+  # PR numbers (+ titles if `gh` is installed) go into a `betaBundle` field that
+  # ships in the package — `npm view cashu-ts@beta betaBundle` — and a
+  # paste-ready summary is printed at the end for your announcement.
+  slug=$(git config --get "remote.$REMOTE.url" | sed -E 's#.*github\.com[:/]##; s#\.git$##')
+  summary=""
+  for pr in "${PRS[@]}"; do
+    title=""
+    if command -v gh >/dev/null 2>&1; then
+      title=$(gh pr view "$pr" --repo "$slug" --json title -q .title 2>/dev/null || true)
+    fi
+    summary+="  #$pr${title:+ — $title}  (https://github.com/$slug/pull/$pr)"$'\n'
+  done
+  prs_csv=$(IFS=,; echo "${PRS[*]}")
+  node -e "const fs=require('fs'),p=require('./package.json');p.betaBundle={base:'$BASE@$BASE_SHA',prs:[$prs_csv]};fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+
+  echo ">> publishing $betaver @beta"
+  npm version "$betaver" --no-git-tag-version --allow-same-version
+  git commit -aqm "chore(beta): $betaver" --no-verify   # throwaway; skip husky/commitlint
+  npm publish --tag beta
+
+  printf '\n=== announce ===\nnpm i cashu-ts@%s   (tag: beta)\nbundled on %s@%s:\n%s\n' "$betaver" "$BASE" "$BASE_SHA" "$summary"
+fi

--- a/scripts/make-experimental.sh
+++ b/scripts/make-experimental.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # ============================================================================
-# make-experimental.sh — rebuild the disposable beta line
+# make-experimental.sh — rebuild the disposable experimental line
 # ============================================================================
 #
 # WHY THIS EXISTS (read this later when you've forgotten):
 #
 #   The branch/dist-tag layout, whatever the current major happens to be:
-#     vN-dev (LTS)  -> @lts      prior major, manual security-only cuts (no RP)
-#     main          -> @latest   current major in dev, FINALIZED work, release-please
-#     experimental  -> @beta     main + speculative PRs, THIS SCRIPT, disposable
+#     vN-dev (LTS)  -> @lts            prior major, manual security-only cuts (no RP)
+#     main          -> @latest         current major in dev, FINALIZED work, release-please
+#     experimental  -> @experimental   main + speculative PRs, THIS SCRIPT, disposable
 #
 #   (During a pre-GA window @latest may still sit on the previous major on its
 #   vN-dev branch and main sits on @next; once the current major ships, @latest
@@ -16,7 +16,7 @@
 #
 #   Speculative work tied to unmerged specs (NUTs that might still change) must
 #   NOT touch main — once on main it's a compatibility promise you can't walk
-#   back. So it rides a throwaway branch published as @beta for real-world
+#   back. So it rides a throwaway branch published as @experimental for real-world
 #   testing, while the PRs stay OPEN against main.
 #
 # THE RULES:
@@ -24,15 +24,15 @@
 #   * NEVER promote from it. NEVER merge it back to main.
 #   * Promote approved work by merging the individual PR into main (normal PR
 #     flow, one at a time onto clean main). Then delete it from PRS below and
-#     rebuild — @latest gains it, @beta drops it.
-#   * Order into beta is irrelevant to main: you promote branches individually,
+#     rebuild — @latest gains it, @experimental drops it.
+#   * Order into experimental is irrelevant to main: you promote branches individually,
 #     so speculative-vs-speculative conflicts here never recur on main.
 #   * git rerere banks your conflict fixes and replays them on the next rebuild,
 #     so this is usually hands-off.
 #
 # USAGE:
 #   ./scripts/make-experimental.sh 698 712        # rebuild with these PRs
-#   PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag beta
+#   PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag experimental
 #   ./scripts/make-experimental.sh                 # no args → read the local list
 #   REMOTE=fork ./scripts/make-experimental.sh 698 # PRs live on a non-default remote
 #
@@ -49,7 +49,7 @@ set -euo pipefail
 
 # --- config ------------------------------------------------------------------
 REMOTE="${REMOTE:-origin}"          # remote hosting the canonical repo + PRs (cashubtc)
-BASE="${BASE:-main}"                # curated line the beta sits on top of
+BASE="${BASE:-main}"                # curated line the experimental branch sits on top of
 BRANCH="${BRANCH:-experimental}"    # version-neutral; survives major bumps
 
 # PR list (merge order): CLI args win; else scripts/.experimental-prs, one PR
@@ -80,7 +80,7 @@ git branch -D "$BRANCH" 2>/dev/null || true
 # refspecs where `origin/*` actually tracks a fork — which would silently build
 # on a stale base. FETCH_HEAD is exactly what we just pulled, refspec-agnostic.
 git checkout -B "$BRANCH" FETCH_HEAD
-BASE_SHA=$(git rev-parse --short HEAD)   # the $BASE commit this beta sits on
+BASE_SHA=$(git rev-parse --short HEAD)   # the $BASE commit this build sits on
 
 for pr in "${PRS[@]}"; do
   echo ">> merging PR #$pr"
@@ -102,14 +102,14 @@ done
 echo ">> $BRANCH rebuilt: $BASE + ${PRS[*]}"
 
 if [[ "${PUBLISH:-}" == "1" ]]; then
-  # Beta version = main's core version + this bundle's commit sha, e.g.
-  # 5.0.0-beta.a1b2c3d. Unique per bundle (sha changes when PRs change), no
-  # state to track, and re-publishing an identical bundle is a harmless no-op
-  # (npm rejects the duplicate version). Prerelease version + the @beta tag mean
-  # plain `npm i cashu-ts` never picks this up — @latest is unaffected.
+  # Version = main's core version + bundle sha, e.g. 5.0.0-beta.a1b2c3d. The
+  # -beta identifier + the explicit @experimental tag mean plain `npm i cashu-ts`
+  # never picks it up (@latest unaffected). Unique per bundle (sha changes with
+  # the PRs); re-publishing an identical bundle is a harmless no-op (npm rejects
+  # the duplicate version).
   # compile (nothing else triggers it on publish) + unit tests on the MERGED
   # tree — each PR passed CI alone, but this catches breakage from combining
-  # them, which is the whole point of the beta. Not full `prtasks`: lint/format/
+  # them, which is the whole point of the experimental build. Not full `prtasks`: lint/format/
   # api-report are repo hygiene that don't affect the published lib/, and
   # api:update mutates files mid-publish. Skip tests with SKIP_TEST=1 to iterate.
   echo ">> building + testing merged tree"
@@ -121,9 +121,9 @@ if [[ "${PUBLISH:-}" == "1" ]]; then
   core=${ver%%-*}
   betaver="${core}-beta.$(git rev-parse --short HEAD)"
 
-  # Record what's in this beta so testers know what they're testing against.
-  # PR numbers (+ titles if `gh` is installed) go into a `betaBundle` field that
-  # ships in the package — `npm view cashu-ts@beta betaBundle` — and a
+  # Record what's in this build so testers know what they're testing against.
+  # PR numbers (+ titles if `gh` is installed) go into an `experimentalBundle` field that
+  # ships in the package — `npm view cashu-ts@experimental experimentalBundle` — and a
   # paste-ready summary is printed at the end for your announcement.
   slug=$(git config --get "remote.$REMOTE.url" | sed -E 's#.*github\.com[:/]##; s#\.git$##')
   summary=""
@@ -135,12 +135,12 @@ if [[ "${PUBLISH:-}" == "1" ]]; then
     summary+="  #$pr${title:+ — $title}  (https://github.com/$slug/pull/$pr)"$'\n'
   done
   prs_csv=$(IFS=,; echo "${PRS[*]}")
-  node -e "const fs=require('fs'),p=require('./package.json');p.betaBundle={base:'$BASE@$BASE_SHA',prs:[$prs_csv]};fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+  node -e "const fs=require('fs'),p=require('./package.json');p.experimentalBundle={base:'$BASE@$BASE_SHA',prs:[$prs_csv]};fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
-  echo ">> publishing $betaver @beta"
+  echo ">> publishing $betaver @experimental"
   npm version "$betaver" --no-git-tag-version --allow-same-version
-  git commit -aqm "chore(beta): $betaver" --no-verify   # throwaway; skip husky/commitlint
-  npm publish --tag beta
+  git commit -aqm "chore(experimental): $betaver" --no-verify   # throwaway; skip husky/commitlint
+  npm publish --tag experimental
 
-  printf '\n=== announce ===\nnpm i cashu-ts@%s   (tag: beta)\nbundled on %s@%s:\n%s\n' "$betaver" "$BASE" "$BASE_SHA" "$summary"
+  printf '\n=== announce ===\nnpm i cashu-ts@%s   (tag: experimental)\nbundled on %s@%s:\n%s\n' "$betaver" "$BASE" "$BASE_SHA" "$summary"
 fi


### PR DESCRIPTION
## What & why

Testing **unmerged NUTs** is a chicken-and-egg problem: implementations don't want to commit specs to `main` (breaking to walk back), but specs need real implementations to iterate. This adds a low-commitment staging channel so speculative work can be published for real-world testing **without touching `main`**.

Speculative PRs stay open against `main` and are bundled onto a disposable `experimental` branch, published to a new **`@experimental`** npm dist-tag. Nothing lands on `main` until it's approved and merged the normal way.

## The dist-tag model (now explicit)

| Tag | Version ids | Meaning |
|---|---|---|
| `latest` | current major | stable |
| `next` | `-rc` | release candidate — will ship |
| `experimental` | `-beta` / `-alpha` | unstable — may change or be withdrawn |
| `vN-lts` | prior major | maintenance |

`@next` = "trust it, it's coming"; `@experimental` = "kick the tires, no promises."

## Changes

- **`scripts/make-experimental.sh`** — rebuilds the throwaway `experimental` branch from `main` + a set of open PRs (by number), and optionally compiles, node-tests, and publishes to `@experimental`. Idempotent, `rerere`-assisted, remote/refspec-agnostic (bases off `FETCH_HEAD`). Records the bundle in an `experimentalBundle` package field + prints a paste-ready announcement so testers know what they're testing.
- **`.github/workflows/version.yml`** — split prerelease routing: `-beta`/`-alpha` → `experimental` (was lumped into `next`), `-rc` → `next`. Only routing changed; version identifiers are untouched.
- **`DEVELOPER.md`** — documents the `experimental` line and the four-tier dist-tag model.
- **`.gitignore`** — ignores the local `scripts/.experimental-prs` bundle list.

## Usage

```bash
./scripts/make-experimental.sh 668 675 697 698        # rebuild locally, inspect
PUBLISH=1 ./scripts/make-experimental.sh 668 675 697  # …compile + test + publish @experimental
```

## Reviewer notes

- The only change to existing release infra is the `version.yml` routing split — if a `-beta`/`-alpha` is ever cut through the CI release flow it now lands on `experimental` instead of `next`. `@latest` and `@next` behaviour for GA/RC releases is unchanged.
- The `experimental` branch is throwaway (never promoted, never merged back); the script publishes locally with an explicit `--tag experimental`.
