### PR TITLE
fix(utils): throw CTSError for malformed token templates

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -302,8 +302,14 @@ function templateFromToken(token: Token): TokenV4Template {
 }
 
 function tokenFromTemplate(template: TokenV4Template): Token {
+  if (!template || !Array.isArray(template.t)) {
+    throw new CTSError('Invalid token template');
+  }
   const proofs: Proof[] = [];
-  template.t.forEach((t) =>
+  template.t.forEach((t) => {
+    if (!t || !Array.isArray(t.p)) {
+      throw new CTSError('Invalid token template');
+    }
     t.p.forEach((p) => {
       proofs.push({
         secret: p.s,
@@ -324,8 +330,8 @@ function tokenFromTemplate(template: TokenV4Template): Token {
           witness: p.w,
         }),
       });
-    }),
-  );
+    });
+  });
   const decodedToken: Token = { mint: template.m, proofs, unit: template.u || 'sat' };
   if (template.d) {
     decodedToken.memo = template.d;

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1468,6 +1468,23 @@ describe('getDecodedTokenBinary edge cases', () => {
   });
 });
 
+describe('tokenFromTemplate rejects valid CBOR of wrong shape', () => {
+  test('getDecodedToken (cashuB) throws CTSError, not a raw TypeError', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat' });
+    const token = 'cashuB' + utils.encodeUint8toBase64Url(body);
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+
+  test('getDecodedTokenBinary (crawB) throws CTSError, not a raw TypeError', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat' });
+    const prefix = new TextEncoder().encode('crawB');
+    const bytes = new Uint8Array(prefix.length + body.length);
+    bytes.set(prefix, 0);
+    bytes.set(body, prefix.length);
+    expect(() => utils.getDecodedTokenBinary(bytes)).toThrow(CTSError);
+  });
+});
+
 describe('deriveKeysetId edge cases', () => {
   test('throws for unknown version byte', () => {
     expect(() => utils.deriveKeysetId(keys, { versionByte: 99 })).toThrow(

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1483,6 +1483,19 @@ describe('tokenFromTemplate rejects valid CBOR of wrong shape', () => {
     bytes.set(body, prefix.length);
     expect(() => utils.getDecodedTokenBinary(bytes)).toThrow(CTSError);
   });
+
+  test('throws CTSError when a token entry has no proofs array', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat', t: [{ i: 'nope' }] });
+    const token = 'cashuB' + utils.encodeUint8toBase64Url(body);
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+
+  test('defaults unit to sat when template omits it', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', t: [] });
+    const token = 'cashuB' + utils.encodeUint8toBase64Url(body);
+    const decoded = utils.getDecodedToken(token, []);
+    expect(decoded).toEqual({ mint: 'http://localhost:3338', proofs: [], unit: 'sat' });
+  });
 });
 
 describe('deriveKeysetId edge cases', () => {


### PR DESCRIPTION
## Problem

`tokenFromTemplate` casts decoded CBOR to `TokenV4Template` with an unchecked cast, then dereferences `template.t.forEach(...)` with no shape validation. CBOR can encode any structure, so a token whose body is well-formed CBOR but not a v4 template (e.g. a map `{ m, u }` with no `t` array) makes `template.t` undefined, and `undefined.forEach` throws a raw `TypeError` instead of the library's `CTSError`.

Every other failure on this path (unsupported version, multi-entry token, short-keyset resolution) throws `CTSError`, so callers that decode attacker-supplied tokens and branch on `e instanceof CTSError` get an unexpected exception type. Reachable from the public `getDecodedToken`, `getTokenMetadata`, and `getDecodedTokenBinary`.

This is a robustness/input-validation issue only (CWE-20). No privilege escalation.

## Fix

Guard the template shape in the shared `tokenFromTemplate`, so both the `cashuB` and `crawB` decode paths are covered by a single change. A malformed template now throws `CTSError('Invalid token template')`.

## Tests

Added regression tests for both entry points (`getDecodedToken` / `getDecodedTokenBinary`) asserting `CTSError` rather than a raw `TypeError`. `npm run prtasks` passes.

---

This finding was discovered by Project Loupe.