### PR TITLE
chore: use tab indentation for Makefiles in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 2
 [etc/*.api.md]
 indent_style = space
 indent_size = 4
+
+# Makefiles require tabs
+[{Makefile,makefile,*.mk}]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# Override for YAML (compose files hate tabs)
+# Override for YAML
 [*.{yml,yaml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Make requires tab-indented recipes. Add a Makefile section to .editorconfig so editors stop converting the tabs to spaces.