### PR TITLE
feat(nut18): pay and validate payment requests end to end

### DIFF
--- a/docs-src/usage/payment_requests.md
+++ b/docs-src/usage/payment_requests.md
@@ -23,13 +23,26 @@ pr.mints; // mints the receiver accepts (string[] | undefined)
 pr.getTransport('nostr'); // the transport of a given type, if present
 ```
 
+## Pay a request from your wallet
+
+`wallet.ops.sendToRequest` builds a send that enforces the request's payer-side rules in one step: the strict/preferred mint list, the unit rule, NUT-05 melt-method support (resolved from the wallet's `MintInfo`), the applicable per-method fee (`mf`), the request's lock, and net-of-input-fees selection. It throws if this wallet's mint cannot fulfil the request.
+
+```typescript
+const { keep, send } = await wallet.ops.sendToRequest(pr, proofs).run();
+
+// Amountless request: pass the chosen amount instead.
+const result = await wallet.ops.sendToRequest(pr, proofs, 100).run();
+```
+
+It returns the normal send builder, so further options (deterministic outputs, keyset, offline modes) chain as usual. The sections below unpack the individual rules for manual control.
+
 ## Which mint may I pay from?
 
 A request may carry a mint list that is either **strict** (send only from these mints) or **preferred** (prefer these, but others are allowed). `isMintListStrict` resolves the NUT-18 default-to-strict semantic so you do not have to:
 
 ```typescript
 // undefined = no list (any mint); true = strict; false = preferred/advisory
-const allowed = !pr.isMintListStrict || pr.mints?.includes(myMint);
+const allowed = !pr.isMintListStrict || pr.includesMint(myMint); // URL-normalized membership
 ```
 
 If `supportedMethods` (`sm`) is set, the sending mint must be able to **melt the request's `unit`** via at least one of those methods (`bolt11`, `bolt12`, `onchain`, etc): the check is against the mint's NUT-05 melt methods for that unit, not its NUT-04 mint methods. Checking that requires the sending mint's capabilities. See [Inspect Mint Capabilities](./mint_capabilities.md).
@@ -140,6 +153,18 @@ const payload: PaymentRequestPayload = {
 
 > [!IMPORTANT]
 > The receiver validates the incoming proofs themselves (DLEQ, and that any timelock is long enough) before accepting. Building a payload does not settle the payment.
+
+## Validating a payment (receiver side)
+
+The requested amount is what the receiver must **net**, so check incoming proofs against the input fees they will cost to swap, plus any per-method fee the payer owed, before treating the payment as settled. A wallet on the payload's mint has everything needed:
+
+```typescript
+if (!wallet.isPaymentRequestSatisfied(pr, payload.proofs)) {
+  // Underpaid: sum(proofs) - inputFees < amount + mf. Ignore or refund.
+}
+```
+
+For an amountless request, pass the amount you expected as the third argument. The check covers the amount only; mint admissibility (`isMintListStrict` / `includesMint`) and proof integrity (DLEQ, locks) remain separate checks.
 
 [nut18]: https://github.com/cashubtc/nuts/blob/main/18.md
 [nut26]: https://github.com/cashubtc/nuts/blob/main/26.md

--- a/docs-src/usage/payment_requests.md
+++ b/docs-src/usage/payment_requests.md
@@ -2,14 +2,18 @@
 
 # Payment Requests (NUT-18 / NUT-26)
 
-A **payment request** lets a receiver describe a payment they want to be paid, encode it (as a string or QR), and hand it to a sender. The sender decodes it, builds a matching token, and delivers it over the transport the request specifies. See [NUT-18][nut18] and its Bech32m encoding [NUT-26][nut26].
+A **payment request** lets a payee describe a payment they want to be paid, encode it (as a string or QR), and hand it to a payer. The payer decodes it, builds a matching token, and delivers it over the transport the request specifies.
 
 Two encodings are supported and both decode through the same API:
 
-- `creqA…`: CBOR + base64url (NUT-18)
-- `CREQB1…`: TLV + Bech32m, more compact and QR-friendly (NUT-26)
+- `creqA…`: CBOR + base64url ([NUT-18][nut18])
+- `CREQB1…`: TLV + Bech32m, more compact and QR-friendly ([NUT-26][nut26])
 
-## Decode an incoming request (sender side)
+The shortest path is three calls: `decodePaymentRequest` → `wallet.ops.sendToRequest` on the payer side, and `wallet.isPaymentRequestSatisfied` on the payee side. Everything else on this page is either request authoring or [manual control](#manual-control) for when you need to unpack the rules yourself.
+
+## Paying a request (payer side)
+
+### 1. Decode it
 
 ```typescript
 import { decodePaymentRequest } from '@cashu/cashu-ts';
@@ -19,11 +23,11 @@ const pr = decodePaymentRequest(scanned); // accepts creqA… or CREQB1…
 pr.amount; // requested Amount (undefined = payer chooses the amount)
 pr.unit; // e.g. 'sat'
 pr.description; // human-readable, show to the user
