### PR TITLE
docs: link GitHub Releases page from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ package.
 
 ---
 
+## Changelog
+
+Release notes for every version — across all release lines (current and LTS) — are on the [GitHub Releases page](https://github.com/cashubtc/cashu-ts/releases).
+
 ## Contribute
 
 We welcome contributions from anyone — newcomers, experienced developers, and AI-assisted workflows alike.


### PR DESCRIPTION
Same change as the v4-dev copy in #722: adds a Changelog section pointing at the GitHub Releases page — the unified release-notes view across release lines, since per-branch CHANGELOG.md files only cover releases cut from their own branch (main's stops at 4.5.0 by design). npm renders the published version's README, so both lines need the pointer.