### PR TITLE
feat(wallet): add experimental NUT-342 efficient recovery

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -418,6 +418,9 @@ export type CurvePoint = {
 export function decodePaymentRequest(paymentRequest: string): PaymentRequest_2;
 
 // @public
+export function decryptDGap(encryptedDGap: string, blindingFactor: bigint): number;
+
+// @public
 export function deriveKeyPair(seed: Uint8Array, purpose: Bip32KeyPurpose, counter: number): {
     pubkey: string;
     privkey: string;
@@ -484,6 +487,9 @@ export type DLEQ = {
     e: Uint8Array;
     r?: bigint;
 };
+
+// @public
+export function encryptDGap(dGap: number, blindingFactor: bigint): string;
 
 // @public (undocumented)
 export type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N ? Acc[number] : Enumerate<N, [...Acc, Acc['length']]>;
@@ -591,6 +597,9 @@ export type GetInfoResponse = {
             }>;
         };
         '29'?: Nut29Info;
+        '342'?: {
+            supported: boolean;
+        };
     };
     motd?: string;
 };
@@ -1121,7 +1130,7 @@ export class MintInfo {
         params: SwapMethod[];
     };
     // (undocumented)
-    isSupported(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20): {
+    isSupported(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20 | 342): {
         supported: boolean;
     };
     // (undocumented)
@@ -1213,6 +1222,9 @@ export class MintInfo {
             }>;
         };
         '29'?: Nut29Info;
+        '342'?: {
+            supported: boolean;
+        };
     };
     // (undocumented)
     get pubkey(): string;
@@ -1826,6 +1838,9 @@ export type ReceiveConfig = {
     onCountersReserved?: OnCountersReserved;
 };
 
