### PR TITLE
docs: describe automated LTS releases and label-driven backports

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,6 +4,12 @@ permissions:
   contents: write
   id-token: write
 
+# *** NOTE: THIS WORKFLOW ONLY EVER RUNS FROM MAIN'S COPY ***
+# Release events execute the default branch's workflow files, so the copies on
+# vN-dev branches are inert: edit LATEST_MAJOR here on main, never anywhere else.
+# (Manual workflow_dispatch runs must also be dispatched from main — dispatching
+# from a vN-dev ref would use that branch's stale copy of this file.)
+#
 # Major version currently published under the npm `latest` dist-tag.
 # Bump this (e.g. "4" -> "5") in a reviewed PR when a new major reaches GA — see the release
 # strategy in DEVELOPER.md. Any major that is not LATEST_MAJOR publishes as `vN-lts`, never `latest`.

--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -143,7 +143,7 @@ Hooks are installed by Husky:
 - `main` tracks the current major and is where active development lands.
 - Each supported prior major has a `vN-dev` LTS branch (`v4-dev`, `v3-dev`) for backports only; don't mix majors in one PR.
 - Backports are label-driven: land the fix on `main`, add a `backport vN-dev` label to the PR, and a bot opens the backport PR. Only cherry-pick manually when the bot fails (it opens a `backport`-labelled issue); never commit directly to a `vN-dev` branch.
