### PR TITLE
ci(backport): move backport marker to title suffix

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,6 +42,11 @@ jobs:
           # the open-issue job below files a tracking issue
           # Ignore merge commits from "update branch" syncs
           merge_commits: skip
+          # Backport marker goes at the END of the title: the default
+          # "[Backport vN-dev]" PREFIX breaks release-please's conventional-
+          # commit parsing after squash-merge (no release PR, no changelog
+          # entry — bit us on #743). A suffix keeps the subject parseable.
+          pull_title: '${pull_title} [backport ${target_branch}]'
 
   open-issue:
     name: Open issue for failed backports


### PR DESCRIPTION
Backport PR titles were `[Backport v4-dev] fix(...): ...` — after squash-merge that subject isn't a conventional commit, so release-please on `v4-dev` ignored it: no 4.6.2 release PR, no changelog entry (#743 hit this).

`pull_title: '${pull_title} [backport ${target_branch}]'` keeps the original conventional subject with the marker as a suffix — still obvious in PR lists, and the head branch (`backport-N-to-vN-dev`) + base branch mark it anyway.

The missed #743 changelog line gets hand-added to the next 4.6.x release PR before merging.