### PR TITLE
ci: lint tests with a tailored ruleset

### DIFF
--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -98,6 +98,7 @@ DEV=1 make nutshell-stable-down
 ## Linting and TypeScript rules
 
 - Lint config lives in `eslint.config.js` (flat config).
+- Tests are linted too, with a relaxed override block (fixture `any`s allowed, but promise correctness and vitest hygiene — no `.only`, no assertion-free tests — are enforced). `test/tsconfig.json` exists so typed rules cover test files.
 - `any` is not allowed (prefer explicit types, generics, or `unknown` with narrowing).
 - Type-only imports/exports are required (`@typescript-eslint/consistent-type-imports`).
 - No Node-only modules in library code (`import/no-nodejs-modules`).

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -111,7 +111,7 @@ git commit --edit --file=.git/COMMIT_EDITMSG
 - `commit-msg`: validates the commit message with Commitlint and points you at `.git/COMMIT_EDITMSG` if the message needs fixing.
 - `pre-commit`: runs `lint-staged` on staged files only.
   - `*.{js,ts}`: `eslint --fix`, then `prettier --write`
-  - `*.{json,md,yml,yaml}`: `prettier --write`
+  - `*.{mjs,cjs,json,md,yml,yaml}`: `prettier --write`
 - `pre-push`: runs repository-wide `npm run check-lint` and `npm run check-format`.
 
 This keeps commits fast while still blocking pushes with lint or formatting drift.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import eslint from '@eslint/js';
