### PR TITLE
perf(wallet): run state-check batches through a bounded request pool

### DIFF
--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -2,6 +2,8 @@ export { default } from './request';
 export { setGlobalRequestOptions, setRequestLogger } from './request';
 export type { RequestFn, RequestFetch, RequestArgs, RequestOptions, ResponseMeta } from './request';
 
+export { BATCH_POOL_SIZE, runPool } from './pool';
+
 export { injectWebSocketImpl } from './ws';
 
 export { WSConnection } from './WSConnection';

--- a/src/transport/pool.ts
+++ b/src/transport/pool.ts
@@ -11,6 +11,10 @@ export const BATCH_POOL_SIZE = 4;
 /**
  * Runs `fn` over `items` with at most `limit` in flight; results keep item order.
  *
+ * @remarks
+ * Not chunked: `limit` workers pull from a shared cursor, so a slow item never stalls the rest.
+ * Lock-free because `next++` claims are synchronous; workers only interleave at the await. Rejects
+ * on the first `fn` rejection (Promise.all); later rejections are absorbed.
  * @internal
  */
 export async function runPool<T, R>(
@@ -19,9 +23,14 @@ export async function runPool<T, R>(
   fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
   const results = new Array<R>(items.length);
+  // Shared cursor: index of the next unclaimed item.
   let next = 0;
+  // Spawn up to `limit` workers, each an immediately-invoked async loop.
   const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    // `next++` reads-then-bumps in one synchronous step, so every index is claimed exactly
+    // once; the worker claims whatever is next by the time its await settles.
     for (let i = next++; i < items.length; i = next++) {
+      // Write by slot, so output order matches input order however workers finish.
       results[i] = await fn(items[i], i);
     }
   });

