### PR TITLE
ci: schedule weekly agenda earlier to absorb cron delays

### DIFF
--- a/.github/workflows/weekly-meeting-agenda.yml
+++ b/.github/workflows/weekly-meeting-agenda.yml
@@ -6,7 +6,7 @@ name: Weekly meeting agenda
 # Standing Reports automatically.
 on:
   schedule:
-    - cron: '23 8 * * 3' # Wednesdays 08:23 UTC (off-peak minute, more reliable), before the 11:00 meeting
+    - cron: '23 5 * * 3' # Wednesdays 05:23 UTC; GitHub delays crons here by 2.5-4h, still lands before the 11:00 meeting
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
GitHub has been running this repo's scheduled workflows 2.5-4 hours late. Renovate's 02:23 cron has fired between 04:53 and 06:17 over the last ten days, and the drift and mutation crons show the same lag. The agenda's 08:23 slot therefore produces an issue after the 11:00 meeting has started (or, as on 8 July, nothing at all: the pending run was dropped when #762 rewrote the schedule mid-window).

Move the cron to 05:23 UTC so the worst observed delay still opens the issue by about 09:30.

Note for the merger: GitHub re-registers the schedule when this file changes on main, which drops any pending run. Merge on any day except Wednesday morning.