### PR TITLE
chore(ci): skip upstream workflows in forks

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,6 +20,7 @@ jobs:
     # Skip closed-unmerged PRs and non-backport label events.
     # Label format: "backport <branch>", e.g. "backport v4-dev"
     if: |
+      github.repository == 'cashubtc/cashu-ts' &&
       github.event.pull_request.merged &&
       (
         github.event.action != 'labeled' ||

--- a/.github/workflows/mutation-testing-weekly.yml
+++ b/.github/workflows/mutation-testing-weekly.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   stryker:
+    if: github.repository == 'cashubtc/cashu-ts'
     runs-on: ubuntu-latest
     timeout-minutes: 300
 

--- a/.github/workflows/nightly-mint-drift.yml
+++ b/.github/workflows/nightly-mint-drift.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   drift:
+    if: github.repository == 'cashubtc/cashu-ts'
     runs-on: ubuntu-24.04
 
     strategy:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.repository == 'cashubtc/cashu-ts'
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5.0.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-docker:
+    if: github.repository == 'cashubtc/cashu-ts'
     permissions:
       contents: write # Needed to push branches and commits
       pull-requests: write # Needed to create PRs

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     # Run on manual dispatch, or on non-prerelease v4 tags from mainline releases.
-    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    if: ${{ github.repository == 'cashubtc/cashu-ts' && (github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-')) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'cashubtc/cashu-ts'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (release tag or manual tag)

--- a/.github/workflows/weekly-meeting-agenda.yml
+++ b/.github/workflows/weekly-meeting-agenda.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   agenda:
+    if: github.repository == 'cashubtc/cashu-ts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Workflows such as GH Pages, Renovate were running (and failing) in forks. This PR guards the workflows to origin repo only