### PR TITLE
fix(scripts): probe docker tags with and without v prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RATE_LIMIT_PM ?= 200
 # Pin versions
 # ------------------------
 CDK_IMAGE_RC ?= cashubtc/mintd:0.14.3
-CDK_IMAGE ?= cashubtc/mintd:v0.16.0
+CDK_IMAGE ?= cashubtc/mintd:0.17.2
 CDK_NAME ?= cashu-dev-cdk
 
 NUT_IMAGE_RC ?= cashubtc/nutshell:0.18.2

--- a/scripts/UpdateMakefileMintVersion.ts
+++ b/scripts/UpdateMakefileMintVersion.ts
@@ -9,7 +9,6 @@ const MAKEFILE = 'Makefile';
 type Dep = {
   name: string;
   githubRepo: string;
-  dockerTagPrefix: string;
   stableVar: string;
   rcVar: string;
 };
@@ -18,14 +17,12 @@ const DEPENDENCIES: Dep[] = [
   {
     name: 'cashubtc/mintd',
     githubRepo: 'cashubtc/cdk',
-    dockerTagPrefix: 'v',
     stableVar: 'CDK_IMAGE',
     rcVar: 'CDK_IMAGE_RC',
   },
   {
     name: 'cashubtc/nutshell',
     githubRepo: 'cashubtc/nutshell',
-    dockerTagPrefix: '',
     stableVar: 'NUT_IMAGE',
     rcVar: 'NUT_IMAGE_RC',
   },
@@ -144,6 +141,16 @@ async function dockerTagExists(repo: string, tag: string): Promise<boolean> {
   return resp.ok;
 }
 
+// Upstream tagging is inconsistent (cdk usually prefixes tags with "v" but
+// sometimes doesn't), so probe both spellings and use whichever exists.
+async function resolveDockerTag(repo: string, version: string): Promise<string | null> {
+  for (const prefix of ['', 'v']) {
+    const tag = `${prefix}${version}`;
+    if (await dockerTagExists(repo, tag)) return tag;
+  }
+  return null;
+}
+
 function updateMakefile(varName: string, newTag: string) {
   const content = fs.readFileSync(MAKEFILE, 'utf-8');
   const regex = new RegExp(`^${varName}\\s*\\?=.*$`, 'm');
@@ -173,11 +180,13 @@ async function main() {
     const rc = getLatestRc(releases);
 
     if (stable) {
-      const dockerTag = `${dep.dockerTagPrefix}${stable}`;
-      if (await dockerTagExists(dep.name, dockerTag)) {
+      const dockerTag = await resolveDockerTag(dep.name, stable);
+      if (dockerTag) {
         updateMakefile(dep.stableVar, `${dep.name}:${dockerTag}`);
       } else {
-        console.log(`Docker image ${dep.name}:${dockerTag} not yet available, skipping`);
+        console.log(
+          `Docker image ${dep.name}:${stable} (with or without v) not yet available, skipping`,
+        );
       }
     }
 
@@ -185,11 +194,13 @@ async function main() {
       const stableVer = stable ? semverKey(stable) : [0, 0, 0];
       const rcVer = semverKey(rc.split('-')[0]);
       if (rcVer.some((v, i) => v > (stableVer[i] || 0))) {
-        const dockerTag = `${dep.dockerTagPrefix}${rc}`;
-        if (await dockerTagExists(dep.name, dockerTag)) {
+        const dockerTag = await resolveDockerTag(dep.name, rc);
+        if (dockerTag) {
           updateMakefile(dep.rcVar, `${dep.name}:${dockerTag}`);
         } else {
-          console.log(`Docker image ${dep.name}:${dockerTag} not yet available, skipping`);
+          console.log(
+            `Docker image ${dep.name}:${rc} (with or without v) not yet available, skipping`,
+          );
         }
       } else {
         console.log(`RC ${rc} is not newer than stable ${stable}, skipping RC update`);


### PR DESCRIPTION
The nightly mint-image updater has been silently stuck since CDK changed its Docker tagging: tags were `v`-prefixed through `v0.16.0`, then became bare (`0.17.2`). The hardcoded `dockerTagPrefix: 'v'` made every probe 404 → "not yet available, skipping" → daily green runs with no update.

Fix: drop the per-dep prefix config and probe both spellings (`resolveDockerTag`), using whichever exists — robust to upstream flip-flopping either way.

Proof included: running the fixed script produced the `CDK_IMAGE` catch-up bump `v0.16.0` → `0.17.2` in this PR. (`CDK_IMAGE_RC` stays at 0.14.3 by design — the RC var only moves when an RC is ahead of stable, and `0.17.2-rc.1` isn't; it self-heals on the next new RC.) Integration CI on this PR doubles as validation against cdk 0.17.2.