### PR TITLE
ci: run release-please on v3-dev to automate LTS releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,10 @@
 name: release-please
+# v3-dev copy: watches and releases this LTS branch only. main's copy
+# (which targets main) is separate — push workflows run per-branch.
 on:
   push:
     branches:
-      - main
+      - v3-dev
 permissions:
   contents: write
   issues: write
@@ -12,8 +14,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4.4.0
         id: release
         with:
           release-type: node
+          target-branch: v3-dev
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Ports #720 to `v3-dev`: the branch copy of `release-please.yml` now watches and targets `v3-dev` (it previously still pointed at `main`, so it never ran here), with the action pinned to v4.4.0 to match v4-dev.

With this in place, merging #769 will make release-please open a v3.7.1 Release PR automatically; merging that tags, creates the GitHub Release, and `version.yml` publishes to npm under the `v3-lts` dist tag as before. The v3.7.0 GitHub Release exists, so release-please has its version baseline.

Suggest merging this before #769 so the backport triggers the Release PR.