-pr.mints; // mints the receiver accepts (string[] | undefined)
+pr.mints; // mints the payee accepts (string[] | undefined)
 pr.getTransport('nostr'); // the transport of a given type, if present
 ```
 
-## Pay a request from your wallet
+### 2. Pay it
 
 `wallet.ops.sendToRequest` builds a send that enforces the request's payer-side rules in one step: the strict/preferred mint list, the unit rule, NUT-05 melt-method support (resolved from the wallet's `MintInfo`), the applicable per-method fee (`mf`), the request's lock, and net-of-input-fees selection. It throws if this wallet's mint cannot fulfil the request.
 
@@ -34,9 +38,88 @@ const { keep, send } = await wallet.ops.sendToRequest(pr, proofs).run();
 const result = await wallet.ops.sendToRequest(pr, proofs, 100).run();
 ```
 
-It returns the normal send builder, so further options (deterministic outputs, keyset, offline modes) chain as usual. The sections below unpack the individual rules for manual control.
+It returns the normal send builder, so further options (deterministic outputs, keyset, offline modes) chain as usual. [Manual control](#manual-control) below unpacks the individual rules.
 
-## Which mint may I pay from?
+### 3. Deliver the payload
+
+Send the payee a `PaymentRequestPayload` over the request's transport (HTTP POST body, Nostr DM, or in-band if no transport is given):
+
+```typescript
+import type { PaymentRequestPayload } from '@cashu/cashu-ts';
+
+const payload: PaymentRequestPayload = {
+  id: pr.id,
+  mint: myMint,
+  unit: pr.unit ?? myUnit, // the requested unit, or the unit of what you send
+  proofs: send, // the locked/selected proofs
+};
+```
+
+> [!IMPORTANT]
+> The payee validates the incoming proofs themselves (DLEQ, and that any timelock is long enough) before accepting. Building a payload does not settle the payment.
+
+## Requesting payment (payee side)
+
+### Create and encode a request
+
+`PaymentRequest.builder()` handles the fiddly parts for you: transport tag formats, NUT-10 lock serialization, mint URL normalization, and cross-field validation. Setters can be called in any order; `build()` validates (eg `mintsPreferred` without mints throws) and returns the `PaymentRequest`.
+
+```typescript
+import { PaymentRequest, P2PKBuilder } from '@cashu/cashu-ts';
+
+const request = PaymentRequest.builder()
+  .id('inv-123')
+  .amount(100, 'sat') // unit is required with amount (NUT-18)
+  .description('Coffee')
+  .addMint('https://my.mint')
+  .mintsPreferred() // advisory list
+  .addNostrTransport(nprofile) // NIP-17 tags applied for you
+  .addHttpPostTransport('https://pay.example.com')
+  .addSupportedMethod('bolt11')
+  .addSupportedMethod('bolt12', 5) // with a per-method fee
+  .lock(new P2PKBuilder().addLockPubkey(payeePk).toOptions()) // nut10 from a P2PK/HTLC lock
+  .build();
+
+request.toEncodedCreqA(); // 'creqA…'  (CBOR)
+request.toEncodedCreqB(); // 'CREQB1…' (TLV + Bech32m, best for QR)
+```
+
+`lock()` takes a complete `P2PKOptions` (eg from `P2PKBuilder`, as with `asP2PK()`) and serializes it into the request's `nut10` option (the exact condition `toP2PKOptions()` reconstructs on the payer side). For NUT-10 kinds beyond P2PK/HTLC, pass a raw option with `nut10()`.
+
+Alternatively, the `PaymentRequest` constructor takes an options object whose keys mirror the class properties; set only what you need. `amount` and each method `fee` accept any `AmountLike` (number, bigint, string, or `Amount`).
+
+```typescript
+import { PaymentRequest, PaymentRequestTransportType } from '@cashu/cashu-ts';
+
+const request = new PaymentRequest({
+  transport: [{ type: PaymentRequestTransportType.POST, target: 'https://pay.example.com' }],
+  id: 'inv-123',
+  amount: 100,
+  unit: 'sat',
+  mints: ['https://my.mint'],
+  description: 'Coffee',
+  mintsPreferred: true, // advisory list
+  supportedMethods: [{ method: 'bolt11' }, { method: 'bolt12', fee: 5 }],
+});
+```
+
+### Validate a payment
+
+The requested amount is what the payee must **net**, so check incoming proofs against the input fees they will cost to swap, plus any per-method fee the payer owed, before treating the payment as settled. A wallet on the payload's mint has everything needed:
+
+```typescript
+if (!wallet.isPaymentRequestSatisfied(pr, payload.proofs)) {
+  // Underpaid: sum(proofs) - inputFees < amount + mf. Ignore or refund.
+}
+```
+
+For an amountless request, pass the amount you expected as the third argument. The check covers the amount only; mint admissibility (`isMintListStrict` / `includesMint`) and proof integrity (DLEQ, locks) remain separate checks.
+
+## Manual control
+
+Everything in this section is enforced for you by `sendToRequest`; skip it unless you need to apply the NUT-18 rules piecemeal (custom selection, offline flows, or inspecting a request before paying).
+
+### Which mint may I pay from?
 
 A request may carry a mint list that is either **strict** (send only from these mints) or **preferred** (prefer these, but others are allowed). `isMintListStrict` resolves the NUT-18 default-to-strict semantic so you do not have to:
 
@@ -47,9 +130,9 @@ const allowed = !pr.isMintListStrict || pr.includesMint(myMint); // URL-normaliz
 
 If `supportedMethods` (`sm`) is set, the sending mint must be able to **melt the request's `unit`** via at least one of those methods (`bolt11`, `bolt12`, `onchain`, etc): the check is against the mint's NUT-05 melt methods for that unit, not its NUT-04 mint methods. Checking that requires the sending mint's capabilities. See [Inspect Mint Capabilities](./mint_capabilities.md).
 
-## How much do I send, including fees?
+### How much do I send, including fees?
 
-Each supported method can carry a fee (`mf`) that compensates the receiver for melting out via it. The fee applies only when paying from a mint outside the request's mint list (or from any mint if no list is set); a payment from a listed mint carries none. When one applies, the payer owes the **lowest** `mf` among the listed methods their mint supports. `amountToSend` computes the total for you: pass the melt methods your mint supports as the second argument.
+Each supported method can carry a fee (`mf`) that compensates the payee for melting out via it. The fee applies only when paying from a mint outside the request's mint list (or from any mint if no list is set); a payment from a listed mint carries none. When one applies, the payer owes the **lowest** `mf` among the listed methods their mint supports. `amountToSend` computes the total for you: pass the melt methods your mint supports as the second argument.
 
 `amountToSend` returns an `Amount`, so it flows straight into `wallet.ops.send` (which accepts any `AmountLike`). Convert only at the edge, for display or serialization.
 
@@ -71,15 +154,15 @@ For an **amountless** request (the payer chooses the amount), use `feesFor` to p
 const total = chosenAmount.add(pr.feesFor(myMint, ['bolt12'])); // mf, or 0 if none applies
 ```
 
-The requested amount is **net of input fees** (NUT-18): the receiver must be able to swap or melt the proofs without dipping below it. Select proofs with fees included:
+The requested amount is **net of input fees** (NUT-18): the payee must be able to swap or melt the proofs without dipping below it. Select proofs with fees included:
 
 ```typescript
-await wallet.ops.send(total, proofs).includeFees(true).run(); // sender covers the receiver's input fee
+await wallet.ops.send(total, proofs).includeFees(true).run(); // payer covers the payee's input fee
 ```
 
-## Locked requests
+### Locked requests
 
-A request may require the token be locked to a spending condition (P2PK / HTLC). `toP2PKOptions()` converts that condition into the options accepted by the P2PK builder, so you can produce proofs locked exactly as the receiver asked:
+A request may require the token be locked to a spending condition (P2PK / HTLC). `toP2PKOptions()` converts that condition into the options accepted by the P2PK builder, so you can produce proofs locked exactly as the payee asked:
 
 ```typescript
 const opts = pr.toP2PKOptions(); // undefined = no lockable nut10 condition
@@ -90,81 +173,6 @@ const { keep, send } = await builder.run();
 ```
 
 See [Create P2PK](./create_p2pk.md) for the builder.
-
-## Create and encode a request (receiver side)
-
-The `PaymentRequest` constructor takes an options object whose keys mirror the class properties; set only what you need. `amount` and each method `fee` accept any `AmountLike` (number, bigint, string, or `Amount`).
-
-```typescript
-import { PaymentRequest, PaymentRequestTransportType } from '@cashu/cashu-ts';
-
-const request = new PaymentRequest({
-  transport: [{ type: PaymentRequestTransportType.POST, target: 'https://pay.example.com' }],
-  id: 'inv-123',
-  amount: 100,
-  unit: 'sat',
-  mints: ['https://my.mint'],
-  description: 'Coffee',
-  mintsPreferred: true, // advisory list
-  supportedMethods: [{ method: 'bolt11' }, { method: 'bolt12', fee: 5 }],
-});
-
-request.toEncodedCreqA(); // 'creqA…'  (CBOR)
-request.toEncodedCreqB(); // 'CREQB1…' (TLV + Bech32m, best for QR)
-```
-
-### The builder
-
-`PaymentRequest.builder()` offers a fluent alternative that also handles the fiddly parts: transport tag formats, NUT-10 lock serialization, and cross-field validation. Setters can be called in any order; `build()` validates (eg `mintsPreferred` without mints throws) and returns the `PaymentRequest`.
-
-```typescript
-import { PaymentRequest, P2PKBuilder } from '@cashu/cashu-ts';
-
-const request = PaymentRequest.builder()
-  .id('inv-123')
-  .amount(100, 'sat') // unit is required with amount (NUT-18)
-  .description('Coffee')
-  .addMint('https://my.mint')
-  .mintsPreferred() // advisory list
-  .addNostrTransport(nprofile) // NIP-17 tags applied for you
-  .addHttpPostTransport('https://pay.example.com')
-  .addSupportedMethod('bolt11')
-  .addSupportedMethod('bolt12', 5) // with a per-method fee
-  .lock(new P2PKBuilder().addLockPubkey(receiverPk).toOptions()) // nut10 from a P2PK/HTLC lock
-  .build();
-```
-
-`lock()` takes a complete `P2PKOptions` (eg from `P2PKBuilder`, as with `asP2PK()`) and serializes it into the request's `nut10` option (the exact condition `toP2PKOptions()` reconstructs on the sender side). For NUT-10 kinds beyond P2PK/HTLC, pass a raw option with `nut10()`.
-
-## Delivering the payment (sender side)
-
-Send the receiver a `PaymentRequestPayload` over the request's transport (HTTP POST body, Nostr DM, or in-band if no transport is given):
-
-```typescript
-import type { PaymentRequestPayload } from '@cashu/cashu-ts';
-
-const payload: PaymentRequestPayload = {
-  id: pr.id,
-  mint: myMint,
-  unit: pr.unit ?? myUnit, // the requested unit, or the unit of what you send
-  proofs: send, // the locked/selected proofs
-};
-```
-
-> [!IMPORTANT]
-> The receiver validates the incoming proofs themselves (DLEQ, and that any timelock is long enough) before accepting. Building a payload does not settle the payment.
-
-## Validating a payment (receiver side)
-
-The requested amount is what the receiver must **net**, so check incoming proofs against the input fees they will cost to swap, plus any per-method fee the payer owed, before treating the payment as settled. A wallet on the payload's mint has everything needed:
-
-```typescript
-if (!wallet.isPaymentRequestSatisfied(pr, payload.proofs)) {
-  // Underpaid: sum(proofs) - inputFees < amount + mf. Ignore or refund.
-}
-```
-
-For an amountless request, pass the amount you expected as the third argument. The check covers the amount only; mint admissibility (`isMintListStrict` / `includesMint`) and proof integrity (DLEQ, locks) remain separate checks.
 
 [nut18]: https://github.com/cashubtc/nuts/blob/main/18.md
 [nut26]: https://github.com/cashubtc/nuts/blob/main/26.md

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1657,6 +1657,7 @@ class PaymentRequest_2 {
     getTransport(type: PaymentRequestTransportType): PaymentRequestTransport | undefined;
     // (undocumented)
     id?: string;
+    includesMint(mintUrl: string): boolean;
     get isMintListStrict(): boolean | undefined;
     // (undocumented)
     mints?: string[];
@@ -2350,6 +2351,7 @@ export class Wallet {
         pending: T[];
         spent: T[];
     }>;
+    isPaymentRequestSatisfied(pr: PaymentRequest_2, proofs: Array<Pick<Proof, 'id' | 'amount'>>, expectedAmount?: AmountLike): boolean;
     get keyChain(): KeyChain;
     get keysetId(): string;
     loadMint(forceRefresh?: boolean): Promise<void>;
@@ -2464,6 +2466,7 @@ export class WalletOps {
     receive(token: Token | string | ProofLike[]): ReceiveBuilder;
     // (undocumented)
     send(amount: AmountLike, proofs: ProofLike[]): SendBuilder;
+    sendToRequest(pr: PaymentRequest_2, proofs: ProofLike[], amount?: AmountLike): SendBuilder;
 }
 
 // @public

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -411,7 +411,7 @@ export function p2pkOptionsToPRNut10(p2pk: P2PKOptions): NUT10Option {
   const normalized = normalizeP2PKOptions(p2pk);
   if (normalized.blindKeys) {
     throw new CTSError(
-      'blindKeys is not expressible in a payment request; the sender applies P2BK blinding per output',
+      'blindKeys is not expressible in a payment request; the payer applies P2BK blinding per output',
     );
   }
   return {

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -116,7 +116,7 @@ export class PaymentRequest {
    */
   feesFor(mint: string, meltMethods?: string[]): Amount {
     this.assertUnitRule();
-    // Fees compensate the receiver for melting out: payments from a listed mint carry none.
+    // Fees compensate the payee for melting out: payments from a listed mint carry none.
     if (!this.supportedMethods?.length || this.mints?.includes(mint)) {
       return Amount.zero();
     }
@@ -533,7 +533,7 @@ export class PaymentRequestBuilder {
   }
 
   /**
-   * Appends an HTTP POST transport; the sender POSTs the payment payload to `url`.
+   * Appends an HTTP POST transport; the payer POSTs the payment payload to `url`.
    */
   addHttpPostTransport(url: string): this {
     return this.addTransport({ type: PaymentRequestTransportType.POST, target: url });

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -149,6 +149,25 @@ export class PaymentRequest {
     return this.amount.add(this.feesFor(mint, meltMethods));
   }
 
+  /**
+   * Whether `mintUrl` is in the request's mint list, compared after URL normalization.
+   *
+   * @remarks
+   * Foreign requests may carry non-normalized or unparsable entries; those fall back to a raw
+   * string comparison. `false` when the request has no mint list.
+   */
+  includesMint(mintUrl: string): boolean {
+    const norm = (u: string) => {
+      try {
+        return normalizeUrl(u);
+      } catch {
+        return u;
+      }
+    };
+    const target = norm(mintUrl);
+    return this.mints?.some((m) => norm(m) === target) ?? false;
+  }
+
   toRawRequest() {
     this.assertUnitRule();
     const rawRequest: RawPaymentRequest = {};

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -28,6 +28,7 @@ import { CTSError, isMintOperationError } from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import { OutputData, type OutputDataLike } from '../model/OutputData';
 import { DefaultOutputDataCreator, type OutputDataCreator } from '../model/OutputDataCreator';
+import type { PaymentRequest } from '../model/PaymentRequest';
 import type {
   GetInfoResponse,
   MeltRequest,
@@ -1491,6 +1492,46 @@ class Wallet {
   getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount {
     const sumPPK = Amount.sum(proofs.map((proof) => this.getProofFeePPK(proof))).toBigInt();
     return Amount.from((sumPPK + 999n) / 1000n);
+  }
+
+  /**
+   * Payee-side NUT-18 settlement check: do these received proofs net the requested amount?
+   *
+   * @remarks
+   * Verifies `sum(proofs) - inputFees >= amount + mf`, with input fees from this wallet's keysets
+   * and `mf` priced from this mint's NUT-05 melt methods for the wallet unit. Checks the amount
+   * only; proof integrity (DLEQ, locks) remains a separate check.
+   * @param pr - The payment request being settled.
+   * @param proofs - The received proofs (from this wallet's mint).
+   * @param expectedAmount - Expected amount for amountless requests; ignored when the request sets
+   *   `a`.
+   * @throws If no amount is available to check against, the request unit does not match this
+   *   wallet, a proof keyset is unknown, or the request is invalid per NUT-18.
+   */
+  isPaymentRequestSatisfied(
+    pr: PaymentRequest,
+    proofs: Array<Pick<Proof, 'id' | 'amount'>>,
+    expectedAmount?: AmountLike,
+  ): boolean {
+    const expected =
+      pr.amount ?? (expectedAmount !== undefined ? Amount.from(expectedAmount) : undefined);
+    if (!expected) {
+      throw new CTSError('amountless payment request: pass the expected amount to check against');
+    }
+    if (pr.unit && pr.unit !== this._unit) {
+      throw new CTSError(`request unit '${pr.unit}' does not match wallet unit '${this._unit}'`);
+    }
+    // mf applies only when this mint is outside the request's mint list (NUT-18).
+    let mf = Amount.zero();
+    if (pr.supportedMethods?.length && !pr.includesMint(this.mint.mintUrl)) {
+      const meltMethods = this.getMintInfo()
+        .supportedMethods('melt')
+        .filter((m) => m.unit === this._unit)
+        .map((m) => m.method);
+      mf = pr.feesFor(this.mint.mintUrl, meltMethods);
+    }
+    const needed = expected.add(mf).add(this.getFeesForProofs(proofs));
+    return sumProofs(proofs).compareTo(needed) >= 0;
   }
 
   /**

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -2,6 +2,7 @@ import { type P2PKOptions } from '../crypto';
 import { Amount, type AmountLike } from '../model/Amount';
 import { CTSError } from '../model/Errors';
 import { type OutputDataLike, type OutputDataFactory } from '../model/OutputData';
+import type { PaymentRequest } from '../model/PaymentRequest';
 import {
   type MeltQuoteBolt11Response,
   type MeltQuoteBolt12Response,
@@ -47,6 +48,64 @@ export class WalletOps {
   constructor(private wallet: Wallet) {}
   send(amount: AmountLike, proofs: ProofLike[]) {
     return new SendBuilder(this.wallet, amount, proofs);
+  }
+  /**
+   * Builds a send that satisfies a NUT-18 payment request from this wallet's mint.
+   *
+   * @remarks
+   * Enforces the payer-side MUSTs: strict mint list, unit rule, NUT-05 melt-method support
+   * (resolved from this wallet's MintInfo), the applicable per-method fee (`mf`), the request's
+   * `nut10` lock, and net-of-input-fees selection (`includeFees(true)`). Requires a loaded mint.
+   * @param pr - The decoded payment request.
+   * @param proofs - Proofs to select from.
+   * @param amount - Payer-chosen amount for amountless requests; forbidden when the request sets
+   *   `a`.
+   * @returns A preconfigured {@link SendBuilder}; chain further options and `.run()`.
+   * @throws If the wallet's mint, unit, or melt methods are unacceptable to the request, the
+   *   request's lock cannot be honoured, or the request is invalid per NUT-18.
+   */
+  sendToRequest(pr: PaymentRequest, proofs: ProofLike[], amount?: AmountLike) {
+    const wallet = this.wallet;
+    if (pr.amount && amount !== undefined) {
+      throw new CTSError('the request specifies its amount; omit the amount argument');
+    }
+    const base = pr.amount ?? (amount !== undefined ? Amount.from(amount) : undefined);
+    if (!base) {
+      throw new CTSError('amountless payment request: pass the chosen amount');
+    }
+    if (pr.amount && !pr.unit) {
+      throw new CTSError('invalid payment request: amount (a) without unit (u)');
+    }
+    if (pr.unit && pr.unit !== wallet.unit) {
+      throw new CTSError(`request unit '${pr.unit}' does not match wallet unit '${wallet.unit}'`);
+    }
+    // Strict mint list: the sender MUST only send proofs from listed mints (NUT-18).
+    const listed = pr.includesMint(wallet.mint.mintUrl);
+    if (pr.isMintListStrict && !listed) {
+      throw new CTSError("this wallet's mint is not in the request's strict mint list");
+    }
+    // Melt-method support and per-method fee (sm/mf): the mint MUST be able to melt the request
+    // unit via at least one listed method; the fee applies only from non-listed mints.
+    let fee = Amount.zero();
+    if (pr.supportedMethods?.length) {
+      const meltMethods = wallet
+        .getMintInfo()
+        .supportedMethods('melt')
+        .filter((m) => m.unit === wallet.unit)
+        .map((m) => m.method);
+      if (!pr.supportedMethods.some((m) => meltMethods.includes(m.method))) {
+        throw new CTSError(`mint cannot melt ${wallet.unit} via any method the request accepts`);
+      }
+      fee = listed ? Amount.zero() : pr.feesFor(wallet.mint.mintUrl, meltMethods);
+    }
+    // A nut10 kind toP2PKOptions cannot express would otherwise send unlocked; fail instead.
+    const lock = pr.toP2PKOptions();
+    if (pr.nut10 && !lock) {
+      throw new CTSError(`cannot honour the request's nut10 lock kind '${pr.nut10.kind}'`);
+    }
+    // Net of input fees (NUT-18): the receiver must net the requested amount after swapping.
+    const builder = new SendBuilder(wallet, base.add(fee), proofs).includeFees(true);
+    return lock ? builder.asP2PK(lock) : builder;
   }
   receive(token: Token | string | ProofLike[]) {
     return new ReceiveBuilder(this.wallet, token);

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -79,7 +79,7 @@ export class WalletOps {
     if (pr.unit && pr.unit !== wallet.unit) {
       throw new CTSError(`request unit '${pr.unit}' does not match wallet unit '${wallet.unit}'`);
     }
-    // Strict mint list: the sender MUST only send proofs from listed mints (NUT-18).
+    // Strict mint list: the payer MUST only send proofs from listed mints (NUT-18).
     const listed = pr.includesMint(wallet.mint.mintUrl);
     if (pr.isMintListStrict && !listed) {
       throw new CTSError("this wallet's mint is not in the request's strict mint list");
@@ -103,7 +103,7 @@ export class WalletOps {
     if (pr.nut10 && !lock) {
       throw new CTSError(`cannot honour the request's nut10 lock kind '${pr.nut10.kind}'`);
     }
-    // Net of input fees (NUT-18): the receiver must net the requested amount after swapping.
+    // Net of input fees (NUT-18): the payee must net the requested amount after swapping.
     const builder = new SendBuilder(wallet, base.add(fee), proofs).includeFees(true);
     return lock ? builder.asP2PK(lock) : builder;
   }

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import type { OutputData, OutputDataLike } from '../../src/model/OutputData';
+import { PaymentRequest } from '../../src/model/PaymentRequest';
 import type {
   Proof,
   MintQuoteBolt11Response,
@@ -121,6 +122,19 @@ type MeltProofsOnchainFn = (
 
 class MockWallet {
   defaultOutputType: () => OutputType = vi.fn(() => ({ type: 'random' as const }));
+
+  // sendToRequest fixtures: a sat wallet on mint.example.com that melts sat via bolt11 only.
+  unit = 'sat';
+  mint = { mintUrl: 'https://mint.example.com' };
+  getMintInfo = vi.fn(() => ({
+    supportedMethods: (op: 'mint' | 'melt') =>
+      op === 'melt'
+        ? [
+            { method: 'bolt11', unit: 'sat' },
+            { method: 'bolt12', unit: 'usd' },
+          ]
+        : [],
+  }));
 
   signP2PKProofs: Mock<SignP2PKFn> = vi.fn<SignP2PKFn>((ps) => ps); // passthrough
   send: Mock<SendFn> = vi.fn<SendFn>(async () => ({ keep: [], send: [] }));
@@ -270,6 +284,104 @@ describe('WalletOps builders', () => {
     wallet = new MockWallet();
     ops = new WalletOps(wallet as unknown as any);
     vi.clearAllMocks();
+  });
+
+  // --------------------------- sendToRequest ---------------------------------
+
+  describe('sendToRequest', () => {
+    // Wallet fixture (MockWallet): unit sat, mint.example.com, melts sat via bolt11 only.
+    const myMint = 'https://mint.example.com';
+
+    it('sends the bare amount with includeFees from a listed mint', async () => {
+      const pr = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        mints: [myMint],
+        supportedMethods: [{ method: 'bolt11', fee: 2 }],
+      });
+      await ops.sendToRequest(pr, proofs).run();
+      const [amount, , config] = wallet.send.mock.calls[0];
+      expect(Amount.from(amount).equals(100)).toBeTruthy(); // listed mint: no mf
+      expect(config).toEqual({ includeFees: true }); // net of input fees (NUT-18)
+    });
+
+    it('adds the lowest applicable mf from a non-listed mint', async () => {
+      const pr = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        mints: ['https://other.mint'],
+        mintsPreferred: true,
+        supportedMethods: [
+          { method: 'bolt11', fee: 2 },
+          { method: 'bolt12', fee: 5 }, // not melt-supported in sat, so not applicable
+        ],
+      });
+      await ops.sendToRequest(pr, proofs).run();
+      expect(Amount.from(wallet.send.mock.calls[0][0]).equals(102)).toBeTruthy();
+    });
+
+    it('matches listed mints after URL normalization', async () => {
+      const pr = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        mints: ['https://MINT.example.com/'], // strict list; normalizes to this wallet's mint
+        supportedMethods: [{ method: 'bolt11', fee: 2 }],
+      });
+      await ops.sendToRequest(pr, proofs).run();
+      expect(Amount.from(wallet.send.mock.calls[0][0]).equals(100)).toBeTruthy();
+    });
+
+    it('rejects a strict mint list that excludes this mint', () => {
+      const pr = new PaymentRequest({ amount: 100, unit: 'sat', mints: ['https://other.mint'] });
+      expect(() => ops.sendToRequest(pr, proofs)).toThrow(/strict mint list/);
+    });
+
+    it('rejects a unit mismatch', () => {
+      const pr = new PaymentRequest({ amount: 100, unit: 'usd' });
+      expect(() => ops.sendToRequest(pr, proofs)).toThrow(/unit/);
+    });
+
+    it('rejects when the mint cannot melt the request unit via any accepted method', () => {
+      // The mock mint melts bolt12 only in usd, so bolt12 does not count for a sat request.
+      const pr = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        supportedMethods: [{ method: 'bolt12' }],
+      });
+      expect(() => ops.sendToRequest(pr, proofs)).toThrow(/cannot melt/);
+    });
+
+    it('handles amountless requests via the amount argument', async () => {
+      const pr = new PaymentRequest({
+        unit: 'sat',
+        supportedMethods: [{ method: 'bolt11', fee: 1 }],
+      });
+      expect(() => ops.sendToRequest(pr, proofs)).toThrow(/chosen amount/);
+      await ops.sendToRequest(pr, proofs, 50).run();
+      // No mint list: the fee applies from any mint.
+      expect(Amount.from(wallet.send.mock.calls[0][0]).equals(51)).toBeTruthy();
+
+      const withAmount = new PaymentRequest({ amount: 100, unit: 'sat' });
+      expect(() => ops.sendToRequest(withAmount, proofs, 50)).toThrow(/omit the amount/);
+    });
+
+    it('applies the nut10 lock and rejects unbuildable kinds', async () => {
+      const locked = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        nut10: { kind: 'P2PK', data: '02'.padEnd(66, 'a') },
+      });
+      await ops.sendToRequest(locked, proofs).run();
+      const outputConfig = wallet.send.mock.calls[0][3];
+      expect(outputConfig?.send.type).toBe('p2pk');
+
+      const exotic = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        nut10: { kind: 'FROST', data: 'xyz' },
+      });
+      expect(() => ops.sendToRequest(exotic, proofs)).toThrow(/nut10 lock/);
+    });
   });
 
   // --------------------------- SendBuilder -----------------------------------

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -238,6 +238,17 @@ describe('payment requests', () => {
       expect(() => foreign.feesFor('https://any.example.com', ['bolt12'])).toThrow(/unit/);
     });
 
