### PR TITLE
fix(wallet): widen config type on bolt12/onchain mint helpers

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2286,12 +2286,8 @@ export class Wallet {
     readonly mint: Mint;
     mintProofs<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>>(method: string, amount: AmountLike, quote: TQuote, config?: MintProofsConfig, outputType?: OutputType): Promise<Proof[]>;
     mintProofsBolt11(amount: AmountLike, quote: string | MintQuoteBolt11Response, config?: MintProofsConfig, outputType?: OutputType): Promise<Proof[]>;
-    mintProofsBolt12(amount: AmountLike, quote: MintQuoteBolt12Response, privkey: string, config?: {
-        keysetId?: string;
-    }, outputType?: OutputType): Promise<Proof[]>;
-    mintProofsOnchain(amount: AmountLike, quote: MintQuoteOnchainResponse, privkey: string, config?: {
-        keysetId?: string;
-    }, outputType?: OutputType): Promise<Proof[]>;
+    mintProofsBolt12(amount: AmountLike, quote: MintQuoteBolt12Response, privkey: string, config?: Omit<MintProofsConfig, 'privkey'>, outputType?: OutputType): Promise<Proof[]>;
+    mintProofsOnchain(amount: AmountLike, quote: MintQuoteOnchainResponse, privkey: string, config?: Omit<MintProofsConfig, 'privkey'>, outputType?: OutputType): Promise<Proof[]>;
     readonly on: WalletEvents;
     readonly ops: WalletOps;
     prepareBatchMint<TQuote extends Pick<MintQuoteBaseResponse, 'quote' | 'pubkey'>>(method: string, entries: Array<{

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2150,7 +2150,7 @@ class Wallet {
     amount: AmountLike,
     quote: MintQuoteBolt12Response,
     privkey: string,
-    config?: { keysetId?: string },
+    config?: Omit<MintProofsConfig, 'privkey'>,
     outputType?: OutputType,
   ): Promise<Proof[]> {
     this.requireSupport('mint', 'bolt12');
@@ -2183,7 +2183,7 @@ class Wallet {
     amount: AmountLike,
     quote: MintQuoteOnchainResponse,
     privkey: string,
-    config?: { keysetId?: string },
+    config?: Omit<MintProofsConfig, 'privkey'>,
     outputType?: OutputType,
   ): Promise<Proof[]> {
     this.requireSupport('mint', 'onchain');

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -1645,7 +1645,10 @@ describe('generic mint/melt methods', () => {
           });
         }),
       );
-      const wallet = new Wallet(mint, { unit: 'sat' });
+      const seed = hexToBytes(
+        'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
+      );
+      const wallet = new Wallet(mint, { unit: 'sat', bip39seed: seed });
       await wallet.loadMint();
 
       const quote: MintQuoteOnchainResponse = {
@@ -1658,10 +1661,14 @@ describe('generic mint/melt methods', () => {
         amount_issued: Amount.from(0),
       };
 
-      const proofs = await wallet.mintProofsOnchain(1, quote, privkey);
+      const onCountersReserved = vi.fn();
+      const proofs = await wallet.mintProofsOnchain(1, quote, privkey, { onCountersReserved });
 
       expect(proofs).toHaveLength(1);
       expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+      expect(onCountersReserved).toHaveBeenCalledWith(
+        expect.objectContaining({ start: 0, count: 1, next: 1 }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

`mintProofsBolt12()` and `mintProofsOnchain()` typed their config as an inline `{ keysetId?: string }`. That literal was written when `MintProofsConfig` was just `{ keysetId, privkey }` (privkey moved to a positional param, since bolt12/onchain quotes are always locked), so at the time it was the full config minus privkey. When `proofsWeHave` and `onCountersReserved` were later added to `MintProofsConfig`, the inline type fell behind: `prepareMint()` honours both at runtime, but the typed helpers rejected them, forcing callers to cast or drop to the builder API.

Both helpers now take `config?: Omit<MintProofsConfig, 'privkey'>`, so they track the shared config type from now on. Pure widening, no behaviour change.

## Changes

- `src/wallet/Wallet.ts`: widen the config parameter on both helpers.
- `test/wallet/wallet-mint.node.test.ts`: the onchain mint test now uses a seeded wallet and asserts `onCountersReserved` fires through the typed helper.
- `etc/cashu-ts.api.md`: regenerated.

## Notes

Reported by a consumer integrating v4.7, who hit the cast on `mintProofsOnchain`. Labelled for v4-dev backport. 

`npm run prtasks` passes.