### PR TITLE
ci: skip mutation score comment on fork PRs

### DIFF
--- a/.github/workflows/mutation-testing-pr.yml
+++ b/.github/workflows/mutation-testing-pr.yml
@@ -113,8 +113,11 @@ jobs:
           '
 
       # Upsert a single sticky comment (found by the hidden marker) on the PR.
+      # Skipped for fork PRs: their GITHUB_TOKEN is read-only no matter what the
+      # permissions block requests, so the comment would 403. The job summary
+      # (written above) still carries the same report.
       - name: Comment score on PR
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Fork PRs run with a read-only `GITHUB_TOKEN` regardless of the requested permissions, so the sticky comment upsert always 403s and fails an otherwise green run (seen on #683). Skip the comment step when the PR head is not this repo; the job summary already carries the same report, and the score gate itself is unaffected.