+    test('includesMint matches the mint list after URL normalization', () => {
+      const pr = new PaymentRequest({
+        id: 'mints',
+        mints: ['https://MINT.example.com/', 'not a url'],
+      });
+      expect(pr.includesMint('https://mint.example.com')).toBe(true); // case + trailing slash
+      expect(pr.includesMint('https://other.example.com')).toBe(false);
+      expect(pr.includesMint('not a url')).toBe(true); // unparsable entries compare raw
+      expect(new PaymentRequest({ id: 'none' }).includesMint('https://any.mint')).toBe(false);
+    });
+
     test('isMintListStrict resolves NUT-18 default-to-strict semantic', () => {
       const noMints = new PaymentRequest({ id: 'no_mints', amount: 100, unit: 'sat' });
       expect(noMints.isMintListStrict).toBeUndefined();

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
 
-import { Wallet, Amount, CTSError, type Proof } from '../../src';
+import { Wallet, Amount, CTSError, PaymentRequest, type Proof } from '../../src';
 
 import { mint, unit, mintUrl, useTestServer } from './_setup';
 
@@ -119,5 +119,65 @@ describe('wallet.maxSpendableAfterFees', () => {
       expect(e).toBeInstanceOf(CTSError);
       expect((e as CTSError).cause).toBeInstanceOf(Error);
     }
+  });
+});
+
+describe('wallet.isPaymentRequestSatisfied', () => {
+  test('enforces the net-of-input-fees formula (NUT-18)', async () => {
+    // Keyset charges 1 sat per proof (1000 ppk), the spec's dust-protection scenario.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 1000 }],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const pr = new PaymentRequest({ id: 'net', amount: 100, unit: 'sat' });
+    // 3 proofs cost 3 sats to swap: 103 - 3 >= 100 nets the amount, 102 - 3 does not.
+    expect(wallet.isPaymentRequestSatisfied(pr, proofsTotalling([50, 50, 3]))).toBe(true);
+    expect(wallet.isPaymentRequestSatisfied(pr, proofsTotalling([50, 50, 2]))).toBe(false);
+  });
+
+  test('adds mf when this mint is outside the request mint list', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const outside = new PaymentRequest({
+      id: 'mf',
+      amount: 100,
+      unit: 'sat',
+      mints: ['https://other.mint'],
+      mintsPreferred: true,
+      supportedMethods: [{ method: 'bolt11', fee: 5 }], // fixture mint melts bolt11/sat
+    });
+    expect(wallet.isPaymentRequestSatisfied(outside, proofsTotalling([105]))).toBe(true);
+    expect(wallet.isPaymentRequestSatisfied(outside, proofsTotalling([104]))).toBe(false);
+
+    // Listed mint (normalized match) owes no mf.
+    const listed = new PaymentRequest({
+      id: 'listed',
+      amount: 100,
+      unit: 'sat',
+      mints: [mintUrl + '/'],
+      supportedMethods: [{ method: 'bolt11', fee: 5 }],
+    });
+    expect(wallet.isPaymentRequestSatisfied(listed, proofsTotalling([100]))).toBe(true);
+  });
+
+  test('rejects unit mismatches and amountless requests without an expectation', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const usd = new PaymentRequest({ id: 'usd', amount: 100, unit: 'usd' });
+    expect(() => wallet.isPaymentRequestSatisfied(usd, proofsTotalling([100]))).toThrow(/unit/);
+
+    const amountless = new PaymentRequest({ id: 'free', unit: 'sat' });
+    expect(() => wallet.isPaymentRequestSatisfied(amountless, proofsTotalling([10]))).toThrow(
+      /amountless/,
+    );
+    expect(wallet.isPaymentRequestSatisfied(amountless, proofsTotalling([10]), 10)).toBe(true);
   });
 });


