### PR TITLE
ci: keep_files on typedoc deploy so releases stop wiping gh-pages

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -46,6 +46,11 @@ jobs:
           destination_dir: .
           publish_dir: ./docs
           cname: cashu-ts.dev
+          # Overlay instead of wiping the branch: /coverage and /mutation
+          # (weekly Stryker report, deployed from main) live alongside the
+          # typedoc root. Tag-triggered runs execute THIS branch's copy, so
+          # this setting must live here on v4-dev, not (only) on main.
+          keep_files: true
 
       - name: Deploy Coverage to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Companion to #736 and #740, on the branch where it actually takes effect: typedoc.yml runs on `v4.*` tag pushes, and tag-triggered workflows execute the file **at the tag's commit** — so #736's `keep_files: true` on main never applies to release deploys. Today's v4.6.1-ref'd run proved it by wiping `/mutation` (restored by hand since).

With this on `v4-dev`, every future v4 release tag carries the fix and `/coverage` + `/mutation` survive release deploys.