--- a/src/transport/pool.ts
+++ b/src/transport/pool.ts
@@ -1,0 +1,30 @@
+/**
+ * Concurrent mint requests for enumerable batch work (e.g. NUT-07 state-check batches).
+ *
+ * @remarks
+ * Modest pool: browsers allow ~6 connections per host and mint rate limits are per-minute windows,
+ * so 4 in flight cuts wall-clock without changing the request count.
+ * @internal
+ */
+export const BATCH_POOL_SIZE = 4;
+
+/**
+ * Runs `fn` over `items` with at most `limit` in flight; results keep item order.
+ *
+ * @internal
+ */
+export async function runPool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let i = next++; i < items.length; i = next++) {
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3128,12 +3128,14 @@ class Wallet {
       const { states: batchStates } = await this.mint.check({
         Ys: YsSlice,
       });
-      const stateMap: { [y: string]: ProofState } = {};
+      // don't trust the mint's ordering: map results onto the request slice so order is
+      // guaranteed and any omitted Y fails loudly instead of misaligning states
+      const proofStatesByY: { [y: string]: ProofState } = {};
       batchStates.forEach((s) => {
-        stateMap[s.Y] = s;
+        proofStatesByY[s.Y] = s;
       });
       return YsSlice.map((y) => {
-        const state = stateMap[y];
+        const state = proofStatesByY[y];
         this.failIfNullish(state, 'Could not find state for proof with Y: ' + y);
         return state;
       });

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -54,6 +54,7 @@ import { CheckStateEnum, type ProofState } from '../model/types/NUT07';
 import { type BatchMintRequest } from '../model/types/NUT29';
 import type { Proof, ProofLike } from '../model/types/proof';
 import type { Token } from '../model/types/token';
+import { BATCH_POOL_SIZE, runPool } from '../transport';
 import type { RequestFetch, RequestFn } from '../transport';
 import {
   getDecodedToken,
@@ -3114,11 +3115,16 @@ class Wallet {
         ? hashToCurveBls(enc.encode(p.secret)).toHex(true)
         : hashToCurve(enc.encode(p.secret)).toHex(true),
     );
+    // Nutshell (mint_max_request_length) and CDK (max_inputs) both cap requests at 1000 items
+    // by default; half that leaves headroom for stricter operator configs.
     // TODO: Replace this with a value from the info endpoint of the mint eventually
-    const BATCH_SIZE = 100;
-    const states: ProofState[] = [];
+    const BATCH_SIZE = 500;
+    const slices: string[][] = [];
     for (let i = 0; i < Ys.length; i += BATCH_SIZE) {
-      const YsSlice = Ys.slice(i, i + BATCH_SIZE);
+      slices.push(Ys.slice(i, i + BATCH_SIZE));
+    }
+    // Slices are independent, so run them through the bounded pool; results keep slice order.
+    const batches = await runPool(slices, BATCH_POOL_SIZE, async (YsSlice) => {
       const { states: batchStates } = await this.mint.check({
         Ys: YsSlice,
       });
@@ -3126,13 +3132,13 @@ class Wallet {
       batchStates.forEach((s) => {
         stateMap[s.Y] = s;
       });
-      for (let j = 0; j < YsSlice.length; j++) {
-        const state = stateMap[YsSlice[j]];
-        this.failIfNullish(state, 'Could not find state for proof with Y: ' + YsSlice[j]);
-        states.push(state);
-      }
-    }
-    return states;
+      return YsSlice.map((y) => {
+        const state = stateMap[y];
+        this.failIfNullish(state, 'Could not find state for proof with Y: ' + y);
+        return state;
+      });
+    });
+    return batches.flat();
   }
 
   /**

--- a/test/wallet/wallet-state.node.test.ts
+++ b/test/wallet/wallet-state.node.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
 
-import { Wallet, CheckStateEnum, Amount } from '../../src';
+import { Wallet, CheckStateEnum, Amount, hashToCurve } from '../../src';
 
 import { mint, unit, mintUrl, useTestServer } from './_setup';
 
@@ -59,6 +59,38 @@ describe('checkProofsStates', () => {
 
     const result = await wallet.checkProofsStates(proofs);
     expect(result[0].witness).toBeNull();
+  });
+});
+
+describe('checkProofsStates batching', () => {
+  test('pools large proof sets into 500-Y batches, preserving order', async () => {
+    const requestSizes: number[] = [];
+    server.use(
+      http.post(mintUrl + '/v1/checkstate', async ({ request }) => {
+        const body = (await request.json()) as { Ys: string[] };
+        requestSizes.push(body.Ys.length);
+        return HttpResponse.json({
+          states: body.Ys.map((Y) => ({ Y, state: CheckStateEnum.UNSPENT, witness: null })),
+        });
+      }),
+    );
+    const many = Array.from({ length: 1250 }, (_, i) => ({
+      id: '00bd033559de27d0',
+      secret: `probe-secret-${i}`,
+    }));
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const states = await wallet.checkProofsStates(many);
+
+    // three batches (concurrent, so arrival order may vary)
+    expect(requestSizes.sort((a, b) => b - a)).toEqual([500, 500, 250]);
+    expect(states).toHaveLength(1250);
+    // states come back in input order regardless of batch completion order
+    const enc = new TextEncoder();
+    many.forEach((p, i) => {
+      expect(states[i].Y).toBe(hashToCurve(enc.encode(p.secret)).toHex(true));
+    });
   });
 });
 


### PR DESCRIPTION
## Summary 

`checkProofsStates` already slices proof sets into batches, but requests them strictly sequentially, so large sets pay one full round trip per batch. Batches are independent reads, so this PR runs them through a small bounded request pool and raises the batch size to match what mints actually accept. 

A 5,000-proof state check drops from 50 sequential requests to 10 requests in ~3 round trips of wall-clock.


## Changes

- New internal `runPool` helper in `src/transport/pool.ts` (marked `@internal`, exported via the transport barrel only, not the public API): runs work items with at most N in flight, results keep item order.
- `checkProofsStates` runs its batches through the pool (4 in flight) instead of a sequential loop. Ordering contract is unchanged: states return in input order.
- Batch size raised from 100 to 500. Nutshell (`mint_max_request_length`) and CDK (`max_inputs`) both cap requests at 1000 items by default; half that leaves headroom for stricter operator configs, since there is no adaptive retry if a mint rejects an oversized batch. The existing TODO to take this from the mint info endpoint stands.
- Test: 1,250 proofs check as three pooled batches (500/500/250) with input order preserved.

## Reviewer Notes

- Rate-limit safety was checked against both reference mints. Nutshell exempts `/v1/checkstate` from its 20/min transaction limiter; only the global 60/min per-IP limit applies, and it is a fixed window (counts requests, blind to concurrency). CDK ships no rate limiting. Fewer, larger batches actually spend the shared budget more slowly.
- Pool size 4 sits under the ~6 connections-per-host limit browsers enforce, and is plain event-loop concurrency (no workers), so it behaves identically in Node, browsers and React Native.
- No public API change: `etc/cashu-ts.api.md` is untouched.
