### PR TITLE
ci: open draft PRs for conflicted backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,6 +28,7 @@ jobs:
 
     outputs:
       was_successful: ${{ steps.create-pr.outputs.was_successful }}
+      created_pull_numbers: ${{ steps.create-pr.outputs.created_pull_numbers }}
 
     steps:
       - uses: actions/checkout@v7
@@ -37,9 +38,11 @@ jobs:
         with:
           # PAT so backport PRs trigger CI (default GITHUB_TOKEN PRs don't)
           github_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          # On conflict the backport fails clean (default): nothing is pushed,
-          # the action comments on the original PR with cherry-pick steps and
-          # the open-issue job below files a tracking issue
+          # On conflict, push the branch with the conflict committed and open
+          # a DRAFT PR (finish it in place: resolve, regenerate the api report,
+          # push). The action comments resolution steps on the original PR and
+          # the open-issue job below still files a tracking issue.
+          conflict_resolution: draft_commit_conflicts
           # Ignore merge commits from "update branch" syncs
           merge_commits: skip
           # Backport marker goes at the END of the title: the default
@@ -64,17 +67,23 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           # via env, never inline: PR titles are untrusted input
           PR_TITLE: ${{ github.event.pull_request.title }}
+          DRAFT_PRS: ${{ needs.backport.outputs.created_pull_numbers }}
         run: |
           SHORT_PR_TITLE=$(
             echo "$PR_TITLE" \
             | awk '{print (length($0) > 40) ? substr($0, 1, 40) "..." : $0}'
           )
+          DRAFT_LINKS=$(echo "${DRAFT_PRS}" | tr ' ' '\n' | sed '/^$/d; s/^/- #/' || true)
           cat > issue-body.md <<EOF
           PR: #${PR_NUMBER}
           Title: ${PR_TITLE}
 
-          Backporting hit a conflict and pushed nothing.
-          Cherry-pick and open the backport PR manually.
+          Backporting hit a conflict. Draft PR(s) with the conflict committed:
+          ${DRAFT_LINKS:-"(none pushed - cherry-pick manually)"}
+
+          Finish in place: resolve the conflicts (take the target branch's
+          \`etc/cashu-ts.api.md\` and rerun \`npm run api:update\`), run
+          \`npm run prtasks\`, push, and mark the PR ready.
           EOF
 
           gh issue create \

--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -143,7 +143,7 @@ Hooks are installed by Husky:
 
 - `main` tracks the current major and is where active development lands.
 - Each supported prior major has a `vN-dev` LTS branch (`v4-dev`, `v3-dev`) for backports only; don't mix majors in one PR.
-- Backports are label-driven: land the fix on `main`, add a `backport vN-dev` label to the PR, and a bot opens the backport PR. Only cherry-pick manually when the bot fails (it opens a `backport`-labelled issue); never commit directly to a `vN-dev` branch.
+- Backports are label-driven: land the fix on `main`, add a `backport vN-dev` label to the PR, and a bot opens the backport PR. On conflict the bot opens a DRAFT PR with the conflict committed (plus a `backport`-labelled tracking issue): finish it in place by resolving the conflicts (take the target branch's `etc/cashu-ts.api.md` and rerun `npm run api:update`), running `npm run prtasks`, pushing, and marking the PR ready. Never commit directly to a `vN-dev` branch.
 - All releases are automated with release-please (don't bump versions by hand): `main` and each `vN-dev` branch run their own copy of the workflow, and merging a branch's Release PR tags, creates the GitHub Release, and publishes to npm.
 - npm `latest` is governed solely by `LATEST_MAJOR` in `.github/workflows/version.yml`.
 


### PR DESCRIPTION
Switches the backport action to `conflict_resolution: draft_commit_conflicts`: on conflict the bot pushes the branch with the conflict committed and opens a draft PR, instead of failing with nothing pushed. Every conflicted backport becomes a finish-in-place job (resolve the test files, take the target branch's `etc/cashu-ts.api.md` and rerun `npm run api:update`, run `npm run prtasks`, mark ready) rather than a from-scratch cherry-pick.

The tracking issue still gets filed (`was_successful` remains false in this mode) and now links the draft PR(s) via the action's `created_pull_numbers` output, with the finish-in-place steps in the body. Both issue-body branches (drafts created / none pushed) render-tested under `bash -e`.

Context: all three backport failures so far (#758, #764, #765) had real test drift alongside api-report conflicts, so auto-resolving `api.md` alone would have rescued none of them; committing the conflict and handing over a branch is the useful improvement. `AGENTS-CONTRIBUTING.md` updated to describe the new flow.

First live test will be #768's `backport v4-dev` label, which is expected to conflict on v4's test files.