### PR TITLE
ci: report mutation score on PRs (job summary + sticky comment)

### DIFF
--- a/.github/workflows/mutation-testing-pr.yml
+++ b/.github/workflows/mutation-testing-pr.yml
@@ -13,8 +13,12 @@ on:
       - 'vitest.stryker.config.ts'
   workflow_dispatch: {}
 
+# contents: read for checkout; pull-requests: write to post the sticky score comment.
+# Uses the built-in GITHUB_TOKEN only (auto read-only on fork PRs) — never a PAT, since
+# this workflow runs untrusted PR code and a write PAT could be exfiltrated.
 permissions:
   contents: read
+  pull-requests: write
 
 # Newer pushes cancel in-flight runs for the same PR.
 concurrency:
@@ -49,6 +53,78 @@ jobs:
 
       - name: Run Stryker (incremental)
         run: npm run test:mutation:incremental
+
+      # Summarise the result to the run page and to comment.md, even on a break-fail.
+      - name: Build report
+        if: ${{ always() }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -f reports/mutation/mutation.json ] || { echo "no mutation report produced"; exit 0; }
+
+          node -e '
+            const fs = require("fs");
+            const r = require("./reports/mutation/mutation.json");
+            const brk = require("./stryker.config.json").thresholds.break ?? 0;
+            const all = Object.entries(r.files).flatMap(([f, v]) =>
+              v.mutants.map((m) => ({ f: f.replace(/^src\//, ""), ...m }))
+            );
+            const by = (s) => all.filter((m) => m.status === s).length;
+            const killed = by("Killed") + by("Timeout");
+            const survived = by("Survived");
+            const noCov = by("NoCoverage");
+            const total = killed + survived + noCov;
+            const score = total ? (killed / total) * 100 : 100;
+            const pass = score >= brk;
+            const icon = pass ? "✅" : "❌";
+            const survivors = all
+              .filter((m) => m.status === "Survived" || m.status === "NoCoverage")
+              .slice(0, 20)
+              .map((m) => `- \`${m.f}:${m.location.start.line}\` ${m.mutatorName}: \`${String(m.replacement || "").replace(/`/g, "‘").slice(0, 80)}\``)
+              .join("\n") || "_none_";
+            const body = `<!-- mutation-pr-report -->
+          ### 🧬 Mutation testing (incremental)
+
+          ${icon} Mutation score: **${score.toFixed(1)}%** (break threshold: ${brk}%)
+
+          | Killed | Survived | No coverage |
+          |--:|--:|--:|
+          | ${killed} | ${survived} | ${noCov} |
+
+          <details><summary>Top ${Math.min(20, survived + noCov)} survivors</summary>
+
+          ${survivors}
+          </details>
+
+          Full interactive report: download the \`mutation-report-pr\` artifact from [this run](${process.env.RUN_URL}). Incremental run re-tests only mutants in changed code.
+          `;
+            fs.writeFileSync("comment.md", body);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body.replace("<!-- mutation-pr-report -->\n", ""));
+          '
+
+      # Upsert a single sticky comment (found by the hidden marker) on the PR.
+      - name: Comment score on PR
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('comment.md')) return;
+            const body = fs.readFileSync('comment.md', 'utf8');
+            const marker = '<!-- mutation-pr-report -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
       - name: Upload mutation report
         if: ${{ always() }}


### PR DESCRIPTION
Follow-up to the mutation PR gate: make the check *write* its result instead of only passing or failing.

Previously a PR mutation run produced a green/red status and a downloadable artifact, nothing more. To see what survived you had to download and open the HTML. This adds two surfaces:

- **Job summary** on the run page: score vs the break threshold, killed/survived/no-coverage counts, top 20 survivors. Zero permissions, always rendered.
- **Sticky PR comment**: the same, upserted in place each push (found by a hidden marker), with a link to the full report artifact. The Codecov-parallel view, visible on the PR without leaving it.

## Security

Posts with the built-in `GITHUB_TOKEN` scoped to `pull-requests: write`, **not** a PAT. This workflow checks out and runs untrusted PR code (`npm ci`, the test suite), so any exposed write secret could be exfiltrated. `GITHUB_TOKEN` is auto-downgraded to read-only on fork PRs, so it is safe here; a PAT would not be. Same-repo PRs (this repo's model) get the write scope and post fine.

## Notes

- The comment step is guarded to `pull_request` events, so `workflow_dispatch` runs just write the job summary.
- The report script was exercised against the current `mutation.json` locally; output verified.