### PR DESCRIPTION
> Stacked on #780 (targets its head branch, so the diff shows only this PR's commits).
Retarget to `main` when #780 merges, last commit of 780 was c864ea503657c6b1adfbe9f3d04d70c38df07dd0

## Summary

Closes the gap between documenting the NUT-18 payer/receiver rules and enforcing them. Until now the docs choreographed four separate steps (mint-list check, melt-method check, `amountToSend`, `includeFees(true)`); a wallet that skipped one could underpay the receiver or violate a spec MUST silently.

**Payer side: `wallet.ops.sendToRequest(pr, proofs, amount?)`** builds a send that enforces the request in one step:

- strict mint list (URL-normalized membership)
- unit rule (request unit must match the wallet)
- NUT-05 melt-method support for the request unit, resolved from the wallet's own `MintInfo` (callers never pass method strings, so the mint-vs-melt and unit-binding mistakes are unrepresentable)
- lowest applicable per-method fee (`mf`), waived for listed mints
- the request's `nut10` lock via `asP2PK`, throwing on kinds it cannot express (an exotic lock would otherwise send unlocked)
- net-of-input-fees selection (`includeFees(true)`)

It returns the normal `SendBuilder`, so output types, keysets and offline modes chain as usual. Amountless requests take the payer-chosen amount as the third argument.