+import vitest from '@vitest/eslint-plugin';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
@@ -14,7 +15,9 @@ export default tseslint.config(
       'dist/**',
       'dist-scripts/**',
       'scripts/**',
-      'test/**',
+      // Consumer smoke harnesses: plain-JS external-consumer simulations in
+      // varying module systems, run by npm scripts — not vitest suites
+      'test/consumer/**',
       'coverage/**',
       'docs/**',
       '.jest/**',
@@ -96,6 +99,41 @@ export default tseslint.config(
         typescript: { project: './tsconfig.json' }, // Explicitly point to tsconfig for path mappings/aliases if any
         node: true,
       },
+    },
+  },
+  // Test files: keep the correctness rules (no-floating-promises catches
+  // vacuously-passing async assertions) but relax fixture ergonomics, and
+  // add vitest hygiene (a committed .only silently skips the suite in CI).
+  {
+    files: ['test/**/*.ts'],
+    plugins: { vitest },
+    rules: {
+      'vitest/no-focused-tests': 'error',
+      'vitest/no-disabled-tests': 'warn',
+      // expect* covers helpers like expectNUT10SecretDataToEqual
+      'vitest/expect-expect': ['error', { assertFunctionNames: ['expect*', 'testRoundtrip'] }],
+      // _-prefix marks intentionally unused (mock params, destructuring)
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+      // mock-socket message types defeat string-ness proofs; runtime is fine
+      '@typescript-eslint/no-base-to-string': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      // async test wrappers and expect(obj.method) are idiomatic in tests
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+      // noop mocks
+      '@typescript-eslint/no-empty-function': 'off',
+      'promise/param-names': 'off',
+      // Tests run under node/playwright, not in consumer bundles
+      'import/no-nodejs-modules': 'off',
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@vitest/browser": "^4.1.5",
         "@vitest/browser-playwright": "^4.1.5",
         "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/eslint-plugin": "^1.6.20",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -3796,6 +3797,37 @@
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.20.tgz",
+      "integrity": "sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@vitest/browser": "^4.1.5",
     "@vitest/browser-playwright": "^4.1.5",
     "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/eslint-plugin": "^1.6.20",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -1,5 +1,14 @@
 // 1) Mock FIRST, and define everything INSIDE the factory (no outer refs)
-import { vi, describe, test, expect, beforeEach, afterEach, Mock, MockInstance } from 'vitest';
+import {
+  vi,
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
 
 vi.mock('../../src/wallet', () => {
   // Instance mock: getCheapestKeyset returns a stub keyset
@@ -29,14 +38,14 @@ vi.mock('../../src/wallet', () => {
 });
 
 // 2) Now import everything else
-import * as wallet from '../../src/wallet';
+import { Amount, type RequestFn } from '../../src';
 import { AuthManager } from '../../src/auth/AuthManager';
+import type { Logger } from '../../src/logger';
+import { OutputData } from '../../src/model/OutputData';
 import type { Proof } from '../../src/model/types';
 import * as utils from '../../src/utils';
 import { encodeBase64toUint8, Bytes } from '../../src/utils';
-import { OutputData } from '../../src/model/OutputData';
-import { Amount, RequestFn } from '../../src';
-import type { Logger } from '../../src/logger';
+import * as wallet from '../../src/wallet';
 
 const mintUrl = 'http://mint.local';
 
@@ -163,7 +172,7 @@ describe('AuthManager: CAT lifecycle', () => {
   });
 
   test('ensureCAT returns possibly expired CAT if no OIDC or refresh fails', async () => {
-    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn, logger: console as any });
+    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn, logger: console });
     am['tokens'] = { accessToken: 'old-cat', expiresAt: Date.now() - 1000 };
     const cat = await am.ensureCAT(30);
     expect(cat).toBe('old-cat');
@@ -195,7 +204,7 @@ describe('AuthManager: constructor limits', () => {
 });
 
 test('ensureCAT warns when refresh throws', async () => {
-  const am = new AuthManager('http://mint', { request: vi.fn(), logger: console as any });
+  const am = new AuthManager('http://mint', { request: vi.fn(), logger: console });
   am['tokens'] = { accessToken: 'old', refreshToken: 'rr', expiresAt: Date.now() - 1 };
   am['oidc'] = { refresh: vi.fn().mockRejectedValue(new Error('nope')) } as any;
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -437,7 +446,7 @@ test('ensureCAT returns undefined when no CAT and no OIDC, hitting validForAtLea
 test('updateFromOIDC early-returns when access_token missing', () => {
   const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn });
   am['tokens'] = { accessToken: 'keep-me', refreshToken: 'r', expiresAt: 123 };
-  am['updateFromOIDC']({} as any);
+  am['updateFromOIDC']({});
   expect(am.getCAT()).toBe('keep-me');
   expect(am['tokens'].refreshToken).toBe('r');
   expect(am['tokens'].expiresAt).toBe(123);
@@ -477,7 +486,7 @@ describe('getBlindAuthToken coverage', () => {
     const am = new AuthManager(mintUrl, {
       request: reqSpy as RequestFn,
       desiredPoolSize: 1,
-      logger: console as any,
+      logger: console,
     });
     am['info'] = fakeInfo({ batMax: 1, blindProtected: true });
     am['keychain'] = {
@@ -504,7 +513,7 @@ describe('getBlindAuthToken coverage', () => {
     const am = new AuthManager(mintUrl, {
       request: reqSpy as RequestFn,
       desiredPoolSize: 1,
-      logger: console as any,
+      logger: console,
     });
     am['info'] = fakeInfo({ batMax: 1, blindProtected: false });
     am['keychain'] = {
@@ -624,7 +633,7 @@ test('getActiveKeys throws if keychain not initialised', () => {
 /* ---------- withLock via concurrent getBlindAuthToken ---------- */
 
 test('withLock serialises concurrent BAT pops', async () => {
-  const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn, logger: console as any });
+  const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn, logger: console });
   am['info'] = fakeInfo({ batMax: 1, blindProtected: true });
   am['keychain'] = {
     getCheapestKeyset: vi.fn().mockReturnValue({ id: 'k', keys: { 1: '02aa' } }),
@@ -689,7 +698,7 @@ test('topUp sets Clear-auth header when mint endpoint requires CAT', async () =>
 
   // Assert the Clear-auth header was set
   expect(reqSpy).toHaveBeenCalledTimes(1);
-  const callArg = reqSpy.mock.calls[0][0] as any;
+  const callArg = reqSpy.mock.calls[0][0];
   expect(callArg.endpoint).toBe('http://mint.local/v1/auth/blind/mint');
   expect(callArg.method).toBe('POST');
   expect(callArg.headers?.['Clear-auth']).toBe('cat123');

--- a/test/auth/OIDCAuth.node.test.ts
+++ b/test/auth/OIDCAuth.node.test.ts
@@ -1,10 +1,10 @@
-import { setupServer } from 'msw/node';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
 import { beforeAll, afterAll, beforeEach, afterEach, describe, test, expect, vi } from 'vitest';
 
 import { OIDCAuth, type OIDCConfig, type TokenResponse } from '../../src/auth/OIDCAuth';
 import { Bytes, encodeUint8toBase64Url } from '../../src/utils';
-import { sha256 } from '@noble/hashes/sha2.js';
 
 const ISSUER = 'http://idp.local/realms/cashu';
 const OIDC_BASE = 'http://oidc.local';
@@ -336,7 +336,7 @@ describe('OIDCAuth: misc coverage', () => {
     server.use(http.get(DISCOVERY, () => new HttpResponse('{not-json', { status: 200 })));
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const oidc = new OIDCAuth(DISCOVERY, { logger: console as any });
+    const oidc = new OIDCAuth(DISCOVERY, { logger: console });
 
     await expect(oidc.loadConfig()).rejects.toThrow('OIDCAuth: invalid discovery document');
     expect(warn).toHaveBeenCalled(); // "OIDCAuth: bad discovery JSON"
@@ -453,7 +453,7 @@ test('postFormStrict returns {} on 200 with bad JSON and logs warn', async () =>
   server.use(http.get(DISCOVERY, () => HttpResponse.json({ token_endpoint: TOKEN })));
 
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-  const oidc = new OIDCAuth(DISCOVERY, { logger: console as any });
+  const oidc = new OIDCAuth(DISCOVERY, { logger: console });
   await oidc.loadConfig();
 
   server.use(http.post(TOKEN, () => new HttpResponse('{bad', { status: 200 })));

--- a/test/auth/createAuthWallet.node.test.ts
+++ b/test/auth/createAuthWallet.node.test.ts
@@ -1,9 +1,10 @@
 // test/auth/createAuthWallet.test.ts (essential handlers and setup)
-import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
 import { beforeAll, beforeEach, afterEach, afterAll, test, describe, expect } from 'vitest';
-import { createAuthWallet } from '../../src/auth/createAuthWallet';
+
 import type { RequestFetch, RequestFn } from '../../src';
+import { createAuthWallet } from '../../src/auth/createAuthWallet';
 
 // ---- Constants
 const mintUrl = 'http://localhost:3338';

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'vitest';
+
 import { Bytes } from '../src/utils/Bytes';
 
 describe('Bytes utility class', () => {

--- a/test/consts.ts
+++ b/test/consts.ts
@@ -1,4 +1,4 @@
-import { KeyChain, KeyChainCache, type MintKeys, type MintKeyset } from '../src';
+import { KeyChain, type KeyChainCache, type MintKeys, type MintKeyset } from '../src';
 
 export const MINTINFORESP = JSON.parse(
   '{"name":"Testnut mint","pubkey":"0296d0aa13b6a31cf0cd974249f28c7b7176d7274712c95a41c7d8066d3f29d679","version":"Nutshell/0.16.3","description":"Mint for testing Cashu wallets","description_long":"This mint usually runs the latest main branch of the nutshell repository. It uses a FakeWallet, all your Lightning invoices will always be marked paid so that you can test minting and melting ecash via Lightning.","contact":[{"method":"email","info":"contact@me.com"},{"method":"twitter","info":"@me"},{"method":"nostr","info":"npub1337"}],"motd":"This is a message of the day field. You should display this field to your users if the content changes!","icon_url":"https://image.nostr.build/46ee47763c345d2cfa3317f042d332003f498ee281fb42808d47a7d3b9585911.png","time":1731684933,"nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat","options":{"description":true}},{"method":"bolt11","unit":"usd","options":{"description":true}},{"method":"bolt11","unit":"eur","options":{"description":true}},{"method":"bolt12","unit":"sat","options":{"description":true}},{"method":"bolt12","unit":"usd","options":{"description":true}},{"method":"bolt12","unit":"eur","options":{"description":true}}],"disabled":false},"5":{"methods":[{"method":"bolt11","unit":"sat"},{"method":"bolt11","unit":"usd"},{"method":"bolt11","unit":"eur"},{"method":"bolt12","unit":"sat"},{"method":"bolt12","unit":"usd"},{"method":"bolt12","unit":"eur"}],"disabled":false},"7":{"supported":true},"8":{"supported":true},"9":{"supported":true},"10":{"supported":true},"11":{"supported":true},"12":{"supported":true},"14":{"supported":true},"17":{"supported":[{"method":"bolt11","unit":"sat","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"usd","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt11","unit":"eur","commands":["bolt11_melt_quote","proof_state","bolt11_mint_quote"]},{"method":"bolt12","unit":"sat","commands":["bolt12_melt_quote","proof_state","bolt12_mint_quote"]},{"method":"bolt12","unit":"usd","commands":["bolt12_melt_quote","proof_state","bolt12_mint_quote"]},{"method":"bolt12","unit":"eur","commands":["bolt12_melt_quote","proof_state","bolt12_mint_quote"]}]}}}',
@@ -201,7 +201,7 @@ export const NUT02_V1_VECTOR1_KEYS: MintKeys = {
     '2': '03fd4ce5a16b65576145949e6f99f445f8249fee17c606b688b504a849cdc452de',
     '4': '02648eccfa4c026960966276fa5a4cae46ce0fd432211a4f449bf84f13aa5f8303',
     '8': '02fdfd6796bfeac490cbee12f778f867f0a2c68f6508d17c649759ea0dc3547528',
-  } as MintKeys['keys'],
+  },
 };
 
 export const NUT02_V1_VECTOR2_KEYS: MintKeys = {
@@ -272,7 +272,7 @@ export const NUT02_V1_VECTOR2_KEYS: MintKeys = {
     '2305843009213693952': '033cdc225962c052d485f7cfbf55a5b2367d200fe1fe4373a347deb4cc99e9a099',
     '4611686018427387904': '024a4b806cf413d14b294719090a9da36ba75209c7657135ad09bc65328fba9e6f',
     '9223372036854775808': '0377a6fe114e291a8d8e991627c38001c8305b23b9e98b1c7b1893f5cd0dda6cad',
-  } as MintKeys['keys'],
+  },
 };
 
 export const NUT02_V2_VECTOR1_KEYS: MintKeys = {

--- a/test/crypto/NUT01.test.ts
+++ b/test/crypto/NUT01.test.ts
@@ -1,15 +1,16 @@
 import { hexToBytes } from '@noble/hashes/utils.js';
+import { describe, expect, test } from 'vitest';
+
 import {
   blindMessage,
   createBlindSignature,
   createNewMintKeys,
   serializeMintKeys,
   deserializeMintKeys,
-  SerializedMintKeys,
+  type SerializedMintKeys,
 } from '../../src/crypto';
-import { PUBKEYS, TEST_PRIV_KEY_PUBS } from '../consts';
-import { describe, expect, test } from 'vitest';
 import { hexToNumber } from '../../src/utils';
+import { PUBKEYS, TEST_PRIV_KEY_PUBS } from '../consts';
 
 describe('test blind sig', () => {
   test('blind sig', async () => {

--- a/test/crypto/NUT09.test.ts
+++ b/test/crypto/NUT09.test.ts
@@ -1,6 +1,7 @@
 import { bytesToHex } from '@noble/curves/utils.js';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
+
 import { deriveSecretAndBlindingFactor, getKeysetIdInt } from '../../src/crypto';
 import { Bytes } from '../../src/utils';
 

--- a/test/crypto/NUT10.test.ts
+++ b/test/crypto/NUT10.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
+
+import { Amount, CTSError, type Proof } from '../../src';
 import { getTagInt, hasTag, parseHTLCSecret, parseSecret } from '../../src/crypto';
-import { Amount, CTSError, Proof } from '../../src';
 
 const proof: Proof = {
   amount: Amount.from(2),

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1,6 +1,9 @@
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { Amount, type OutputDataLike } from '../../src';
 import {
   createP2PKsecret,
   signP2PKProof,
@@ -9,7 +12,7 @@ import {
   getP2PKExpectedWitnessPubkeys,
   getP2PKSigFlag,
   getP2PKWitnessSignatures,
-  Secret,
+  type Secret,
   isP2PKSpendAuthorised,
   getPubKeyFromPrivKey,
   createRandomSecretKey,
@@ -26,10 +29,8 @@ import {
   normalizeP2PKOptions,
   verifyP2PKSpendingConditions,
 } from '../../src/crypto';
-import { Proof, P2PKWitness } from '../../src/model/types';
-import { sha256 } from '@noble/hashes/sha2.js';
-import { Amount, OutputDataLike } from '../../src';
 import { ConsoleLogger, NULL_LOGGER } from '../../src/logger';
+import { type Proof, type P2PKWitness } from '../../src/model/types';
 
 const PRIVKEY = schnorr.utils.randomSecretKey();
 const PUBKEY = bytesToHex(getPubKeyFromPrivKey(PRIVKEY));
@@ -532,7 +533,7 @@ describe('P2BK fixed-vector ECDH tweak', () => {
     const Z = E.multiply(pBig);
     const Zx = Z.toBytes(false).slice(1, 33); // 32B X from uncompressed SEC1
     const i0 = new Uint8Array([0x00]);
-    let r = secp256k1.Point.Fn.fromBytes(sha256(new Uint8Array([...P2BK_DST, ...Zx, ...i0])));
+    const r = secp256k1.Point.Fn.fromBytes(sha256(new Uint8Array([...P2BK_DST, ...Zx, ...i0])));
 
     // Check blinded point matches P + r·G
     const expectPprime = P.add(secp256k1.Point.BASE.multiply(r));
@@ -940,7 +941,7 @@ describe('branch coverage helpers', () => {
     secret,
     C: 'C',
     amount: 1 as any, // satisfy type if needed by your model
-    id: 'x' as any,
+    id: 'x',
     witness: undefined,
   });
 
@@ -965,7 +966,7 @@ describe('branch coverage helpers', () => {
   });
 
   test('getP2PKWitnessSignatures, witness object with signatures undefined', () => {
-    const sigs = getP2PKWitnessSignatures({} as any);
+    const sigs = getP2PKWitnessSignatures({});
     expect(sigs).toEqual([]); // covers object path with fallback
   });
 });
@@ -986,13 +987,13 @@ describe('SIG_ALL, both message formats are actually signed', () => {
         id: '00a1',
         C: '03'.padEnd(66, '1'),
         secret,
-      } as Proof,
+      },
       {
         amount: Amount.from(2),
         id: '00a2',
         C: '03'.padEnd(66, '2'),
         secret,
-      } as Proof,
+      },
     ];
 
     // 3. Minimal outputs satisfying OutputDataLike
@@ -1333,9 +1334,9 @@ describe('NUT-11 test vectors', () => {
       {
         amount: Amount.from(2),
         id: '00bfa73302d12ffd',
-        secret: `[\"P2PK\",{\"nonce\":\"bbf9edf441d17097e39f5095a3313ba24d3055ab8a32f758ff41c10d45c4f3de\",\"data\":\"${pub}\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]`,
+        secret: `["P2PK",{"nonce":"bbf9edf441d17097e39f5095a3313ba24d3055ab8a32f758ff41c10d45c4f3de","data":"${pub}","tags":[["sigflag","SIG_ALL"]]}]`,
         C: '02a9d461ff36448469dccf828fa143833ae71c689886ac51b62c8d61ddaa10028b',
-        witness: `{\"signatures\":[\"${sig}\"]}`,
+        witness: `{"signatures":["${sig}"]}`,
       },
     ];
     const outputs = [

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -1,6 +1,7 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
+
 import {
   createBlindSignature,
   hash_e,
@@ -12,8 +13,8 @@ import {
   constructUnblindedSignature,
   createRandomRawBlindedMessage,
 } from '../../src/crypto';
-import { OutputData } from '../../src/model/OutputData';
 import { Amount } from '../../src/model/Amount';
+import { OutputData } from '../../src/model/OutputData';
 
 describe('test hash_e', () => {
   test('test hash_e function', async () => {
@@ -54,7 +55,7 @@ describe('test DLEQ scheme', () => {
 
     // Mint
     const blindSignature = createBlindSignature(blindMessage.B_, mintPrivKey, '');
-    let dleqProof = createDLEQProof(blindMessage.B_, mintPrivKey);
+    const dleqProof = createDLEQProof(blindMessage.B_, mintPrivKey);
 
     // Wallet(Alice)
     const proof = constructUnblindedSignature(

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -1,5 +1,6 @@
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
+
 import { BLS_FR_ORDER, deriveSecretAndBlindingFactor } from '../../src/crypto';
 import { Bytes } from '../../src/utils';
 

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -1,4 +1,8 @@
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/curves/utils.js';
 import { describe, expect, test, vi } from 'vitest';
+
+import { Amount, type Proof } from '../../src';
 import {
   createHTLCHash,
   createHTLCsecret,
@@ -10,9 +14,6 @@ import {
   verifyHTLCHash,
   verifyHTLCSpendingConditions,
 } from '../../src/crypto';
-import { Amount, Proof } from '../../src';
-import { schnorr } from '@noble/curves/secp256k1.js';
-import { bytesToHex } from '@noble/curves/utils.js';
 
 const PRIVKEY = schnorr.utils.randomSecretKey();
 const PUBKEY = bytesToHex(getPubKeyFromPrivKey(PRIVKEY));

--- a/test/crypto/NUT20.test.ts
+++ b/test/crypto/NUT20.test.ts
@@ -1,12 +1,13 @@
-import { test, describe, expect } from 'vitest';
-import { signMintQuote, verifyMintQuoteSignature } from '../../src/crypto';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { Amount, MintRequest } from '../../src';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { test, describe, expect } from 'vitest';
+
+import { Amount, type MintRequest } from '../../src';
+import { signMintQuote, verifyMintQuoteSignature } from '../../src/crypto';
 
 describe('mint quote signatures', () => {
   test('valid signature verification', () => {
-    let mintRequest = {
+    const mintRequest = {
       quote: '9d745270-1405-46de-b5c5-e2762b4f5e00',
       outputs: [
         {
@@ -45,7 +46,7 @@ describe('mint quote signatures', () => {
     expect(verifyMintQuoteSignature(pubkey, quote, blindedMessages, sig)).toBe(true);
   });
   test('invalid signature verification', () => {
-    let mintRequest = {
+    const mintRequest = {
       quote: '9d745270-1405-46de-b5c5-e2762b4f5e00',
       outputs: [
         {
@@ -84,7 +85,7 @@ describe('mint quote signatures', () => {
     expect(verifyMintQuoteSignature(pubkey, quote, blindedMessages, sig)).toBe(false);
   });
   test('signature creation', () => {
-    let mintRequest = {
+    const mintRequest = {
       quote: '9d745270-1405-46de-b5c5-e2762b4f5e00',
       outputs: [
         {

--- a/test/crypto/NUT27.test.ts
+++ b/test/crypto/NUT27.test.ts
@@ -1,5 +1,6 @@
-import { test, describe, expect } from 'vitest';
 import { hexToBytes } from '@noble/hashes/utils.js';
+import { test, describe, expect } from 'vitest';
+
 import {
   deriveMintBackupKeys,
   buildMintBackupPayload,

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -1,4 +1,7 @@
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { describe, expect, test } from 'vitest';
+
 import {
   pointFromHex,
   deriveP2BKSecretKey,
@@ -6,8 +9,6 @@ import {
   deriveP2BKSecretKeys,
 } from '../../src/crypto';
 import { hexToNumber, numberToHexPadded64 } from '../../src/utils';
-import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
-import { describe, expect, test } from 'vitest';
 
 describe('blinded pubkeys & scalar arithmetic', () => {
   test('deriveP2BKSecretKey corresponds to pubkey addition: (p+r)·G == p·G + r·G', () => {

--- a/test/crypto/NUT29.test.ts
+++ b/test/crypto/NUT29.test.ts
@@ -1,8 +1,9 @@
-import { test, describe, expect } from 'vitest';
-import { signMintQuote, verifyMintQuoteSignature } from '../../src/crypto';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
+import { test, describe, expect } from 'vitest';
+
 import { Amount } from '../../src';
+import { signMintQuote, verifyMintQuoteSignature } from '../../src/crypto';
 
 /**
  * NUT-29 test vectors for batch mint signatures.

--- a/test/crypto/bls.test.ts
+++ b/test/crypto/bls.test.ts
@@ -1,8 +1,9 @@
-import { bytesToHex, hexToBytes, numberToBytesBE } from '@noble/curves/utils.js';
 import { bls12_381 } from '@noble/curves/bls12-381.js';
+import { bytesToHex, hexToBytes, numberToBytesBE } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
+
 import {
   BLS_FR_ORDER,
   BLS_HASH_TO_CURVE_DST,
@@ -237,7 +238,6 @@ describe('batchVerifyUnblindedSignatureBls', () => {
   // expand into two spendable proofs.
   test('rejects the C1 + C2 = C aggregation forgery (per-proof randomness)', () => {
     const aScalar = 5n;
-    const aBytes = hexToBytes(aScalar.toString(16).padStart(64, '0'));
     const K2 = bls12_381.G2.Point.BASE.multiply(aScalar);
     const secret1 = new TextEncoder().encode('forgery-victim-1');
     const secret2 = new TextEncoder().encode('forgery-victim-2');

--- a/test/crypto/bls_random_scalar.test.ts
+++ b/test/crypto/bls_random_scalar.test.ts
@@ -1,5 +1,6 @@
 import { numberToBytesBE } from '@noble/curves/utils.js';
 import { afterEach, describe, expect, test, vi } from 'vitest';
+
 import { BLS_FR_ORDER, blindMessageBls } from '../../src/crypto';
 
 // randomScalar() (module-private in curve_bls.ts) feeds the no-r path of blindMessageBls — the
@@ -9,6 +10,7 @@ import { BLS_FR_ORDER, blindMessageBls } from '../../src/crypto';
 const { randomBytesMock } = vi.hoisted(() => ({ randomBytesMock: vi.fn() }));
 
 vi.mock('@noble/curves/utils.js', async (importActual) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest importActual generic
   const actual = await importActual<typeof import('@noble/curves/utils.js')>();
   return { ...actual, randomBytes: randomBytesMock };
 });

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -1,5 +1,9 @@
 import { bls12_381 } from '@noble/curves/bls12-381.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { describe, expect, test } from 'vitest';
+
 import {
   asBlsG1Point,
   asSecpPoint,
@@ -17,11 +21,8 @@ import {
   isBlsKeyset,
   pointFromBytes,
 } from '../../src/crypto';
-import { Bytes } from '../../src/utils';
-import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
-import { describe, expect, test } from 'vitest';
-import { sha256 } from '@noble/hashes/sha2.js';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
+import { Bytes } from '../../src/utils';
 
 const SECRET_MESSAGE = 'test_message';
 
@@ -52,25 +53,25 @@ describe('test crypto scheme', () => {
 
 describe('testing hash to curve', () => {
   test('testing string 0000....00', async () => {
-    let secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000000');
-    let Y = hashToCurve(secret);
-    let hexY = Y.toHex(true);
+    const secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000000');
+    const Y = hashToCurve(secret);
+    const hexY = Y.toHex(true);
     expect(hexY).toBe('024cce997d3b518f739663b757deaec95bcd9473c30a14ac2fd04023a739d1a725');
   });
 
   test('testing string 0000....01', async () => {
-    let secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
-    let Y = hashToCurve(secret);
-    let hexY = Y.toHex(true);
+    const secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
+    const Y = hashToCurve(secret);
+    const hexY = Y.toHex(true);
     expect(hexY).toBe('022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf');
   });
 });
 
 describe('test blinding message', () => {
   test('testing string 0000....01', async () => {
-    var enc = new TextEncoder();
-    let secretUInt8 = enc.encode(SECRET_MESSAGE);
-    let { B_ } = blindMessage(
+    const enc = new TextEncoder();
+    const secretUInt8 = enc.encode(SECRET_MESSAGE);
+    const { B_ } = blindMessage(
       secretUInt8,
       Bytes.toBigInt(
         hexToBytes('0000000000000000000000000000000000000000000000000000000000000001'),
@@ -96,12 +97,12 @@ describe('test blinding message', () => {
 
 describe('test unblinding signature', () => {
   test('testing string 0000....01', async () => {
-    let C_ = pointFromHex('02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2');
-    let r = Bytes.toBigInt(
+    const C_ = pointFromHex('02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2');
+    const r = Bytes.toBigInt(
       hexToBytes('0000000000000000000000000000000000000000000000000000000000000001'),
     );
-    let A = pointFromHex('020000000000000000000000000000000000000000000000000000000000000001');
-    let C = unblindSignature(C_, r, A);
+    const A = pointFromHex('020000000000000000000000000000000000000000000000000000000000000001');
+    const C = unblindSignature(C_, r, A);
     expect(C.toHex(true)).toBe(
       '03c724d7e6a5443b39ac8acf11f40420adc4f99a02e7cc1b57703d9391f6d129cd',
     );

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -18,8 +18,11 @@
 // - Nutshell:
 // docker rm -f -v nutshell
 
-import { vi, test, describe, expect } from 'vitest';
 import { secp256k1, schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
+import { vi, test, describe, expect } from 'vitest';
+
 import {
   Mint,
   Wallet,
@@ -31,23 +34,21 @@ import {
   type Token,
   MintOperationError,
   OutputData,
-  OutputDataFactory,
-  OutputConfig,
-  OutputType,
+  type OutputDataFactory,
+  type OutputConfig,
+  type OutputType,
   P2PKBuilder,
-  MintQuoteBaseResponse,
+  type MintQuoteBaseResponse,
   getEncodedToken,
   hexToNumber,
   isBlsKeyset,
   numberToHexPadded64,
   sumProofs,
-  HasKeysetKeys,
+  type HasKeysetKeys,
   NetworkError,
-  AmountLike,
+  type AmountLike,
   CTSError,
 } from '../src';
-import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
-import { sha256 } from '@noble/hashes/sha2.js';
 
 const mintUrl = 'http://127.0.0.1:3338';
 const unit = 'sat';
@@ -77,7 +78,7 @@ async function untilMintQuotePaid(wallet: Wallet, quote: MintQuoteBaseResponse) 
   }
 }
 
-function expectNUT10SecretDataToEqual(p: Array<Proof>, s: string) {
+function expectNUT10SecretDataToEqual(p: Proof[], s: string) {
   p.forEach((p) => {
     const parsedSecret = JSON.parse(p.secret);
     expect(parsedSecret[1].data).toBe(s);
@@ -85,7 +86,7 @@ function expectNUT10SecretDataToEqual(p: Array<Proof>, s: string) {
 }
 
 function expectBlindedSecretDataToEqualECDH(
-  proofs: Array<Proof>,
+  proofs: Proof[],
   bobPrivHex: Uint8Array, // receiver’s private key
   bobPubHex: string, // receiver’s SEC1-compressed pubkey P
 ) {
@@ -653,6 +654,7 @@ describe('mint api', () => {
     expect(res).toBe(1);
     expect(mint.webSocketConnection?.activeSubscriptions.length).toBe(0);
   });
+  // eslint-disable-next-line vitest/expect-expect -- await-based: event promises resolving is the assertion
   test('websocket proof state + mint quote updates', async () => {
     const mint = new Mint(mintUrl);
     const wallet = new Wallet(mint);
@@ -794,7 +796,7 @@ describe('dleq', () => {
     if (isV3Mint(wallet)) return; // v3 proofs use pairing verification, no DLEQ
     const mintRequest = await wallet.createMintQuoteBolt11(8);
     await untilMintQuotePaid(wallet, mintRequest);
-    let proofs = await wallet.mintProofsBolt11(8, mintRequest.quote);
+    const proofs = await wallet.mintProofsBolt11(8, mintRequest.quote);
     // alter dleq signature
     proofs.forEach((p) => {
       if (p.dleq != undefined) {

--- a/test/logger/helpers.test.ts
+++ b/test/logger/helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
+
 import { fail, failIf, safeCallback } from '../../src/logger';
 import type { Logger } from '../../src/logger';
 

--- a/test/logger/logger.test.ts
+++ b/test/logger/logger.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, test, expect, vi } from 'vitest';
+
 import { ConsoleLogger, NULL_LOGGER } from '../../src/logger';
 
 afterEach(() => {

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -1,5 +1,8 @@
+import { type Client, Server, WebSocket } from 'mock-socket';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { Client, Server, WebSocket } from 'mock-socket';
+
 import {
   Mint,
   MintInfo,
@@ -10,8 +13,6 @@ import {
   Amount,
 } from '../../src';
 import type { AuthProvider, Logger, RequestFn } from '../../src';
-import { HttpResponse, http } from 'msw';
-import { setupServer } from 'msw/node';
 import { MINTINFORESP } from '../consts';
 
 type ReqArgs = {
@@ -882,7 +883,7 @@ describe('Mint normalization', () => {
 
     const response = await mint.mintBatchBolt11({
       quotes: ['q1', 'q2'],
-      quote_amounts: [Amount.from(1), Amount.from(2)] as any,
+      quote_amounts: [Amount.from(1), Amount.from(2)],
       outputs: [],
     });
 
@@ -903,7 +904,7 @@ describe('Mint normalization', () => {
 
     const response = await mint.mintBatchBolt12({
       quotes: ['q1'],
-      quote_amounts: [Amount.from(4)] as any,
+      quote_amounts: [Amount.from(4)],
       outputs: [],
     });
 

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+
 import { Amount } from '../../src/model/Amount';
 
 describe('Amount.from validation', () => {

--- a/test/model/AmountWithUnit.test.ts
+++ b/test/model/AmountWithUnit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+
 import { Amount, AmountWithUnit, AmountWithUnitError } from '../../src/model/Amount';
 
 describe('AmountWithUnit construction', () => {
@@ -252,8 +253,10 @@ describe('AmountWithUnit implicit coercion is safe', () => {
   const a = AmountWithUnit.from(100, 'sat');
 
   it('template literals produce unit-bearing string', () => {
+    /* eslint-disable @typescript-eslint/restrict-template-expressions -- template coercion is the tested behavior */
     expect(`${a}`).toBe('[sat]: 100');
     expect(`balance: ${a}`).toBe('balance: [sat]: 100');
+    /* eslint-enable @typescript-eslint/restrict-template-expressions */
   });
 
   it('String(x) produces unit-bearing string', () => {

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+
 import { MintInfo } from '../../src/model/MintInfo';
 import { MINTINFORESP } from '../consts';
 
@@ -92,7 +93,7 @@ describe('MintInfo protected endpoint matching', () => {
           cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
         },
       },
-    } as any);
+    });
     expect(info.isSupported(19)).toEqual({
       supported: true,
       params: {
@@ -131,7 +132,7 @@ describe('MintInfo protected endpoint matching', () => {
           protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
         },
       },
-    } as any);
+    });
 
     // min/max amounts are AmountLike — wire bigint values pass through as-is
     expect(info.nuts['4'].methods[0].min_amount).toBe(1n);
@@ -181,7 +182,7 @@ describe('MintInfo protected endpoint matching', () => {
           ],
         },
       },
-    } as any);
+    });
 
     const methods = info.nuts['4'].methods;
     expect(methods[0].method_name).toBe('Bolt11');
@@ -203,7 +204,7 @@ describe('MintInfo protected endpoint matching', () => {
           ],
         },
       },
-    } as any);
+    });
 
     const methods = info.nuts['4'].methods;
     expect(methods[0].method_name).toBeNull();
@@ -222,7 +223,7 @@ describe('MintInfo protected endpoint matching', () => {
           methods: [{ method: hugeMethod, unit: 'sat', min_amount: null, max_amount: null }],
         },
       },
-    } as any);
+    });
 
     expect(info.nuts['4'].methods[0].method_name).toBeNull();
   });
@@ -243,7 +244,7 @@ describe('MintInfo protected endpoint matching', () => {
           methods: [{ method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null }],
         },
       },
-    } as any);
+    });
 
     expect(info.supportedMethods('mint').map((m) => m.method)).toEqual(['bolt11', 'bolt12']);
     expect(info.supportedMethods('melt')).toEqual([]);
@@ -260,7 +261,7 @@ describe('MintInfo protected endpoint matching', () => {
               cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
             },
           },
-        } as any),
+        }),
     ).toThrow('nuts.19.ttl');
   });
 });
@@ -294,7 +295,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
         ...MINTINFORESP.nuts,
         29: { max_batch_size: 100, methods: ['bolt11', 'bolt12'] },
       },
-    } as any);
+    });
     expect(info.isSupported(29)).toEqual({
       supported: true,
       params: { max_batch_size: 100, methods: ['bolt11', 'bolt12'] },
@@ -308,7 +309,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
         ...MINTINFORESP.nuts,
         29: { methods: ['bolt11'] },
       },
-    } as any);
+    });
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
     expect(result.params).toEqual({ methods: ['bolt11'], max_batch_size: 100 });
@@ -321,7 +322,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
         ...MINTINFORESP.nuts,
         29: { max_batch_size: 50 },
       },
-    } as any);
+    });
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
     expect(result.params).toEqual({ max_batch_size: 50 });
@@ -334,7 +335,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
         ...MINTINFORESP.nuts,
         29: { max_batch_size: '100' as any },
       },
-    } as any);
+    });
     const result = info.isSupported(29);
     expect(result.supported).toBe(true);
     expect(result.params?.max_batch_size).toBe(100);
@@ -349,7 +350,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
           ...MINTINFORESP.nuts,
           29: { max_batch_size: 2.5, methods: ['bolt11'] },
         },
-      } as any,
+      },
       logger,
     );
     const result = info.isSupported(29);
@@ -370,7 +371,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
           ...MINTINFORESP.nuts,
           29: { max_batch_size: NaN },
         },
-      } as any,
+      },
       logger,
     );
     const result = info.isSupported(29);
