### PR TITLE
ci: publish mutation report to Pages, stop wiping gh-pages siblings

### DIFF
--- a/.github/workflows/mutation-testing-weekly.yml
+++ b/.github/workflows/mutation-testing-weekly.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+  contents: write # deploys the HTML report to gh-pages
   issues: write
 
 jobs:
@@ -38,6 +38,13 @@ jobs:
           name: mutation-report
           path: reports/mutation/
           retention-days: 90
+
+      - name: Deploy report to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./reports/mutation
+          destination_dir: mutation
 
       - name: Open report issue
         if: ${{ always() }}
@@ -74,7 +81,7 @@ jobs:
 
           ${top}
 
-          Full interactive report: [mutation-report artifact](${process.env.RUN_URL}) (open \`mutation.html\`).
+          Full interactive report: https://cashu-ts.dev/mutation/mutation.html (latest run; previous weeks in the [run artifacts](${process.env.RUN_URL})).
 
           💡 Local loop: \`npm run test:mutation:incremental\` re-tests only mutants in changed code.
           `);

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -46,6 +46,9 @@ jobs:
           destination_dir: .
           publish_dir: ./docs
           cname: cashu-ts.dev
+          # Overlay instead of wiping the branch: /coverage and /mutation
+          # (weekly Stryker report) live alongside the typedoc root
+          keep_files: true
 
       - name: Deploy Coverage to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -378,6 +378,15 @@ Promoting a new major happens in two steps:
 
 1. **Incoming major lands on `main`.** release-please proposes the new major; cut release candidates (`-rc`), which publish to `next`. Leave `LATEST_MAJOR` unchanged so `latest` keeps pointing at the outgoing major. Cut the outgoing major's `vN-dev` branch; in its first commit, point that branch's `release-please.yml` copy at itself (`on.push.branches` and `target-branch`), and create the `backport vN-dev` label. Maintenance releases then flow from the branch automatically.
 2. **GA.** Bump `LATEST_MAJOR` in `version.yml` (one-line PR on `main` - the only place it matters) and cut the release on `main` - it publishes to `latest`, and the previous major automatically drops to `vN-lts`. Update the branch table above.
+3. **Docs site switchover.** The typedoc deploy overlays gh-pages (`keep_files: true`, so `/coverage` and `/mutation` survive between deploys) - which means pages removed by the new major's docs linger until cleaned. Everything on gh-pages is a regenerable build artifact, so the clean is nuke-and-rebuild:
+
+   ```bash
+   git push origin --delete gh-pages          # stale site gone (Pages setting survives)
+   gh workflow run typedoc.yml                # rebuilds docs root + CNAME + coverage
+   gh workflow run mutation-testing-weekly.yml # rebuilds /mutation (close the extra report issue)
+   ```
+
+   Site 404s for the few minutes between delete and redeploy. Also retarget typedoc.yml's tag trigger (`v4.*`) to the new major.
 
 ### Notes on Versioning
 


### PR DESCRIPTION
The weekly mutation report's "download a zip, unzip, open mutation.html" flow was three hops too many. This deploys the interactive HTML report to **https://cashu-ts.dev/mutation/mutation.html** (same peaceiris pattern as coverage) and links that from the weekly issue; the 90-day artifact stays as history of previous weeks.

Prerequisite fix discovered on the way: the typedoc root deploy (`destination_dir: .`, default `keep_files: false`) **wipes the entire gh-pages branch** on every v4 release — that's why only `coverage/v4.6.1` exists there today (older coverage dirs got nuked). `keep_files: true` makes it overlay, so `/coverage` and `/mutation` survive between releases. Trade-off: typedoc pages removed by a future docs restructure linger until a manual clean — DEVELOPER.md now documents the nuke-and-rebuild recipe as step 3 of the major-transition checklist (along with retargeting typedoc's `v4.*` tag trigger at v5 GA).

After merge: dispatch `mutation-testing-weekly.yml` once to publish the first report to the Pages URL (it'll open a report issue — close it or keep as this week's).