### PR TITLE
ci: add label-triggered backport automation for LTS branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,79 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    # Run on merge (close) or if a backport label is added after merging
+    types: [closed, labeled]
+
+# Single backport workflow per PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # Skip closed-unmerged PRs and non-backport label events.
+    # Label format: "backport <branch>", e.g. "backport v4-dev"
+    if: |
+      github.event.pull_request.merged &&
+      (
+        github.event.action != 'labeled' ||
+        startsWith(github.event.label.name, 'backport')
+      )
+
+    outputs:
+      was_successful: ${{ steps.create-pr.outputs.was_successful }}
+
+    steps:
+      - uses: actions/checkout@v5
+      - id: create-pr
+        name: Create backport pull requests
+        uses: korthout/backport-action@v4.5.2
+        with:
+          # PAT so backport PRs trigger CI (default GITHUB_TOKEN PRs don't)
+          github_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # On conflict the backport fails clean (default): nothing is pushed,
+          # the action comments on the original PR with cherry-pick steps and
+          # the open-issue job below files a tracking issue
+          # Ignore merge commits from "update branch" syncs
+          merge_commits: skip
+
+  open-issue:
+    name: Open issue for failed backports
+    runs-on: ubuntu-latest
+    needs: backport
+    if: ${{ needs.backport.outputs.was_successful == 'false' }}
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Create issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # via env, never inline: PR titles are untrusted input
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          SHORT_PR_TITLE=$(
+            echo "$PR_TITLE" \
+            | awk '{print (length($0) > 40) ? substr($0, 1, 40) "..." : $0}'
+          )
+          cat > issue-body.md <<EOF
+          PR: #${PR_NUMBER}
+          Title: ${PR_TITLE}
+
+          Backporting hit a conflict and pushed nothing.
+          Cherry-pick and open the backport PR manually.
+          EOF
+
+          gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Backport PR #${PR_NUMBER}: ${SHORT_PR_TITLE}" \
+            --label backport \
+            --body-file issue-body.md

--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -141,7 +141,8 @@ Hooks are installed by Husky:
 ## Branching and releases
 
 - `main` tracks the current major and is where active development lands.
-- Each supported prior major has a `vN-dev` LTS branch (`v4-dev`, `v3-dev`) for backports only; target the matching branch and don't mix majors in one PR.
+- Each supported prior major has a `vN-dev` LTS branch (`v4-dev`, `v3-dev`) for backports only; don't mix majors in one PR.
+- Backports are label-driven: land the fix on `main`, add a `backport vN-dev` label to the PR, and a bot opens the backport PR. Only cherry-pick manually when the bot fails (it opens a `backport`-labelled issue); never commit directly to a `vN-dev` branch.
 - Current-major releases on `main` are automated with release-please (don't bump versions by hand). LTS releases on `vN-dev` are cut manually (tag + GitHub Release).
 - npm `latest` is governed solely by `LATEST_MAJOR` in `.github/workflows/version.yml`.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -25,7 +25,7 @@ npm run test:prepare
 Open PRs against the branch for the major you are targeting (don't mix majors in one PR):
 
 - Features and fixes for the current major → `main`
-- Backports to a maintained prior major → that major's `vN-dev` branch
+- Backports to a maintained prior major → land the fix on `main` first, then add a `backport vN-dev` label to the PR (before or after merge); a bot opens the backport PR automatically. If it hits a conflict it pushes nothing and files a `backport`-labelled tracking issue for a manual cherry-pick against that `vN-dev` branch.
 
 Current branches:
 


### PR DESCRIPTION
Backports merged PRs labelled `backport <branch>` (e.g. `backport v4-dev`) via [korthout/backport-action](https://github.com/korthout/backport-action), mirroring CDK's setup.

- Triggers on merge with the label present, or when the label is added to an already-merged PR
- Uses the `RELEASE_PLEASE_TOKEN` PAT so backport PRs run CI
- On conflict it fails clean (no conflict markers pushed anywhere), the action comments cherry-pick steps on the original PR, and a second job opens a tracking issue labelled `backport`
- `merge_commits: skip` ignores merge commits from "update branch" syncs

Labels `backport`, `backport v4-dev`, `backport v3-dev` already created; legacy `lts backport` removed (base branch + auto title prefix carry that info).