@@ -391,7 +392,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
           ...MINTINFORESP.nuts,
           29: { max_batch_size: -1 },
         },
-      } as any,
+      },
       logger,
     );
     const result = info.isSupported(29);
@@ -412,7 +413,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
           ...MINTINFORESP.nuts,
           29: { max_batch_size: 500 },
         },
-      } as any,
+      },
       logger,
     );
     const result = info.isSupported(29);
@@ -433,7 +434,7 @@ describe('MintInfo NUT-29 batch minting info', () => {
           ...MINTINFORESP.nuts,
           29: { max_batch_size: 100 },
         },
-      } as any,
+      },
       logger,
     );
     const result = info.isSupported(29);
@@ -467,7 +468,7 @@ describe('MintInfo NUT-22 bat_max_mint normalization', () => {
             protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
           },
         },
-      } as any,
+      },
       logger,
     );
     expect(info.nuts['22']?.bat_max_mint).toBe(100);
@@ -489,7 +490,7 @@ describe('MintInfo NUT-22 bat_max_mint normalization', () => {
             protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
           },
         },
-      } as any,
+      },
       logger,
     );
     expect(info.nuts['22']?.bat_max_mint).toBe(100);
@@ -511,7 +512,7 @@ describe('MintInfo NUT-22 bat_max_mint normalization', () => {
             protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
           },
         },
