### PR TITLE
fix(p2bk): align HTLC key slots with the [data, ...pubkeys, ...refund] order (NUT-28) (#763)

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -368,7 +368,7 @@ export type DeriveKeysetIdOptions = {
 };
 
 // @public
-export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array): {
+export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array, dataIsPubkey?: boolean): {
     blinded: string[];
     Ehex: string;
 };
@@ -377,7 +377,7 @@ export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array)
 export function deriveP2BKSecretKey(privkey: string | bigint, rBlind: string | bigint, blindPubkey?: Uint8Array, naturalPub?: Uint8Array): string | null;
 
 // @public
-export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[]): string[];
+export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[], dataIsPubkey?: boolean): string[];
 
 // @public @deprecated (undocumented)
 export const deriveSecret: (seed: Uint8Array, keysetId: string, counter: number) => Uint8Array;

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -621,7 +621,12 @@ export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof:
   // Extract pubkeys and keyset ID from proof
   const secret = parseP2PKSecret(proof.secret);
   const pubs = [...getP2PKWitnessPubkeys(secret), ...getP2PKWitnessRefundkeys(secret)];
-  return deriveP2BKSecretKeys(Ehex, privs, pubs);
+  // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
+  const dataIsPubkey = getSecretKind(secret) === 'P2PK';
+  const keys = deriveP2BKSecretKeys(Ehex, privs, pubs, dataIsPubkey);
+  // Deprecated: retry from slot 0 for HTLC proofs blinded by older releases; remove next major
+  if (!dataIsPubkey && !keys.length) return deriveP2BKSecretKeys(Ehex, privs, pubs);
+  return keys;
 }
 
 // ------------------------------

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -23,13 +23,17 @@ export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1'
  * This is the Sender side API.
  * @param pubkeys Ordered SEC1 compressed pubkeys, [data, ...pubkeys, ...refund]
  * @param eBytes Optional. Fixed ephemeral secret key to use (eg for SIG_ALL / testing)
+ * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
+ *   first pubkey takes slot 1.
  * @returns Blinded pubkeys in the same order, and Ehex as SEC1 compressed hex, 33 bytes.
  * @throws If a blinded key is at infinity.
  */
 export function deriveP2BKBlindedPubkeys(
   pubkeys: string[],
   eBytes?: Uint8Array,
+  dataIsPubkey = true,
 ): { blinded: string[]; Ehex: string } {
+  const slotOffset = dataIsPubkey ? 0 : 1;
   if (!pubkeys.length) return { blinded: [], Ehex: '' };
   // Create fresh ephemeral secret (e) if not supplied, and calculate pubkey (E)
   eBytes = eBytes ?? secp256k1.utils.randomSecretKey(); // 32 bytes
@@ -38,7 +42,7 @@ export function deriveP2BKBlindedPubkeys(
   // Blind each pubkey in turn
   const blinded = pubkeys.map((pubkey, i) => {
     const P = pointFromHex(pubkey);
-    const r = deriveP2BKBlindingTweakFromECDH(P, e, i);
+    const r = deriveP2BKBlindingTweakFromECDH(P, e, i + slotOffset);
     const P_ = P.add(secp256k1.Point.BASE.multiply(r));
     if (P_.equals(secp256k1.Point.ZERO)) throw new CTSError('Blinded key at infinity');
     return P_.toHex(true);
@@ -60,13 +64,17 @@ export function deriveP2BKBlindedPubkeys(
  * @param Ehex Ephemeral public key (E) as SEC1 hex.
  * @param privateKey Secret key or array of secret keys, hex.
  * @param blindPubKey Blinded public key or array of blinded public keys, hex.
+ * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
+ *   first pubkey takes slot 1.
  * @returns Array of derived secret keys as 64 char hex.
  */
 export function deriveP2BKSecretKeys(
   Ehex: string,
   privateKey: string | string[],
   blindPubKey: string | string[],
+  dataIsPubkey = true,
 ): string[] {
+  const slotOffset = dataIsPubkey ? 0 : 1;
   const privs = Array.isArray(privateKey) ? privateKey : [privateKey];
   const pubs = Array.isArray(blindPubKey) ? blindPubKey : [blindPubKey];
   const out = new Set<string>();
@@ -75,7 +83,7 @@ export function deriveP2BKSecretKeys(
     const p = secp256k1.Point.Fn.fromBytes(hexToBytes(privHex));
     const P = secp256k1.getPublicKey(hexToBytes(privHex), true); // 33 bytes, validates on curve
     pubs.forEach((hexP_, i) => {
-      const r = deriveP2BKBlindingTweakFromECDH(E, p, i);
+      const r = deriveP2BKBlindingTweakFromECDH(E, p, i + slotOffset);
       const P_ = hexToBytes(hexP_);
       const kHex = deriveP2BKSecretKey(privHex, r, P_, P);
       if (kHex) out.add(kHex); // add only when this priv matches this P′

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -202,7 +202,8 @@ export class OutputData implements OutputDataLike {
     let Ehex: string | undefined;
     if (p2pk.blindKeys) {
       const ordered = [...lockKeys, ...refundKeys];
-      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered);
+      // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
+      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered, undefined, !isHTLC);
       if (isHTLC) {
         // hashlock is in data, all locking keys into pubkeys
         pubkeys = blinded.slice(0, lockKeys.length);

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -26,6 +26,7 @@ import {
   buildLegacyP2PKSigAllMessage,
   createSecret,
   isHTLCSpendAuthorised,
+  maybeDeriveP2BKPrivateKeys,
   normalizeP2PKOptions,
   verifyP2PKSpendingConditions,
 } from '../../src/crypto';
@@ -1784,5 +1785,29 @@ describe('verifyP2PKSpendingConditions signer counts', () => {
       ]),
     };
     expect(verifyP2PKSpendingConditions(proof).main.requiredSigners).toBe(2);
+  });
+});
+
+describe('P2BK legacy HTLC unblinding', () => {
+  const mkProof = (secret: string): Proof => ({
+    amount: Amount.from(1),
+    id: '00000000000',
+    C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+    secret,
+  });
+
+  test('maybeDeriveP2BKPrivateKeys falls back to legacy slot 0 indexing for HTLC proofs', () => {
+    // Pre-fix senders blinded HTLC lock keys from slot 0; those proofs must stay spendable.
+    const privBytes = createRandomSecretKey();
+    const pubHex = bytesToHex(getPubKeyFromPrivKey(privBytes));
+    const {
+      blinded: [P0_],
+      Ehex,
+    } = deriveP2BKBlindedPubkeys([pubHex]); // legacy: first lock key at slot 0
+    const secret = `["HTLC",{"nonce":"aa","data":"ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5","tags":[["pubkeys","${P0_}"]]}]`;
+    const proof = { ...mkProof(secret), p2pk_e: Ehex };
+    const derived = maybeDeriveP2BKPrivateKeys(bytesToHex(privBytes), proof);
+    const derivedPubs = derived.map((k) => bytesToHex(getPubKeyFromPrivKey(hexToBytes(k))));
+    expect(derivedPubs).toContain(P0_);
   });
 });

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -237,3 +237,25 @@ describe('P2BK test vectors, public API only', () => {
     }
   });
 });
+
+describe('slot offset (NUT-28: the data tag occupies slot 0)', () => {
+  // Fixed vector from 'P2BK test vectors, public API only' above: for an HTLC the hashlock
+  // holds slot 0, so the first lock key must be blinded/unblinded with slot index 1.
+  const eHex = '1cedb9df0c6872188b560ace9e35fd55c2532d53e19ae65b46159073886482ca';
+  const Ehex = '02a8cda4cf448bfce9a9e46e588c06ea1780fcb94e3bbdf3277f42995d403a8b0c';
+  const pubKeyBob = '02771fed6cb88aaac38b8b32104a942bf4b8f4696bc361171b3c7d06fa2ebddf06';
+  const privKeyBob = 'ad37e8abd800be3e8272b14045873f4353327eedeb702b72ddcc5c5adff5129c';
+  const slot1Blinded = '0352fb6d93360b7c2538eedf3c861f32ea5883fceec9f3e573d9d84377420da838';
+  const slot1DerivedSk2 = '9d1ffe00e1da5af5c882b1ea5ec8c18893e09349803c3c9e552823490af22458';
+
+  test('deriveP2BKBlindedPubkeys blinds the first key at slot 1 when data is not a pubkey', () => {
+    const { blinded } = deriveP2BKBlindedPubkeys([pubKeyBob], hexToBytes(eHex), false);
+    expect(blinded).toStrictEqual([slot1Blinded]);
+  });
+
+  test('deriveP2BKSecretKeys derives the slot 1 key when data is not a pubkey', () => {
+    expect(deriveP2BKSecretKeys(Ehex, privKeyBob, slot1Blinded, false)).toStrictEqual([
+      slot1DerivedSk2,
+    ]);
+  });
+});

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -1,6 +1,8 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { describe, expect, test } from 'vitest';
 
-import { getPubKeyFromPrivKey } from '../../src/crypto';
+import { getPubKeyFromPrivKey, P2BK_DST, pointFromHex } from '../../src/crypto';
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import { OutputData, isOutputDataFactory } from '../../src/model/OutputData';
 import type { OutputDataFactory, OutputDataLike } from '../../src/model/OutputData';
@@ -113,6 +115,32 @@ describe('OutputData helpers', () => {
     const deserialized = OutputData.deserialize(OutputData.serialize(output));
 
     expect(deserialized.ephemeralE).toBe(output.ephemeralE);
+  });
+
+  test('HTLC blinding starts lock keys at slot 1 (NUT-28: hashlock occupies slot 0)', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const output = OutputData.createSingleP2PKData(
+      {
+        pubkey,
+        hashlock: 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5',
+        blindKeys: true,
+      },
+      1,
+      '009a1f293253e41e',
+    );
+
+    const [, secret] = JSON.parse(new TextDecoder().decode(output.secret)) as [
+      string,
+      { data: string; tags: string[][] },
+    ];
+    const blinded = secret.tags.find(([tag]) => tag === 'pubkeys')![1];
+    // Independent receiver-side NUT-28 math: r1 = sha256(DST || Zx || 0x01), P' = P + r1·G
+    const p = secp256k1.Point.Fn.fromBytes(privkey);
+    const Zx = secp256k1.Point.fromHex(output.ephemeralE!).multiply(p).toBytes(true).slice(1);
+    const r1 = Bytes.toBigInt(sha256(Bytes.concat(P2BK_DST, Zx, Uint8Array.of(1))));
+    const expected = pointFromHex(pubkey).add(secp256k1.Point.BASE.multiply(r1)).toHex(true);
+    expect(blinded).toBe(expected);
   });
 
   test('keeps blinded HTLC lock keys in pubkeys tags', () => {


### PR DESCRIPTION
Manual backport of #763 to `v4-dev` (the bot hit conflicts; closes #764).

Source changes applied cleanly. The conflicts were confined to tests and the generated API report:

- Kept only the test blocks #763 added (slot-offset vectors, legacy slot 0 fallback); the conflicting context was later main-only describes that v4 does not have.
- Ported the end-to-end slot 1 check into `test/model/OutputDataCreator.test.ts` using the v4 options shape (`{ pubkey, hashlock, blindKeys }`), as `test/model/OutputData.test.ts` does not exist on v4.
- Regenerated `etc/cashu-ts.api.md`; the diff is the two new optional `dataIsPubkey` params.

`npm run prtasks` passes on v4-dev (162 files, 4627 tests).