### PR TITLE
docs: typedoc dispatch needs --ref of latest released tag

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -6,6 +6,9 @@ on:
   push:
     tags:
       - 'v4.*'
+  # Manual runs: pick the latest release tag of the npm-latest major as the
+  # ref — dispatching from main publishes unreleased next-major docs whenever
+  # main is ahead of latest (e.g. during an rc phase)
   workflow_dispatch:
 
 jobs:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -382,11 +382,15 @@ Promoting a new major happens in two steps:
 
    ```bash
    git push origin --delete gh-pages          # stale site gone (Pages setting survives)
-   gh workflow run typedoc.yml                # rebuilds docs root + CNAME + coverage
+   gh workflow run typedoc.yml --ref vX.Y.Z   # rebuilds docs root + CNAME + coverage
    gh workflow run mutation-testing-weekly.yml # rebuilds /mutation (close the extra report issue)
    ```
 
    Site 404s for the few minutes between delete and redeploy. Also retarget typedoc.yml's tag trigger (`v4.*`) to the new major.
+
+   ⚠️ **Always dispatch typedoc with `--ref <latest release tag of the npm-latest major>`.** A bare dispatch builds from `main` - wrong whenever `main` is ahead of `latest` (e.g. during an rc phase, the site would show unreleased next-major docs).
+
+   ⚠️ **typedoc.yml changes must land on the branch releases are tagged from.** Tag-triggered (and tag-ref'd) runs execute the workflow file _at that ref_, so edits to `main`'s copy never affect release deploys - keep `v4-dev`'s copy in sync (e.g. the `keep_files: true` setting protecting `/coverage` and `/mutation`).
 
 ### Notes on Versioning
 


### PR DESCRIPTION
Two lessons from today's Pages testing, written down where they'll be found:

1. `gh workflow run typedoc.yml` without `--ref` builds from main — during an rc phase that publishes unreleased next-major docs (this happened: v5-rc docs went live while npm `latest` was 4.6.1; fixed by re-dispatching with `--ref v4.6.1`). The major-transition recipe now says `--ref vX.Y.Z` and both files carry a warning.
2. Tag-triggered runs execute the workflow file at the tag's commit, so typedoc.yml fixes on main (like #736's `keep_files: true`) never affect release deploys — they must land on `v4-dev`. Companion PR adds it there.