-- Current-major releases on `main` are automated with release-please (don't bump versions by hand). LTS releases on `vN-dev` are cut manually (tag + GitHub Release).
+- All releases are automated with release-please (don't bump versions by hand): `main` and each `vN-dev` branch run their own copy of the workflow, and merging a branch's Release PR tags, creates the GitHub Release, and publishes to npm.
 - npm `latest` is governed solely by `LATEST_MAJOR` in `.github/workflows/version.yml`.
 
 ## Common pitfalls (save time)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -301,7 +301,7 @@ npm install <pkg> --save-dev
 
 Cashu-TS uses semantic versioning.
 
-`main` is the single primary development branch and tracks the **current major**. All new development is merged into `main` via pull requests. Each supported **prior major** is maintained on its own `vN-dev` branch for critical/security fixes only - open backports as a separate PR against the matching `vN-dev` branch (do not mix majors in a single PR). See [Branching model](#branching-model).
+`main` is the single primary development branch and tracks the **current major**. All new development is merged into `main` via pull requests. Each supported **prior major** is maintained on its own `vN-dev` branch for critical/security fixes only - backports are label-driven: land the fix on `main` and add a `backport vN-dev` label to the PR (do not mix majors in a single PR). See [Branching model](#branching-model).
 
 ## Releases
 
@@ -342,22 +342,17 @@ Two distinct pre-release channels - don't conflate them:
 
 From `main` we only ever ship `-rc` (→ `next`) or full GA (→ `latest`); anything `-experimental` (or `-alpha`/`-beta`) is unstable and lives on `experimental`. Rule of thumb: `@next` = "trust it, it's coming"; `@experimental` = "kick the tires, no promises".
 
-### LTS releases on `vN-dev` (manual)
+### LTS releases on `vN-dev` (release-please)
 
-release-please only watches `main`, so prior-major maintenance releases are cut manually:
+LTS releases work exactly like `main` releases. Each `vN-dev` branch carries its own copy of the release-please workflow pointed at itself (`on.push.branches` + `target-branch` - push workflows run per-branch, so the copies never interfere):
 
-1. Open a release PR targeting `vN-dev`.
-2. Commit or cherry-pick the fix to the `vN-dev` branch.
-3. Bump `package.json` to the next patch version (e.g. `4.5.1`).
-4. Merge the PR into `v4-dev`.
-5. Tag the merged `v4-dev` commit that contains the version bump:
-   ```bash
-   git fetch origin v4-dev --tags
-   git tag -a v4.5.1 origin/v4-dev -m "v4.5.1"
-   git push origin v4.5.1
-   ```
-6. Create a GitHub Release from the tag (or use `workflow_dispatch` on the publish workflow with the tag).
-7. The publish workflow detects major version 4 and publishes to npm with the `v4-lts` dist-tag.
+1. Fixes land on `main` and reach `vN-dev` via `backport vN-dev` labels (see [Branching model](#branching-model)).
+2. Each backport merged into `vN-dev` creates or updates that branch's Release PR (e.g. `chore(v4-dev): release 4.6.1`), aggregating the changelog and computing the next version from the conventional commits.
+3. Merging the Release PR is the release action: it tags, publishes the GitHub Release, and `version.yml` pushes to npm with the dist-tag derived from `LATEST_MAJOR` (`latest` while the major is current, `vN-lts` after).
+
+No manual version bumps, tags, or GitHub Releases - and never commit directly to a `vN-dev` branch.
+
+> **Publish routing note:** release-triggered workflows always run from `main`'s `version.yml` (release events execute the default branch's workflow files), so `LATEST_MAJOR` only ever needs updating on `main`. The `version.yml` and `release-please.yml` copies on `vN-dev` branches are inert except for the `release-please.yml` branch pointer described above.
 
 ### npm dist-tags
 
@@ -381,15 +376,15 @@ release-please only watches `main`, so prior-major maintenance releases are cut 
 
 Promoting a new major happens in two steps:
 
-1. **Incoming major lands on `main`.** release-please proposes the new major; cut release candidates (`-rc`), which publish to `next`. Leave `LATEST_MAJOR` unchanged so `latest` keeps pointing at the outgoing major, and start cutting the outgoing major's maintenance releases from its `vN-dev` branch.
-2. **GA.** Bump `LATEST_MAJOR` in `version.yml` (one-line PR) and cut the release on `main` - it publishes to `latest`, and the previous major automatically drops to `vN-lts`. Update the branch table above.
+1. **Incoming major lands on `main`.** release-please proposes the new major; cut release candidates (`-rc`), which publish to `next`. Leave `LATEST_MAJOR` unchanged so `latest` keeps pointing at the outgoing major. Cut the outgoing major's `vN-dev` branch; in its first commit, point that branch's `release-please.yml` copy at itself (`on.push.branches` and `target-branch`), and create the `backport vN-dev` label. Maintenance releases then flow from the branch automatically.
+2. **GA.** Bump `LATEST_MAJOR` in `version.yml` (one-line PR on `main` - the only place it matters) and cut the release on `main` - it publishes to `latest`, and the previous major automatically drops to `vN-lts`. Update the branch table above.
 
 ### Notes on Versioning
 
 - Follow **Conventional Commits** to ensure correct version bumps.
 - Breaking API changes must be clearly marked (`feat!` / `fix!` or `BREAKING CHANGE:`) to trigger a major version bump.
-- Version numbers on `main` are determined automatically by release-please; contributors should not attempt to control versions directly.
-- LTS and RC versions are bumped manually in `package.json`.
+- Version numbers on `main` and `vN-dev` branches are determined automatically by each branch's release-please; contributors should not attempt to control versions directly.
+- RC cadence on `main` is controlled with `Release-As:` commit footers; nothing is bumped by hand in `package.json`.
 
 ## Troubleshooting (common issues)
 

--- a/docs-src/versions_releases.md
+++ b/docs-src/versions_releases.md
@@ -4,18 +4,19 @@
 
 This project uses **Semantic Versioning** and a simplified branching model.
 
-- `main` represents the current major version (v4) and is the only branch for active development.
-- The previous major version (v3) is supported via a long-lived **maintenance branch**, used for critical fixes only.
+- `main` represents the **current major version** and is the only branch for active development.
+- Each still-supported prior major is maintained on a long-lived `vN-dev` branch (e.g. `v4-dev`, `v3-dev`), used for critical fixes only.
 - Direct commits to protected branches are not allowed; all changes are introduced via pull requests.
 
 ### Quick pointers
 
-- Target `main` as the base branch for all v4 feature and fix pull requests.
-- Target the v3 maintenance branch only for critical fixes to the previous major version.
+- Target `main` as the base branch for all feature and fix pull requests.
+- Backports to a prior major are label-driven: land the fix on `main`, then add a `backport vN-dev` label to the PR — a bot opens the backport PR automatically.
 - Do **not** mix changes for multiple major versions in a single pull request.
-- Releases are automated using **release-please** and are created by merging the Release PR.
+- Releases are automated using **release-please** on `main` and each `vN-dev` branch, and are created by merging that branch's Release PR.
 - Follow **Conventional Commits** to ensure correct version bumps.
 - Breaking API changes must be clearly marked to trigger a major version bump.
 - Version numbers are determined automatically by release-please; contributors should not attempt to control versions directly.
+- Release notes for every version across all release lines are on the [GitHub Releases page](https://github.com/cashubtc/cashu-ts/releases).
 
 For a fuller developer-focused guide (setup, hooks, release steps and troubleshooting) see [the developer guide](../DEVELOPER.md).


### PR DESCRIPTION
Updates main's docs to the new reality now that the backport bot (#719, #720) and per-branch release-please are live:

- **DEVELOPER.md**: replaces the 7-step manual LTS release section with the release-please flow; adds the publish-routing note (release events run main's `version.yml`, so `LATEST_MAJOR` is only ever bumped on main); extends the major-transition checklist with the `vN-dev` cut steps (fix the branch's release-please.yml pointer + create the backport label); fixes the stale backport line in the release-strategy intro and the manual-bump note.
- **AGENTS-CONTRIBUTING.md**: LTS releases no longer described as manual.
- **docs-src/versions_releases.md**: was still describing main as v4 with a single v3 maintenance branch; now version-agnostic, covers `vN-dev` branches, label-driven backports, and links the GitHub Releases page.