### PR TITLE
ci: add dependabot for github-actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Keeps action pins in .github/workflows current (Node-runtime deprecations,
+  # security fixes). npm deps are managed manually; mint Docker images are
+  # handled by the nightly renovate.yml script.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ['*']
+
+  # The composite action pins its own versions and needs its own entry
+  - package-ecosystem: github-actions
+    directory: /.github/actions/integration-against-mint
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ['*']


### PR DESCRIPTION
Nothing currently watches GitHub Action versions — the custom renovate.yml only updates mint Docker images — so Node-runtime deprecations accrued silently: `actions/checkout@v4` (9 workflows), `actions/setup-node@v4` (+ one **@v3** in renovate.yml, one @v4 in the composite action), `peaceiris/actions-gh-pages@v3`, `peter-evans/create-pull-request@v5`. These trigger the Node 20 deprecation warning now and will hard-fail when GitHub pulls Node 20.

This adds Dependabot's `github-actions` ecosystem: weekly, grouped into a single PR per directory, covering both `.github/workflows/` and the `integration-against-mint` composite action. Its first run will generate the full catch-up sweep for review (the two third-party majors included as visible line items — check their changelogs before merging).

Scope deliberately excludes npm (managed manually) and mint images (the nightly script, fixed in #726, owns those).