### PR TITLE
[Backport v4-dev] fix(utils): throw CTSError for malformed token templates

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -291,8 +291,14 @@ function templateFromToken(token: Token): TokenV4Template {
 }
 
 function tokenFromTemplate(template: TokenV4Template): Token {
+  if (!template || !Array.isArray(template.t)) {
+    throw new CTSError('Invalid token template');
+  }
   const proofs: Proof[] = [];
-  template.t.forEach((t) =>
+  template.t.forEach((t) => {
+    if (!t || !Array.isArray(t.p)) {
+      throw new CTSError('Invalid token template');
+    }
     t.p.forEach((p) => {
       proofs.push({
         secret: p.s,
@@ -313,8 +319,8 @@ function tokenFromTemplate(template: TokenV4Template): Token {
           witness: p.w,
         }),
       });
-    }),
-  );
+    });
+  });
   const decodedToken: Token = { mint: template.m, proofs, unit: template.u || 'sat' };
   if (template.d) {
     decodedToken.memo = template.d;

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1111,6 +1111,36 @@ describe('getDecodedTokenBinary edge cases', () => {
   });
 });
 
+describe('tokenFromTemplate rejects valid CBOR of wrong shape', () => {
+  test('getDecodedToken (cashuB) throws CTSError, not a raw TypeError', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat' });
+    const token = 'cashuB' + utils.encodeUint8toBase64Url(body);
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+
+  test('getDecodedTokenBinary (crawB) throws CTSError, not a raw TypeError', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat' });
+    const prefix = new TextEncoder().encode('crawB');
+    const bytes = new Uint8Array(prefix.length + body.length);
+    bytes.set(prefix, 0);
+    bytes.set(body, prefix.length);
+    expect(() => utils.getDecodedTokenBinary(bytes)).toThrow(CTSError);
+  });
+
+  test('throws CTSError when a token entry has no proofs array', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat', t: [{ i: 'nope' }] });
+    const token = 'cashuB' + utils.encodeUint8toBase64Url(body);
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+
+  test('defaults unit to sat when template omits it', () => {
+    const body = utils.encodeCBOR({ m: 'http://localhost:3338', t: [] });
+    const token = 'cashuB' + utils.encodeUint8toBase64Url(body);
+    const decoded = utils.getDecodedToken(token, []);
+    expect(decoded).toEqual({ mint: 'http://localhost:3338', proofs: [], unit: 'sat' });
+  });
+});
+
 describe('deriveKeysetId edge cases', () => {
   test('throws for unknown version byte', () => {
     expect(() => utils.deriveKeysetId(keys, { versionByte: 99 })).toThrow(

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../src/crypto';
 import { test, describe, expect } from 'vitest';
 import { Amount, MintKeys, type Keys, type Proof, type Token, Keyset } from '../../src';
+import { CTSError } from '../../src/model/Errors';
 import * as utils from '../../src/utils';
 import {
   NUT02_V1_VECTOR1_KEYS,


### PR DESCRIPTION
# Description
Backport of #742 to `v4-dev`.