### PR TITLE
[Backport v4-dev] fix(p2pk): cap NUT-28 locking slots at 11 (#753)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test-results
 .claude
 .githooks
 .husky/_
+reports
+.stryker-tmp

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,11 @@
 dist
 node_modules
+.claude
 package-lock.json
 temp
 etc
 coverage
+reports
+.stryker-tmp
 docs
 CHANGELOG.md

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,8 @@ export default tseslint.config(
   {
     ignores: [
       'node_modules/**',
+      '.claude/**',
+      '.stryker-tmp/**',
       'dist/**',
       'dist-scripts/**',
       'scripts/**',

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -227,9 +227,14 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   if (pubkeys.length === 0 && !isHTLC) {
     throw new CTSError('P2PK requires at least one pubkey');
   }
-  const totalKeys = pubkeys.length + refundKeys.length;
-  if (totalKeys > 10) {
-    throw new CTSError(`Too many pubkeys, ${totalKeys} provided, maximum allowed is 10 in total`);
+  // NUT-28: up to 11 locking slots in [data, ...pubkeys, ...refund] (i_byte 0x00..0x0A). Slot 0 is
+  // the first pubkey for P2PK, but the hashlock for HTLC, so HTLC's hashlock costs a slot on top of
+  // the keys. P2PK thus allows 11 keys, HTLC 10.
+  const slotCount = (isHTLC ? 1 : 0) + pubkeys.length + refundKeys.length;
+  if (slotCount > 11) {
+    throw new CTSError(
+      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is 11 in total`,
+    );
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
 

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1481,6 +1481,22 @@ describe('normalizeP2PKOptions', () => {
       /invalid sigflag/i,
     );
   });
+
+  test('P2PK: data pubkey counts as a slot, so 11 keys fill 11 slots and 12 overflow (NUT-28)', () => {
+    // NUT-28 allows up to 11 slots in [data, ...pubkeys, ...refund] (i_byte 0x00..0x0A). For P2PK
+    // slot 0 is the first pubkey, so 11 pubkeys fill the 11 slots and a 12th overflows.
+    const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c'].map((c) => _comp(c));
+    expect(() => normalizeP2PKOptions({ pubkey: keys.slice(0, 11) })).not.toThrow(); // 11 slots
+    expect(() => normalizeP2PKOptions({ pubkey: keys })).toThrow(/maximum allowed is 11/); // 12 slots
+  });
+
+  test('HTLC: hashlock fills slot 0, so only 10 keys fit before overflowing 11 slots (NUT-28)', () => {
+    // For HTLC the data slot is the hashlock, not a key, so signing keys max out one lower than P2PK.
+    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+    const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b'].map((c) => _comp(c));
+    expect(() => normalizeP2PKOptions({ pubkey: keys.slice(0, 10), hashlock })).not.toThrow(); // hash + 10 = 11 slots
+    expect(() => normalizeP2PKOptions({ pubkey: keys, hashlock })).toThrow(/maximum allowed is 11/); // hash + 11 = 12 slots
+  });
 });
 
 describe('parseP2PKSecret — duplicate tag rejection', () => {

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -176,17 +176,28 @@ describe('P2PKBuilder.toOptions()', () => {
     ).toThrow(/requires refund keys/i);
   });
 
-  it('enforces combined lock+refund keys limit of 10', () => {
-    // build 11 distinct keys
-    const chars = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b'];
+  it('enforces the combined lock+refund slot limit of 11 (NUT-28)', () => {
+    // 12 distinct keys; NUT-28 allows up to 11 slots ([data, ...pubkeys, ...refund]).
+    const chars = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c'];
     const keys = chars.map((c, i) => comp(c as any, i % 2 === 0 ? '02' : '03'));
 
-    const b = new P2PKBuilder()
-      .addLockPubkey(keys.slice(0, 8)) // 8 locks
-      .lockUntil(Date.now() + 60)
-      .addRefundPubkey(keys.slice(8)); // 3 refunds => total 11
+    // 8 locks + 3 refunds = 11 slots: allowed.
+    expect(() =>
+      new P2PKBuilder()
+        .addLockPubkey(keys.slice(0, 8))
+        .lockUntil(Date.now() + 60)
+        .addRefundPubkey(keys.slice(8, 11))
+        .toOptions(),
+    ).not.toThrow();
 
-    expect(() => b.toOptions()).toThrow(/Too many pubkeys/i);
+    // 8 locks + 4 refunds = 12 slots: rejected.
+    expect(() =>
+      new P2PKBuilder()
+        .addLockPubkey(keys.slice(0, 8))
+        .lockUntil(Date.now() + 60)
+        .addRefundPubkey(keys.slice(8))
+        .toOptions(),
+    ).toThrow(/Too many pubkeys/i);
   });
 
   it('round-trips via fromOptions', () => {


### PR DESCRIPTION
Backport of #753 to `v4-dev`, plus a follow-up ignore-hygiene commit. Closes #758.

## Why it needed a manual backport

`normalizeP2PKOptions` differs between branches: `main` splits the primary key into a separate `data` slot (`{ kind, data, pubkeys }`), while `v4-dev` carries it inline in the `pubkey` array (`{ pubkey, hashlock }`, no `kind`). A straight cherry-pick conflicted in both `NUT11.ts` and `NUT11.test.ts`.

## The fix

Same NUT-28 rule, re-expressed for the v4-dev shape. NUT-28 allows up to 11 locking slots in `[data, ...pubkeys, ...refund]` (i_byte `0x00`..`0x0A`); slot 0 is the first pubkey for P2PK but the hashlock for HTLC:

```ts
const slotCount = (isHTLC ? 1 : 0) + pubkeys.length + refundKeys.length;
if (slotCount > 11) { ... }
```

- P2PK: the data slot is one of the `pubkey` entries, so 11 keys allowed (was 10, the bug).
- HTLC: the hashlock costs slot 0, so 10 keys, unchanged.

The old cap counted signing keys only, under-counting P2PK by one. The guard is over-restrictive rather than permissive, so it fails safe: a spec-valid P2PK construction was refused, nothing worse.

## Also included

`chore:` backporting the `reports`/`.stryker-tmp` exclusions `main` already carries (`.gitignore`, `.prettierignore`, `eslint.config.js`), so generated artifacts can't be swept into a commit. Skips main entries for paths absent on v4-dev.

## Verification

`npm run prtasks` green: full suite passes, NUT11 boundary tests added for both P2PK (11/12) and HTLC (10/11).