+// @public
+export type RecoveryGapProvider = (keysetId: string) => Promise<number | undefined>;
+
 // @public (undocumented)
 export type RequestArgs = {
     endpoint: string;
@@ -1860,6 +1875,12 @@ export type ResponseMeta = {
 // @public (undocumented)
 export type RestoreConfig = {
     keysetId?: string;
+};
+
+// @public
+export type RestoreEfficientConfig = {
+    keysetId?: string;
+    probeWindow?: number;
 };
 
 // @public (undocumented)
@@ -1957,6 +1978,7 @@ export type SerializedBlindedMessage = {
     amount: Amount;
     B_: string;
     id: string;
+    d_gap?: number | string;
 };
 
 // @public
@@ -1965,6 +1987,7 @@ export type SerializedBlindedSignature = {
     amount: Amount;
     C_: string;
     dleq?: SerializedDLEQ;
+    d_gap?: number | string;
 };
 
 // @public (undocumented)
@@ -2223,6 +2246,7 @@ export class Wallet {
         requireSigDleq?: boolean;
         customRequest?: RequestFn;
         requestFetch?: RequestFetch;
+        recoveryGapProvider?: RecoveryGapProvider;
         logger?: Logger;
     });
     batchRestore(config?: BatchRestoreConfig): Promise<{
@@ -2310,6 +2334,10 @@ export class Wallet {
     prepareSwapToSend(amount: AmountLike, proofs: ProofLike[], config?: SendConfig, outputConfig?: OutputConfig): Promise<SwapPreview>;
     receive(token: Token | string | ProofLike[], config?: ReceiveConfig, outputType?: OutputType): Promise<Proof[]>;
     restore(start: number, count: number, config?: RestoreConfig): Promise<{
+        proofs: Proof[];
+        lastCounterWithSignature?: number;
+    }>;
+    restoreEfficient(config?: RestoreEfficientConfig): Promise<{
         proofs: Proof[];
         lastCounterWithSignature?: number;
     }>;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1881,6 +1881,7 @@ export type RestoreConfig = {
 export type RestoreEfficientConfig = {
     keysetId?: string;
     probeWindow?: number;
+    filterSpent?: boolean;
 };
 
 // @public (undocumented)

--- a/examples/nut342_recovery/Makefile
+++ b/examples/nut342_recovery/Makefile
@@ -9,6 +9,7 @@
 DOCKER ?= docker
 BIND_ADDR ?= 127.0.0.1
 PORT ?= 3338
+RATE_LIMIT_PM ?= 200
 
 NUT_342_CTX ?= https://github.com/cashubtc/nutshell.git\#feat/efficient-recovery
 NUT_342_IMAGE ?= cashu-dev-nutshell-342:local
@@ -21,7 +22,9 @@ NUT_ENVS = \
 	-e MINT_INPUT_FEE_PPK=100 \
 	-e MINT_LISTEN_HOST=0.0.0.0 \
 	-e MINT_LISTEN_PORT=3338 \
-	-e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY
+	-e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY \
+	-e MINT_TRANSACTION_RATE_LIMIT_PER_MINUTE=$(RATE_LIMIT_PM) \
+	-e MINT_GLOBAL_RATE_LIMIT_PER_MINUTE=$(RATE_LIMIT_PM)
 
 .PHONY: build up down demo demo-ci logs
 

--- a/examples/nut342_recovery/Makefile
+++ b/examples/nut342_recovery/Makefile
@@ -1,0 +1,52 @@
+# One-liner setup / teardown for the draft NUT-342 efficient recovery demo.
+#
+# Builds a Nutshell mint from the open reference-implementation PR branch
+# (cashubtc/nutshell#1081); no published image carries NUT-342 while the
+# spec (cashubtc/nuts#342) is a draft.
+#
+# Targets: up / demo / down / demo-ci / logs
+
+DOCKER ?= docker
+BIND_ADDR ?= 127.0.0.1
+PORT ?= 3338
+
+NUT_342_CTX ?= https://github.com/cashubtc/nutshell.git\#feat/efficient-recovery
+NUT_342_IMAGE ?= cashu-dev-nutshell-342:local
+NUT_342_NAME ?= cashu-dev-nutshell-342
+
+DEMO_CMD = npx tsx nut342_recovery_demo.ts
+
+NUT_ENVS = \
+	-e MINT_LIGHTNING_BACKEND=FakeWallet \
+	-e MINT_INPUT_FEE_PPK=100 \
+	-e MINT_LISTEN_HOST=0.0.0.0 \
+	-e MINT_LISTEN_PORT=3338 \
+	-e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY
+
+.PHONY: build up down demo demo-ci logs
+
+build:
+	$(DOCKER) build -t $(NUT_342_IMAGE) $(NUT_342_CTX)
+
+up: build
+	-$(DOCKER) rm -f -v $(NUT_342_NAME) >/dev/null 2>&1 || true
+	$(DOCKER) run -d --name $(NUT_342_NAME) \
+		-p $(BIND_ADDR):$(PORT):3338 \
+		$(NUT_ENVS) \
+		$(NUT_342_IMAGE) poetry run mint
+	@echo "✅ NUT-342 mint running on http://localhost:$(PORT). Run 'make demo'."
+
+down:
+	-$(DOCKER) rm -f -v $(NUT_342_NAME)
+
+demo:
+	@echo "🧪 Running NUT-342 efficient recovery demo..."
+	$(DEMO_CMD)
+
+demo-ci: up
+	@sleep 5
+	$(DEMO_CMD)
+	$(MAKE) down
+
+logs:
+	$(DOCKER) logs -f $(NUT_342_NAME)

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -147,6 +147,7 @@ async function main() {
   } catch {
     // The static invoice melts only once per mint instance. On re-runs, melt
     // one of the mint's own invoices instead (internal settlement, no change).
+    // plus we don't actually mint proofs from this quote (no accounting)
     console.log('External invoice already melted on this mint; melting an internal one instead');
     const target = await wallet.createMintQuoteBolt11(2000);
     await meltSats(wallet, target.request);

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -12,7 +12,7 @@
  * rounds, a Lightning melt with NUT-08 change, and one sent token that is never claimed. Every
  * operation backs up an encrypted recovery gap on the mint. Then a second wallet with the same seed
  * recovers everything via `restoreEfficient()`, including the unclaimed token. A plain
- * `batchRestore()` (NUT-13 linear scan) runs last for comparison.
+ * `batchRestore()` (the linear NUT-09 restore scan) runs last for comparison.
  */
 import { randomBytes } from '@noble/hashes/utils.js';
 
@@ -188,7 +188,7 @@ async function main() {
     console.log('  all search requests were <=25-nonce probes: the NUT-342 path ran, no fallback');
   }
 
-  // For comparison: the NUT-13 linear scan. Its cost grows with wallet age
+  // For comparison: the linear NUT-09 restore scan. Its cost grows with wallet age
   // (total counters used) and it silently misses proofs beyond the gap limit;
   // the NUT-342 search stays at ~30 requests regardless of age.
   const linear = countingFetch();

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -173,7 +173,8 @@ async function main() {
   const recovery = new Wallet(mintUrl, { bip39seed: seed, requestFetch: efficient.wrapped });
   await recovery.loadMint();
 
-  const restored = await recovery.restoreEfficient();
+  // filterSpent off: the demo compares raw restore traffic and state-checks explicitly below
+  const restored = await recovery.restoreEfficient({ filterSpent: false });
   const { unspent } = await recovery.groupProofsByState(restored.proofs);
   console.log(
     `restoreEfficient: recovered ${sumProofs(unspent)} sats ` +

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -62,7 +62,13 @@ function countingFetch() {
       stats.nonces += body.outputs.length;
       stats.sizes.push(body.outputs.length);
     }
-    return fetch(input, init);
+    // One retry on a dropped keep-alive socket: the dev mint closes idle connections
+    // during the demo's long derivation pauses, and this traffic is read-only.
+    try {
+      return await fetch(input, init);
+    } catch {
+      return fetch(input, init);
+    }
   };
   return { wrapped, stats };
 }

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -1,0 +1,216 @@
+/**
+ * Live demo of draft NUT-342 efficient wallet recovery (cashubtc/nuts#342).
+ *
+ * Requires a mint running the Nutshell reference implementation branch (cashubtc/nutshell#1081) on
+ * port 3338. From this directory:
+ *
+ *     make up
+ *     make demo
+ *     make down
+ *
+ * Flow: a wallet with a `recoveryGapProvider` gets a thorough workout — two mints, several swap
+ * rounds, a Lightning melt with NUT-08 change, and one sent token that is never claimed. Every
+ * operation backs up an encrypted recovery gap on the mint. Then a second wallet with the same seed
+ * recovers everything via `restoreEfficient()`, including the unclaimed token. A plain
+ * `batchRestore()` (NUT-13 linear scan) runs last for comparison.
+ */
+import { randomBytes } from '@noble/hashes/utils.js';
+
+import { MeltQuoteState, MintQuoteState, Wallet, sumProofs, type Proof } from '../../src';
+
+const mintUrl = 'http://localhost:3338';
+const seed = randomBytes(64);
+
+// A 2000 sat bolt11 invoice; the FakeWallet backend "pays" it instantly.
+const externalInvoice =
+  'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
+
+// ---------------------------------------------------------------------------
+// Minimal app-side store. A real wallet persists proofs and, for NUT-342,
+// which counter range each operation's outputs came from. The provider must
+// report the lowest counter among unspent AND pending proofs — pending
+// includes tokens we sent that the receiver has not claimed yet.
+// ---------------------------------------------------------------------------
+let proofs: Proof[] = []; // live wallet proofs
+const sentPending: Proof[] = []; // sent, not yet claimed by the receiver
+const batches: Array<{ start: number; secrets: Set<string> }> = [];
+let reservedStart: number | undefined;
+const onCountersReserved = (c: { start: number }) => (reservedStart = c.start);
+
+function track(newProofs: Proof[]) {
+  if (reservedStart === undefined) return; // op produced no deterministic outputs
+  batches.push({ start: reservedStart, secrets: new Set(newProofs.map((p) => p.secret)) });
+  reservedStart = undefined;
+}
+
+async function firstUnspentCounter(): Promise<number | undefined> {
+  const liveSecrets = new Set([...proofs, ...sentPending].map((p) => p.secret));
+  const live = batches.filter((b) => [...b.secrets].some((s) => liveSecrets.has(s)));
+  return live.length ? Math.min(...live.map((b) => b.start)) : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// A fetch wrapper that records NUT-09 restore traffic (requests + nonces).
+// ---------------------------------------------------------------------------
+function countingFetch() {
+  const stats = { requests: 0, nonces: 0, sizes: [] as number[] };
+  const wrapped: typeof fetch = async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url.endsWith('/v1/restore') && typeof init?.body === 'string') {
+      const body = JSON.parse(init.body) as { outputs: unknown[] };
+      stats.requests++;
+      stats.nonces += body.outputs.length;
+      stats.sizes.push(body.outputs.length);
+    }
+    return fetch(input, init);
+  };
+  return { wrapped, stats };
+}
+
+// ---------------------------------------------------------------------------
+// Wallet operations, each tracking counters and proofs in the app store
+// ---------------------------------------------------------------------------
+async function mintSats(wallet: Wallet, amount: number) {
+  const quote = await wallet.createMintQuoteBolt11(amount);
+  while ((await wallet.checkMintQuoteBolt11(quote.quote)).state !== MintQuoteState.PAID) {
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  const minted = await wallet.mintProofsBolt11(amount, quote, { onCountersReserved });
+  proofs.push(...minted);
+  track(minted);
+  console.log(`Minted ${amount} sats (balance ${sumProofs(proofs)})`);
+}
+
+async function selfSwap(wallet: Wallet, amount: number) {
+  const { keep, send } = await wallet.send(amount, proofs, { onCountersReserved });
+  proofs = keep;
+  track([...keep, ...send]);
+  const received = await wallet.receive(send, { onCountersReserved });
+  proofs.push(...received);
+  track(received);
+  console.log(`Swapped ${amount} sats through the mint (balance ${sumProofs(proofs)})`);
+}
+
+async function sendUnclaimed(wallet: Wallet, amount: number) {
+  const { keep, send } = await wallet.send(amount, proofs, { onCountersReserved });
+  proofs = keep;
+  track([...keep, ...send]);
+  sentPending.push(...send);
+  console.log(`Sent a ${amount} sat token nobody claims (balance ${sumProofs(proofs)})`);
+}
+
+async function meltSats(wallet: Wallet, invoice: string) {
+  const meltQuote = await wallet.createMeltQuoteBolt11(invoice);
+  const amountToMelt = meltQuote.amount.add(meltQuote.fee_reserve);
+  const { keep, send } = await wallet.send(amountToMelt, proofs, {
+    onCountersReserved,
+    includeFees: true,
+  });
+  proofs = keep;
+  track([...keep, ...send]);
+  const { change } = await wallet.meltProofsBolt11(meltQuote, send, { onCountersReserved });
+  proofs.push(...change);
+  track(change); // NUT-08 change blanks are deterministic outputs too
+  while ((await wallet.checkMeltQuoteBolt11(meltQuote.quote)).state !== MeltQuoteState.PAID) {
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  console.log(
+    `Melted ${meltQuote.amount} sats over Lightning, ` +
+      `${sumProofs(change)} sats change (balance ${sumProofs(proofs)})`,
+  );
+}
+
+async function main() {
+  // ------------------------------------------------------------------
+  // Phase 1: a working wallet that backs up recovery gaps as it goes
+  // ------------------------------------------------------------------
+  const wallet = new Wallet(mintUrl, {
+    bip39seed: seed,
+    recoveryGapProvider: firstUnspentCounter,
+  });
+  await wallet.loadMint();
+
+  if (!wallet.getMintInfo().isSupported(342).supported) {
+    console.error('Mint does not advertise NUT-342. Run "make up" in this directory first.');
+    process.exit(1);
+  }
+  console.log(`Mint advertises NUT-342 support (${wallet.keysetId})\n`);
+
+  // A thorough workout: every operation writes fresh encrypted gaps
+  await mintSats(wallet, 1000);
+  await selfSwap(wallet, 400);
+  await selfSwap(wallet, 150);
+  await mintSats(wallet, 1500);
+  await sendUnclaimed(wallet, 21);
+  try {
+    await meltSats(wallet, externalInvoice);
+  } catch {
+    // The static invoice melts only once per mint instance. On re-runs, melt
+    // one of the mint's own invoices instead (internal settlement, no change).
+    console.log('External invoice already melted on this mint; melting an internal one instead');
+    const target = await wallet.createMintQuoteBolt11(2000);
+    await meltSats(wallet, target.request);
+  }
+  await selfSwap(wallet, 100);
+  await selfSwap(wallet, 42);
+
+  const balance = sumProofs(proofs);
+  const pending = sumProofs(sentPending);
+  const expected = balance.add(pending);
+  const nextCounter = await wallet.counters.peekNext(wallet.keysetId);
+  console.log(
+    `\nWallet state: ${balance} sats live + ${pending} sats sent-unclaimed, ` +
+      `counters used 0..${nextCounter - 1}, first unspent counter ${await firstUnspentCounter()}`,
+  );
+
+  // ------------------------------------------------------------------
+  // Phase 2: the device is lost. Recover from seed alone.
+  // ------------------------------------------------------------------
+  console.log('\n--- Device lost! Recovering from seed on a fresh wallet ---\n');
+
+  const efficient = countingFetch();
+  const recovery = new Wallet(mintUrl, { bip39seed: seed, requestFetch: efficient.wrapped });
+  await recovery.loadMint();
+
+  const restored = await recovery.restoreEfficient();
+  const { unspent } = await recovery.groupProofsByState(restored.proofs);
+  console.log(
+    `restoreEfficient: recovered ${sumProofs(unspent)} sats ` +
+      `(${unspent.length} unspent of ${restored.proofs.length} issued, ` +
+      `T=${restored.lastCounterWithSignature})`,
+  );
+  console.log(
+    `  ${efficient.stats.requests} restore requests, ${efficient.stats.nonces} nonces revealed ` +
+      `(final window: ${efficient.stats.sizes.at(-1)} nonces)`,
+  );
+  if (efficient.stats.sizes.slice(0, -1).every((s) => s <= 25)) {
+    console.log('  all search requests were <=25-nonce probes: the NUT-342 path ran, no fallback');
+  }
+
+  // For comparison: the NUT-13 linear scan. Its cost grows with wallet age
+  // (total counters used) and it silently misses proofs beyond the gap limit;
+  // the NUT-342 search stays at ~30 requests regardless of age.
+  const linear = countingFetch();
+  const legacy = new Wallet(mintUrl, { bip39seed: seed, requestFetch: linear.wrapped });
+  await legacy.loadMint();
+  const scanned = await legacy.batchRestore();
+  console.log(
+    `\nbatchRestore:     recovered ${sumProofs(
+      (await legacy.groupProofsByState(scanned.proofs)).unspent,
+    )} sats`,
+  );
+  console.log(`  ${linear.stats.requests} restore requests, ${linear.stats.nonces} nonces sent`);
+
+  if (!sumProofs(unspent).equals(expected)) {
+    throw new Error(`Recovery mismatch: expected ${expected}, got ${sumProofs(unspent)}`);
+  }
+  console.log(
+    `\nSuccess: recovered ${expected} sats = live balance (${balance}) ` +
+      `+ unclaimed sent token (${pending})`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.0-rc.3",
       "license": "MIT",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
         "@scure/base": "^2.2.0",
@@ -2243,6 +2244,18 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "ws": "^8.20.0"
   },
   "dependencies": {
+    "@noble/ciphers": "^2.2.0",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@scure/base": "^2.2.0",

--- a/src/crypto/NUT342.ts
+++ b/src/crypto/NUT342.ts
@@ -1,0 +1,58 @@
+import { gcm } from '@noble/ciphers/aes.js';
+import { numberToBytesBE } from '@noble/curves/utils.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils.js';
+
+import { CTSError } from '../model/Errors';
+import { Bytes, numberToHexPadded64 } from '../utils';
+
+const NONCE_SIZE = 12;
+const GAP_SIZE = 4;
+const TAG_SIZE = 16;
+const MAX_GAP = 0xffffffff;
+
+// AES-128-GCM key from the output's blinding factor: SHA256(r)[0:16].
+function deriveKey(blindingFactor: bigint): Uint8Array {
+  return sha256(hexToBytes(numberToHexPadded64(blindingFactor))).slice(0, 16);
+}
+
+/**
+ * Encrypts a NUT-342 (draft) recovery gap with the output's blinding factor.
+ *
+ * @remarks
+ * Returns hex `nonce || ciphertext || tag` (32 bytes) for the `d_gap` field.
+ * @throws {@link CTSError} If `dGap` is not an unsigned 32-bit integer.
+ */
+export function encryptDGap(dGap: number, blindingFactor: bigint): string {
+  if (!Number.isInteger(dGap) || dGap < 0 || dGap > MAX_GAP) {
+    throw new CTSError('d_gap must be an unsigned 32-bit integer');
+  }
+  const nonce = randomBytes(NONCE_SIZE);
+  const encrypted = gcm(deriveKey(blindingFactor), nonce).encrypt(numberToBytesBE(dGap, GAP_SIZE));
+  return bytesToHex(Bytes.concat(nonce, encrypted));
+}
+
+/**
+ * Decrypts and authenticates a NUT-342 (draft) `d_gap` value.
+ *
+ * @throws {@link CTSError} If the payload is malformed or fails authentication.
+ */
+export function decryptDGap(encryptedDGap: string, blindingFactor: bigint): number {
+  let payload: Uint8Array;
+  try {
+    payload = hexToBytes(encryptedDGap);
+  } catch (e) {
+    throw new CTSError('encrypted d_gap is not valid hex', { cause: e });
+  }
+  if (payload.length !== NONCE_SIZE + GAP_SIZE + TAG_SIZE) {
+    throw new CTSError('invalid encrypted d_gap length');
+  }
+  try {
+    const plaintext = gcm(deriveKey(blindingFactor), payload.subarray(0, NONCE_SIZE)).decrypt(
+      payload.subarray(NONCE_SIZE),
+    );
+    return Number(Bytes.toBigInt(plaintext));
+  } catch (e) {
+    throw new CTSError('d_gap decryption failed', { cause: e });
+  }
+}

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -10,4 +10,5 @@ export * from './NUT13';
 export * from './NUT14';
 export { signMintQuote, verifyMintQuoteSignature } from './NUT20';
 export * from './NUT27';
+export * from './NUT342';
 export * from './NUT28';

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -177,7 +177,7 @@ export class MintInfo {
   }
 
   isSupported(num: 4 | 5): { disabled: boolean; params: SwapMethod[] };
-  isSupported(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20): { supported: boolean };
+  isSupported(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20 | 342): { supported: boolean };
   isSupported(num: 17): { supported: boolean; params?: WebSocketSupport[] };
   isSupported(num: 15): { supported: boolean; params?: MPPMethod[] };
   isSupported(num: 19): { supported: boolean; params?: Nut19Policy };
@@ -195,7 +195,8 @@ export class MintInfo {
       case 11:
       case 12:
       case 14:
-      case 20: {
+      case 20:
+      case 342: {
         return this.checkGenericNut(num);
       }
       case 17: {
@@ -243,7 +244,7 @@ export class MintInfo {
     return false;
   }
 
-  private checkGenericNut(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20) {
+  private checkGenericNut(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20 | 342) {
     return this._mintInfo.nuts[num]?.supported ? { supported: true } : { supported: false };
   }
 

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -80,6 +80,10 @@ export type GetInfoResponse = {
       protected_endpoints: Array<{ method: 'GET' | 'POST'; path: string }>;
     };
     '29'?: Nut29Info;
+    '342'?: {
+      // Efficient wallet recovery (draft, experimental)
+      supported: boolean;
+    };
   };
   motd?: string;
 };

--- a/src/model/types/blinded.ts
+++ b/src/model/types/blinded.ts
@@ -19,6 +19,11 @@ export type SerializedBlindedMessage = {
    * Keyset id.
    */
   id: string;
+  /**
+   * NUT-342 (draft, experimental) recovery gap: plaintext integer or hex-encoded AES-128-GCM
+   * payload. Omitted unless the wallet backs up recovery gaps.
+   */
+  d_gap?: number | string;
 };
 
 /**
@@ -44,6 +49,10 @@ export type SerializedBlindedSignature = {
    * DLEQ Proof.
    */
   dleq?: SerializedDLEQ;
+  /**
+   * NUT-342 (draft, experimental) recovery gap, echoed verbatim from the stored BlindedMessage.
+   */
+  d_gap?: number | string;
 };
 
 /*

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1747,14 +1747,16 @@ class Wallet {
    * Binary-searches the counter space for the last issued signature, reads its recovery gap and
    * batch-restores that window. Falls back to `batchRestore` (the linear NUT-09 restore scan) when
    * the mint does not advertise support, no gap was backed up, or the search fails. Like
-   * `batchRestore`, returned proofs may include spent ones; filter with `checkProofsStates`.
+   * `batchRestore`, spent proofs are dropped before returning; `lastCounterWithSignature` still
+   * reflects every found signature.
    * @param options.keysetId Which keysetId to restore. Defaults to the instance's.
    * @param options.probeWindow Counters probed per binary-search request (defaults to 25).
+   * @param options.filterSpent Drop spent proofs (NUT-07) before returning. Default is `true`.
    */
   async restoreEfficient(
     config?: RestoreEfficientConfig,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
-    const { keysetId, probeWindow = 25 } = config ?? {};
+    const { keysetId, probeWindow = 25, filterSpent = true } = config ?? {};
     this.failIf(
       !Number.isInteger(probeWindow) || probeWindow < 1,
       'probeWindow must be a positive integer',
@@ -1762,7 +1764,15 @@ class Wallet {
     if (this._mintInfo?.isSupported(342).supported) {
       try {
         const result = await this.restoreFromGapBackup(probeWindow, keysetId);
-        if (result) return result;
+        if (result) {
+          if (filterSpent && result.proofs.length > 0) {
+            const states = await this.checkProofsStates(result.proofs);
+            result.proofs = result.proofs.filter(
+              (_, i) => states[i].state !== CheckStateEnum.SPENT,
+            );
+          }
+          return result;
+        }
         this._logger.info('No NUT-342 gap backup found, falling back to linear NUT-09 scan');
       } catch (e) {
         this._logger.warn('NUT-342 recovery failed, falling back to linear NUT-09 scan', {
@@ -1770,7 +1780,7 @@ class Wallet {
         });
       }
     }
-    return this.batchRestore({ keysetId, filterSpent: false });
+    return this.batchRestore({ keysetId, filterSpent });
   }
 
   /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -7,6 +7,8 @@
 
 import { type AuthProvider } from '../auth/AuthProvider';
 import {
+  decryptDGap,
+  encryptDGap,
   signMintQuote,
   findSigningKey,
   signP2PKProofs as cryptoSignP2PKProofs,
@@ -91,8 +93,10 @@ import {
   type SwapTransaction,
   type MeltProofsResponse,
   type SendResponse,
+  type RecoveryGapProvider,
   type RestoreConfig,
   type BatchRestoreConfig,
+  type RestoreEfficientConfig,
   type SecretsPolicy,
   type SwapPreview,
   type MintPreview,
@@ -169,6 +173,7 @@ class Wallet {
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
   private _requireSigDleq = false;
+  private _recoveryGapProvider?: RecoveryGapProvider;
   private _logger: Logger;
 
   /**
@@ -214,6 +219,10 @@ class Wallet {
    * @param options.requestFetch Custom fetch-compatible transport for mint HTTP requests. Use this
    *   for per-wallet OHTTP, Tor, native HTTP clients, or proxies while preserving the default
    *   request pipeline. Ignored when `customRequest` is supplied.
+   * @param options.recoveryGapProvider Experimental (draft NUT-342). Returns the lowest
+   *   deterministic counter among the app's unspent and pending proofs for a keyset. When set and
+   *   the mint advertises support, deterministic outputs carry an encrypted recovery gap that
+   *   `restoreEfficient` uses to skip the NUT-13 linear scan.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -232,6 +241,7 @@ class Wallet {
       requireSigDleq?: boolean;
       customRequest?: RequestFn;
       requestFetch?: RequestFetch;
+      recoveryGapProvider?: RecoveryGapProvider; // optional, draft NUT-342
       logger?: Logger;
     },
   ) {
@@ -271,6 +281,7 @@ class Wallet {
     this._keyChain = new KeyChain(this.mint, this._unit);
     this._denominationTarget = options?.denominationTarget ?? this._denominationTarget;
     this._requireSigDleq = options?.requireSigDleq ?? this._requireSigDleq;
+    this._recoveryGapProvider = options?.recoveryGapProvider;
   }
 
   // Convenience wrappers for "log and throw"
@@ -669,6 +680,7 @@ class Wallet {
       requireSigDleq: this._requireSigDleq,
       logger: this._logger,
       counterSource: opts?.counterSource ?? this._counterSource,
+      recoveryGapProvider: this._recoveryGapProvider,
     });
     // Load mint info from our caches
     newWallet.loadMintFromCache(this.getMintInfo().cache, this._keyChain.cache);
@@ -805,11 +817,11 @@ class Wallet {
    * @param outputType The output configuration.
    * @returns Prepared output data.
    */
-  private createOutputData(
+  private async createOutputData(
     amount: AmountLike,
     keyset: Keyset,
     outputType: OutputType,
-  ): OutputDataLike[] {
+  ): Promise<OutputDataLike[]> {
     const outputAmount = this.parseAmount(amount, 'createOutputData', true); // allow zero
     if (
       // 'custom' OutputType has no denominations. Every other OutputType does.
@@ -849,6 +861,7 @@ class Wallet {
           keyset,
           outputType.denominations,
         );
+        await this.attachRecoveryGaps(outputData, outputType.counter, keyset.id);
         break;
       case 'p2pk':
         outputData = this._outputDataCreator.createP2PKData(
@@ -882,6 +895,32 @@ class Wallet {
       }
     }
     return outputData;
+  }
+
+  /**
+   * Attaches encrypted NUT-342 (draft) recovery gaps to a deterministic output batch.
+   *
+   * @remarks
+   * No-op unless a `recoveryGapProvider` is configured and the mint advertises support. Assumes the
+   * default creator's counter alignment (output `i` uses `startCounter + i`).
+   */
+  private async attachRecoveryGaps(
+    outputData: OutputDataLike[],
+    startCounter: number,
+    keysetId: string,
+  ): Promise<void> {
+    if (!this._recoveryGapProvider || outputData.length === 0) return;
+    if (!this._mintInfo?.isSupported(342).supported) return;
+    const firstUnspent = (await this._recoveryGapProvider(keysetId)) ?? startCounter;
+    this.failIf(
+      !Number.isInteger(firstUnspent) || firstUnspent < 0,
+      'recoveryGapProvider must return a non-negative integer counter',
+    );
+    // The new outputs are themselves unspent, so the window never starts after this batch
+    const first = Math.min(firstUnspent, startCounter);
+    outputData.forEach((output, i) => {
+      output.blindedMessage.d_gap = encryptDGap(startCounter + i - first, output.blindingFactor);
+    });
   }
 
   /**
@@ -1064,7 +1103,7 @@ class Wallet {
     });
 
     // Create outputs and execute swap
-    const outputs = this.createOutputData(this.preparedTotal(receiveOT), keyset, receiveOT);
+    const outputs = await this.createOutputData(this.preparedTotal(receiveOT), keyset, receiveOT);
 
     // Return SwapPreview
     return {
@@ -1306,8 +1345,8 @@ class Wallet {
     });
 
     // Create the output data
-    const sendOutputs = this.createOutputData(sendAmount, keyset, sendOT);
-    const keepOutputs = this.createOutputData(keepAmount, keyset, keepOT);
+    const sendOutputs = await this.createOutputData(sendAmount, keyset, sendOT);
+    const keepOutputs = await this.createOutputData(keepAmount, keyset, keepOT);
 
     // Return SwapPreview
     return {
@@ -1682,8 +1721,118 @@ class Wallet {
     count: number,
     config?: RestoreConfig,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
-    this.failIfNullish(this._seed, 'Cashu Wallet must be initialized with a seed to use restore');
     const { keysetId } = config || {};
+    const found = await this.restoreSignatures(start, count, keysetId);
+    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+
+    const restoredProofs: Proof[] = [];
+    let lastCounterWithSignature: number | undefined;
+
+    for (const { counter, signature, output } of found) {
+      lastCounterWithSignature = counter;
+      output.blindedMessage.amount = signature.amount;
+      restoredProofs.push(output.toProof(signature, keyset));
+    }
+
+    return {
+      proofs: restoredProofs,
+      lastCounterWithSignature,
+    };
+  }
+
+  /**
+   * Restores deterministic proofs using the draft NUT-342 recovery scheme (experimental).
+   *
+   * @remarks
+   * Binary-searches the counter space for the last issued signature, reads its recovery gap and
+   * batch-restores that window. Falls back to `batchRestore` (NUT-13 linear scan) when the mint
+   * does not advertise support, no gap was backed up, or the search fails. Like `batchRestore`,
+   * returned proofs may include spent ones; filter with `checkProofsStates`.
+   * @param options.keysetId Which keysetId to restore. Defaults to the instance's.
+   * @param options.probeWindow Counters probed per binary-search request (defaults to 25).
+   */
+  async restoreEfficient(
+    config?: RestoreEfficientConfig,
+  ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
+    const { keysetId, probeWindow = 25 } = config ?? {};
+    this.failIf(
+      !Number.isInteger(probeWindow) || probeWindow < 1,
+      'probeWindow must be a positive integer',
+    );
+    if (this._mintInfo?.isSupported(342).supported) {
+      try {
+        const result = await this.restoreFromGapBackup(probeWindow, keysetId);
+        if (result) return result;
+        this._logger.info('No NUT-342 gap backup found, falling back to NUT-13 scan');
+      } catch (e) {
+        this._logger.warn('NUT-342 recovery failed, falling back to NUT-13 scan', { error: e });
+      }
+    }
+    return this.batchRestore({ keysetId, filterSpent: false });
+  }
+
+  /**
+   * NUT-342 (draft) recovery core: locate the last issued counter T via windowed binary search,
+   * decrypt its `d_gap` and restore `[T - d_gap, T]`.
+   *
+   * @returns Undefined when the mint has no signatures or no gap metadata for T (caller falls back
+   *   to the NUT-13 scan).
+   */
+  private async restoreFromGapBackup(
+    probeWindow: number,
+    keysetId?: string,
+  ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number } | undefined> {
+    // Legacy keysets derive hardened BIP-32 children, capping counters at 2^31; HMAC keysets
+    // (v1 and later) use the full u32 space the spec searches.
+    const id = keysetId ?? this.keysetId;
+    const isLegacy = !/^[0-9a-fA-F]+$/.test(id) || id.startsWith('00');
+    const maxCounter = isLegacy ? 0x7fffffff : 0xffffffff;
+
+    // A window counts as issued if ANY counter in it has a signature. This tolerates derivation
+    // gaps up to probeWindow without breaking the search's monotonicity assumption.
+    const probe = (windowIndex: number) => {
+      const start = windowIndex * probeWindow;
+      return this.restoreSignatures(start, Math.min(probeWindow, maxCounter - start + 1), keysetId);
+    };
+
+    const firstWindow = await probe(0);
+    if (firstWindow.length === 0) return undefined;
+
+    let lo = 0;
+    let hi = Math.floor(maxCounter / probeWindow);
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi + 1) / 2);
+      if ((await probe(mid)).length > 0) lo = mid;
+      else hi = mid - 1;
+    }
+
+    const terminalWindow = lo === 0 ? firstWindow : await probe(lo);
+    const terminal = terminalWindow[terminalWindow.length - 1];
+    if (!terminal || terminal.signature.d_gap == null) return undefined;
+
+    const { counter: t, signature, output } = terminal;
+    const dGap =
+      typeof signature.d_gap === 'string'
+        ? decryptDGap(signature.d_gap, output.blindingFactor)
+        : Number(signature.d_gap);
+    this.failIf(!Number.isInteger(dGap) || dGap < 0 || dGap > t, 'Mint returned an invalid d_gap');
+
+    return this.restore(t - dGap, dGap + 1, { keysetId });
+  }
+
+  /**
+   * Queries the NUT-09 restore endpoint for issued signatures over a deterministic counter range.
+   *
+   * @returns One entry per counter with an issued signature, ascending.
+   */
+  private async restoreSignatures(
+    start: number,
+    count: number,
+    keysetId?: string,
+  ): Promise<
+    Array<{ counter: number; signature: SerializedBlindedSignature; output: OutputDataLike }>
+  > {
+    this.failIfNullish(this._seed, 'Cashu Wallet must be initialized with a seed to use restore');
 
     // Ensure we have keys - wallet only loads active keysets by default
     await this._keyChain.ensureKeysetKeys(keysetId ?? this.keysetId);
@@ -1707,22 +1856,16 @@ class Wallet {
     const signatureMap: { [sig: string]: SerializedBlindedSignature } = {};
     outputs.forEach((o, i) => (signatureMap[o.B_] = signatures[i]));
 
-    const restoredProofs: Proof[] = [];
-    let lastCounterWithSignature: number | undefined;
-
+    const found: Array<{
+      counter: number;
+      signature: SerializedBlindedSignature;
+      output: OutputDataLike;
+    }> = [];
     for (let i = 0; i < outputData.length; i++) {
-      const matchingSig = signatureMap[outputData[i].blindedMessage.B_];
-      if (matchingSig) {
-        lastCounterWithSignature = start + i;
-        outputData[i].blindedMessage.amount = matchingSig.amount;
-        restoredProofs.push(outputData[i].toProof(matchingSig, keyset));
-      }
+      const signature = signatureMap[outputData[i].blindedMessage.B_];
+      if (signature) found.push({ counter: start + i, signature, output: outputData[i] });
     }
-
-    return {
-      proofs: restoredProofs,
-      lastCounterWithSignature,
-    };
+    return found;
   }
 
   // -----------------------------------------------------------------
@@ -2279,7 +2422,7 @@ class Wallet {
     });
 
     // Create outputs and mint payload
-    const outputs = this.createOutputData(mintAmount, keyset, mintOT);
+    const outputs = await this.createOutputData(mintAmount, keyset, mintOT);
     const blindedMessages = outputs.map((d) => d.blindedMessage);
     const mintPayload: MintRequest = {
       outputs: blindedMessages,
@@ -2476,7 +2619,7 @@ class Wallet {
     }
 
     // Create consolidated output data
-    const outputs = this.createOutputData(totalAmount, keyset, mintOT);
+    const outputs = await this.createOutputData(totalAmount, keyset, mintOT);
     const blindedMessages = outputs.map((d) => d.blindedMessage);
 
     // Sign each locked quote over ALL blinded messages (NUT-29).
@@ -3000,7 +3143,7 @@ class Wallet {
       });
       // Generate the blank outputs (no fees as we are receiving change)
       // Remember, zero amount + zero denomination passes splitAmount validation
-      outputData = this.createOutputData(0, keyset, meltOT);
+      outputData = await this.createOutputData(0, keyset, meltOT);
     }
 
     // Create melt preview

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -222,7 +222,7 @@ class Wallet {
    * @param options.recoveryGapProvider Experimental (draft NUT-342). Returns the lowest
    *   deterministic counter among the app's unspent and pending proofs for a keyset. When set and
    *   the mint advertises support, deterministic outputs carry an encrypted recovery gap that
-   *   `restoreEfficient` uses to skip the NUT-13 linear scan.
+   *   `restoreEfficient` uses to skip the linear NUT-09 restore scan.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -1745,9 +1745,9 @@ class Wallet {
    *
    * @remarks
    * Binary-searches the counter space for the last issued signature, reads its recovery gap and
-   * batch-restores that window. Falls back to `batchRestore` (NUT-13 linear scan) when the mint
-   * does not advertise support, no gap was backed up, or the search fails. Like `batchRestore`,
-   * returned proofs may include spent ones; filter with `checkProofsStates`.
+   * batch-restores that window. Falls back to `batchRestore` (the linear NUT-09 restore scan) when
+   * the mint does not advertise support, no gap was backed up, or the search fails. Like
+   * `batchRestore`, returned proofs may include spent ones; filter with `checkProofsStates`.
    * @param options.keysetId Which keysetId to restore. Defaults to the instance's.
    * @param options.probeWindow Counters probed per binary-search request (defaults to 25).
    */
@@ -1763,9 +1763,11 @@ class Wallet {
       try {
         const result = await this.restoreFromGapBackup(probeWindow, keysetId);
         if (result) return result;
-        this._logger.info('No NUT-342 gap backup found, falling back to NUT-13 scan');
+        this._logger.info('No NUT-342 gap backup found, falling back to linear NUT-09 scan');
       } catch (e) {
-        this._logger.warn('NUT-342 recovery failed, falling back to NUT-13 scan', { error: e });
+        this._logger.warn('NUT-342 recovery failed, falling back to linear NUT-09 scan', {
+          error: e,
+        });
       }
     }
     return this.batchRestore({ keysetId, filterSpent: false });
@@ -1776,7 +1778,7 @@ class Wallet {
    * decrypt its `d_gap` and restore `[T - d_gap, T]`.
    *
    * @returns Undefined when the mint has no signatures or no gap metadata for T (caller falls back
-   *   to the NUT-13 scan).
+   *   to the linear NUT-09 scan).
    */
   private async restoreFromGapBackup(
     probeWindow: number,

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -54,6 +54,10 @@ export type RestoreEfficientConfig = {
    * the cost of revealing more nonces per probe. Default is `25`.
    */
   probeWindow?: number;
+  /**
+   * Drop spent proofs (NUT-07) before returning. Default is `true`
+   */
+  filterSpent?: boolean;
 };
 
 /**

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -45,6 +45,28 @@ export type BatchRestoreConfig = {
 };
 
 /**
+ * Config for {@link Wallet.restoreEfficient} (draft NUT-342, experimental).
+ */
+export type RestoreEfficientConfig = {
+  keysetId?: string;
+  /**
+   * Counters probed per binary-search request. Larger windows tolerate larger derivation gaps at
+   * the cost of revealing more nonces per probe. Default is `25`.
+   */
+  probeWindow?: number;
+};
+
+/**
+ * Returns the lowest deterministic counter among the app's unspent AND pending proofs for a keyset,
+ * or undefined when there are none (draft NUT-342, experimental).
+ *
+ * @remarks
+ * Pending proofs (e.g. inputs reserved for an in-flight swap or melt) MUST be included, or recovery
+ * windows may miss live proofs.
+ */
+export type RecoveryGapProvider = (keysetId: string) => Promise<number | undefined>;
+
+/**
  * Shared properties for most `OutputType` variants (except 'custom').
  */
 export interface SharedOutputTypeProps {

--- a/test/crypto/NUT342.test.ts
+++ b/test/crypto/NUT342.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import { decryptDGap, encryptDGap } from '../../src';
+
+const r = BigInt('0x' + '01'.repeat(32));
+
+describe('NUT-342 d_gap encryption', () => {
+  test.each([0, 1, 65536, 0xffffffff])('round trip %i', (dGap) => {
+    const encrypted = encryptDGap(dGap, r);
+    // nonce (12) || ciphertext (4) || tag (16) = 32 bytes hex
+    expect(encrypted).toHaveLength(64);
+    expect(decryptDGap(encrypted, r)).toBe(dGap);
+  });
+
+  test('uses a random nonce', () => {
+    expect(encryptDGap(42, r)).not.toBe(encryptDGap(42, r));
+  });
+
+  test('rejects the wrong blinding factor', () => {
+    const encrypted = encryptDGap(42, r);
+    expect(() => decryptDGap(encrypted, r + 1n)).toThrow('d_gap decryption failed');
+  });
+
+  test('rejects tampered ciphertext', () => {
+    const encrypted = encryptDGap(42, r);
+    const i = 26; // inside the 4-byte ciphertext region
+    const tampered =
+      encrypted.slice(0, i) + (encrypted[i] === '0' ? '1' : '0') + encrypted.slice(i + 1);
+    expect(() => decryptDGap(tampered, r)).toThrow('d_gap decryption failed');
+  });
+
+  test.each([-1, 0x100000000, 1.5, NaN])('rejects out-of-range gap %s', (dGap) => {
+    expect(() => encryptDGap(dGap, r)).toThrow('unsigned 32-bit');
+  });
+
+  test('rejects bad payload length and non-hex input', () => {
+    expect(() => decryptDGap('00'.repeat(31), r)).toThrow('invalid encrypted d_gap length');
+    expect(() => decryptDGap('zz'.repeat(32), r)).toThrow('not valid hex');
+  });
+});

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -263,6 +263,63 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(restoreCalls()).toBeLessThan(40);
   });
 
+  test('re-probes the terminal window when T lies beyond window 0', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // counters span two probe windows (0..4 and 5..9), so the search converges
+    // on window 1 and must fetch the terminal window again for its d_gap
+    const issued = new Map(
+      [0, 1, 2, 6, 7].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, d_gap: encryptDGap(c, output.blindingFactor) },
+        ];
+      }),
+    );
+    useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(res.proofs).toHaveLength(5);
+    expect(res.lastCounterWithSignature).toBe(7);
+  });
+
+  test('falls back when the terminal window vanishes mid-search', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // counters 5..6 sit in window 1; the mint answers for them exactly once,
+    // so the terminal re-probe comes back empty (inconsistent mint)
+    const window1 = new Map([5, 6].map((c) => [blank(seed, c).blindedMessage.B_, c] as const));
+    const anchor = blank(seed, 0).blindedMessage.B_;
+    let window1Answers = 1;
+    server.use(
+      http.post(mintUrl + '/v1/restore', async ({ request }) => {
+        const body = (await request.json()) as { outputs: Array<{ id: string; B_: string }> };
+        const hits = body.outputs.filter((o) => o.B_ === anchor || window1.has(o.B_));
+        const isWindow1 = hits.some((o) => window1.has(o.B_));
+        if (isWindow1 && window1Answers-- <= 0) {
+          return HttpResponse.json({ outputs: [], signatures: [] });
+        }
+        return HttpResponse.json({
+          outputs: hits,
+          signatures: hits.map((o) => ({ id: o.id, amount: 1, C_: VALID_POINT })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const mockBatch = vi
+      .spyOn(wallet, 'batchRestore')
+      .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
+
+    await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(mockBatch).toHaveBeenCalledTimes(1);
+  });
+
   test('accepts a plaintext integer d_gap', async () => {
     use342Info();
     const seed = randomBytes(64);

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -58,6 +58,13 @@ function useFakeRestoreMint(issued: Map<string, { counter: number; d_gap?: numbe
       }
       return HttpResponse.json({ outputs, signatures });
     }),
+    // default filterSpent state check: everything unspent
+    http.post(mintUrl + '/v1/checkstate', async ({ request }) => {
+      const body = (await request.json()) as { Ys: string[] };
+      return HttpResponse.json({
+        states: body.Ys.map((Y) => ({ Y, state: 'UNSPENT', witness: null })),
+      });
+    }),
   );
   return () => calls;
 }
@@ -263,6 +270,61 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(restoreCalls()).toBeLessThan(40);
   });
 
+  test('drops spent proofs by default', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    const issued = new Map(
+      [0, 1, 2].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, d_gap: encryptDGap(c, output.blindingFactor) },
+        ];
+      }),
+    );
+    useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const mockStates = vi
+      .spyOn(wallet, 'checkProofsStates')
+      .mockResolvedValue([
+        { state: CheckStateEnum.UNSPENT },
+        { state: CheckStateEnum.SPENT },
+        { state: CheckStateEnum.PENDING },
+      ] as ProofState[]);
+
+    const res = await wallet.restoreEfficient({ probeWindow: 5 });
+    // spent dropped, pending kept; the counter still reflects every signature
+    expect(res.proofs).toHaveLength(2);
+    expect(res.lastCounterWithSignature).toBe(2);
+    expect(mockStates).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps spent proofs with filterSpent: false', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    const issued = new Map(
+      [0, 1, 2].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, d_gap: encryptDGap(c, output.blindingFactor) },
+        ];
+      }),
+    );
+    useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const mockStates = vi.spyOn(wallet, 'checkProofsStates');
+
+    const res = await wallet.restoreEfficient({ probeWindow: 5, filterSpent: false });
+    expect(res.proofs).toHaveLength(3);
+    // raw mode adds no state-check traffic
+    expect(mockStates).not.toHaveBeenCalled();
+  });
+
   test('re-probes the terminal window when T lies beyond window 0', async () => {
     use342Info();
     const seed = randomBytes(64);
@@ -346,7 +408,7 @@ describe('restoreEfficient (draft NUT-342)', () => {
     const res = await wallet.restoreEfficient();
 
     expect(res.proofs).toHaveLength(0);
-    expect(mockBatch).toHaveBeenCalledWith({ keysetId: undefined, filterSpent: false });
+    expect(mockBatch).toHaveBeenCalledWith({ keysetId: undefined, filterSpent: true });
   });
 
   test('falls back when the mint has no signatures at all', async () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -2,14 +2,65 @@ import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
-import { Wallet, Amount, CheckStateEnum, type Proof, type ProofState } from '../../src';
+import {
+  Wallet,
+  Amount,
+  CheckStateEnum,
+  OutputData,
+  decryptDGap,
+  encryptDGap,
+  type Proof,
+  type ProofState,
+} from '../../src';
+import { DUMMY_TEST_KEYS } from '../consts';
 
-import { useTestServer, mint, unit, dummyKeysResp, mintUrl, logger } from './_setup';
+import { useTestServer, mint, unit, dummyKeysResp, mintUrl, mintInfoResp, logger } from './_setup';
 
 const server = useTestServer();
 
 const allUnspent = (n: number): ProofState[] =>
   Array(n).fill({ state: CheckStateEnum.UNSPENT }) as ProofState[];
+
+const VALID_POINT = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
+const KEYSET_ID = DUMMY_TEST_KEYS.id;
+
+// NUT-342 (draft) test helpers
+const mintInfo342 = {
+  ...mintInfoResp,
+  nuts: { ...mintInfoResp.nuts, '342': { supported: true } },
+};
+const use342Info = () =>
+  server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfo342)));
+
+// Deterministic blank for a counter; blinding factor depends only on (seed, keyset, counter)
+const blank = (seed: Uint8Array, counter: number) =>
+  OutputData.createDeterministicData(0, seed, counter, DUMMY_TEST_KEYS, [0])[0];
+
+// Fake NUT-09 endpoint: answers per-B_ from the issued map, echoing stored d_gap values
+function useFakeRestoreMint(issued: Map<string, { counter: number; d_gap?: number | string }>) {
+  let calls = 0;
+  server.use(
+    http.post(mintUrl + '/v1/restore', async ({ request }) => {
+      calls++;
+      const body = (await request.json()) as { outputs: Array<{ id: string; B_: string }> };
+      const outputs: unknown[] = [];
+      const signatures: unknown[] = [];
+      for (const output of body.outputs) {
+        const hit = issued.get(output.B_);
+        if (!hit) continue;
+        outputs.push(output);
+        signatures.push({
+          id: output.id,
+          amount: 1,
+          C_: VALID_POINT,
+          ...(hit.d_gap !== undefined && { d_gap: hit.d_gap }),
+        });
+      }
+      return HttpResponse.json({ outputs, signatures });
+    }),
+  );
+  return () => calls;
+}
 
 describe('Restoring deterministic proofs', () => {
   test('Batch restore', async () => {
@@ -183,5 +234,193 @@ describe('restore', () => {
     expect(res.proofs.length).toBeGreaterThan(0);
     // proofs should be of amount 1 because we overprinted 1 in the signatures
     expect(res.proofs.every((p) => p.amount.equals(Amount.from(1)))).toBe(true);
+  });
+});
+
+describe('restoreEfficient (draft NUT-342)', () => {
+  test('recovers the gap window via binary search and encrypted d_gap', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // issued counters 0, 1, 3 — counter 2 is a derivation gap inside the window
+    const issued = new Map(
+      [0, 1, 3].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, d_gap: encryptDGap(c, output.blindingFactor) },
+        ];
+      }),
+    );
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(res.proofs).toHaveLength(3);
+    expect(res.lastCounterWithSignature).toBe(3);
+    // first window + ~29 binary-search probes + final window restore, far below a linear scan
+    expect(restoreCalls()).toBeLessThan(40);
+  });
+
+  test('accepts a plaintext integer d_gap', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    const issued = new Map(
+      [0, 1, 2].map((c) => [blank(seed, c).blindedMessage.B_, { counter: c, d_gap: c }] as const),
+    );
+    useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(res.proofs).toHaveLength(3);
+    expect(res.lastCounterWithSignature).toBe(2);
+  });
+
+  test('falls back to batchRestore when the mint lacks support', async () => {
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
+    await wallet.loadMint();
+    const mockBatch = vi
+      .spyOn(wallet, 'batchRestore')
+      .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
+
+    const res = await wallet.restoreEfficient();
+
+    expect(res.proofs).toHaveLength(0);
+    expect(mockBatch).toHaveBeenCalledWith({ keysetId: undefined, filterSpent: false });
+  });
+
+  test('falls back when the mint has no signatures at all', async () => {
+    use342Info();
+    const restoreCalls = useFakeRestoreMint(new Map());
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
+    await wallet.loadMint();
+    const mockBatch = vi
+      .spyOn(wallet, 'batchRestore')
+      .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
+
+    await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(restoreCalls()).toBe(1); // empty first window short-circuits the search
+    expect(mockBatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back when the terminal signature carries no d_gap', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    const issued = new Map(
+      [0, 1].map((c) => [blank(seed, c).blindedMessage.B_, { counter: c }] as const),
+    );
+    useFakeRestoreMint(issued);
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const mockBatch = vi
+      .spyOn(wallet, 'batchRestore')
+      .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
+
+    await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(mockBatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back when the mint returns an invalid d_gap', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    const output = blank(seed, 0);
+    // gap of 5 for t=0 would rewind past counter 0
+    const issued = new Map([
+      [output.blindedMessage.B_, { counter: 0, d_gap: encryptDGap(5, output.blindingFactor) }],
+    ]);
+    useFakeRestoreMint(issued);
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const mockBatch = vi
+      .spyOn(wallet, 'batchRestore')
+      .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
+
+    await wallet.restoreEfficient({ probeWindow: 5 });
+
+    expect(mockBatch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('recovery gap attachment (draft NUT-342)', () => {
+  const oneSatProof = {
+    id: '00bd033559de27d0',
+    amount: Amount.from(1),
+    secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
+    C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
+  };
+
+  function useSwapCapture() {
+    const captured: { outputs: Array<{ id: string; amount: number; d_gap?: string }> } = {
+      outputs: [],
+    };
+    server.use(
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        const body = (await request.json()) as typeof captured;
+        captured.outputs = body.outputs;
+        return HttpResponse.json({
+          signatures: body.outputs.map((o) => ({ id: o.id, amount: o.amount, C_: VALID_POINT })),
+        });
+      }),
+    );
+    return captured;
+  }
+
+  test('attaches encrypted d_gap to deterministic outputs when the mint advertises support', async () => {
+    use342Info();
+    const captured = useSwapCapture();
+    const seed = randomBytes(64);
+    const provider = vi.fn(async () => undefined);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed, recoveryGapProvider: provider });
+    await wallet.loadMint();
+    await wallet.receive([oneSatProof]);
+
+    expect(provider).toHaveBeenCalledWith(KEYSET_ID);
+    expect(captured.outputs).toHaveLength(1);
+    const dGap = captured.outputs[0].d_gap;
+    expect(typeof dGap).toBe('string');
+    // fresh wallet: counter 0 is the first unspent, so the gap is 0
+    expect(decryptDGap(dGap as string, blank(seed, 0).blindingFactor)).toBe(0);
+  });
+
+  test('computes the gap from the provider counter', async () => {
+    use342Info();
+    const captured = useSwapCapture();
+    const seed = randomBytes(64);
+
+    const wallet = new Wallet(mint, {
+      unit,
+      bip39seed: seed,
+      counterInit: { [KEYSET_ID]: 10 },
+      recoveryGapProvider: async () => 4,
+    });
+    await wallet.loadMint();
+    await wallet.receive([oneSatProof]);
+
+    // output counter 10, first unspent 4 -> gap 6
+    expect(decryptDGap(captured.outputs[0].d_gap as string, blank(seed, 10).blindingFactor)).toBe(
+      6,
+    );
+  });
+
+  test('attaches nothing when the mint lacks support', async () => {
+    const captured = useSwapCapture();
+    const provider = vi.fn(async () => undefined);
+
+    const wallet = new Wallet(mint, {
+      unit,
+      bip39seed: randomBytes(64),
+      recoveryGapProvider: provider,
+    });
+    await wallet.loadMint();
+    await wallet.receive([oneSatProof]);
+
+    expect(provider).not.toHaveBeenCalled();
+    expect(captured.outputs[0].d_gap).toBeUndefined();
   });
 });


