### PR TITLE
ci: run release-please on v4-dev to automate LTS releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,10 @@
 name: release-please
+# v4-dev copy: watches and releases this LTS branch only. main's copy
+# (which targets main) is separate — push workflows run per-branch.
 on:
   push:
     branches:
-      - main
+      - v4-dev
 permissions:
   contents: write
   issues: write
@@ -16,4 +18,5 @@ jobs:
         id: release
         with:
           release-type: node
+          target-branch: v4-dev
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Points this branch's release-please copy at `v4-dev` (`on.push.branches` + `target-branch`). Push workflows run per-branch, so main's copy — mid v5 transition — is untouched.

What happens on merge: release-please anchors on the v4.6.0 GitHub Release and immediately opens `chore(v4-dev): release 4.6.1` covering the 4 backported fixes (#704 #706 #711 #714). Review that PR's version/changelog as live validation; merging it tags, creates the GitHub Release, and the existing release-triggered `version.yml` publishes to npm with the dist-tag routed by `LATEST_MAJOR`.

`v3-dev` gets the same two-line edit when its first backport lands. Docs follow-up on main will replace the "LTS releases are cut manually" guidance.