### PR TITLE
chore(npm): exclude local build/test artifacts from published tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,8 @@ src
 examples
 /lib/cashu-ts.iife.js
 /lib/cashu-ts.iife.js.map
+
+# local build/test artifacts (absent in CI; keep out of local publishes)
+/temp
+/test-results
+/.claude


### PR DESCRIPTION
`.npmignore` didn't list `temp/`, `test-results/`, or `.claude/`. Because npm ignores `.gitignore` when an `.npmignore` exists, a **local** `npm publish` (e.g. via `scripts/make-experimental.sh`) packed ~1.9MB of local-only artifacts — including `temp/cashu-ts.api.json` (1.5MB), `test-results/junit.xml`, and `.claude/settings.local.json`.

CI releases are unaffected (a clean checkout has none of these dirs), so this only bites local publishes. Fix adds the three to `.npmignore`; verified tarball drops from 71→66 files.

Follow-up thought (not in this PR): the package still ships a lot via denylist (dev configs, benches, husky, AGENTS.md…); a `files` allowlist would be tighter, but that's a separate maintainer call.