### PR DESCRIPTION
## NUT

- https://github.com/cashubtc/nuts/pull/342

## Description

Implements the draft **efficient wallet recovery** scheme proposed in cashubtc/nuts#342, wire-compatible with the Nutshell reference implementation (cashubtc/nutshell#1081). Wallets back up an encrypted "recovery gap" (`d_gap`) on each deterministic output; recovery then binary-searches the counter space for the last issued signature and batch-restores `[T - d_gap, T]`, replacing the linear NUT-09 restore scan with roughly 30 requests and a constant number of revealed nonces.

**Marked experimental**: the spec is a draft and the `342` identifier is placeholder (it will be renamed when a NUT number is assigned).

## Changes

- `src/crypto/NUT342.ts`: `encryptDGap`/`decryptDGap`, AES-128-GCM keyed from `SHA256(r)[0:16]`, wire format `hex(nonce || ciphertext || tag)`. Adds `@noble/ciphers` (zero-dependency) rather than WebCrypto, for React Native compatibility and a sync API.
- **Send side**: new optional `recoveryGapProvider` wallet option. The app returns the lowest deterministic counter among its unspent and pending proofs (cashu-ts has no proof store). Gaps are attached in `createOutputData` (now async), so swap, receive, mint and melt change are all covered by one seam. Gated on the provider being set and the mint advertising `nuts["342"]`.
- **Recovery side**: new `wallet.restoreEfficient({ keysetId?, probeWindow? })`. Uses windowed binary-search probes (default window 25, matching Nutshell) so isolated derivation gaps inside a window do not break the search. Falls back to `batchRestore` when the mint lacks support, no gap was backed up, or the search fails. `restore()` is refactored onto a shared private helper; its behaviour is unchanged.
- Wire types gain optional `d_gap` on `SerializedBlindedMessage`/`SerializedBlindedSignature`; `MintInfo.isSupported(342)` and the NUT-06 typing are extended. Plaintext integer gaps from other wallets are accepted.

## Reviewer Notes

- **Provider contract**: `recoveryGapProvider` must include *pending* proofs, or gaps written during a swap can undercount and the recovery window may miss kept outputs. Documented on the type.
- Legacy `00` keysets derive hardened BIP-32 children, so their counter space caps at `2^31 - 1`; the search bound is keyset-dependent. The spec assumes `2^32` universally, which may be worth a spec note.
- No integration test yet: no released mint supports the draft (Nutshell PR is unmerged). Unit tests cover the crypto round-trip, binary search with an in-window derivation gap, plaintext gaps, all fallback paths and gap attachment; a cross-implementation test vector should follow once a mint ships support. A live end-to-end demo against a mint built from the Nutshell PR branch is included: see `examples/nut342_recovery` (`make up` / `make demo` / `make down`).
- Backwards compatible: `d_gap` is omitted from requests unless the feature is enabled, and all existing restore APIs are unchanged.