-      } as any,
+      },
       logger,
     );
     expect(info.nuts['22']?.bat_max_mint).toBe(50);

--- a/test/model/OutputData.bls.test.ts
+++ b/test/model/OutputData.bls.test.ts
@@ -11,8 +11,8 @@ import {
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 import { Amount } from '../../src/model/Amount';
 import { OutputData } from '../../src/model/OutputData';
-import { deriveKeysetId } from '../../src/utils';
 import type { HasKeysetKeys, SerializedBlindedSignature } from '../../src/model/types';
+import { deriveKeysetId } from '../../src/utils';
 
 // v3 (BLS12-381) round-trip through OutputData → simulated mint sign → toProof → pairing verify.
 //

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
-import { Amount, type AmountLike } from '../../src/model/Amount';
-import { DefaultOutputDataCreator } from '../../src/model/OutputDataCreator';
-import { OutputData, isOutputDataFactory } from '../../src/model/OutputData';
 import { getPubKeyFromPrivKey } from '../../src/crypto';
-import { Bytes } from '../../src/utils';
+import { Amount, type AmountLike } from '../../src/model/Amount';
+import { OutputData, isOutputDataFactory } from '../../src/model/OutputData';
 import type { OutputDataFactory, OutputDataLike } from '../../src/model/OutputData';
+import { DefaultOutputDataCreator } from '../../src/model/OutputDataCreator';
 import type { HasKeysetKeys, SerializedBlindedSignature, Proof } from '../../src/model/types';
+import { Bytes } from '../../src/utils';
 
 describe('DefaultOutputDataCreator', () => {
   test('delegates single deterministic output creation to OutputData', () => {

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -1,12 +1,16 @@
 import { test, describe, expect } from 'vitest';
-import { SigAll, SigAllSigningPackage, MeltQuoteState, Amount } from '../../src';
-import type {
-  OutputDataLike,
-  Proof,
-  P2PKWitness,
-  SerializedBlindedMessage,
-  MeltPreview,
-  SwapPreview,
+
+import {
+  SigAll,
+  type SigAllSigningPackage,
+  MeltQuoteState,
+  Amount,
+  type OutputDataLike,
+  type Proof,
+  type P2PKWitness,
+  type SerializedBlindedMessage,
+  type MeltPreview,
+  type SwapPreview,
 } from '../../src';
 
 const dummyProof: Proof = {

--- a/test/transport/WSConnection.test.ts
+++ b/test/transport/WSConnection.test.ts
@@ -1,7 +1,8 @@
+import { type Client, Server, WebSocket } from 'mock-socket';
+import { vi, test, describe, expect, afterAll } from 'vitest';
+
 import { WSConnection, injectWebSocketImpl } from '../../src';
 import type { Logger } from '../../src';
-import { Client, Server, WebSocket } from 'mock-socket';
-import { vi, test, describe, expect, afterAll } from 'vitest';
 
 injectWebSocketImpl(WebSocket);
 
@@ -48,23 +49,24 @@ describe('testing WSConnection', () => {
     expect(connectionSpy).toHaveBeenCalled();
   });
   test('requesting subscription', async () => {
-    const message = (await new Promise(async (res) => {
+    const messagePromise = new Promise<string>((res) => {
       server.on('connection', (socket) => {
         socket.on('message', (m) => {
           res(m.toString());
         });
       });
-      const conn = new WSConnection(fakeUrl);
-      await conn.connect();
+    });
+    const conn = new WSConnection(fakeUrl);
+    await conn.connect();
 
-      const callback = vi.fn();
-      const errorCallback = vi.fn();
-      conn.createSubscription(
-        { kind: 'bolt11_mint_quote', filters: ['12345'] },
-        callback,
-        errorCallback,
-      );
-    })) as string;
+    const callback = vi.fn();
+    const errorCallback = vi.fn();
+    conn.createSubscription(
+      { kind: 'bolt11_mint_quote', filters: ['12345'] },
+      callback,
+      errorCallback,
+    );
+    const message = await messagePromise;
     expect(JSON.parse(message)).toMatchObject({
       jsonrpc: '2.0',
       method: 'subscribe',
@@ -86,18 +88,18 @@ describe('testing WSConnection', () => {
   });
   test('unsubscribing', async () => {
     let wsSocket: Client;
-    let subId: string;
     const conn = new WSConnection(fakeUrl);
-    await new Promise<void>(async (res) => {
+    const connected = new Promise<void>((res) => {
       server.on('connection', (socket) => {
         wsSocket = socket;
         res();
       });
-      conn.connect();
     });
+    await conn.connect();
+    await connected;
     const callback = vi.fn();
     const errorCallback = vi.fn();
-    subId = conn.createSubscription(
+    const subId = conn.createSubscription(
       { kind: 'bolt11_mint_quote', filters: ['123'] },
       callback,
       errorCallback,
@@ -112,14 +114,14 @@ describe('testing WSConnection', () => {
         }
       });
     });
-    await waitForSubscription(conn, subId!);
+    await waitForSubscription(conn, subId);
 
-    const message = await new Promise(async (res) => {
+    const message = await new Promise((res) => {
       wsSocket.on('message', (m) => {
         const parsed = JSON.parse(m.toString());
         if (parsed.method === 'unsubscribe') res(parsed);
       });
-      conn.cancelSubscription(subId!, callback);
+      conn.cancelSubscription(subId, callback);
     });
     expect(message).toMatchObject({ jsonrpc: '2.0', method: 'unsubscribe' });
   });
@@ -333,7 +335,8 @@ describe('WSConnection – close and lifecycle', () => {
         serverSocket = socket;
         res();
       });
-      conn.connect();
+      // connection event (below) is the sync point; connect() result unused
+      void conn.connect();
     });
 
     const closeCb = vi.fn();
@@ -360,7 +363,8 @@ describe('WSConnection – close and lifecycle', () => {
         socket.on('message', () => {}); // absorb subscribe, leave RPC pending
         res();
       });
-      conn.connect();
+      // connection event (below) is the sync point; connect() result unused
+      void conn.connect();
     });
 
     const errorCb = vi.fn();
@@ -387,7 +391,8 @@ describe('WSConnection – close and lifecycle', () => {
         socket.on('message', () => {}); // leave RPC pending
         res();
       });
-      conn.connect();
+      // connection event (below) is the sync point; connect() result unused
+      void conn.connect();
     });
 
     const errorCb = vi.fn();
@@ -414,7 +419,8 @@ describe('WSConnection – close and lifecycle', () => {
         serverSocket = socket;
         res();
       });
-      conn.connect();
+      // connection event (below) is the sync point; connect() result unused
+      void conn.connect();
     });
 
     serverSocket.dispatchEvent(new Event('error'));
@@ -680,7 +686,8 @@ describe('WSConnection – listener management', () => {
         socket.on('message', () => {}); // keep RPCs pending
         res();
       });
-      conn.connect();
+      // connection event (below) is the sync point; connect() result unused
+      void conn.connect();
     });
 
     const errorCb1 = vi.fn().mockImplementation(() => {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -1,4 +1,7 @@
+import { HttpResponse, http, delay } from 'msw';
+import { setupServer } from 'msw/node';
 import { beforeAll, beforeEach, test, describe, expect, afterAll, afterEach, vi } from 'vitest';
+
 import {
   Wallet,
   HttpResponseError,
@@ -7,10 +10,10 @@ import {
   RateLimitError,
   type ResponseMeta,
   type RequestFetch,
+  setGlobalRequestOptions,
+  type Nut19Policy,
 } from '../../src';
-import { HttpResponse, http, delay } from 'msw';
-import { setupServer } from 'msw/node';
-import { setGlobalRequestOptions } from '../../src';
+import { NULL_LOGGER, type Logger } from '../../src/logger';
 import request, { setRequestLogger } from '../../src/transport';
 import {
   parseRetryAfter,
@@ -19,8 +22,6 @@ import {
   errorMessage,
 } from '../../src/transport/request';
 import { MINTCACHE } from '../consts';
-import { Nut19Policy } from '../../src';
-import { NULL_LOGGER, type Logger } from '../../src/logger';
 
 // Setup mint cache for loadMint()
 const mintUrl = 'https://localhost:3338';
@@ -1434,6 +1435,7 @@ describe('onResponseMeta callback', () => {
 
     const result = await request({
       endpoint,
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async-callback tolerance is what's under test
       onResponseMeta: async () => {
         throw new Error('async boom');
       },
@@ -1526,6 +1528,7 @@ describe('onResponseMeta callback', () => {
 
     const result = await request({
       endpoint,
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async-callback tolerance is what's under test
       onResponseMeta: async () => {
         throw new Error('per-request async boom');
       },

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  // Gives eslint's typed rules (projectService) a project covering test/ —
+  // the root tsconfig only includes src/. Not used by builds or vitest.
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/test/utils/JSONInt.test.ts
+++ b/test/utils/JSONInt.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
 import { JSONInt } from '../../src/utils/JSONInt';
 
 describe('bigint support baseline', () => {
@@ -158,6 +159,7 @@ describe('parse option: fallbackTo', () => {
   test('defaults to number when BigInt is unavailable', () => {
     const result = JSONInt.parse(input) as { key: number };
     expect(typeof result.key).toBe('number');
+    // eslint-disable-next-line no-loss-of-precision -- precision loss is what's asserted
     expect(result.key).toBe(12345678901234567);
   });
 

--- a/test/utils/base64.test.ts
+++ b/test/utils/base64.test.ts
@@ -1,3 +1,5 @@
+import { test, describe, expect } from 'vitest';
+
 import {
   encodeBase64ToJson,
   encodeBase64toUint8,
@@ -5,7 +7,6 @@ import {
   encodeUint8toBase64,
   isBase64String,
 } from '../../src/utils';
-import { test, describe, expect } from 'vitest';
 describe('testing uint8 encoding', () => {
   test('uint8 to base64', async () => {
     const message = 'test';

--- a/test/utils/bech32m.test.ts
+++ b/test/utils/bech32m.test.ts
@@ -6,10 +6,11 @@
  */
 
 import { describe, test, expect } from 'vitest';
+
+import { PaymentRequest } from '../../src/model/PaymentRequest';
 import { decodeBech32mToBytes, encodeBech32m } from '../../src/utils/bech32m';
 import { decodeTLV, encodeTLV } from '../../src/utils/tlv';
 import type { DecodedTLVPaymentRequest } from '../../src/utils/tlv';
-import { PaymentRequest } from '../../src/model/PaymentRequest';
 import { PaymentRequestTransportType } from '../../src/wallet/types/payment-requests';
 
 describe('NUT-26 Test Vectors', () => {

--- a/test/utils/cbor.test.ts
+++ b/test/utils/cbor.test.ts
@@ -1,6 +1,7 @@
-import { decodeCBOR, encodeCBOR, Bytes } from '../../src/utils';
 import { hexToBytes } from '@noble/curves/utils.js';
 import { test, describe, expect } from 'vitest';
+
+import { decodeCBOR, encodeCBOR, Bytes } from '../../src/utils';
 // Note: do NOT import 'fs' or 'path' at top-level — the browser test runner
 // will attempt to import them and Vite externalizes those modules which causes
 // runtime errors. Load them dynamically inside a Node-only guard below.
@@ -135,7 +136,7 @@ describe('cbor decoder', () => {
   });
 
   test.each(decoderThrows)('decode throws for $name', ({ buf, throws }) => {
-    expect(() => decodeCBOR(buf)).toThrow(throws as RegExp);
+    expect(() => decodeCBOR(buf)).toThrow(throws);
   });
 
   test('decode byte string with 8-byte length (additionalInfo 27) decodes when hi=0,lo=5', () => {
@@ -215,33 +216,33 @@ describe('cbor encoder', () => {
   test('encode byte/string/array header forms (24 and 256 lengths)', () => {
     // byte string length 24 -> header should be 0x58 0x18
     const bs24 = new Uint8Array(24).fill(0x01);
-    const encBs24 = encodeCBOR(bs24 as any);
+    const encBs24 = encodeCBOR(bs24);
     expect(encBs24[0]).toBe(0x58);
     expect(encBs24[1]).toBe(24);
 
     // byte string length 256 -> header 0x59 0x01 0x00 (2-byte big-endian)
     const bs256 = new Uint8Array(256).fill(0x02);
-    const encBs256 = encodeCBOR(bs256 as any);
+    const encBs256 = encodeCBOR(bs256);
     expect(encBs256[0]).toBe(0x59);
     expect(encBs256[1]).toBe(0x01);
     expect(encBs256[2]).toBe(0x00);
 
     // string length 24
     const s24 = 'a'.repeat(24);
-    const encS24 = encodeCBOR(s24 as any);
+    const encS24 = encodeCBOR(s24);
     expect(encS24[0]).toBe(0x78);
     expect(encS24[1]).toBe(24);
 
     // array length 24 -> header 0x98 0x18
     const arr24 = new Array(24).fill(0).map((_, i) => i);
-    const encArr24 = encodeCBOR(arr24 as any);
+    const encArr24 = encodeCBOR(arr24);
     expect(encArr24[0]).toBe(0x98);
     expect(encArr24[1]).toBe(24);
   });
 
   test('encode string length 256 uses 2-byte length header and roundtrips', () => {
     const s256 = 'a'.repeat(256);
-    const enc = encodeCBOR(s256 as any);
+    const enc = encodeCBOR(s256);
     expect(enc[0]).toBe(0x79);
     expect(enc[1]).toBe(0x01);
     expect(enc[2]).toBe(0x00);
@@ -250,7 +251,7 @@ describe('cbor encoder', () => {
 
   test('encode array length 256 uses 2-byte length header and roundtrips', () => {
     const arr256 = Array.from({ length: 256 }, (_, i) => i);
-    const enc = encodeCBOR(arr256 as any);
+    const enc = encodeCBOR(arr256);
     expect(enc[0]).toBe(0x99);
     expect(enc[1]).toBe(0x01);
     expect(enc[2]).toBe(0x00);
@@ -259,7 +260,7 @@ describe('cbor encoder', () => {
 
   test('encode negative integer -257 uses 2-byte negative integer form and roundtrips', () => {
     const v = -257;
-    const enc = encodeCBOR(v as any);
+    const enc = encodeCBOR(v);
     expect(enc[0]).toBe(0x39);
     expect(enc[1]).toBe(0x01);
     expect(enc[2]).toBe(0x00);
@@ -268,7 +269,7 @@ describe('cbor encoder', () => {
 
   test('encode negative integer -25 uses 1-byte negative integer form and roundtrips', () => {
     const v = -25;
-    const enc = encodeCBOR(v as any);
+    const enc = encodeCBOR(v);
     expect(enc[0]).toBe(0x38);
     expect(enc[1]).toBe(24);
     expect(decodeCBOR(enc)).toBe(v);
@@ -276,7 +277,7 @@ describe('cbor encoder', () => {
 
   test('encode negative integer -65537 uses 4-byte negative integer form and roundtrips', () => {
     const v = -65537;
-    const enc = encodeCBOR(v as any);
+    const enc = encodeCBOR(v);
     expect(enc[0]).toBe(0x3a);
     expect(enc[1]).toBe(0x00);
     expect(enc[2]).toBe(0x01);
@@ -288,7 +289,7 @@ describe('cbor encoder', () => {
   test('encode byte string length 65536 uses 4-byte length header and roundtrips', () => {
     const len = 65536;
     const bs = new Uint8Array(len).fill(0x7f);
-    const enc = encodeCBOR(bs as any);
+    const enc = encodeCBOR(bs);
     // 0x5a indicates 4-byte length for byte strings
     expect(enc[0]).toBe(0x5a);
     expect(enc[1]).toBe(0x00);
@@ -303,7 +304,7 @@ describe('cbor encoder', () => {
   test('encode string length 65536 uses 4-byte length header and roundtrips', () => {
     const len = 65536;
     const s = 'a'.repeat(len);
-    const enc = encodeCBOR(s as any);
+    const enc = encodeCBOR(s);
     // 0x7a indicates 4-byte length for text strings
     expect(enc[0]).toBe(0x7a);
     expect(enc[1]).toBe(0x00);
@@ -317,21 +318,21 @@ describe('cbor encoder', () => {
 
   test('encodes max 32 bit unsigned integer and roundtrips', () => {
     const n = 0xffffffff; // 4294967295
-    const enc = encodeCBOR(n as any);
+    const enc = encodeCBOR(n);
     expect(Array.from(enc)).toEqual([0x1a, 0xff, 0xff, 0xff, 0xff]);
     expect(decodeCBOR(enc)).toBe(n);
   });
 
   test('encodes min 32 bit unsigned integer and roundtrips', () => {
     const n = 0x00010000; // 65536
-    const enc = encodeCBOR(n as any);
+    const enc = encodeCBOR(n);
     expect(Array.from(enc)).toEqual([0x1a, 0x00, 0x01, 0x00, 0x00]);
     expect(decodeCBOR(enc)).toBe(n);
   });
 
   test('encodes number >= 2^32 via bigint delegation and roundtrips', () => {
     const n = 4294967296; // 2^32, first value beyond 4-byte unsigned
-    const enc = encodeCBOR(n as any);
+    const enc = encodeCBOR(n);
     // Should use 8-byte form (additional-info 27)
     expect(enc[0]).toBe(0x1b);
     expect(enc.length).toBe(9);
@@ -340,7 +341,7 @@ describe('cbor encoder', () => {
 
   test('encodes negative number beyond -2^32 via bigint delegation and roundtrips', () => {
     const n = -4294967297; // first value beyond 4-byte negative
-    const enc = encodeCBOR(n as any);
+    const enc = encodeCBOR(n);
     // Should use 8-byte form under major type 1 (0x3b)
     expect(enc[0]).toBe(0x3b);
     expect(enc.length).toBe(9);
@@ -348,7 +349,7 @@ describe('cbor encoder', () => {
   });
 
   test.each(encoderThrows)('encoding unsupported $name throws', ({ decoded, throws }) => {
-    expect(() => encodeCBOR(decoded)).toThrow(throws as RegExp);
+    expect(() => encodeCBOR(decoded)).toThrow(throws);
   });
 
   test('encodes maps with 256 (2-byte) and 65536 (4-byte) lengths and roundtrips', () => {
@@ -384,7 +385,7 @@ describe('cbor encoder', () => {
   test('encodes negative integers correctly and roundtrips', () => {
     const values = [-1, -10, -1000];
     for (const v of values) {
-      const encoded = encodeCBOR(v as any);
+      const encoded = encodeCBOR(v);
       const decoded = decodeCBOR(encoded);
       expect(decoded).toBe(v);
       // inspect header bytes for a couple of cases
@@ -403,68 +404,68 @@ describe('cbor encoder', () => {
 
   test('direct integer branch coverage (0, 1, -1)', () => {
     // ensure encodeNumber handles unsigned and negative integer paths
-    const enc0 = encodeCBOR(0 as any);
+    const enc0 = encodeCBOR(0);
     expect(enc0[0]).toBe(0x00);
 
-    const enc1 = encodeCBOR(1 as any);
+    const enc1 = encodeCBOR(1);
     expect(enc1[0]).toBe(0x01);
 
-    const encNeg1 = encodeCBOR(-1 as any);
+    const encNeg1 = encodeCBOR(-1);
     expect(encNeg1[0]).toBe(0x20);
   });
 
   test('encodes bigint values using 8-byte uint64 form and roundtrips', () => {
     // Small bigint that fits in short form
     const small = 10n;
-    const encSmall = encodeCBOR(small as any);
+    const encSmall = encodeCBOR(small);
     expect(encSmall[0]).toBe(0x0a);
     expect(decodeCBOR(encSmall)).toBe(10);
 
     // bigint in 1-byte form
     const b200 = 200n;
-    const enc200 = encodeCBOR(b200 as any);
+    const enc200 = encodeCBOR(b200);
     expect(enc200[0]).toBe(0x18);
     expect(decodeCBOR(enc200)).toBe(200);
 
     // bigint in 2-byte form
     const b1000 = 1000n;
-    const enc1000 = encodeCBOR(b1000 as any);
+    const enc1000 = encodeCBOR(b1000);
     expect(enc1000[0]).toBe(0x19);
     expect(decodeCBOR(enc1000)).toBe(1000);
 
     // bigint in 4-byte form
     const b100000 = 100000n;
-    const enc100000 = encodeCBOR(b100000 as any);
+    const enc100000 = encodeCBOR(b100000);
     expect(enc100000[0]).toBe(0x1a);
     expect(decodeCBOR(enc100000)).toBe(100000);
 
     // bigint that exceeds 32-bit -> 8-byte uint64 form
     const big = 2n ** 33n; // 8589934592
-    const encBig = encodeCBOR(big as any);
+    const encBig = encodeCBOR(big);
     expect(encBig[0]).toBe(0x1b); // additional-info 27
     expect(decodeCBOR(encBig)).toBe(Number(big)); // fits in safe integer
 
     // bigint that exceeds MAX_SAFE_INTEGER -> decoded as bigint
     const huge = 2n ** 53n + 1n; // 9007199254740993
-    const encHuge = encodeCBOR(huge as any);
+    const encHuge = encodeCBOR(huge);
     expect(encHuge[0]).toBe(0x1b);
     expect(decodeCBOR(encHuge)).toBe(huge);
 
     // max uint64
     const maxUint64 = 2n ** 64n - 1n;
-    const encMax = encodeCBOR(maxUint64 as any);
+    const encMax = encodeCBOR(maxUint64);
     expect(encMax[0]).toBe(0x1b);
     expect(decodeCBOR(encMax)).toBe(maxUint64);
   });
 
   test('encodes negative bigint values and roundtrips', () => {
     const neg = -1n;
-    const encNeg = encodeCBOR(neg as any);
+    const encNeg = encodeCBOR(neg);
     expect(encNeg[0]).toBe(0x20);
     expect(decodeCBOR(encNeg)).toBe(-1);
 
     const negBig = -(2n ** 33n);
-    const encNegBig = encodeCBOR(negBig as any);
+    const encNegBig = encodeCBOR(negBig);
     expect(encNegBig[0]).toBe(0x3b); // major type 1, additional-info 27
     expect(decodeCBOR(encNegBig)).toBe(Number(negBig));
   });
@@ -478,7 +479,7 @@ describe('cbor encoder', () => {
     // 1.5
     {
       const v = 1.5;
-      const encoded = encodeCBOR(v as any);
+      const encoded = encodeCBOR(v);
       // float64 prefix 0xfb
       expect(encoded[0]).toBe(0xfb);
       const decoded = decodeCBOR(encoded) as number;
@@ -487,7 +488,7 @@ describe('cbor encoder', () => {
     // NaN
     {
       const v = NaN;
-      const encoded = encodeCBOR(v as any);
+      const encoded = encodeCBOR(v);
       expect(encoded[0]).toBe(0xfb);
       const decoded = decodeCBOR(encoded) as number;
       expect(Number.isNaN(decoded)).toBe(true);
@@ -495,7 +496,7 @@ describe('cbor encoder', () => {
     // Infinity
     {
       const v = Infinity;
-      const encoded = encodeCBOR(v as any);
+      const encoded = encodeCBOR(v);
       expect(encoded[0]).toBe(0xfb);
       const decoded = decodeCBOR(encoded) as number;
       expect(decoded).toBe(Infinity);
@@ -522,7 +523,7 @@ describe('cbor encoder', () => {
       return realObjectKeys(obj);
     };
     try {
-      expect(() => encodeCBOR(sentinel as any)).toThrow();
+      expect(() => encodeCBOR(sentinel)).toThrow();
     } finally {
       (Object.keys as any) = realObjectKeys;
     }
@@ -533,17 +534,12 @@ describe('cbor encoder', () => {
   test('encode byte string too long throws (fake Uint8Array)', () => {
     const fake = Object.create(Uint8Array.prototype);
     Object.defineProperty(fake, 'length', { value: 4294967296 });
-    expect(() => encodeCBOR(fake as any)).toThrow(/Byte string too long to encode/);
+    expect(() => encodeCBOR(fake)).toThrow(/Byte string too long to encode/);
   });
 
   test('encode string too long throws (mock TextEncoder)', () => {
     const RealTextEncoder = (globalThis as any).TextEncoder;
     // mock encode to return an object with huge length
-    (class MockTE {
-      encode(_: string) {
-        return { length: 4294967296 } as any;
-      }
-    }) as any;
     (globalThis as any).TextEncoder = function () {
       return { encode: (_s: string) => ({ length: 4294967296 }) as any };
     };
@@ -601,11 +597,11 @@ describe('raw v4 token cbor en/decoding', () => {
     const encoded = encodeCBOR(token);
     // const encodedString = Buffer.from(encoded).toString('base64url');
     const encodedString = base64urlEncode(encoded);
-    expect(encodedString).toBe(expectedBase64.replace(/\=+$/, ''));
+    expect(encodedString).toBe(expectedBase64.replace(/=+$/, ''));
   });
   test('decode v4 raw', () => {
-    // const decoded = decodeCBOR(Buffer.from(expectedBase64.replace(/\=+$/, ''), 'base64url'));
-    const decoded = decodeCBOR(base64urlDecode(expectedBase64.replace(/\=+$/, '')));
+    // const decoded = decodeCBOR(Buffer.from(expectedBase64.replace(/=+$/, ''), 'base64url'));
+    const decoded = decodeCBOR(base64urlDecode(expectedBase64.replace(/=+$/, '')));
     expect(decoded).toEqual(token);
   });
 });
@@ -620,6 +616,7 @@ describe('CBOR Test Vectors', () => {
     // file and rely on the focused unit tests above. Register a skipped
     // test so the test suite isn't empty (Vitest errors when a suite has
     // no tests).
+    // eslint-disable-next-line vitest/no-disabled-tests -- permanent browser-env placeholder, not a temporary skip
     test.skip('CBOR test vectors are skipped in browser environments', () => {
       // intentionally empty
     });
@@ -627,7 +624,9 @@ describe('CBOR Test Vectors', () => {
   }
 
   // Node-only: require fs/path dynamically to avoid bundling them for browser
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { readFileSync } = require('fs');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { resolve } = require('path');
   const testVectorsPath = resolve(__dirname, 'cbor-test-vectors/appendix_a.json');
   const _vectors: any[] = JSON.parse(readFileSync(testVectorsPath, 'utf-8'));
@@ -637,7 +636,7 @@ describe('CBOR Test Vectors', () => {
   const _vectorRows = _vectors.map((v, i) => [`CBOR vector ${v.cbor}`, v, i]);
 
   test.each(_vectorRows)('%s', (_title, vector, _index) => {
-    const { hex } = vector as any;
+    const { hex } = vector;
 
     // Skip vectors that contain indefinite/streaming markers (these are
     // outside the current decoder scope). This matches test vectors that
@@ -698,17 +697,19 @@ describe('CBOR Test Vectors', () => {
       if ((majorType === 0 || majorType === 1) && additionalInfo === 27) {
         skipEncode = true;
       }
-    } catch {}
+    } catch {
+      // encode not byte-identical for this vector; decode still asserted below
+    }
 
     // Always attempt decode to surface decode-time errors for every vector
     const decodedResult = decodeCBOR(Buffer.from(hex, 'hex'));
 
     // If the vector provides an expected decoded value, assert equality
     if ('decoded' in vector) {
-      expect(decodedResult).toEqual((vector as any).decoded);
+      expect(decodedResult).toEqual(vector.decoded);
 
       // Only run encode round-trip assertions for vectors that explicitly opt-in
-      if (!(vector as any).roundtrip) return;
+      if (!vector.roundtrip) return;
 
       // If we previously determined this vector cannot be round-tripped by
       // our encoder (float16/32/64, 8-byte integers, etc.), skip the
@@ -719,7 +720,7 @@ describe('CBOR Test Vectors', () => {
       // doesn't support (big integers outside JS safe integer range) or
       // for CBOR bignum tagged forms (tag 2/3) where JSON fixtures cannot
       // represent the precise BigInt value.
-      const decodedVal = (vector as any).decoded;
+      const decodedVal = vector.decoded;
       if (typeof decodedVal === 'number' && !Number.isSafeInteger(decodedVal)) {
         // needs BigInt/bignum support; skip encode assertion
         return;
@@ -727,7 +728,7 @@ describe('CBOR Test Vectors', () => {
       // skip tag-2/3 encoded bignums
       if (hex.startsWith('c2') || hex.startsWith('c3')) return;
 
-      const encodedResult = encodeCBOR((vector as any).decoded);
+      const encodedResult = encodeCBOR(vector.decoded);
       expect(Buffer.from(encodedResult).toString('hex')).toBe(hex);
     }
   });

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1,3 +1,7 @@
+import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
+import { test, describe, expect } from 'vitest';
+
+import { Amount, type MintKeys, type Keys, type Proof, type Token, Keyset } from '../../src';
 import {
   blindMessage,
   constructUnblindedSignature,
@@ -7,20 +11,8 @@ import {
   getPubKeyFromPrivKey,
   getG2PubKeyFromPrivKey,
 } from '../../src/crypto';
-import { test, describe, expect } from 'vitest';
-import { Amount, MintKeys, type Keys, type Proof, type Token, Keyset } from '../../src';
 import { CTSError } from '../../src/model/Errors';
 import * as utils from '../../src/utils';
-import {
-  NUT02_V1_VECTOR1_KEYS,
-  NUT02_V1_VECTOR2_KEYS,
-  NUT02_V2_VECTOR1_KEYS,
-  NUT02_V2_VECTOR2_KEYS,
-  NUT02_V2_VECTOR3_KEYS,
-  NUT02_V3_VECTOR1_KEYS,
-  NUT02_V3_VECTOR2_KEYS,
-  PUBKEYS,
-} from '../consts';
 import {
   bigIntStringify,
   getKeysetAmounts,
@@ -34,7 +26,16 @@ import {
   sortProofsById,
   normalizeUrl,
 } from '../../src/utils';
-import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
+import {
+  NUT02_V1_VECTOR1_KEYS,
+  NUT02_V1_VECTOR2_KEYS,
+  NUT02_V2_VECTOR1_KEYS,
+  NUT02_V2_VECTOR2_KEYS,
+  NUT02_V2_VECTOR3_KEYS,
+  NUT02_V3_VECTOR1_KEYS,
+  NUT02_V3_VECTOR2_KEYS,
+  PUBKEYS,
+} from '../consts';
 
 const keys: Keys = {};
 for (let i = 1; i <= 2048; i *= 2) {
@@ -95,7 +96,7 @@ describe('test split custom amounts ', () => {
   test('testing non pow2', async () => {
     expect(() => utils.splitAmount(6, keys, illegal)).toThrow();
   });
-  const empty: Array<number> = [];
+  const empty: number[] = [];
   test('testing empty', async () => {
     const chunks = utils.splitAmount(5, keys, empty, 'desc');
     expect(chunks.map((a) => a.toNumber())).toStrictEqual([4, 1]);
@@ -1164,7 +1165,7 @@ describe('test deprecated base64 keyset id derivation', () => {
       '4611686018427387904': '02217ec885b5d75100a20b4337498afefd4ef76e4082cf361d32ae869c695e34a5',
       '9223372036854775808': '039f14f18f3ceaca7dcf18cd212eaf2656e65c337fc4a98cd4e7c119982338e57a',
     };
-    const idB64 = utils.deriveKeysetId(keys as unknown as Keys, { isDeprecatedBase64: true });
+    const idB64 = utils.deriveKeysetId(keys, { isDeprecatedBase64: true });
     expect(idB64).toBe('9mlfd5vCzgGl');
   });
   test('verifies MiniBits base64 keyset id', () => {

--- a/test/utils/tlv-roundtrip.test.ts
+++ b/test/utils/tlv-roundtrip.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, test, expect } from 'vitest';
+
 import { decodeBech32mToBytes, encodeBech32m } from '../../src/utils/bech32m';
 import { decodeTLV, encodeTLV } from '../../src/utils/tlv';
 import type { DecodedTLVPaymentRequest } from '../../src/utils/tlv';

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+
 import {
   EphemeralCounterSource,
   type CounterRange,
@@ -102,22 +103,22 @@ describe('EphemeralCounterSource', () => {
   it('advanceToAtLeast handles previously unset counter', async () => {
     const src = new EphemeralCounterSource();
     await src.advanceToAtLeast('k', 3); // k not set yet
-    let snap = await src.snapshot();
+    const snap = await src.snapshot();
     expect(snap.k).toBe(3);
   });
 
   it('setNext sets absolute next and rejects negatives', async () => {
     const src = new EphemeralCounterSource();
-    await src.setNext!('k', 10);
+    await src.setNext('k', 10);
     const r = await src.reserve('k', 1);
     expect(r).toEqual({ start: 10, count: 1 });
-    await expect(src.setNext!('k', -5)).rejects.toThrow(/negative next/);
+    await expect(src.setNext('k', -5)).rejects.toThrow(/negative next/);
   });
 
   it('snapshot returns a shallow copy (mutations to returned object do not affect source)', async () => {
     const src = new EphemeralCounterSource({ a: 1 });
     const snap1 = await src.snapshot();
-    snap1.a = 999 as any; // mutate the snapshot
+    snap1.a = 999; // mutate the snapshot
     const snap2 = await src.snapshot();
     expect(snap2).toEqual({ a: 1 }); // source unchanged
   });

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+
 import { P2PKBuilder, type P2PKOptions } from '../../src/';
 
 // helpers to make valid hex keys

--- a/test/wallet/WalletCounters.test.ts
+++ b/test/wallet/WalletCounters.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+
 import {
   WalletCounters,
   EphemeralCounterSource,

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { WalletEvents } from '../../src/wallet/WalletEvents';
-import type { Proof } from '../../src/model/types';
-import { hashToCurve } from '../../src/crypto';
-import { OperationCounters } from '../../src/wallet';
+
 import { Amount } from '../../src';
+import { hashToCurve } from '../../src/crypto';
+import type { Proof } from '../../src/model/types';
+import { type OperationCounters } from '../../src/wallet';
+import { WalletEvents } from '../../src/wallet/WalletEvents';
 
 // Helper: flush microtasks (needed because cancelSafely runs them async)
 const flushMicrotasks = async (n = 2) => {
@@ -645,9 +646,9 @@ describe('WalletEvents', () => {
       });
       const c3 = Promise.resolve(vi.fn());
 
-      g.add(c1);
-      g.add(c2);
-      g.add(c3);
+      void g.add(c1);
+      void g.add(c2);
+      void g.add(c3);
 
       g(); // invoke the composite canceller directly
       expect(g.cancelled).toBe(true);
@@ -660,7 +661,7 @@ describe('WalletEvents', () => {
       expect(inner).toHaveBeenCalled();
 
       const postCancel = vi.fn();
-      g.add(postCancel);
+      void g.add(postCancel);
       await flushMicrotasks();
       expect(postCancel).toHaveBeenCalled();
     });
@@ -668,7 +669,7 @@ describe('WalletEvents', () => {
     it('group canceller is idempotent, only cancels once', async () => {
       const g = events.group();
       const c = vi.fn();
-      g.add(c);
+      void g.add(c);
       g();
       g(); // second call no-op
       await flushMicrotasks();
@@ -677,7 +678,7 @@ describe('WalletEvents', () => {
 
     it('group handles rejected Promise<SubscriptionCanceller> without throwing', async () => {
       const g = events.group();
-      g.add(Promise.reject(new Error('reject-me')));
+      void g.add(Promise.reject(new Error('reject-me')));
       g();
       await flushMicrotasks();
       expect(g.cancelled).toBe(true);
@@ -689,7 +690,7 @@ describe('WalletEvents', () => {
       const throws = vi.fn(() => {
         throw new Error('boom');
       });
-      g.add(throws);
+      void g.add(throws);
       await flushMicrotasks();
       expect(throws).toHaveBeenCalled();
     });
@@ -785,7 +786,7 @@ describe('WalletEvents', () => {
       const g = events.group();
       g(); // cancel first
       const rejected = Promise.reject(new Error('nope'));
-      g.add(rejected);
+      void g.add(rejected);
       await flushMicrotasks();
       expect(g.cancelled).toBe(true);
     });

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { WalletOps } from '../../src/wallet/WalletOps';
-import { Amount, type AmountLike } from '../../src/model/Amount';
 
+import { Amount, type AmountLike } from '../../src/model/Amount';
+import type { OutputData, OutputDataLike } from '../../src/model/OutputData';
 import type {
   Proof,
   MintQuoteBolt11Response,
@@ -12,7 +12,6 @@ import type {
   MeltQuoteBolt12Response,
   MeltQuoteOnchainResponse,
 } from '../../src/model/types';
-import type { OutputData, OutputDataLike } from '../../src/model/OutputData';
 import type {
   OutputType,
   OutputConfig,
@@ -26,6 +25,7 @@ import type {
   MeltPreview,
   MintPreview,
 } from '../../src/wallet/types';
+import { WalletOps } from '../../src/wallet/WalletOps';
 
 // ---- Function signatures for typed mocks ------------------------------------
 
@@ -146,7 +146,7 @@ class MockWallet {
   checkMintQuoteBolt11: Mock<CheckMintQuoteBolt11Fn> = vi.fn<CheckMintQuoteBolt11Fn>(
     async (id) => ({
       quote: id,
-      state: 'UNPAID' as any,
+      state: 'UNPAID',
       expiry: 0,
       request: '',
       amount: Amount.from(0),
@@ -195,7 +195,7 @@ const melt11: MeltQuoteBolt11Response = {
   quote: 'mq11',
   amount: Amount.from(5),
   fee_reserve: Amount.from(1),
-  state: 'UNPAID' as any,
+  state: 'UNPAID',
   expiry: 0,
   payment_preimage: null,
   request: 'lnbc1...',
@@ -206,7 +206,7 @@ const melt12: MeltQuoteBolt12Response = {
   quote: 'mq12',
   amount: Amount.from(7),
   fee_reserve: Amount.from(2),
-  state: 'UNPAID' as any,
+  state: 'UNPAID',
   expiry: 0,
   payment_preimage: null,
   request: 'lno1...',
@@ -227,7 +227,7 @@ const mint12: MintQuoteBolt12Response = {
 const meltOnchainSingle: MeltQuoteOnchainResponse = {
   quote: 'mq-onchain-melt-1',
   amount: Amount.from(10),
-  state: 'UNPAID' as any,
+  state: 'UNPAID',
   expiry: 0,
   request: 'bc1qrecipient',
   unit: 'sat',
@@ -239,7 +239,7 @@ const meltOnchainSingle: MeltQuoteOnchainResponse = {
 const meltOnchainMulti: MeltQuoteOnchainResponse = {
   quote: 'mq-onchain-melt-2',
   amount: Amount.from(10),
-  state: 'UNPAID' as any,
+  state: 'UNPAID',
   expiry: 0,
   request: 'bc1qrecipient',
   unit: 'sat',
@@ -679,14 +679,15 @@ describe('WalletOps builders', () => {
       expect(wallet.completeMint).toHaveBeenCalledWith(preview);
     });
 
+    // eslint-disable-next-line vitest/expect-expect -- compile-time check: @ts-expect-error is the assertion
     it('bolt12 requires privkey at compile time', () => {
       if (false as boolean) {
         // This is a compiler check - if you remove the exclude line below the
         // compiler should complain 'MintBuilder<"bolt12", false>' is not assignable
         // @ts-expect-error run should not be callable before privkey
-        ops.mintBolt12(7, mint12).run();
+        void ops.mintBolt12(7, mint12).run();
         // @ts-expect-error prepare should not be callable before privkey
-        ops.mintBolt12(7, mint12).prepare();
+        void ops.mintBolt12(7, mint12).prepare();
       }
 
       void ops.mintBolt12(7, mint12).privkey('k').run();
@@ -776,12 +777,13 @@ describe('WalletOps builders', () => {
       expect(cfg).toMatchObject({ privkey: 'new' });
     });
 
+    // eslint-disable-next-line vitest/expect-expect -- compile-time check: @ts-expect-error is the assertion
     it('onchain requires privkey at compile time', () => {
       if (false as boolean) {
         // @ts-expect-error run should not be callable before privkey
-        ops.mintOnchain(8, mintOnchain).run();
+        void ops.mintOnchain(8, mintOnchain).run();
         // @ts-expect-error prepare should not be callable before privkey
-        ops.mintOnchain(8, mintOnchain).prepare();
+        void ops.mintOnchain(8, mintOnchain).prepare();
       }
 
       void ops.mintOnchain(8, mintOnchain).privkey('k').run();
@@ -1031,7 +1033,7 @@ describe('WalletOps builders', () => {
     it('passes through the meltProofsOnchain return value', async () => {
       const change = [{ amount: Amount.one(), id: '00bd033559de27d0', secret: 's', C: 'C' }];
       wallet.meltProofsOnchain.mockResolvedValueOnce({
-        quote: { ...meltOnchainSingle, state: 'PAID' as any },
+        quote: { ...meltOnchainSingle, state: 'PAID' },
         change,
       });
 

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -1,8 +1,9 @@
 import { test, describe, expect } from 'vitest';
-import { Amount, type Keys, type Proof, OutputType } from '../../src';
-import { PUBKEYS } from '../consts';
-import { getKeepAmounts, stringifyOutputTypeForLog } from '../../src/wallet/_internal';
+
+import { Amount, type Keys, type Proof, type OutputType } from '../../src';
 import { OutputData } from '../../src/model/OutputData';
+import { getKeepAmounts, stringifyOutputTypeForLog } from '../../src/wallet/_internal';
+import { PUBKEYS } from '../consts';
 
 describe('getKeepAmounts', () => {
   const amountsWeHave = [1, 2, 4, 4, 4, 8];

--- a/test/wallet/_setup.ts
+++ b/test/wallet/_setup.ts
@@ -1,8 +1,9 @@
-import { setupServer, type SetupServerApi } from 'msw/node';
-import { HttpResponse, http } from 'msw';
-import { beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
-import { Mint, ConsoleLogger, injectWebSocketImpl } from '../../src';
 import { WebSocket } from 'mock-socket';
+import { HttpResponse, http } from 'msw';
+import { setupServer, type SetupServerApi } from 'msw/node';
+import { beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+
+import { Mint, ConsoleLogger, injectWebSocketImpl } from '../../src';
 import { DUMMY_TEST_KEYS, DUMMY_TEST_KEYSET } from '../consts';
 
 injectWebSocketImpl(WebSocket);

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Amount, Mint, Wallet, type MintKeys, Keyset, Proof } from '../../src';
+
+import { Amount, Mint, Wallet, type MintKeys, Keyset, type Proof } from '../../src';
 import { MINTCACHE } from '../consts';
 
 type ReqArgs = {
@@ -13,7 +14,7 @@ const makeRequestSpy = <T>(payload: T) => {
   const calls: ReqArgs[] = [];
   const req = async (options: ReqArgs) => {
     if (options.endpoint.endsWith('/v1/info')) {
-      return MINTCACHE.mintInfo as any;
+      return MINTCACHE.mintInfo;
     }
     calls.push({
       endpoint: options.endpoint,
@@ -67,7 +68,7 @@ describe('Mint (BOLT12) – instance methods via customRequest', () => {
     const customRequest = async (options: ReqArgs) => {
       calls.push(options.endpoint);
       if (options.endpoint.endsWith('/v1/info')) {
-        return MINTCACHE.mintInfo as any;
+        return MINTCACHE.mintInfo;
       }
       throw new Error('unexpected endpoint');
     };
@@ -220,7 +221,7 @@ describe('Mint (BOLT12) – instance methods via customRequest', () => {
     const { req, calls } = makeRequestSpy(response);
     const mint = new Mint(mintUrl, { customRequest: req });
     const meltQuotePayload = { request: 'lno1offer...', unit: 'sat', amount: 100 };
-    const res = await mint.createMeltQuoteBolt12(meltQuotePayload as any);
+    const res = await mint.createMeltQuoteBolt12(meltQuotePayload);
     expect(res.quote).toBe(response.quote);
     expect(res.amount).toEqual(Amount.from(response.amount));
     expect(res.fee_reserve).toEqual(Amount.from(response.fee_reserve));
@@ -308,7 +309,7 @@ describe('Mint (BOLT12) – instance methods via customRequest', () => {
     const { req, calls } = makeRequestSpy(response);
     const mint = new Mint(mintUrl, { customRequest: req });
     const meltPayload = { quote: 'm123', inputs: [], outputs: [] };
-    const res = await mint.meltBolt12(meltPayload as any);
+    const res = await mint.meltBolt12(meltPayload);
     expect(res.quote).toBe(response.quote);
     expect(res.amount).toEqual(Amount.from(response.amount));
     const c = calls[0];
@@ -336,7 +337,7 @@ describe('Mint (BOLT12) – instance methods', () => {
       amount: 21,
       unit: 'sat',
       pubkey: '02abcd',
-    } as any);
+    });
     expect(res).toEqual(response);
     expect(spy).toHaveBeenCalledWith({ amount: 21, unit: 'sat', pubkey: '02abcd' });
   });
@@ -359,7 +360,7 @@ describe('Mint (BOLT12) – instance methods', () => {
     const s3 = vi
       .spyOn(mint, 'checkMeltQuoteBolt12')
       .mockResolvedValue(responses.checkMeltQuoteBolt12 as any);
-    const s4 = vi.spyOn(mint, 'mintBolt12').mockResolvedValue(responses.mintBolt12 as any);
+    const s4 = vi.spyOn(mint, 'mintBolt12').mockResolvedValue(responses.mintBolt12);
     const s5 = vi.spyOn(mint, 'meltBolt12').mockResolvedValue(responses.meltBolt12 as any);
     expect(
       await mint.createMeltQuoteBolt12({
@@ -480,7 +481,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     const wallet = new Wallet(mint);
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
-    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks as any);
+    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([]);
     const meltQuote = {
       quote: 'm1',
@@ -513,7 +514,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     const wallet = new Wallet(mint);
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
-    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks as any);
+    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
         blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },
@@ -573,7 +574,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     const wallet = new Wallet(mint);
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
-    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks as any);
+    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
         blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -1,5 +1,5 @@
-import { setupServer } from 'msw/node';
 import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
 import { beforeAll, beforeEach, afterAll, afterEach, test, describe, expect, vi } from 'vitest';
 
 import { Mint, KeyChain, Keyset, type MintKeyset, type MintKeys } from '../../src';

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -1,11 +1,11 @@
 import { test, describe, expect } from 'vitest';
+
 import {
   decodePaymentRequest,
   OutputData,
   PaymentRequest,
-  PaymentRequestTransport,
   PaymentRequestTransportType,
-  NUT10Option,
+  type NUT10Option,
 } from '../../src/index';
 
 describe('payment requests', () => {
@@ -16,7 +16,7 @@ describe('payment requests', () => {
           type: PaymentRequestTransportType.NOSTR,
           target: 'asd',
           tags: [['n', '17']],
-        } as PaymentRequestTransport,
+        },
       ],
       '4840f51e',
       1000,
@@ -28,7 +28,7 @@ describe('payment requests', () => {
         kind: 'P2PK',
         data: 'pubkey',
         tags: [['tag', 'tag-value']],
-      } as NUT10Option,
+      },
     );
     const pr = request.toEncodedRequest();
     expect(pr).toBeDefined();
@@ -86,7 +86,7 @@ describe('payment requests', () => {
         {
           type: PaymentRequestTransportType.POST,
           target: 'https://example.com/pay',
-        } as PaymentRequestTransport,
+        },
       ],
       'bigint_test',
       largeAmount,
@@ -210,7 +210,7 @@ describe('payment requests', () => {
             ['timeout', '7200'],
             ['refund', '03abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890cd'],
           ],
-        } as NUT10Option,
+        },
       );
 
       const encoded = pr.toEncodedCreqB();
@@ -244,7 +244,7 @@ describe('payment requests', () => {
           kind: 'P2PK',
           data: '02abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
           tags: [],
-        } as NUT10Option,
+        },
       );
 
       const decoded = PaymentRequest.fromEncodedRequest(pr.toEncodedCreqB());

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { selectProofsRGLI } from '../../src/wallet/SelectProofs';
-import { Proof } from '../../src/model/types';
-import { Amount } from '../../src/model/Amount';
+
 import { sumProofs } from '../../src';
+import { Amount } from '../../src/model/Amount';
+import { type Proof } from '../../src/model/types';
+import { selectProofsRGLI } from '../../src/wallet/SelectProofs';
 
 // -----------------------------------------------------------------
 // Most paths are exercised via wallet tests.
@@ -43,7 +44,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
     const kc = keychainStub({ A: 2000 });
     const { logger } = loggerSpy();
 
-    const res = selectProofsRGLI(proofs as any, 1, kc, true, false, logger);
+    const res = selectProofsRGLI(proofs, 1, kc, true, false, logger);
     expect(res.send).toHaveLength(0);
     expect(res.keep).toHaveLength(2);
   });
@@ -55,7 +56,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
     ];
     const kc = keychainStub({ A: 0 });
     // target smaller than smallest candidate, binary search returns null, endIndex zero
-    const res = selectProofsRGLI(proofs as any, 5, kc, false, true);
+    const res = selectProofsRGLI(proofs, 5, kc, false, true);
     expect(res.send).toHaveLength(0);
     expect(res.keep).toHaveLength(2);
   });
@@ -66,7 +67,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
       { id: 'A', amount: Amount.from(4), secret: 's2', C: 'C2' },
     ];
     const kc = keychainStub({ A: 0 });
-    const res = selectProofsRGLI(proofs as any, 6, kc, false, false);
+    const res = selectProofsRGLI(proofs, 6, kc, false, false);
     expect(res.send.length + res.keep.length).toBe(2);
     expect(res.send.length).toBeGreaterThan(0);
   });
@@ -77,7 +78,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
       { id: 'A', amount: Amount.from(4), secret: 's2', C: 'C2' },
     ];
     const kc = keychainStub({ A: 0 });
-    const res = selectProofsRGLI(proofs as any, Amount.from('6'), kc, false, false);
+    const res = selectProofsRGLI(proofs, Amount.from('6'), kc, false, false);
     expect(res.send.length).toBeGreaterThan(0);
   });
 
@@ -102,7 +103,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
       { id: 'A', amount: Amount.from(3), secret: 's2', C: 'C2' },
     ];
     const kc = keychainStub({ A: 0 });
-    const res = selectProofsRGLI(proofs as any, 10, kc, true, false);
+    const res = selectProofsRGLI(proofs, 10, kc, true, false);
     expect(res.send).toHaveLength(0);
     expect(res.keep).toHaveLength(2);
   });
@@ -116,7 +117,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
     const kc = keychainStub({ L: 600 }); // ceil(600 / 1000) equals one per thousand proofs
     const { logger, calls } = loggerSpy();
 
-    const res = selectProofsRGLI(proofs as any, 15, kc, true, false, logger);
+    const res = selectProofsRGLI(proofs, 15, kc, true, false, logger);
     const sum = sumProofs(res.send);
     const fee = Math.ceil((res.send.length * 600) / 1000);
     expect(sum.subtract(fee).greaterThanOrEqual(15)).toBeTruthy();
@@ -134,7 +135,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
     let index = 0;
     vi.spyOn(Math, 'random').mockImplementation(() => randomValues[index++] ?? 0.9);
 
-    const res = selectProofsRGLI(proofs as any, 9, kc, false, false);
+    const res = selectProofsRGLI(proofs, 9, kc, false, false);
 
     expect(res.send.map((p) => p.amount.toNumber()).sort((a, b) => a - b)).toEqual([4, 5]);
     expect(res.keep.map((p) => p.amount.toNumber())).toEqual([6]);

--- a/test/wallet/wallet-assertAmount.test.ts
+++ b/test/wallet/wallet-assertAmount.test.ts
@@ -29,18 +29,10 @@ describe('parseAmount tests', () => {
   });
 
   test('rejects unsupported types', () => {
-    expect(() => wallet.parseAmount(true as unknown, 'test')).toThrow(
-      'Unsupported amount input type',
-    );
-    expect(() => wallet.parseAmount(false as unknown, 'test')).toThrow(
-      'Unsupported amount input type',
-    );
-    expect(() => wallet.parseAmount({} as unknown, 'test')).toThrow(
-      'Unsupported amount input type',
-    );
-    expect(() => wallet.parseAmount(null as unknown, 'test')).toThrow(
-      'Unsupported amount input type',
-    );
+    expect(() => wallet.parseAmount(true, 'test')).toThrow('Unsupported amount input type');
+    expect(() => wallet.parseAmount(false, 'test')).toThrow('Unsupported amount input type');
+    expect(() => wallet.parseAmount({}, 'test')).toThrow('Unsupported amount input type');
+    expect(() => wallet.parseAmount(null, 'test')).toThrow('Unsupported amount input type');
     expect(() => wallet.parseAmount(undefined as unknown, 'test')).toThrow(
       'Unsupported amount input type',
     );

--- a/test/wallet/wallet-auth.node.test.ts
+++ b/test/wallet/wallet-auth.node.test.ts
@@ -1,6 +1,8 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
-import { Wallet, Mint, AuthProvider } from '../../src';
+
+import { Wallet, Mint, type AuthProvider } from '../../src';
+
 import { mint, mintUrl, useTestServer } from './_setup';
 
 const server = useTestServer();

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -1,6 +1,8 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
+
 import { Wallet, Amount, CTSError, type Proof } from '../../src';
+
 import { mint, unit, mintUrl, useTestServer } from './_setup';
 
 const server = useTestServer();

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -14,9 +14,9 @@ import {
   type RequestFetch,
   type RequestFn,
 } from '../../src';
-
 import { NULL_LOGGER } from '../../src/logger';
 import { MINTCACHE } from '../consts';
+
 import {
   mintUrl,
   mint,

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -1,11 +1,11 @@
+import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
-
-import { randomBytes } from '@noble/hashes/utils.js';
 
 import { Wallet, type MintKeys, type MintKeyset } from '../../src';
 import { deriveKeysetId, isValidHex, isBase64String } from '../../src/utils';
 import { DUMMY_TEST_KEYS, DUMMY_TEST_KEYSET, PUBKEYS } from '../consts';
+
 import { useTestServer, mint, mintUrl, token3sat } from './_setup';
 
 const server = useTestServer();

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
@@ -10,13 +11,12 @@ import {
   OutputData,
   type SerializedOutputData,
   type SerializedBlindedSignature,
-  MeltQuoteBolt12Response,
-  AuthProvider,
-  OutputType,
+  type MeltQuoteBolt12Response,
+  type AuthProvider,
+  type OutputType,
   Amount,
 } from '../../src';
 
-import { randomBytes } from '@noble/hashes/utils.js';
 import { useTestServer, mint, mintUrl, unit, invoice, logger, mintInfoResp } from './_setup';
 
 const server = useTestServer();
@@ -504,7 +504,7 @@ describe('melt proofs', () => {
           C: 'C2',
         },
       ];
-      let seenBody: any | undefined;
+      let seenBody: any;
       server.use(
         http.post(mintUrl + '/v1/melt/bolt11', async ({ request }) => {
           const body = await request.json();
@@ -571,7 +571,7 @@ describe('melt proofs', () => {
           C: 'C2',
         },
       ];
-      let seenBody: any | undefined;
+      let seenBody: any;
       server.use(
         http.post(mintUrl + '/v1/melt/bolt12', async ({ request }) => {
           const body = await request.json();

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@noble/curves/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
@@ -12,13 +13,12 @@ import {
   type MintQuoteOnchainResponse,
   MeltQuoteState,
   MintQuoteState,
-  MintQuoteBolt11Response,
+  type MintQuoteBolt11Response,
   Amount,
-  AmountLike,
+  type AmountLike,
 } from '../../src';
-
 import { Bytes, sumProofs } from '../../src/utils';
-import { hexToBytes } from '@noble/curves/utils.js';
+
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
 
 const server = useTestServer();

--- a/test/wallet/wallet-p2pk.node.test.ts
+++ b/test/wallet/wallet-p2pk.node.test.ts
@@ -4,7 +4,7 @@ import { Wallet, OutputData } from '../../src';
 
 import { mint, useTestServer } from './_setup';
 
-const server = useTestServer();
+useTestServer();
 
 // Valid-format 33-byte compressed pubkeys for testing
 const PK1 = '02' + 'aa'.repeat(32);

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@noble/curves/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
 
@@ -11,7 +12,6 @@ import {
   type ProofLike,
 } from '../../src';
 
-import { hexToBytes } from '@noble/curves/utils.js';
 import { mint, unit, token3sat, mintUrl, logger, useTestServer } from './_setup';
 
 const server = useTestServer();
@@ -524,7 +524,7 @@ describe('receive', () => {
 
     const customData = OutputData.createRandomData(
       3,
-      wallet.keyChain.getKeyset('00bd033559de27d0')!,
+      wallet.keyChain.getKeyset('00bd033559de27d0'),
       [1, 1, 1],
     );
     const proofs = await wallet.receive(token3sat, {}, { type: 'custom', data: customData });

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -1,9 +1,9 @@
+import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
 import { Wallet, Amount, type Proof } from '../../src';
 
-import { randomBytes } from '@noble/hashes/utils.js';
 import { useTestServer, mint, unit, dummyKeysResp, mintUrl, logger } from './_setup';
 
 const server = useTestServer();
@@ -15,10 +15,10 @@ describe('Restoring deterministic proofs', () => {
     let rounds = 0;
     const mockRestore = vi
       .spyOn(wallet, 'restore')
-      .mockImplementation(async (): Promise<{ proofs: Array<Proof> }> => {
+      .mockImplementation(async (): Promise<{ proofs: Proof[] }> => {
         if (rounds === 0) {
           rounds++;
-          return { proofs: Array(21).fill(1) as Array<Proof> };
+          return { proofs: Array(21).fill(1) as Proof[] };
         }
         rounds++;
         return { proofs: [] };
@@ -35,10 +35,10 @@ describe('Restoring deterministic proofs', () => {
     const mockRestore = vi
       .spyOn(wallet, 'restore')
       .mockImplementation(
-        async (): Promise<{ proofs: Array<Proof>; lastCounterWithSignature?: number }> => {
+        async (): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> => {
           if (rounds === 0) {
             rounds++;
-            return { proofs: Array(42).fill(1) as Array<Proof>, lastCounterWithSignature: 41 };
+            return { proofs: Array(42).fill(1) as Proof[], lastCounterWithSignature: 41 };
           }
           rounds++;
           return { proofs: [] };
@@ -61,7 +61,7 @@ describe('restore', () => {
     const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32), logger });
     await wallet.loadMint();
     interface RestoreBody {
-      outputs: Array<unknown>;
+      outputs: unknown[];
     }
     let seenBody: RestoreBody = { outputs: [] };
 

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@noble/curves/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
 
@@ -10,9 +11,7 @@ import {
   type ProofLike,
   type OutputConfig,
 } from '../../src';
-
 import { Bytes } from '../../src/utils';
-import { hexToBytes } from '@noble/curves/utils.js';
 
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
 
@@ -22,7 +21,7 @@ const mintInfoRespWithNut12 = {
   nuts: { ...mintInfoResp.nuts, 12: { supported: true } },
 };
 
-function expectNUT10SecretDataToEqual(p: Array<Proof>, s: string) {
+function expectNUT10SecretDataToEqual(p: Proof[], s: string) {
   p.forEach((p) => {
     const parsedSecret = JSON.parse(p.secret);
     expect(parsedSecret[1].data).toBe(s);
@@ -846,7 +845,7 @@ describe('send', () => {
     server.use(
       http.post(mintUrl + '/v1/swap', async ({ request }) => {
         const body = (await request.json()) as {
-          outputs: { amount: number; B_: string; id: string }[];
+          outputs: Array<{ amount: number; B_: string; id: string }>;
         };
         return HttpResponse.json({
           signatures: body.outputs.map((o) => ({

--- a/test/wallet/wallet-state.node.test.ts
+++ b/test/wallet/wallet-state.node.test.ts
@@ -1,6 +1,8 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
+
 import { Wallet, CheckStateEnum, Amount } from '../../src';
+
 import { mint, unit, mintUrl, useTestServer } from './_setup';
 
 const server = useTestServer();

--- a/test/wallet/wallet-websocket.node.test.ts
+++ b/test/wallet/wallet-websocket.node.test.ts
@@ -1,3 +1,4 @@
+import { Server } from 'mock-socket';
 import { test, describe, expect } from 'vitest';
 
 import {
@@ -8,10 +9,9 @@ import {
   type MintQuoteBolt11Response,
 } from '../../src';
 
-import { Server } from 'mock-socket';
 import { mint, useTestServer } from './_setup';
 
-const server = useTestServer();
+useTestServer();
 
 describe('WebSocket Updates', () => {
   test('mint update', async () => {
@@ -38,16 +38,17 @@ describe('WebSocket Updates', () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
 
-    const state = await new Promise(async (res, rej) => {
+    const state = await new Promise((res, rej) => {
       const callback = (p: MintQuoteBolt11Response) => {
         if (p.state === MintQuoteState.PAID) {
           res(p);
         }
       };
-      await wallet.on.mintQuoteUpdates(['123'], callback, () => {
-        rej();
-        console.log('error');
-      });
+      wallet.on
+        .mintQuoteUpdates(['123'], callback, () => {
+          rej(new Error('mint quote subscription error'));
+        })
+        .catch(rej);
     });
     expect(state).toMatchObject({ quote: '123' });
     mint.disconnectWebSocket();
@@ -77,18 +78,19 @@ describe('WebSocket Updates', () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
 
-    const state = await new Promise(async (res, rej) => {
+    const state = await new Promise((res, rej) => {
       const callback = (p: MeltQuoteBolt11Response) => {
         console.log(p);
         if (p.state === MeltQuoteState.PAID) {
           res(p);
         }
       };
-      await wallet.on.meltQuoteUpdates(['123'], callback, (e) => {
-        console.log(e);
-        rej();
-        console.log('error');
-      });
+      wallet.on
+        .meltQuoteUpdates(['123'], callback, (e) => {
+          console.log(e);
+          rej(new Error('melt quote subscription error'));
+        })
+        .catch(rej);
     });
     expect(state).toMatchObject({ quote: '123' });
     server.close();


### PR DESCRIPTION
Tests were formatted but excluded from eslint, so the rules that catch silently vacuous tests were never enforced. Those rules are the point of this change:

- `no-floating-promises`: an unawaited `expect(...).resolves` passes unconditionally
- `vitest/no-focused-tests`: a committed `.only` skips the rest of the suite while CI stays green
- `vitest/expect-expect`: flags tests that assert nothing

## Setup

- eslint override block for `test/**`: production correctness rules stay on; fixture ergonomics are relaxed (eg `as any`); vitest hygiene is enforced
- `test/tsconfig.json` (2 lines) gives the typed rules project coverage. Builds and vitest are unaffected.
- `test/consumer/**` stays ignored: plain-JS external-consumer simulations in varying module systems, not vitest suites
- `@vitest/eslint-plugin` added as a dev dependency (no transitive dependencies)

## Findings

No vacuously passing tests existed. The 18 floating promises were intentional fire-and-forget, now marked with `void` or restructured. Real improvements:

- websocket subscription-setup failures now reject with proper Errors instead of hanging the test until timeout
- three `new Promise(async ...)` executors, which swallow rejections, restructured
- dead mock code and unused variables removed

Deliberate patterns (compile-time checks, async-callback tolerance tests, a precision-loss assertion, the permanent browser skip) carry documented eslint-disable comments rather than code changes.

The remaining ~700 changes are pure autofix: import order, inline type imports, 113 redundant type assertions, `prefer-const`.

## Verification

Repo-wide `eslint '**/*.{js,ts}'` exits 0 and all 1654 node unit tests pass. During the work, an early edit deleted a variable that was still in use and the suite caught it within seconds: the safety net this PR strengthens, working.
