### PR TITLE
ci: gate mutation score and add incremental PR run

### DIFF
--- a/.github/workflows/mutation-testing-pr.yml
+++ b/.github/workflows/mutation-testing-pr.yml
@@ -1,0 +1,59 @@
+name: Mutation testing (PR)
+
+# Incremental Stryker run for pull requests: re-tests only mutants in changed code
+# against the baseline seeded by the weekly full run. A regression that drops the
+# overall score below the `break` threshold (stryker.config.json) fails the check.
+# Codecov gates line coverage; this is the coarser "are the tests still meaningful" net.
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'stryker.config.json'
+      - 'vitest.stryker.config.ts'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Newer pushes cancel in-flight runs for the same PR.
+concurrency:
+  group: mutation-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stryker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Restore the newest baseline seeded by the weekly run. A miss (e.g. fork PR, or
+      # before the first weekly) just means --incremental does a full run instead.
+      - name: Restore incremental baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-incremental-none
+          restore-keys: |
+            stryker-incremental-
+
+      - name: Run Stryker (incremental)
+        run: npm run test:mutation:incremental
+
+      - name: Upload mutation report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-report-pr
+          path: reports/mutation/
+          retention-days: 14

--- a/.github/workflows/mutation-testing-weekly.yml
+++ b/.github/workflows/mutation-testing-weekly.yml
@@ -28,8 +28,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # --incremental on a fresh checkout has no baseline, so this is still a full
+      # authoritative run; the point is that it *writes* reports/stryker-incremental.json,
+      # which the PR workflow restores to re-test only mutants in changed code.
       - name: Run Stryker
-        run: npm run test:mutation
+        run: npm run test:mutation:incremental
+
+      # Seed the incremental baseline for PR runs. Written mid-run, so it exists even if
+      # the score dips below the break threshold and the step above fails.
+      - name: Cache incremental baseline
+        if: ${{ always() }}
+        uses: actions/cache/save@v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-incremental-${{ github.run_id }}
 
       - name: Upload mutation report
         if: ${{ always() }}
@@ -40,6 +52,7 @@ jobs:
           retention-days: 90
 
       - name: Deploy report to GitHub Pages
+        if: ${{ always() }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -15,7 +15,7 @@
   "htmlReporter": { "fileName": "reports/mutation/mutation.html" },
   "jsonReporter": { "fileName": "reports/mutation/mutation.json" },
   "incrementalFile": "reports/stryker-incremental.json",
-  "thresholds": { "high": 90, "low": 70, "break": null },
+  "thresholds": { "high": 90, "low": 70, "break": 80 },
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true
 }


### PR DESCRIPTION
Turns the weekly mutation run from a passive report into a regression gate, and adds a per-PR incremental check so new survivors are caught against the fixed baseline.

## Why

The weekly job had `break: null`, so it never failed on score, and its issue only listed the first 10 survivors (always the same `Wallet.ts` lines). Against a floor of ~600 immovable/equivalent mutants, a new regression moved the aggregate score by ~0.02% and never showed up. There was no way to tell a real regression from the baseline.

## Change

- **`break: 80`** in `stryker.config.json`. A run scoring below 80 now fails (we sit at ~89.4%, so ~9 points of margin absorbs Timeout jitter). Deliberately lenient: Codecov already gates line coverage, so Stryker is the coarse "are the tests still meaningful" net, not a tight gate.
- **Weekly** switches to `--incremental`. On a fresh checkout there is no baseline, so it is still a full authoritative run, but it now writes `reports/stryker-incremental.json`, which it caches for PRs. Written mid-run, so the baseline is seeded even if the score breaks. The report also publishes to Pages on a break-fail (`if: always()`).
- **New `mutation-testing-pr.yml`**: on PRs touching `src/`, `test/`, or the Stryker config, restore the cached baseline and run `--incremental`, re-testing only mutants in changed code. A regression that drops the overall score below 80 fails the PR. A cache miss (e.g. before the first weekly) degrades gracefully to a full run.

## Try-it-out notes

- The PR gate only becomes fully useful once a weekly has run and seeded the cache; until then PR runs do a full pass.
- No untrusted event input is used in either workflow (no injection surface).