**Receiver side: `wallet.isPaymentRequestSatisfied(pr, proofs, expectedAmount?)`** checks `sum(proofs) - inputFees >= amount + mf` before a payment is treated as settled, with input fees from the wallet's keysets and `mf` priced from its melt methods. Scope is the amount only; DLEQ/lock validation stays separate.

**`PaymentRequest.includesMint(url)`** is the shared primitive: mint-list membership compared after URL normalization (unparsable foreign entries fall back to a raw comparison). The docs' previous `pr.mints?.includes(myMint)` example had the normalization footgun this removes.

## Design notes

- Both checks live on `Wallet`/`WalletOps` because that is where the state lives (mint URL, unit, keyset fees, melt methods). An earlier draft put the settlement check on `PaymentRequest` and needed three wallet-state options passed in; review moved it.
- `sendToRequest` returns the builder rather than running it, so `.includeFees(false)` after the fact remains possible: deliberate opt-out, not a hole, and it keeps the builder contract uniform.
- The low-level pieces (`feesFor`, `amountToSend`, `isMintListStrict`) are unchanged and remain the manual-control path; docs now lead with the one-step call and keep the manual recipe below it.

## Tests

- `sendToRequest`: fee quadrants (listed/unlisted, with/without list), URL-normalized strict-list matching, unit mismatch, unit-bound melt rejection, amountless handling, lock honour/reject.
- `isPaymentRequestSatisfied`: net-of-fees formula against a 1000 ppk keyset (the spec's dust scenario), `mf` inside/outside the mint list, unit mismatch, amountless expectation.
- `includesMint`: case/trailing-slash normalization, unparsable entries, absent list.
