### PR TITLE
chore(release): use -experimental prerelease identifier for experimental builds

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
-          if echo "$VERSION" | grep -qE '[-](beta|alpha)'; then
+          if echo "$VERSION" | grep -qE '[-](experimental|beta|alpha)'; then
             # experimental / unstable — off the release path; may change or be withdrawn
             echo "tag=experimental" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,5 @@
 # AGENTS
 
-Using cashu-ts? This file is for you. Developing cashu-ts itself? See
-`AGENTS-CONTRIBUTING.md` (alongside this file in a repo checkout, or
-[on GitHub](https://github.com/cashubtc/cashu-ts/blob/main/AGENTS-CONTRIBUTING.md)).
-
 TypeScript library for Cashu ecash wallets and mint interaction.
 
 ## Before you write code
@@ -26,3 +22,11 @@ deprecations before moving to the next. Some majors also ship a deeper
 - Usage recipes: `docs-src/` (contains usage, wallet events, WalletOps builder)
 - Full API reference: `etc/cashu-ts.api.md` (or `lib/types/index.d.ts`)
 - Migration guides: `migration-*.md` (plus any `.SKILL.md`)
+
+## Contributing to Cashu-TS Development
+
+Checkout the git repo at: https://github.com/cashubtc/cashu-ts
+
+**Study** `AGENTS-CONTRIBUTING.md` (alongside this file in a repo checkout).
+
+It contains repo map and conventions, coding guidelines, commit hygiene and more.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -20,7 +20,7 @@ npm run test:prepare
 
 ### Branching model
 
-`main` always tracks the **current major** under active development — there is no separate development branch for it. Each still-supported **prior major** is maintained on its own long-lived `vN-dev` branch for fixes only.
+`main` always tracks the **current major** under active development - there is no separate development branch for it. Each still-supported **prior major** is maintained on its own long-lived `vN-dev` branch for fixes only.
 
 Open PRs against the branch for the major you are targeting (don't mix majors in one PR):
 
@@ -31,9 +31,9 @@ Current branches:
 
 | Branch   | Major | Status                             |
 | -------- | ----- | ---------------------------------- |
-| `main`   | v5    | Current — active development       |
-| `v4-dev` | v4    | LTS — critical/security fixes only |
-| `v3-dev` | v3    | LTS — critical/security fixes only |
+| `main`   | v5    | Current - active development       |
+| `v4-dev` | v4    | LTS - critical/security fixes only |
+| `v3-dev` | v3    | LTS - critical/security fixes only |
 
 Notes:
 
@@ -49,9 +49,9 @@ Speculative work tied to **unmerged NUTs** (specs that may still change) is **no
 PUBLISH=1 ./scripts/make-experimental.sh 698   # …and npm publish --tag experimental
 ```
 
-The branch is throwaway, rebuilt from scratch each run, never promoted from and never merged back. Work graduates by merging its individual PR into `main` the normal way. The bundle is passed as PR-number args (or kept in the gitignored `scripts/.experimental-prs`), so changing the mix is a local operation — no PR required. See the script header for the full rationale.
+The branch is throwaway, rebuilt from scratch each run, never promoted from and never merged back. Work graduates by merging its individual PR into `main` the normal way. The bundle is passed as PR-number args (or kept in the gitignored `scripts/.experimental-prs`), so changing the mix is a local operation - no PR required. See the script header for the full rationale.
 
-### ⚠️ Important — run `npm ci` after switching major branches
+### ⚠️ Important - run `npm ci` after switching major branches
 
 When switching between major branches (for example `main` and a `vN-dev` branch) the lockfile and installed dependencies can differ. This frequently causes confusing failures when compiling or running `api-extractor`.
 
@@ -69,7 +69,7 @@ rm -rf node_modules
 npm ci
 ```
 
-This callout is important — please don't skip it when moving between major branches, it saves a lot of time debugging mysterious build/test failures.
+This callout is important - please don't skip it when moving between major branches, it saves a lot of time debugging mysterious build/test failures.
 
 ## Environment & toolchain
 
@@ -301,7 +301,7 @@ npm install <pkg> --save-dev
 
 Cashu-TS uses semantic versioning.
 
-`main` is the single primary development branch and tracks the **current major**. All new development is merged into `main` via pull requests. Each supported **prior major** is maintained on its own `vN-dev` branch for critical/security fixes only — open backports as a separate PR against the matching `vN-dev` branch (do not mix majors in a single PR). See [Branching model](#branching-model).
+`main` is the single primary development branch and tracks the **current major**. All new development is merged into `main` via pull requests. Each supported **prior major** is maintained on its own `vN-dev` branch for critical/security fixes only - open backports as a separate PR against the matching `vN-dev` branch (do not mix majors in a single PR). See [Branching model](#branching-model).
 
 ## Releases
 
@@ -335,12 +335,12 @@ Releases on `main` are automated with [release-please](https://github.com/google
 
 ### Pre-releases: `next` (RC) vs `experimental` (unstable)
 
-Two distinct pre-release channels — don't conflate them:
+Two distinct pre-release channels - don't conflate them:
 
-- **`next` — release candidates.** `-rc` versions only. The one pre-release we ship from `main`: finalized work that _will_ become GA barring a blocker. Cut from `main` (via a `Release-As: X.Y.Z-rc.1` footer) or a short-lived branch off `main`. `npm i @cashu/cashu-ts@next`.
-- **`experimental` — unstable.** `-beta` / `-alpha` versions. Off the release path: speculative bundles of _unmerged_ PRs for real-world testing; may change or be withdrawn and are **not** guaranteed to ship. Produced by [`scripts/make-experimental.sh`](#the-experimental-line), published under `@experimental`. `npm i @cashu/cashu-ts@experimental`.
+- **`next` - release candidates.** `-rc` versions only. The one pre-release we ship from `main`: finalized work that _will_ become GA barring a blocker. Cut from `main` (via a `Release-As: X.Y.Z-rc.1` footer) or a short-lived branch off `main`. `npm i @cashu/cashu-ts@next`.
+- **`experimental` - unstable.** `-experimental` versions (e.g. `5.0.0-experimental.a1b2c3d`). Off the release path: speculative bundles of _unmerged_ PRs for real-world testing; may change or be withdrawn and are **not** guaranteed to ship. Produced by [`scripts/make-experimental.sh`](#the-experimental-line), published under `@experimental`. `npm i @cashu/cashu-ts@experimental`.
 
-From `main` we only ever ship `-rc` (→ `next`) or full GA (→ `latest`); anything `-alpha`/`-beta` is unstable and lives on `experimental`. Rule of thumb: `@next` = "trust it, it's coming"; `@experimental` = "kick the tires, no promises".
+From `main` we only ever ship `-rc` (→ `next`) or full GA (→ `latest`); anything `-experimental` (or `-alpha`/`-beta`) is unstable and lives on `experimental`. Rule of thumb: `@next` = "trust it, it's coming"; `@experimental` = "kick the tires, no promises".
 
 ### LTS releases on `vN-dev` (manual)
 
@@ -363,7 +363,7 @@ release-please only watches `main`, so prior-major maintenance releases are cut 
 
 `version.yml` derives the dist-tag from the version being published (checked in this order):
 
-- `-beta` / `-alpha` → `experimental` (unstable)
+- `-experimental` / `-beta` / `-alpha` → `experimental` (unstable)
 - `-rc` → `next` (release candidate)
 - Major equal to `LATEST_MAJOR` (a workflow-level env var) → `latest`
 - Any other major → `vN-lts`
@@ -371,18 +371,18 @@ release-please only watches `main`, so prior-major maintenance releases are cut 
 | Version            | Tag            | Stability                     | Install                                    |
 | ------------------ | -------------- | ----------------------------- | ------------------------------------------ |
 | Current major (GA) | `latest`       | stable                        | `npm install @cashu/cashu-ts`              |
-| `-rc`              | `next`         | release candidate — will ship | `npm install @cashu/cashu-ts@next`         |
-| `-beta` / `-alpha` | `experimental` | unstable — may change/vanish  | `npm install @cashu/cashu-ts@experimental` |
+| `-rc`              | `next`         | release candidate - will ship | `npm install @cashu/cashu-ts@next`         |
+| `-experimental`    | `experimental` | unstable - may change/vanish  | `npm install @cashu/cashu-ts@experimental` |
 | Prior major        | `vN-lts`       | maintenance                   | `npm install @cashu/cashu-ts@v3-lts`       |
 
-> `latest` is governed **solely** by `LATEST_MAJOR` in `version.yml`. Any major that is not `LATEST_MAJOR` (and is not a prerelease) falls through to `vN-lts` and can never accidentally become `latest`. `experimental` and `next` are separate channels: a `-beta`/`-alpha` never lands on `next`, and neither ever becomes `latest`.
+> `latest` is governed **solely** by `LATEST_MAJOR` in `version.yml`. Any major that is not `LATEST_MAJOR` (and is not a prerelease) falls through to `vN-lts` and can never accidentally become `latest`. `experimental` and `next` are separate channels: an `-experimental` build never lands on `next`, and neither ever becomes `latest`.
 
 ### Major transitions
 
 Promoting a new major happens in two steps:
 
 1. **Incoming major lands on `main`.** release-please proposes the new major; cut release candidates (`-rc`), which publish to `next`. Leave `LATEST_MAJOR` unchanged so `latest` keeps pointing at the outgoing major, and start cutting the outgoing major's maintenance releases from its `vN-dev` branch.
-2. **GA.** Bump `LATEST_MAJOR` in `version.yml` (one-line PR) and cut the release on `main` — it publishes to `latest`, and the previous major automatically drops to `vN-lts`. Update the branch table above.
+2. **GA.** Bump `LATEST_MAJOR` in `version.yml` (one-line PR) and cut the release on `main` - it publishes to `latest`, and the previous major automatically drops to `vN-lts`. Update the branch table above.
 
 ### Notes on Versioning
 

--- a/scripts/make-experimental.sh
+++ b/scripts/make-experimental.sh
@@ -102,8 +102,9 @@ done
 echo ">> $BRANCH rebuilt: $BASE + ${PRS[*]}"
 
 if [[ "${PUBLISH:-}" == "1" ]]; then
-  # Version = main's core version + bundle sha, e.g. 5.0.0-beta.a1b2c3d. The
-  # -beta identifier + the explicit @experimental tag mean plain `npm i cashu-ts`
+  # Version = main's core version + bundle sha, e.g. 5.0.0-experimental.a1b2c3d.
+  # The -experimental identifier (matches the dist-tag; beta/rc stay reserved for
+  # real prereleases) + the explicit @experimental tag mean plain `npm i cashu-ts`
   # never picks it up (@latest unaffected). Unique per bundle (sha changes with
   # the PRs); re-publishing an identical bundle is a harmless no-op (npm rejects
   # the duplicate version).
@@ -119,7 +120,7 @@ if [[ "${PUBLISH:-}" == "1" ]]; then
   [[ "${SKIP_TEST:-}" == "1" ]] || npx vitest run --project node
   ver=$(node -p "require('./package.json').version")
   core=${ver%%-*}
-  betaver="${core}-beta.$(git rev-parse --short HEAD)"
+  expver="${core}-experimental.$(git rev-parse --short HEAD)"
 
   # Record what's in this build so testers know what they're testing against.
   # PR numbers (+ titles if `gh` is installed) go into an `experimentalBundle` field that
@@ -137,10 +138,10 @@ if [[ "${PUBLISH:-}" == "1" ]]; then
   prs_csv=$(IFS=,; echo "${PRS[*]}")
   node -e "const fs=require('fs'),p=require('./package.json');p.experimentalBundle={base:'$BASE@$BASE_SHA',prs:[$prs_csv]};fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
-  echo ">> publishing $betaver @experimental"
-  npm version "$betaver" --no-git-tag-version --allow-same-version
-  git commit -aqm "chore(experimental): $betaver" --no-verify   # throwaway; skip husky/commitlint
+  echo ">> publishing $expver @experimental"
+  npm version "$expver" --no-git-tag-version --allow-same-version
+  git commit -aqm "chore(experimental): $expver" --no-verify   # throwaway; skip husky/commitlint
   npm publish --tag experimental
 
-  printf '\n=== announce ===\nnpm i cashu-ts@%s   (tag: experimental)\nbundled on %s@%s:\n%s\n' "$betaver" "$BASE" "$BASE_SHA" "$summary"
+  printf '\n=== announce ===\nnpm i cashu-ts@%s   (tag: experimental)\nbundled on %s@%s:\n%s\n' "$expver" "$BASE" "$BASE_SHA" "$summary"
 fi


### PR DESCRIPTION
## Summary

Experimental bundles (from #715) now publish as `X.Y.Z-experimental.<sha>` instead of `X.Y.Z-beta.<sha>`. The experimental dist-tag is unchanged.

## Why

- **beta promises graduation.** A beta is a prerelease of the next stable. These builds bundle unmerged NUT PRs that may never ship at all, which is exactly what "experimental" means.
- **Namespace collision.** Semver orders numeric prerelease identifiers below alphanumeric ones, so a real future `5.0.0-beta.1` would sort *below* `5.0.0-beta.a1b2c3d`. Tools resolving "latest matching prerelease" would pick the experimental bundle. Using `-experimental.` keeps the beta/rc lane clean for actual prereleases.
- **Precedent.** React uses the same pattern: experimental dist-tag with `0.0.0-experimental-<sha>` versions. Matching identifier to tag makes version strings self-describing.

## Changes

- `scripts/make-experimental.sh`: version string is now `<core>-experimental.<sha>`
- `.github/workflows/version.yml`: dist-tag guard accepts `experimental` (beta/alpha kept as a catch-all so stray unstable versions still route to the experimental dist-tag, never `latest`/`next`)
- `DEVELOPER.md`: channel docs updated to lead with `-experimental`
- `AGENTS.md`: contributor pointer moved into its own section