### PR TITLE
fix(p2bk): NUT-28 slot cap and HTLC key slot order for v3 

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -292,7 +292,7 @@ export type DeriveKeysetIdOptions = {
 };
 
 // @public
-export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array): {
+export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array, dataIsPubkey?: boolean): {
     blinded: string[];
     Ehex: string;
 };
@@ -301,7 +301,7 @@ export function deriveP2BKBlindedPubkeys(pubkeys: string[], eBytes?: Uint8Array)
 export function deriveP2BKSecretKey(privkey: string | bigint, rBlind: string | bigint, blindPubkey?: Uint8Array, naturalPub?: Uint8Array): string | null;
 
 // @public
-export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[]): string[];
+export function deriveP2BKSecretKeys(Ehex: string, privateKey: string | string[], blindPubKey: string | string[], dataIsPubkey?: boolean): string[];
 
 // @public (undocumented)
 export const deriveSecret: (seed: Uint8Array, keysetId: string, counter: number) => Uint8Array;

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -540,7 +540,12 @@ export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof:
   // Extract pubkeys and keyset ID from proof
   const secret = parseP2PKSecret(proof.secret);
   const pubs = [...getP2PKWitnessPubkeys(secret), ...getP2PKWitnessRefundkeys(secret)];
-  return deriveP2BKSecretKeys(Ehex, privs, pubs);
+  // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
+  const dataIsPubkey = getSecretKind(secret) === 'P2PK';
+  const keys = deriveP2BKSecretKeys(Ehex, privs, pubs, dataIsPubkey);
+  // Deprecated: retry from slot 0 for HTLC proofs blinded by older releases; remove next major
+  if (!dataIsPubkey && !keys.length) return deriveP2BKSecretKeys(Ehex, privs, pubs);
+  return keys;
 }
 
 // ------------------------------

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -22,13 +22,17 @@ export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1'
  * This is the Sender side API.
  * @param pubkeys Ordered SEC1 compressed pubkeys, [data, ...pubkeys, ...refund]
  * @param eBytes Optional. Fixed ephemeral secret key to use (eg for SIG_ALL / testing)
+ * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
+ *   first pubkey takes slot 1.
  * @returns Blinded pubkeys in the same order, and Ehex as SEC1 compressed hex, 33 bytes.
  * @throws If a blinded key is at infinity.
  */
 export function deriveP2BKBlindedPubkeys(
   pubkeys: string[],
   eBytes?: Uint8Array,
+  dataIsPubkey = true,
 ): { blinded: string[]; Ehex: string } {
+  const slotOffset = dataIsPubkey ? 0 : 1;
   if (!pubkeys.length) return { blinded: [], Ehex: '' };
   // Create fresh ephemeral secret (e) if not supplied, and calculate pubkey (E)
   eBytes = eBytes ?? secp256k1.utils.randomSecretKey(); // 32 bytes
@@ -37,7 +41,7 @@ export function deriveP2BKBlindedPubkeys(
   // Blind each pubkey in turn
   const blinded = pubkeys.map((pubkey, i) => {
     const P = pointFromHex(pubkey);
-    const r = deriveP2BKBlindingTweakFromECDH(P, e, i);
+    const r = deriveP2BKBlindingTweakFromECDH(P, e, i + slotOffset);
     const P_ = P.add(secp256k1.Point.BASE.multiply(r));
     if (P_.equals(secp256k1.Point.ZERO)) throw new Error('Blinded key at infinity');
     return P_.toHex(true);
@@ -59,13 +63,17 @@ export function deriveP2BKBlindedPubkeys(
  * @param Ehex Ephemeral public key (E) as SEC1 hex.
  * @param privateKey Secret key or array of secret keys, hex.
  * @param blindPubKey Blinded public key or array of blinded public keys, hex.
+ * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
+ *   first pubkey takes slot 1.
  * @returns Array of derived secret keys as 64 char hex.
  */
 export function deriveP2BKSecretKeys(
   Ehex: string,
   privateKey: string | string[],
   blindPubKey: string | string[],
+  dataIsPubkey = true,
 ): string[] {
+  const slotOffset = dataIsPubkey ? 0 : 1;
   const privs = Array.isArray(privateKey) ? privateKey : [privateKey];
   const pubs = Array.isArray(blindPubKey) ? blindPubKey : [blindPubKey];
   const out = new Set<string>();
@@ -74,7 +82,7 @@ export function deriveP2BKSecretKeys(
     const p = secp256k1.Point.Fn.fromBytes(hexToBytes(privHex));
     const P = secp256k1.getPublicKey(hexToBytes(privHex), true); // 33 bytes, validates on curve
     pubs.forEach((hexP_, i) => {
-      const r = deriveP2BKBlindingTweakFromECDH(E, p, i);
+      const r = deriveP2BKBlindingTweakFromECDH(E, p, i + slotOffset);
       const P_ = hexToBytes(hexP_);
       const kHex = deriveP2BKSecretKey(privHex, r, P_, P);
       if (kHex) out.add(kHex); // add only when this priv matches this P′

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -208,7 +208,8 @@ export class OutputData implements OutputDataLike<HasKeysetKeys> {
     let Ehex: string | undefined;
     if (p2pk.blindKeys) {
       const ordered = [...lockKeys, ...refundKeys];
-      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered);
+      // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
+      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered, undefined, !isHTLC);
       if (isHTLC) {
         // hashlock is in data, all locking keys into pubkeys
         pubkeys = blinded.slice(0, lockKeys.length);

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -100,9 +100,14 @@ export class P2PKBuilder {
       );
     }
 
-    const total = locks.length + refunds.length;
-    if (total > 10)
-      throw new Error(`Too many pubkeys, ${total} provided, maximum allowed is 10 in total`);
+    // NUT-28: up to 11 locking slots in [data, ...pubkeys, ...refund] (i_byte 0x00..0x0A). Slot 0
+    // is the first pubkey for P2PK, but the hashlock for HTLC, so HTLC's hashlock costs a slot on
+    // top of the keys. P2PK thus allows 11 keys, HTLC 10.
+    const slotCount = (this.hashlock ? 1 : 0) + locks.length + refunds.length;
+    if (slotCount > 11)
+      throw new Error(
+        `Too many pubkeys, ${slotCount} slots provided, maximum allowed is 11 in total`,
+      );
 
     // Clamp required signatures to available keys
     const reqLock = this.nSigs ? Math.min(Math.max(1, this.nSigs), locks.length) : undefined;

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -28,6 +28,7 @@ import {
   createSecret,
   getP2PKNSigsRefund,
   isHTLCSpendAuthorised,
+  maybeDeriveP2BKPrivateKeys,
 } from '../../src/crypto';
 import { Proof, P2PKWitness } from '../../src/model/types';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -1392,5 +1393,29 @@ describe('NUT-11 test vectors', () => {
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
     const mts = buildP2PKSigAllMessage(proofs, outputs, quote);
     expect(isHTLCSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
+  });
+});
+
+describe('P2BK legacy HTLC unblinding', () => {
+  const mkProof = (secret: string): Proof => ({
+    amount: 1,
+    id: '00000000000',
+    C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+    secret,
+  });
+
+  test('maybeDeriveP2BKPrivateKeys falls back to legacy slot 0 indexing for HTLC proofs', () => {
+    // Pre-fix senders blinded HTLC lock keys from slot 0; those proofs must stay spendable.
+    const privBytes = createRandomSecretKey();
+    const pubHex = bytesToHex(getPubKeyFromPrivKey(privBytes));
+    const {
+      blinded: [P0_],
+      Ehex,
+    } = deriveP2BKBlindedPubkeys([pubHex]); // legacy: first lock key at slot 0
+    const secret = `["HTLC",{"nonce":"aa","data":"ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5","tags":[["pubkeys","${P0_}"]]}]`;
+    const proof = { ...mkProof(secret), p2pk_e: Ehex };
+    const derived = maybeDeriveP2BKPrivateKeys(bytesToHex(privBytes), proof);
+    const derivedPubs = derived.map((k) => bytesToHex(getPubKeyFromPrivKey(hexToBytes(k))));
+    expect(derivedPubs).toContain(P0_);
   });
 });

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -236,3 +236,25 @@ describe('P2BK test vectors, public API only', () => {
     }
   });
 });
+
+describe('slot offset (NUT-28: the data tag occupies slot 0)', () => {
+  // Fixed vector from 'P2BK test vectors, public API only' above: for an HTLC the hashlock
+  // holds slot 0, so the first lock key must be blinded/unblinded with slot index 1.
+  const eHex = '1cedb9df0c6872188b560ace9e35fd55c2532d53e19ae65b46159073886482ca';
+  const Ehex = '02a8cda4cf448bfce9a9e46e588c06ea1780fcb94e3bbdf3277f42995d403a8b0c';
+  const pubKeyBob = '02771fed6cb88aaac38b8b32104a942bf4b8f4696bc361171b3c7d06fa2ebddf06';
+  const privKeyBob = 'ad37e8abd800be3e8272b14045873f4353327eedeb702b72ddcc5c5adff5129c';
+  const slot1Blinded = '0352fb6d93360b7c2538eedf3c861f32ea5883fceec9f3e573d9d84377420da838';
+  const slot1DerivedSk2 = '9d1ffe00e1da5af5c882b1ea5ec8c18893e09349803c3c9e552823490af22458';
+
+  test('deriveP2BKBlindedPubkeys blinds the first key at slot 1 when data is not a pubkey', () => {
+    const { blinded } = deriveP2BKBlindedPubkeys([pubKeyBob], hexToBytes(eHex), false);
+    expect(blinded).toStrictEqual([slot1Blinded]);
+  });
+
+  test('deriveP2BKSecretKeys derives the slot 1 key when data is not a pubkey', () => {
+    expect(deriveP2BKSecretKeys(Ehex, privKeyBob, slot1Blinded, false)).toStrictEqual([
+      slot1DerivedSk2,
+    ]);
+  });
+});

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -1,5 +1,10 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { describe, it, expect } from 'vitest';
 import { P2PKBuilder, P2PKOptions } from '../../src/';
+import { getPubKeyFromPrivKey, P2BK_DST, pointFromHex } from '../../src/crypto';
+import { OutputData } from '../../src/model/OutputData';
+import { Bytes } from '../../src/utils';
 
 // helpers to make valid hex keys
 const xonly = (ch: string) => ch.repeat(64); // 32-byte X-only
@@ -367,5 +372,37 @@ describe('P2PKBuilder.blindKeys()', () => {
 
     const round = P2PKBuilder.fromOptions(opts).toOptions();
     expect(round.blindKeys).toBe(true);
+  });
+
+  it('HTLC blinding starts lock keys at slot 1 (NUT-28: hashlock occupies slot 0)', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const output = OutputData.createSingleP2PKData(
+      {
+        pubkey,
+        hashlock: 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5',
+        blindKeys: true,
+      },
+      1,
+      '009a1f293253e41e',
+    );
+
+    const [, secret] = JSON.parse(new TextDecoder().decode(output.secret)) as [
+      string,
+      { data: string; tags: string[][] },
+    ];
+    const blinded = secret.tags.find(([tag]) => tag === 'pubkeys')![1];
+    // Ehex is stashed privately and only surfaces on the proof, so round-trip via toProof
+    const G = secp256k1.Point.BASE.toHex(true);
+    const proof = output.toProof(
+      { id: '009a1f293253e41e', amount: 1, C_: G },
+      { id: '009a1f293253e41e', keys: { '1': G } },
+    );
+    // Independent receiver-side NUT-28 math: r1 = sha256(DST || Zx || 0x01), P' = P + r1·G
+    const p = secp256k1.Point.Fn.fromBytes(privkey);
+    const Zx = secp256k1.Point.fromHex(proof.p2pk_e!).multiply(p).toBytes(true).slice(1);
+    const r1 = Bytes.toBigInt(sha256(Bytes.concat(P2BK_DST, Zx, Uint8Array.of(1))));
+    const expected = pointFromHex(pubkey).add(secp256k1.Point.BASE.multiply(r1)).toHex(true);
+    expect(blinded).toBe(expected);
   });
 });

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -121,17 +121,38 @@ describe('P2PKBuilder.toOptions()', () => {
     expect('requiredRefundSignatures' in o2).toBe(false);
   });
 
-  it('enforces combined lock+refund keys limit of 10', () => {
-    // build 11 distinct keys
-    const chars = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b'];
+  it('enforces the combined lock+refund slot limit of 11 (NUT-28)', () => {
+    // 12 distinct keys; NUT-28 allows up to 11 slots ([data, ...pubkeys, ...refund]).
+    const chars = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c'];
     const keys = chars.map((c, i) => comp(c as any, i % 2 === 0 ? '02' : '03'));
 
-    const b = new P2PKBuilder()
-      .addLockPubkey(keys.slice(0, 8)) // 8 locks
-      .lockUntil(Date.now() + 60)
-      .addRefundPubkey(keys.slice(8)); // 3 refunds => total 11
+    // 8 locks + 3 refunds = 11 slots: allowed.
+    expect(() =>
+      new P2PKBuilder()
+        .addLockPubkey(keys.slice(0, 8))
+        .lockUntil(Date.now() + 60)
+        .addRefundPubkey(keys.slice(8, 11))
+        .toOptions(),
+    ).not.toThrow();
 
-    expect(() => b.toOptions()).toThrow(/Too many pubkeys/i);
+    // 8 locks + 4 refunds = 12 slots: rejected.
+    expect(() =>
+      new P2PKBuilder()
+        .addLockPubkey(keys.slice(0, 8))
+        .lockUntil(Date.now() + 60)
+        .addRefundPubkey(keys.slice(8))
+        .toOptions(),
+    ).toThrow(/Too many pubkeys/i);
+
+    // HTLC: hashlock occupies slot 0, so 11 keys is one too many.
+    expect(() =>
+      new P2PKBuilder()
+        .addHashlock('ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5')
+        .addLockPubkey(keys.slice(0, 8))
+        .lockUntil(Date.now() + 60)
+        .addRefundPubkey(keys.slice(8, 11))
+        .toOptions(),
+    ).toThrow(/Too many pubkeys/i);
   });
 
   it('round-trips via fromOptions', () => {


### PR DESCRIPTION
Manual backport of #753 and #763 to `v3-dev` (the bots hit conflicts; see #765 and #764). Two commits, one per original fix.

v3 predates the `normalizeP2PKOptions` refactor, so the adaptations are larger than the v4 round (#767):

- **Slot cap (#753)**: applied in `P2PKBuilder.toOptions()`, where v3 keeps its key limit (there is no `normalizeP2PKOptions` on this branch). Same semantics: 11 slots in `[data, ...pubkeys, ...refund]`, so P2PK allows 11 keys and HTLC 10. Purely loosening for P2PK, unchanged for HTLC, so no existing caller breaks.
- **HTLC slot order (#763)**: source changes applied cleanly (`dataIsPubkey` param on the NUT-28 derivations, sender passes `!isHTLC`, receiver derives with the matching offset and retries from slot 0 for proofs blinded by older releases).
- Tests ported to v3 idioms: builder cap test extended with an HTLC case; the end-to-end slot 1 check lives in `P2PKBuilder.test.ts` and round-trips through `toProof()` because v3 stashes the ephemeral key privately rather than exposing `ephemeralE`; the legacy fallback test uses `amount: number`.

`npm run prtasks` passes on v3-dev (71 files, 1761 tests).

Closes #765.