### PR TITLE
fix(p2bk): align HTLC key slots with the [data, ...pubkeys, ...refund] order (NUT-28)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -415,7 +415,7 @@ export function deriveMintBackupKeys(seed: Uint8Array): {
 };
 
 // @public
-export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array): {
+export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array, dataIsPubkey?: boolean): {
     blinded: string[];
     Ehex: string;
 };
@@ -424,7 +424,7 @@ export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array)
 export function deriveP2BKSecretKey(privkey: string | bigint, rBlind: string | bigint, blindPubkey?: Uint8Array, naturalPub?: Uint8Array): string | null;
 
 // @public
-export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[]): string[];
+export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[], dataIsPubkey?: boolean): string[];
 
 // @public
 export function deriveSecretAndBlindingFactor(seed: Uint8Array, keysetId: string, counter: number): {

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -664,7 +664,12 @@ export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof:
   // Extract pubkeys and keyset ID from proof
   const secret = parseP2PKSecret(proof.secret);
   const pubs = [...getP2PKWitnessPubkeys(secret), ...getP2PKWitnessRefundkeys(secret)];
-  return deriveP2BKSecretKeys(Ehex, privs, pubs);
+  // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
+  const dataIsPubkey = getSecretKind(secret) === 'P2PK';
+  const keys = deriveP2BKSecretKeys(Ehex, privs, pubs, dataIsPubkey);
+  // Deprecated: retry from slot 0 for HTLC proofs blinded by older releases; remove next major
+  if (!dataIsPubkey && !keys.length) return deriveP2BKSecretKeys(Ehex, privs, pubs);
+  return keys;
 }
 
 // ------------------------------

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -23,13 +23,17 @@ export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1'
  * This is the Sender side API.
  * @param pubkeys Ordered SEC1 compressed pubkeys, [data, ...pubkeys, ...refund]
  * @param eBytes Optional. Fixed ephemeral secret key to use (eg for SIG_ALL / testing)
+ * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
+ *   first pubkey takes slot 1.
  * @returns Blinded pubkeys in the same order, and Ehex as SEC1 compressed hex, 33 bytes.
  * @throws If a blinded key is at infinity.
  */
 export function deriveP2BKBlindedPubkeys(
   pubkeys: string[],
   eBytes?: Uint8Array,
+  dataIsPubkey = true,
 ): { blinded: string[]; Ehex: string } {
+  const slotOffset = dataIsPubkey ? 0 : 1;
   if (!pubkeys.length) return { blinded: [], Ehex: '' };
   // Create fresh ephemeral secret (e) if not supplied, and calculate pubkey (E)
   eBytes = eBytes ?? secp256k1.utils.randomSecretKey(); // 32 bytes
@@ -38,7 +42,7 @@ export function deriveP2BKBlindedPubkeys(
   // Blind each pubkey in turn
   const blinded = pubkeys.map((pubkey, i) => {
     const P = pointFromHex(pubkey);
-    const r = deriveP2BKBlindingTweakFromECDH(P, e, i);
+    const r = deriveP2BKBlindingTweakFromECDH(P, e, i + slotOffset);
     const P_ = P.add(secp256k1.Point.BASE.multiply(r));
     if (P_.equals(secp256k1.Point.ZERO)) throw new CTSError('Blinded key at infinity');
     return P_.toHex(true);
@@ -60,13 +64,17 @@ export function deriveP2BKBlindedPubkeys(
  * @param Ehex Ephemeral public key (E) as SEC1 hex.
  * @param privateKey Secret key or array of secret keys, hex.
  * @param blindPubKey Blinded public key or array of blinded public keys, hex.
+ * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
+ *   first pubkey takes slot 1.
  * @returns Array of derived secret keys as 64 char hex.
  */
 export function deriveP2BKSecretKeys(
   Ehex: string,
   privateKey: string | string[],
   blindPubKey: string | string[],
+  dataIsPubkey = true,
 ): string[] {
+  const slotOffset = dataIsPubkey ? 0 : 1;
   const privs = Array.isArray(privateKey) ? privateKey : [privateKey];
   const pubs = Array.isArray(blindPubKey) ? blindPubKey : [blindPubKey];
   const out = new Set<string>();
@@ -75,7 +83,7 @@ export function deriveP2BKSecretKeys(
     const p = secp256k1.Point.Fn.fromBytes(hexToBytes(privHex));
     const P = secp256k1.getPublicKey(hexToBytes(privHex), true); // 33 bytes, validates on curve
     pubs.forEach((hexP_, i) => {
-      const r = deriveP2BKBlindingTweakFromECDH(E, p, i);
+      const r = deriveP2BKBlindingTweakFromECDH(E, p, i + slotOffset);
       const P_ = hexToBytes(hexP_);
       const kHex = deriveP2BKSecretKey(privHex, r, P_, P);
       if (kHex) out.add(kHex); // add only when this priv matches this P′

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -286,7 +286,8 @@ export class OutputData implements OutputDataLike {
     if (normalized.blindKeys) {
       const lockKeys = isHTLC ? pubkeys : [data, ...pubkeys];
       const ordered = [...lockKeys, ...refundKeys];
-      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered);
+      // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
+      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered, undefined, !isHTLC);
       if (isHTLC) {
         // hashlock is in data, all locking keys into pubkeys
         pubkeys = blinded.slice(0, lockKeys.length);

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -2093,6 +2093,21 @@ describe('signing edge cases', () => {
     expect(result.witness).toBeUndefined();
   });
 
+  test('maybeDeriveP2BKPrivateKeys falls back to legacy slot 0 indexing for HTLC proofs', () => {
+    // Pre-fix senders blinded HTLC lock keys from slot 0; those proofs must stay spendable.
+    const privBytes = createRandomSecretKey();
+    const pubHex = bytesToHex(getPubKeyFromPrivKey(privBytes));
+    const {
+      blinded: [P0_],
+      Ehex,
+    } = deriveP2BKBlindedPubkeys([pubHex]); // legacy: first lock key at slot 0
+    const secret = `["HTLC",{"nonce":"aa","data":"ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5","tags":[["pubkeys","${P0_}"]]}]`;
+    const proof = { ...mkProof(secret), p2pk_e: Ehex };
+    const derived = maybeDeriveP2BKPrivateKeys(bytesToHex(privBytes), proof);
+    const derivedPubs = derived.map((k) => bytesToHex(getPubKeyFromPrivKey(hexToBytes(k))));
+    expect(derivedPubs).toContain(P0_);
+  });
+
   test('maybeDeriveP2BKPrivateKeys tolerates a missing proof', () => {
     const priv = bytesToHex(createRandomSecretKey());
     expect(maybeDeriveP2BKPrivateKeys(priv, undefined as unknown as Proof)).toStrictEqual([priv]);

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -238,6 +238,28 @@ describe('P2BK test vectors, public API only', () => {
   });
 });
 
+describe('slot offset (NUT-28: the data tag occupies slot 0)', () => {
+  // Fixed vector from 'P2BK test vectors, public API only' above: for an HTLC the hashlock
+  // holds slot 0, so the first lock key must be blinded/unblinded with slot index 1.
+  const eHex = '1cedb9df0c6872188b560ace9e35fd55c2532d53e19ae65b46159073886482ca';
+  const Ehex = '02a8cda4cf448bfce9a9e46e588c06ea1780fcb94e3bbdf3277f42995d403a8b0c';
+  const pubKeyBob = '02771fed6cb88aaac38b8b32104a942bf4b8f4696bc361171b3c7d06fa2ebddf06';
+  const privKeyBob = 'ad37e8abd800be3e8272b14045873f4353327eedeb702b72ddcc5c5adff5129c';
+  const slot1Blinded = '0352fb6d93360b7c2538eedf3c861f32ea5883fceec9f3e573d9d84377420da838';
+  const slot1DerivedSk2 = '9d1ffe00e1da5af5c882b1ea5ec8c18893e09349803c3c9e552823490af22458';
+
+  test('deriveP2BKBlindedPubkeys blinds the first key at slot 1 when data is not a pubkey', () => {
+    const { blinded } = deriveP2BKBlindedPubkeys([pubKeyBob], hexToBytes(eHex), false);
+    expect(blinded).toStrictEqual([slot1Blinded]);
+  });
+
+  test('deriveP2BKSecretKeys derives the slot 1 key when data is not a pubkey', () => {
+    expect(deriveP2BKSecretKeys(Ehex, privKeyBob, slot1Blinded, false)).toStrictEqual([
+      slot1DerivedSk2,
+    ]);
+  });
+});
+
 describe('NUT28 uncovered branches and guards', () => {
   const toHex = (x: bigint) => numberToHexPadded64(x);
   const randScalar = () => hexToNumber(bytesToHex(secp256k1.utils.randomSecretKey()));

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -1,4 +1,6 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -6,6 +8,7 @@ import {
   createDLEQProof,
   getPubKeyFromPrivKey,
   pointFromHex,
+  P2BK_DST,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 import { Amount } from '../../src/model/Amount';
@@ -17,7 +20,7 @@ import {
   RESERVED_P2PK_TAGS,
 } from '../../src/model/OutputData';
 import type { HasKeysetKeys, SerializedBlindedSignature } from '../../src/model/types';
-import { deriveKeysetId, numberToHexPadded64 } from '../../src/utils';
+import { Bytes, deriveKeysetId, numberToHexPadded64 } from '../../src/utils';
 
 // secp256k1 (v0/v1) round-trip through OutputData -> simulated mint sign+DLEQ -> toProof.
 // The mint side is simulated with createBlindSignature/createDLEQProof: the curve math matches a
@@ -254,6 +257,24 @@ describe('OutputData.createSingleP2PKData tag construction', () => {
     expect(pubkeysTag?.[1]).not.toBe(lock1);
     expect(pubkeysTag?.[2]).not.toBe(lock2);
     expect(refundTag?.slice(1)).toHaveLength(1);
+  });
+
+  test('HTLC blinding starts lock keys at slot 1 (NUT-28: hashlock occupies slot 0)', () => {
+    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+    const lockPriv = secpPriv(1);
+    const lock1 = pub(1);
+    const out = OutputData.createSingleP2PKData(
+      { kind: 'HTLC', data: hashlock, pubkeys: [lock1], blindKeys: true },
+      1,
+      KEYSET_ID,
+    );
+    const blinded = readSecret(out).tags.find(([t]) => t === 'pubkeys')![1];
+    // Independent receiver-side NUT-28 math: r1 = sha256(DST || Zx || 0x01), P' = P + r1·G
+    const p = secp256k1.Point.Fn.fromBytes(lockPriv);
+    const Zx = secp256k1.Point.fromHex(out.ephemeralE!).multiply(p).toBytes(true).slice(1);
+    const r1 = Bytes.toBigInt(sha256(Bytes.concat(P2BK_DST, Zx, Uint8Array.of(1))));
+    const expected = pointFromHex(lock1).add(secp256k1.Point.BASE.multiply(r1)).toHex(true);
+    expect(blinded).toBe(expected);
   });
 
   test('emits a locktime tag for locktime 0 (boundary)', () => {


### PR DESCRIPTION
## Summary

NUT-28 numbers locking slots by position in `[data, ...pubkeys, ...refund]`, with slot 0 held by the `data` tag. For HTLC secrets the data is the hashlock, so locking and refund keys belong in slots 1+. Previously both blinding and unblinding indexed HTLC keys from slot 0; #753 corrected the slot count but not the numbering. This aligns the derivation with the spec.

## Changes

- `deriveP2BKBlindedPubkeys` / `deriveP2BKSecretKeys` take an optional `dataIsPubkey = true`; when false the first key derives at slot 1. Existing callers are unaffected.
- `OutputData.createSingleP2PKData` blinds HTLC lock keys from slot 1.
- `maybeDeriveP2BKPrivateKeys` unblinds with the matching slot order, and retries HTLC proofs from slot 0 so keys blinded by earlier releases still derive. The fallback is deprecated and will be removed in the next major.

## Tests

- Slot 1 blinding and derivation pinned against the existing NUT-28 fixed vectors.
- End-to-end check that an HTLC `blindKeys` output matches independently computed slot 1 receiver math.
- Legacy HTLC proofs (slot 0 blinding) still derive via the fallback.

`npm run prtasks` passes.