### PR TITLE
feat(wallet): batched probe search for NUT-342 recovery

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1881,6 +1881,8 @@ export type RestoreConfig = {
 export type RestoreEfficientConfig = {
     keysetId?: string;
     probeWindow?: number;
+    batchSize?: number;
+    probeBudget?: number;
     filterSpent?: boolean;
 };
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1883,6 +1883,7 @@ export type RestoreEfficientConfig = {
     probeWindow?: number;
     batchSize?: number;
     probeBudget?: number;
+    ladderSkip?: number;
     filterSpent?: boolean;
 };
 

--- a/examples/nut342_recovery/Makefile
+++ b/examples/nut342_recovery/Makefile
@@ -9,7 +9,7 @@
 DOCKER ?= docker
 BIND_ADDR ?= 127.0.0.1
 PORT ?= 3338
-RATE_LIMIT_PM ?= 200
+RATE_LIMIT_PM ?= 5000
 
 NUT_342_CTX ?= https://github.com/cashubtc/nutshell.git\#feat/efficient-recovery
 NUT_342_IMAGE ?= cashu-dev-nutshell-342:local

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -154,15 +154,10 @@ async function refreshOldest(wallet: Wallet, minNet = 10) {
     if (k >= byAge.length) return; // all old value is dust; nothing sensible to refresh
   }
   const rest = proofs.filter((p) => !oldest.includes(p));
-  // net of the input fee, so the swap consumes every old proof
-  const fee = wallet.getFeesForProofs(oldest);
-  const { keep, send } = await wallet.send(sumProofs(oldest).subtract(fee), oldest, {
-    onCountersReserved,
-  });
-  proofs = [...rest, ...keep];
-  track([...keep, ...send]);
-  const received = await wallet.receive(send, { onCountersReserved });
-  proofs.push(...received);
+  // One swap: receiving our own proofs re-issues them as fresh deterministic outputs,
+  // netting the input fee itself.
+  const received = await wallet.receive(oldest, { onCountersReserved });
+  proofs = [...rest, ...received];
   track(received);
   console.log(
     `Refreshed ${oldest.length} oldest proofs (first unspent counter now ${await firstUnspentCounter()})`,

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -129,7 +129,7 @@ async function selfSwap(wallet: Wallet, amount: number) {
   });
   proofs = keep;
   track([...keep, ...send]);
-  const received = await wallet.receive(send, { onCountersReserved, proofsWeHave: keep });
+  const received = await wallet.receive(send, { onCountersReserved });
   proofs.push(...received);
   track(received);
   console.log(`Swapped ${amount} sats through the mint (balance ${sumProofs(proofs)})`);
@@ -218,10 +218,17 @@ async function main() {
   }
   console.log(`Mint advertises NUT-342 support (${wallet.keysetId})\n`);
 
-  // A thorough workout: every operation writes fresh encrypted gaps.
-  // Random-value swap churn approximates real wallet wear; override rounds
-  // with CHURN_ROUNDS=n for a longer history.
+  // A thorough workout: every operation writes fresh encrypted gaps. Knobs, so the
+  // d_gap regimes in the PR table are one-liners:
+  //   CHURN_ROUNDS=n     swap rounds per churn block (default 4)
+  //   REFRESH_EVERY=n    oldest-refresh cadence; 0 disables it (default 20)
+  //   SPEND_FRAC=f       max spend as a fraction of balance; small values model a
+  //                      lump-funded wallet making everyday payments (default 0.9)
+  //   PIN_MID=1          send the unclaimed token mid-history, pinning d_gap at ~T/2
   const churnRounds = Number(process.env.CHURN_ROUNDS ?? 4);
+  const refreshEvery = Number(process.env.REFRESH_EVERY ?? 20);
+  const spendFrac = Number(process.env.SPEND_FRAC ?? 0.9);
+  const pinMid = process.env.PIN_MID === '1';
   const churn = async (rounds: number) => {
     for (let i = 0; i < rounds; i++) {
       const balance = Number(sumProofs(proofs).toBigInt());
@@ -229,15 +236,16 @@ async function main() {
         console.log(`Balance ${balance} too low to keep churning; stopping early`);
         return;
       }
-      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance * 0.9)));
-      // every 20 rounds, roll the oldest proofs forward (see refreshOldest)
-      if (i % 20 === 19) await refreshOldest(wallet);
+      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance * spendFrac)));
+      // periodically roll the oldest proofs forward (see refreshOldest)
+      if (refreshEvery > 0 && i % refreshEvery === refreshEvery - 1) await refreshOldest(wallet);
     }
   };
 
   await mintSats(wallet, 10000);
   await churn(churnRounds);
   await mintSats(wallet, 15000);
+  if (pinMid) await sendUnclaimed(wallet, 21);
   try {
     await meltSats(wallet, externalInvoice);
   } catch {
@@ -249,10 +257,10 @@ async function main() {
     await meltSats(wallet, target.request);
   }
   await churn(churnRounds);
-  // Sent late in history: a pending token pins first-unspent at its own counter (the
-  // provider must include it), so an unclaimed token sent mid-history would cap d_gap
-  // at ~half of T no matter how well the wallet consolidates.
-  await sendUnclaimed(wallet, 21);
+  // Sent late in history by default: a pending token pins first-unspent at its own
+  // counter (the provider must include it), so an unclaimed token sent mid-history
+  // (PIN_MID=1) caps d_gap at ~T/2 no matter how well the wallet consolidates.
+  if (!pinMid) await sendUnclaimed(wallet, 21);
 
   const balance = sumProofs(proofs);
   const pending = sumProofs(sentPending);

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -129,10 +129,44 @@ async function selfSwap(wallet: Wallet, amount: number) {
   });
   proofs = keep;
   track([...keep, ...send]);
-  const received = await wallet.receive(send, { onCountersReserved });
+  const received = await wallet.receive(send, { onCountersReserved, proofsWeHave: keep });
   proofs.push(...received);
   track(received);
   console.log(`Swapped ${amount} sats through the mint (balance ${sumProofs(proofs)})`);
+}
+
+// Wallet policy: refresh the oldest live proofs through the mint. d_gap is pinned by the
+// single oldest unspent proof, so rolling old proofs forward keeps the recovery window
+// small no matter how the regular churn selects its inputs.
+async function refreshOldest(wallet: Wallet, minNet = 10) {
+  const liveSecrets = new Set(proofs.map((p) => p.secret));
+  const byAge = batches
+    .filter((b) => [...b.secrets].some((s) => liveSecrets.has(s)))
+    .sort((a, b) => a.start - b.start);
+  if (byAge.length === 0) return;
+  // Grow the sweep until it clears fees with room to spare: dust batches alone would
+  // produce a zero-output receive (and skipping them would pin d_gap forever).
+  let oldest: Proof[] = [];
+  for (let k = 4; ; k += 4) {
+    const slice = byAge.slice(0, k);
+    oldest = proofs.filter((p) => slice.some((b) => b.secrets.has(p.secret)));
+    if (sumProofs(oldest).compareTo(wallet.getFeesForProofs(oldest).add(minNet)) >= 0) break;
+    if (k >= byAge.length) return; // all old value is dust; nothing sensible to refresh
+  }
+  const rest = proofs.filter((p) => !oldest.includes(p));
+  // net of the input fee, so the swap consumes every old proof
+  const fee = wallet.getFeesForProofs(oldest);
+  const { keep, send } = await wallet.send(sumProofs(oldest).subtract(fee), oldest, {
+    onCountersReserved,
+  });
+  proofs = [...rest, ...keep];
+  track([...keep, ...send]);
+  const received = await wallet.receive(send, { onCountersReserved });
+  proofs.push(...received);
+  track(received);
+  console.log(
+    `Refreshed ${oldest.length} oldest proofs (first unspent counter now ${await firstUnspentCounter()})`,
+  );
 }
 
 async function sendUnclaimed(wallet: Wallet, amount: number) {
@@ -195,14 +229,15 @@ async function main() {
         console.log(`Balance ${balance} too low to keep churning; stopping early`);
         return;
       }
-      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance / 3)));
+      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance * 0.9)));
+      // every 20 rounds, roll the oldest proofs forward (see refreshOldest)
+      if (i % 20 === 19) await refreshOldest(wallet);
     }
   };
 
   await mintSats(wallet, 10000);
   await churn(churnRounds);
   await mintSats(wallet, 15000);
-  await sendUnclaimed(wallet, 21);
   try {
     await meltSats(wallet, externalInvoice);
   } catch {
@@ -214,6 +249,10 @@ async function main() {
     await meltSats(wallet, target.request);
   }
   await churn(churnRounds);
+  // Sent late in history: a pending token pins first-unspent at its own counter (the
+  // provider must include it), so an unclaimed token sent mid-history would cap d_gap
+  // at ~half of T no matter how well the wallet consolidates.
+  await sendUnclaimed(wallet, 21);
 
   const balance = sumProofs(proofs);
   const pending = sumProofs(sentPending);

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -8,11 +8,13 @@
  *     make demo
  *     make down
  *
- * Flow: a wallet with a `recoveryGapProvider` gets a thorough workout — two mints, several swap
- * rounds, a Lightning melt with NUT-08 change, and one sent token that is never claimed. Every
+ * Flow: a wallet with a `recoveryGapProvider` gets a thorough workout — two mints, random-value
+ * swap churn, a Lightning melt with NUT-08 change, and one sent token that is never claimed. Every
  * operation backs up an encrypted recovery gap on the mint. Then a second wallet with the same seed
- * recovers everything via `restoreEfficient()`, including the unclaimed token. A plain
- * `batchRestore()` (the linear NUT-09 restore scan) runs last for comparison.
+ * recovers everything via `restoreEfficient()` (batched exponential-ladder search plus chunked
+ * window restore, typically ~4 requests). A plain `batchRestore()` (the linear NUT-09 restore scan)
+ * runs last for comparison, including the count of issued signatures each method lets the mint
+ * link.
  */
 import { randomBytes } from '@noble/hashes/utils.js';
 
@@ -50,27 +52,51 @@ async function firstUnspentCounter(): Promise<number | undefined> {
 }
 
 // ---------------------------------------------------------------------------
-// A fetch wrapper that records NUT-09 restore traffic (requests + nonces).
+// A fetch wrapper that records NUT-09 restore traffic. "Sent" counts unique
+// blinded messages revealed to the mint; "linked" counts the issued signatures
+// the mint could associate with this recovery session — the privacy metric.
 // ---------------------------------------------------------------------------
 function countingFetch() {
-  const stats = { requests: 0, nonces: 0, sizes: [] as number[] };
+  const stats = {
+    requests: 0,
+    total: 0,
+    sizes: [] as number[],
+    sent: new Set<string>(),
+    linked: new Set<string>(),
+  };
   const wrapped: typeof fetch = async (input, init) => {
     const url = input instanceof Request ? input.url : String(input);
-    if (url.endsWith('/v1/restore') && typeof init?.body === 'string') {
-      const body = JSON.parse(init.body) as { outputs: unknown[] };
+    const isRestore = url.endsWith('/v1/restore') && typeof init?.body === 'string';
+    if (isRestore) {
+      const body = JSON.parse(init!.body as string) as { outputs: Array<{ B_: string }> };
       stats.requests++;
-      stats.nonces += body.outputs.length;
+      stats.total += body.outputs.length;
       stats.sizes.push(body.outputs.length);
+      body.outputs.forEach((o) => stats.sent.add(o.B_));
     }
     // One retry on a dropped keep-alive socket: the dev mint closes idle connections
     // during the demo's long derivation pauses, and this traffic is read-only.
+    let res: Response;
     try {
-      return await fetch(input, init);
+      res = await fetch(input, init);
     } catch {
-      return fetch(input, init);
+      res = await fetch(input, init);
     }
+    if (isRestore && res.ok) {
+      const data = (await res.clone().json()) as { outputs?: Array<{ B_: string }> };
+      (data.outputs ?? []).forEach((o) => stats.linked.add(o.B_));
+    }
+    return res;
   };
   return { wrapped, stats };
+}
+
+function reportStats(label: string, stats: ReturnType<typeof countingFetch>['stats']) {
+  console.log(
+    `  ${label}: ${stats.requests} requests (sizes: ${stats.sizes.join(', ')}),\n` +
+      `  ${stats.total} messages sent (${stats.sent.size} unique), ` +
+      `${stats.linked.size} issued signatures linked`,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -88,7 +114,11 @@ async function mintSats(wallet: Wallet, amount: number) {
 }
 
 async function selfSwap(wallet: Wallet, amount: number) {
-  const { keep, send } = await wallet.send(amount, proofs, { onCountersReserved });
+  // includeFees: sender covers the receive fee, so tiny amounts stay receivable
+  const { keep, send } = await wallet.send(amount, proofs, {
+    onCountersReserved,
+    includeFees: true,
+  });
   proofs = keep;
   track([...keep, ...send]);
   const received = await wallet.receive(send, { onCountersReserved });
@@ -108,6 +138,10 @@ async function sendUnclaimed(wallet: Wallet, amount: number) {
 async function meltSats(wallet: Wallet, invoice: string) {
   const meltQuote = await wallet.createMeltQuoteBolt11(invoice);
   const amountToMelt = meltQuote.amount.add(meltQuote.fee_reserve);
+  if (sumProofs(proofs).compareTo(amountToMelt.add(30)) < 0) {
+    console.log(`Balance too low to melt ${meltQuote.amount} sats; skipping the melt leg`);
+    return;
+  }
   const { keep, send } = await wallet.send(amountToMelt, proofs, {
     onCountersReserved,
     includeFees: true,
@@ -142,10 +176,23 @@ async function main() {
   }
   console.log(`Mint advertises NUT-342 support (${wallet.keysetId})\n`);
 
-  // A thorough workout: every operation writes fresh encrypted gaps
+  // A thorough workout: every operation writes fresh encrypted gaps.
+  // Random-value swap churn approximates real wallet wear; override rounds
+  // with CHURN_ROUNDS=n for a longer history.
+  const churnRounds = Number(process.env.CHURN_ROUNDS ?? 4);
+  const churn = async (rounds: number) => {
+    for (let i = 0; i < rounds; i++) {
+      const balance = Number(sumProofs(proofs).toBigInt());
+      if (balance < 20) {
+        console.log(`Balance ${balance} too low to keep churning; stopping early`);
+        return;
+      }
+      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance / 4)));
+    }
+  };
+
   await mintSats(wallet, 1000);
-  await selfSwap(wallet, 400);
-  await selfSwap(wallet, 150);
+  await churn(churnRounds);
   await mintSats(wallet, 1500);
   await sendUnclaimed(wallet, 21);
   try {
@@ -158,8 +205,7 @@ async function main() {
     const target = await wallet.createMintQuoteBolt11(2000);
     await meltSats(wallet, target.request);
   }
-  await selfSwap(wallet, 100);
-  await selfSwap(wallet, 42);
+  await churn(churnRounds);
 
   const balance = sumProofs(proofs);
   const pending = sumProofs(sentPending);
@@ -187,17 +233,11 @@ async function main() {
       `(${unspent.length} unspent of ${restored.proofs.length} issued, ` +
       `T=${restored.lastCounterWithSignature})`,
   );
-  console.log(
-    `  ${efficient.stats.requests} restore requests, ${efficient.stats.nonces} nonces revealed ` +
-      `(final window: ${efficient.stats.sizes.at(-1)} nonces)`,
-  );
-  if (efficient.stats.sizes.slice(0, -1).every((s) => s <= 25)) {
-    console.log('  all search requests were <=25-nonce probes: the NUT-342 path ran, no fallback');
-  }
+  reportStats('NUT-342 ladder', efficient.stats);
 
   // For comparison: the linear NUT-09 restore scan. Its cost grows with wallet age
   // (total counters used) and it silently misses proofs beyond the gap limit;
-  // the NUT-342 search stays at ~30 requests regardless of age.
+  // the NUT-342 batched search stays at ~4 requests regardless of age.
   const linear = countingFetch();
   const legacy = new Wallet(mintUrl, { bip39seed: seed, requestFetch: linear.wrapped });
   await legacy.loadMint();
@@ -207,7 +247,7 @@ async function main() {
       (await legacy.groupProofsByState(scanned.proofs)).unspent,
     )} sats`,
   );
-  console.log(`  ${linear.stats.requests} restore requests, ${linear.stats.nonces} nonces sent`);
+  reportStats('NUT-09 scan   ', linear.stats);
 
   if (!sumProofs(unspent).equals(expected)) {
     throw new Error(`Recovery mismatch: expected ${expected}, got ${sumProofs(unspent)}`);

--- a/examples/nut342_recovery/nut342_recovery_demo.ts
+++ b/examples/nut342_recovery/nut342_recovery_demo.ts
@@ -18,7 +18,14 @@
  */
 import { randomBytes } from '@noble/hashes/utils.js';
 
-import { MeltQuoteState, MintQuoteState, Wallet, sumProofs, type Proof } from '../../src';
+import {
+  ConsoleLogger,
+  MeltQuoteState,
+  MintQuoteState,
+  Wallet,
+  sumProofs,
+  type Proof,
+} from '../../src';
 
 const mintUrl = 'http://localhost:3338';
 const seed = randomBytes(64);
@@ -91,9 +98,10 @@ function countingFetch() {
   return { wrapped, stats };
 }
 
-function reportStats(label: string, stats: ReturnType<typeof countingFetch>['stats']) {
+function reportStats(label: string, stats: ReturnType<typeof countingFetch>['stats'], ms: number) {
   console.log(
-    `  ${label}: ${stats.requests} requests (sizes: ${stats.sizes.join(', ')}),\n` +
+    `  ${label}: ${stats.requests} requests in ${(ms / 1000).toFixed(1)}s ` +
+      `(sizes: ${stats.sizes.join(', ')}),\n` +
       `  ${stats.total} messages sent (${stats.sent.size} unique), ` +
       `${stats.linked.size} issued signatures linked`,
   );
@@ -187,13 +195,13 @@ async function main() {
         console.log(`Balance ${balance} too low to keep churning; stopping early`);
         return;
       }
-      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance / 4)));
+      await selfSwap(wallet, 1 + Math.floor(Math.random() * Math.max(1, balance / 3)));
     }
   };
 
-  await mintSats(wallet, 1000);
+  await mintSats(wallet, 10000);
   await churn(churnRounds);
-  await mintSats(wallet, 1500);
+  await mintSats(wallet, 15000);
   await sendUnclaimed(wallet, 21);
   try {
     await meltSats(wallet, externalInvoice);
@@ -222,18 +230,28 @@ async function main() {
   console.log('\n--- Device lost! Recovering from seed on a fresh wallet ---\n');
 
   const efficient = countingFetch();
-  const recovery = new Wallet(mintUrl, { bip39seed: seed, requestFetch: efficient.wrapped });
+  // Debug logger: recovery degrades silently (chunk retries, scan fallback) without one.
+  const recovery = new Wallet(mintUrl, {
+    bip39seed: seed,
+    requestFetch: efficient.wrapped,
+    logger: new ConsoleLogger('debug'),
+  });
   await recovery.loadMint();
 
   // filterSpent off: the demo compares raw restore traffic and state-checks explicitly below
+  const efficientStart = performance.now();
   const restored = await recovery.restoreEfficient({ filterSpent: false });
+  const efficientMs = performance.now() - efficientStart;
   const { unspent } = await recovery.groupProofsByState(restored.proofs);
   console.log(
     `restoreEfficient: recovered ${sumProofs(unspent)} sats ` +
       `(${unspent.length} unspent of ${restored.proofs.length} issued, ` +
       `T=${restored.lastCounterWithSignature})`,
   );
-  reportStats('NUT-342 ladder', efficient.stats);
+  reportStats('NUT-342 ladder', efficient.stats, efficientMs);
+  console.log(
+    '  (sizes are the search: ladder, grid rounds, tile; then the d_gap window in chunks)',
+  );
 
   // For comparison: the linear NUT-09 restore scan. Its cost grows with wallet age
   // (total counters used) and it silently misses proofs beyond the gap limit;
@@ -241,13 +259,16 @@ async function main() {
   const linear = countingFetch();
   const legacy = new Wallet(mintUrl, { bip39seed: seed, requestFetch: linear.wrapped });
   await legacy.loadMint();
-  const scanned = await legacy.batchRestore();
+  const scanStart = performance.now();
+  // filterSpent off: restoreEfficient returns unfiltered, so the comparison stays like for like
+  const scanned = await legacy.batchRestore({ filterSpent: false });
+  const scanMs = performance.now() - scanStart;
   console.log(
     `\nbatchRestore:     recovered ${sumProofs(
       (await legacy.groupProofsByState(scanned.proofs)).unspent,
     )} sats`,
   );
-  reportStats('NUT-09 scan   ', linear.stats);
+  reportStats('NUT-09 scan   ', linear.stats, scanMs);
 
   if (!sumProofs(unspent).equals(expected)) {
     throw new Error(`Recovery mismatch: expected ${expected}, got ${sumProofs(unspent)}`);

--- a/scripts/bench-nut342-recovery.ts
+++ b/scripts/bench-nut342-recovery.ts
@@ -19,6 +19,7 @@ import { DUMMY_TEST_KEYS } from '../test/consts';
 const RTT_MS = Number(process.env.RTT_MS ?? 50);
 const T_VALUES = (process.env.T_LIST ?? '100,1000,10000,100000').split(',').map(Number);
 const GRIDS = process.env.GRIDS?.split(',').map(Number);
+const SKIPS = process.env.SKIPS?.split(',').map(Number) ?? [undefined];
 const MAX_T = Math.max(...T_VALUES);
 const D_GAP = 100;
 const SKIP_EVERY = 137; // counter c is never issued when c % 137 === 136
@@ -125,7 +126,12 @@ function mockMint(t: number) {
   return { wrapped, stats };
 }
 
-async function run(method: 'efficient' | 'legacy', tRequested: number, probeBudget?: number) {
+async function run(
+  method: 'efficient' | 'legacy',
+  tRequested: number,
+  probeBudget?: number,
+  ladderSkip?: number,
+) {
   let t = tRequested;
   while (skipped(t)) t--; // T itself must be issued
   const { wrapped, stats } = mockMint(t);
@@ -137,12 +143,16 @@ async function run(method: 'efficient' | 'legacy', tRequested: number, probeBudg
       ? await wallet.restoreEfficient({
           probeWindow: 25,
           ...(probeBudget && { probeBudget }),
+          ...(ladderSkip && { ladderSkip }),
         })
       : await wallet.batchRestore();
   await wallet.groupProofsByState(res.proofs);
   const wallMs = Date.now() - started;
   return {
-    method: method === 'efficient' ? (probeBudget ? `${LABEL}-g${probeBudget}` : LABEL) : 'legacy',
+    method:
+      method === 'efficient'
+        ? `${LABEL}${probeBudget ? `-g${probeBudget}` : ''}${ladderSkip ? `-s${ladderSkip}` : ''}`
+        : 'legacy',
     T: t,
     calls: stats.restoreCalls + stats.checkCalls,
     restoreCalls: stats.restoreCalls,
@@ -159,8 +169,10 @@ async function run(method: 'efficient' | 'legacy', tRequested: number, probeBudg
 const rows: Array<Record<string, unknown>> = [];
 for (const t of T_VALUES) {
   for (const grid of GRIDS ?? [undefined]) {
-    rows.push(await run('efficient', t, grid));
-    console.error(`efficient T=${t} grid=${grid ?? 'default'} done`);
+    for (const skip of SKIPS) {
+      rows.push(await run('efficient', t, grid, skip));
+      console.error(`efficient T=${t} grid=${grid ?? 'default'} skip=${skip ?? 0} done`);
+    }
   }
   if (!process.env.SKIP_LEGACY) {
     rows.push(await run('legacy', t));

--- a/scripts/bench-nut342-recovery.ts
+++ b/scripts/bench-nut342-recovery.ts
@@ -1,0 +1,170 @@
+/**
+ * NUT-342 recovery strategy benchmark.
+ *
+ * Mirrors the Nutshell reference benchmark setup: probe batch 25, d_gap=100, one skipped counter
+ * every 137 derivations, T in {100, 1k, 10k, 100k}. Runs the current branch's restoreEfficient
+ * (plus optionally the linear NUT-09 batchRestore scan) against an in-process mock mint with a
+ * simulated RTT per POST.
+ *
+ *     npx tsx scripts/bench-nut342-recovery.ts
+ *
+ * Env knobs: BRANCH_LABEL (row label), SKIP_LEGACY=1, T_LIST=100,1000,..., GRIDS=30,12,8
+ * (probeBudget sweep, ladder branch only), RTT_MS=50.
+ */
+import { randomBytes } from '@noble/hashes/utils.js';
+
+import { OutputData, Wallet, deriveKeysetId } from '../src';
+import { DUMMY_TEST_KEYS } from '../test/consts';
+
+const RTT_MS = Number(process.env.RTT_MS ?? 50);
+const T_VALUES = (process.env.T_LIST ?? '100,1000,10000,100000').split(',').map(Number);
+const GRIDS = process.env.GRIDS?.split(',').map(Number);
+const MAX_T = Math.max(...T_VALUES);
+const D_GAP = 100;
+const SKIP_EVERY = 137; // counter c is never issued when c % 137 === 136
+const VALID_POINT = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
+// Real derived v1 id (verification-proof) -> fast HMAC derivation
+const KEYSET_ID = deriveKeysetId(DUMMY_TEST_KEYS.keys, {
+  unit: 'sat',
+  versionByte: 1,
+  input_fee_ppk: 0,
+});
+const KEYSET = { id: KEYSET_ID, unit: 'sat', input_fee_ppk: 0, keys: DUMMY_TEST_KEYS.keys };
+const MINT_URL = 'http://bench.local:3338';
+const LABEL = process.env.BRANCH_LABEL ?? 'efficient';
+
+const skipped = (c: number) => c % SKIP_EVERY === SKIP_EVERY - 1;
+
+// Derive B_ for every counter once (shared across runs)
+console.error(`deriving ${MAX_T + 1} blanks...`);
+const seed = randomBytes(64);
+const blanks = OutputData.createDeterministicData(0, seed, 0, KEYSET, Array(MAX_T + 1).fill(0));
+const counterByB = new Map<string, number>();
+blanks.forEach((b, c) => counterByB.set(b.blindedMessage.B_, c));
+console.error('derivation done');
+
+type Stats = {
+  restoreCalls: number;
+  checkCalls: number;
+  sent: number;
+  unique: Set<string>;
+  linked: Set<string>;
+  checkedYs: number;
+};
+
+function mockMint(t: number) {
+  const stats: Stats = {
+    restoreCalls: 0,
+    checkCalls: 0,
+    sent: 0,
+    unique: new Set(),
+    linked: new Set(),
+    checkedYs: 0,
+  };
+  const issued = (c: number) => c <= t && !skipped(c);
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+  const wrapped: typeof fetch = async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url.endsWith('/v1/info')) {
+      return json({
+        name: 'bench',
+        pubkey: VALID_POINT,
+        version: 'bench/0',
+        contact: [],
+        nuts: {
+          '4': { methods: [{ method: 'bolt11', unit: 'sat' }], disabled: false },
+          '5': { methods: [{ method: 'bolt11', unit: 'sat' }], disabled: false },
+          '7': { supported: true },
+          '9': { supported: true },
+          '342': { supported: true },
+        },
+      });
+    }
+    if (url.includes('/v1/keysets')) {
+      return json({ keysets: [{ id: KEYSET_ID, unit: 'sat', active: true, input_fee_ppk: 0 }] });
+    }
+    if (url.includes('/v1/keys')) {
+      return json({ keysets: [KEYSET] });
+    }
+    if (url.endsWith('/v1/restore')) {
+      await new Promise((r) => setTimeout(r, RTT_MS));
+      stats.restoreCalls++;
+      const body = JSON.parse(String(init?.body)) as { outputs: Array<{ id: string; B_: string }> };
+      stats.sent += body.outputs.length;
+      const outputs: unknown[] = [];
+      const signatures: unknown[] = [];
+      for (const o of body.outputs) {
+        stats.unique.add(o.B_);
+        const c = counterByB.get(o.B_);
+        if (c === undefined || !issued(c)) continue;
+        stats.linked.add(o.B_);
+        outputs.push(o);
+        signatures.push({
+          id: o.id,
+          amount: 1,
+          C_: VALID_POINT,
+          ...(c === t && { d_gap: D_GAP }), // plaintext gap, per the reference run
+        });
+      }
+      return json({ outputs, signatures });
+    }
+    if (url.endsWith('/v1/checkstate')) {
+      await new Promise((r) => setTimeout(r, RTT_MS));
+      stats.checkCalls++;
+      const body = JSON.parse(String(init?.body)) as { Ys: string[] };
+      stats.checkedYs += body.Ys.length;
+      return json({ states: body.Ys.map((Y) => ({ Y, state: 'UNSPENT', witness: null })) });
+    }
+    throw new Error('unmocked url: ' + url);
+  };
+  return { wrapped, stats };
+}
+
+async function run(method: 'efficient' | 'legacy', tRequested: number, probeBudget?: number) {
+  let t = tRequested;
+  while (skipped(t)) t--; // T itself must be issued
+  const { wrapped, stats } = mockMint(t);
+  const wallet = new Wallet(MINT_URL, { bip39seed: seed, requestFetch: wrapped });
+  await wallet.loadMint();
+  const started = Date.now();
+  const res =
+    method === 'efficient'
+      ? await wallet.restoreEfficient({
+          probeWindow: 25,
+          ...(probeBudget && { probeBudget }),
+        })
+      : await wallet.batchRestore();
+  await wallet.groupProofsByState(res.proofs);
+  const wallMs = Date.now() - started;
+  return {
+    method: method === 'efficient' ? (probeBudget ? `${LABEL}-g${probeBudget}` : LABEL) : 'legacy',
+    T: t,
+    calls: stats.restoreCalls + stats.checkCalls,
+    restoreCalls: stats.restoreCalls,
+    checkCalls: stats.checkCalls,
+    messages: stats.sent,
+    unique: stats.unique.size,
+    linked: stats.linked.size,
+    proofsChecked: stats.checkedYs,
+    recoveredT: res.lastCounterWithSignature,
+    wallMs,
+  };
+}
+
+const rows: Array<Record<string, unknown>> = [];
+for (const t of T_VALUES) {
+  for (const grid of GRIDS ?? [undefined]) {
+    rows.push(await run('efficient', t, grid));
+    console.error(`efficient T=${t} grid=${grid ?? 'default'} done`);
+  }
+  if (!process.env.SKIP_LEGACY) {
+    rows.push(await run('legacy', t));
+    console.error(`legacy T=${t} done`);
+  }
+}
+console.log(JSON.stringify(rows, null, 1));

--- a/scripts/bench-nut342-recovery.ts
+++ b/scripts/bench-nut342-recovery.ts
@@ -140,12 +140,14 @@ async function run(
   const started = Date.now();
   const res =
     method === 'efficient'
-      ? await wallet.restoreEfficient({
+      ? // filterSpent off for both methods: each state-checks once, via groupProofsByState below
+        await wallet.restoreEfficient({
           probeWindow: 25,
+          filterSpent: false,
           ...(probeBudget && { probeBudget }),
           ...(ladderSkip && { ladderSkip }),
         })
-      : await wallet.batchRestore();
+      : await wallet.batchRestore({ filterSpent: false });
   await wallet.groupProofsByState(res.proofs);
   const wallMs = Date.now() - started;
   return {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1884,6 +1884,7 @@ class Wallet {
         let prev = lo - probeWindow;
         for (let i = 1; i <= gridBudget; i++) {
           const pos = Math.max(lo + Math.floor(step * i), prev + probeWindow);
+          /* c8 ignore next -- defensive; the clamp binds only when step < probeWindow, which keeps pos < ceiling */
           if (pos >= ceiling) break;
           ranges.push(window(pos));
           prev = pos;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1753,7 +1753,7 @@ class Wallet {
    * `lastCounterWithSignature` still reflects every found signature.
    * @param options.keysetId Which keysetId to restore. Defaults to the instance's.
    * @param options.probeWindow Nonces per probe window (defaults to 25).
-   * @param options.batchSize Chunk size for the final window restore (defaults to 300).
+   * @param options.batchSize Chunk size for the final window restore (defaults to 500).
    * @param options.probeBudget Probe windows per search request (defaults to 12).
    * @param options.filterSpent Drop spent proofs (NUT-07) before returning. Default is `true`.
    */
@@ -1763,7 +1763,7 @@ class Wallet {
     const {
       keysetId,
       probeWindow = 25,
-      batchSize = 300,
+      batchSize = 500,
       probeBudget = 12,
       ladderSkip = 0,
       filterSpent = true,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1746,8 +1746,9 @@ class Wallet {
    * @remarks
    * Locates the last issued counter T with batched probe rounds (an exponential ladder, then grid
    * refinement), reads its recovery gap and restores `[T - d_gap, T]` in concurrent chunks:
-   * typically ~4 requests regardless of wallet age. Falls back to `batchRestore` (the linear NUT-09
-   * restore scan) when the mint does not advertise support, no gap was backed up, or the search
+   * typically ~4 requests regardless of wallet age. A found T with no backed-up gap restores `[0,
+   * T]` outright plus a gap-limit scan above. Falls back to `batchRestore` (the linear NUT-09
+   * restore scan) when the mint does not advertise support, no signatures exist, or the search
    * fails. Like `batchRestore`, spent proofs are dropped before returning;
    * `lastCounterWithSignature` still reflects every found signature.
    * @param options.keysetId Which keysetId to restore. Defaults to the instance's.
@@ -1803,7 +1804,9 @@ class Wallet {
           }
           return result;
         }
-        this._logger.info('No NUT-342 gap backup found, falling back to linear NUT-09 scan');
+        this._logger.info(
+          'No signatures found by NUT-342 probe, falling back to linear NUT-09 scan',
+        );
       } catch (e) {
         this._logger.warn('NUT-342 recovery failed, falling back to linear NUT-09 scan', {
           error: e,
@@ -1822,8 +1825,8 @@ class Wallet {
    * below it, assuming derivation gaps stay shorter than the window. Round 1 brackets T with an
    * exponential ladder in ONE request; later rounds tile or grid the remaining zone, one request
    * each, so T is pinned in ~3 rounds for any realistic wallet.
-   * @returns Undefined when the mint has no signatures or no gap metadata for T (caller falls back
-   *   to the linear NUT-09 scan).
+   * @returns Undefined when the mint has no signatures (caller falls back to the linear NUT-09
+   *   scan).
    */
   private async restoreFromGapBackup(
     probeWindow: number,
@@ -1896,13 +1899,20 @@ class Wallet {
       ceiling = ranges.map((r) => r.start).find((s) => s > floor.counter) ?? ceiling;
     }
 
-    if (floor.signature.d_gap == null) return undefined;
     const { counter: t, signature, output } = floor;
-    const dGap =
-      typeof signature.d_gap === 'string'
-        ? decryptDGap(signature.d_gap, output.blindingFactor)
-        : Number(signature.d_gap);
-    this.failIf(!Number.isInteger(dGap) || dGap < 0 || dGap > t, 'Mint returned an invalid d_gap');
+    // No backed-up gap for T: the probe still pinned it, so restore the whole space below T
+    // rather than discard the search, then gap-check above it for linear-scan parity.
+    let dGap = t;
+    if (signature.d_gap != null) {
+      dGap =
+        typeof signature.d_gap === 'string'
+          ? decryptDGap(signature.d_gap, output.blindingFactor)
+          : Number(signature.d_gap);
+      this.failIf(
+        !Number.isInteger(dGap) || dGap < 0 || dGap > t,
+        'Mint returned an invalid d_gap',
+      );
+    }
 
     // Restore [T - d_gap, T] in batchSize chunks. The range is known up front, so chunks run
     // through a bounded worker pool: full concurrency benefit, same total request count.
@@ -1919,6 +1929,24 @@ class Wallet {
         lastCounterWithSignature = Math.max(
           lastCounterWithSignature ?? 0,
           result.lastCounterWithSignature,
+        );
+      }
+    }
+
+    if (signature.d_gap == null) {
+      // Probe windows sample sparsely above T, so scan one gap limit past it: same ending
+      // guarantee as the linear scan, and any proofs found there are merged in.
+      const tail = await this.batchRestore({
+        batchSize,
+        counter: t + 1,
+        keysetId,
+        filterSpent: false,
+      });
+      proofs.push(...tail.proofs);
+      if (tail.lastCounterWithSignature !== undefined) {
+        lastCounterWithSignature = Math.max(
+          lastCounterWithSignature ?? 0,
+          tail.lastCounterWithSignature,
         );
       }
     }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1764,11 +1764,16 @@ class Wallet {
       probeWindow = 25,
       batchSize = 300,
       probeBudget = 12,
+      ladderSkip = 0,
       filterSpent = true,
     } = config ?? {};
     this.failIf(
       !Number.isInteger(probeBudget) || probeBudget < 2 || probeBudget > 40,
       'probeBudget must be an integer between 2 and 40',
+    );
+    this.failIf(
+      !Number.isInteger(ladderSkip) || ladderSkip < 0 || ladderSkip > 20,
+      'ladderSkip must be an integer between 0 and 20',
     );
     this.failIf(
       !Number.isInteger(probeWindow) || probeWindow < 1,
@@ -1786,6 +1791,7 @@ class Wallet {
           probeWindow,
           batchSize,
           probeBudget,
+          ladderSkip,
           keysetId,
         );
         if (result) {
@@ -1823,6 +1829,7 @@ class Wallet {
     probeWindow: number,
     batchSize: number,
     gridBudget: number,
+    ladderSkip: number,
     keysetId?: string,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number } | undefined> {
     // Legacy keysets derive hardened BIP-32 children, capping counters at 2^31; HMAC keysets
@@ -1835,16 +1842,30 @@ class Wallet {
       count: Math.min(probeWindow, maxCounter - start + 1),
     });
 
-    // Round 1: window 0 plus exponentially spaced rungs, all in one request.
-    const ladder: CounterRange[] = [window(0)];
-    for (let pos = probeWindow; pos <= maxCounter; pos *= 2) ladder.push(window(pos));
-    const first = await this.restoreSignaturesBatch(ladder, keysetId);
-    if (first.length === 0) return undefined;
+    // Round 1: exponentially spaced rungs in one request. With ladderSkip=0 this probes from
+    // counter 0; skipped low rungs avoid linking counters every aged wallet has used.
+    const ladder: CounterRange[] = ladderSkip === 0 ? [window(0)] : [];
+    for (let pos = probeWindow * 2 ** ladderSkip; pos <= maxCounter; pos *= 2) {
+      ladder.push(window(pos));
+    }
+    let first = await this.restoreSignaturesBatch(ladder, keysetId);
+    let rungs = ladder;
+    if (first.length === 0) {
+      if (ladderSkip === 0) return undefined;
+      // Stage 2: the keyset lives below the first rung, so fire the skipped rungs after all.
+      // Only young keysets reach here, and their low counters sit largely inside the recovery
+      // window, so the deferred rungs cost little extra linkage.
+      const lowRungs: CounterRange[] = [window(0)];
+      for (let k = 0; k < ladderSkip; k++) lowRungs.push(window(probeWindow * 2 ** k));
+      first = await this.restoreSignaturesBatch(lowRungs, keysetId);
+      if (first.length === 0) return undefined;
+      rungs = [...lowRungs, ...ladder];
+    }
 
     // floor: highest counter with a signature so far (candidate T).
     // ceiling: exclusive upper bound on T (lowest probe position proven empty above floor).
     let floor = first[first.length - 1];
-    let ceiling = ladder.map((r) => r.start).find((s) => s > floor.counter) ?? maxCounter + 1;
+    let ceiling = rungs.map((r) => r.start).find((s) => s > floor.counter) ?? maxCounter + 1;
 
     // Rounds 2+: narrow (floor, ceiling) with one batched request per round. A zone within
     // budget is tiled outright; a larger one is gridded evenly and narrowed on the answer.
@@ -1874,8 +1895,8 @@ class Wallet {
       ceiling = ranges.map((r) => r.start).find((s) => s > floor.counter) ?? ceiling;
     }
 
+    if (floor.signature.d_gap == null) return undefined;
     const { counter: t, signature, output } = floor;
-    if (signature.d_gap == null) return undefined;
     const dGap =
       typeof signature.d_gap === 'string'
         ? decryptDGap(signature.d_gap, output.blindingFactor)

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1918,9 +1918,19 @@ class Wallet {
     // through a bounded worker pool: full concurrency benefit, same total request count.
     const starts: number[] = [];
     for (let s = t - dGap; s <= t; s += batchSize) starts.push(s);
-    const results = await runPool(starts, BATCH_POOL_SIZE, (s) =>
-      this.restore(s, Math.min(batchSize, t - s + 1), { keysetId }),
+    const chunk = (s: number) => this.restore(s, Math.min(batchSize, t - s + 1), { keysetId });
+    // Failed chunks retry once after the pool drains: a transient error costs one extra request
+    // instead of discarding the pinned T for the caller's full-scan fallback.
+    const attempts = await runPool(starts, BATCH_POOL_SIZE, (s) =>
+      chunk(s).catch((e) => {
+        this._logger.debug('NUT-342 window chunk failed, retrying once', { start: s, error: e });
+        return undefined;
+      }),
     );
+    const results = [];
+    for (let i = 0; i < attempts.length; i++) {
+      results.push(attempts[i] ?? (await chunk(starts[i])));
+    }
     const proofs: Proof[] = [];
     let lastCounterWithSignature: number | undefined;
     for (const result of results) {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1744,26 +1744,50 @@ class Wallet {
    * Restores deterministic proofs using the draft NUT-342 recovery scheme (experimental).
    *
    * @remarks
-   * Binary-searches the counter space for the last issued signature, reads its recovery gap and
-   * batch-restores that window. Falls back to `batchRestore` (the linear NUT-09 restore scan) when
-   * the mint does not advertise support, no gap was backed up, or the search fails. Like
-   * `batchRestore`, spent proofs are dropped before returning; `lastCounterWithSignature` still
-   * reflects every found signature.
+   * Locates the last issued counter T with batched probe rounds (an exponential ladder, then grid
+   * refinement), reads its recovery gap and restores `[T - d_gap, T]` in concurrent chunks:
+   * typically ~4 requests regardless of wallet age. Falls back to `batchRestore` (the linear NUT-09
+   * restore scan) when the mint does not advertise support, no gap was backed up, or the search
+   * fails. Like `batchRestore`, spent proofs are dropped before returning;
+   * `lastCounterWithSignature` still reflects every found signature.
    * @param options.keysetId Which keysetId to restore. Defaults to the instance's.
-   * @param options.probeWindow Counters probed per binary-search request (defaults to 25).
+   * @param options.probeWindow Nonces per probe window (defaults to 25).
+   * @param options.batchSize Chunk size for the final window restore (defaults to 300).
+   * @param options.probeBudget Probe windows per search request (defaults to 12).
    * @param options.filterSpent Drop spent proofs (NUT-07) before returning. Default is `true`.
    */
   async restoreEfficient(
     config?: RestoreEfficientConfig,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
-    const { keysetId, probeWindow = 25, filterSpent = true } = config ?? {};
+    const {
+      keysetId,
+      probeWindow = 25,
+      batchSize = 300,
+      probeBudget = 12,
+      filterSpent = true,
+    } = config ?? {};
+    this.failIf(
+      !Number.isInteger(probeBudget) || probeBudget < 2 || probeBudget > 40,
+      'probeBudget must be an integer between 2 and 40',
+    );
     this.failIf(
       !Number.isInteger(probeWindow) || probeWindow < 1,
       'probeWindow must be a positive integer',
     );
+    // Upper bound keeps recovery chunks inside common mint request caps and far below V8's
+    // spread-argument limit when chunk results are merged.
+    this.failIf(
+      !Number.isInteger(batchSize) || batchSize < 1 || batchSize > 1000,
+      'batchSize must be an integer between 1 and 1000',
+    );
     if (this._mintInfo?.isSupported(342).supported) {
       try {
-        const result = await this.restoreFromGapBackup(probeWindow, keysetId);
+        const result = await this.restoreFromGapBackup(
+          probeWindow,
+          batchSize,
+          probeBudget,
+          keysetId,
+        );
         if (result) {
           if (filterSpent && result.proofs.length > 0) {
             const states = await this.checkProofsStates(result.proofs);
@@ -1784,14 +1808,21 @@ class Wallet {
   }
 
   /**
-   * NUT-342 (draft) recovery core: locate the last issued counter T via windowed binary search,
-   * decrypt its `d_gap` and restore `[T - d_gap, T]`.
+   * NUT-342 (draft) recovery core: locate the last issued counter T with batched probe rounds,
+   * decrypt its `d_gap` and restore `[T - d_gap, T]` in concurrent chunks.
    *
+   * @remarks
+   * A probe window with any signature proves T is at or beyond it; an empty window proves T is
+   * below it, assuming derivation gaps stay shorter than the window. Round 1 brackets T with an
+   * exponential ladder in ONE request; later rounds tile or grid the remaining zone, one request
+   * each, so T is pinned in ~3 rounds for any realistic wallet.
    * @returns Undefined when the mint has no signatures or no gap metadata for T (caller falls back
    *   to the linear NUT-09 scan).
    */
   private async restoreFromGapBackup(
     probeWindow: number,
+    batchSize: number,
+    gridBudget: number,
     keysetId?: string,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number } | undefined> {
     // Legacy keysets derive hardened BIP-32 children, capping counters at 2^31; HMAC keysets
@@ -1799,37 +1830,77 @@ class Wallet {
     const id = keysetId ?? this.keysetId;
     const isLegacy = !/^[0-9a-fA-F]+$/.test(id) || id.startsWith('00');
     const maxCounter = isLegacy ? 0x7fffffff : 0xffffffff;
+    const window = (start: number): CounterRange => ({
+      start,
+      count: Math.min(probeWindow, maxCounter - start + 1),
+    });
 
-    // A window counts as issued if ANY counter in it has a signature. This tolerates derivation
-    // gaps up to probeWindow without breaking the search's monotonicity assumption.
-    const probe = (windowIndex: number) => {
-      const start = windowIndex * probeWindow;
-      return this.restoreSignatures(start, Math.min(probeWindow, maxCounter - start + 1), keysetId);
-    };
+    // Round 1: window 0 plus exponentially spaced rungs, all in one request.
+    const ladder: CounterRange[] = [window(0)];
+    for (let pos = probeWindow; pos <= maxCounter; pos *= 2) ladder.push(window(pos));
+    const first = await this.restoreSignaturesBatch(ladder, keysetId);
+    if (first.length === 0) return undefined;
 
-    const firstWindow = await probe(0);
-    if (firstWindow.length === 0) return undefined;
+    // floor: highest counter with a signature so far (candidate T).
+    // ceiling: exclusive upper bound on T (lowest probe position proven empty above floor).
+    let floor = first[first.length - 1];
+    let ceiling = ladder.map((r) => r.start).find((s) => s > floor.counter) ?? maxCounter + 1;
 
-    let lo = 0;
-    let hi = Math.floor(maxCounter / probeWindow);
-    while (lo < hi) {
-      const mid = Math.floor((lo + hi + 1) / 2);
-      if ((await probe(mid)).length > 0) lo = mid;
-      else hi = mid - 1;
+    // Rounds 2+: narrow (floor, ceiling) with one batched request per round. A zone within
+    // budget is tiled outright; a larger one is gridded evenly and narrowed on the answer.
+    for (let round = 0; floor.counter + 1 < ceiling; round++) {
+      this.failIf(round >= 16, 'NUT-342 probe rounds did not converge');
+      const lo = floor.counter + 1;
+      const width = ceiling - lo;
+      const tiled = width <= gridBudget * probeWindow;
+      const ranges: CounterRange[] = [];
+      if (tiled) {
+        for (let pos = lo; pos < ceiling; pos += probeWindow) {
+          ranges.push({ start: pos, count: Math.min(probeWindow, ceiling - pos) });
+        }
+      } else {
+        const step = width / (gridBudget + 1);
+        let prev = lo - probeWindow;
+        for (let i = 1; i <= gridBudget; i++) {
+          const pos = Math.max(lo + Math.floor(step * i), prev + probeWindow);
+          if (pos >= ceiling) break;
+          ranges.push(window(pos));
+          prev = pos;
+        }
+      }
+      const found = await this.restoreSignaturesBatch(ranges, keysetId);
+      if (found.length > 0) floor = found[found.length - 1];
+      if (tiled) break; // zone fully probed: floor is T
+      ceiling = ranges.map((r) => r.start).find((s) => s > floor.counter) ?? ceiling;
     }
 
-    const terminalWindow = lo === 0 ? firstWindow : await probe(lo);
-    const terminal = terminalWindow[terminalWindow.length - 1];
-    if (!terminal || terminal.signature.d_gap == null) return undefined;
-
-    const { counter: t, signature, output } = terminal;
+    const { counter: t, signature, output } = floor;
+    if (signature.d_gap == null) return undefined;
     const dGap =
       typeof signature.d_gap === 'string'
         ? decryptDGap(signature.d_gap, output.blindingFactor)
         : Number(signature.d_gap);
     this.failIf(!Number.isInteger(dGap) || dGap < 0 || dGap > t, 'Mint returned an invalid d_gap');
 
-    return this.restore(t - dGap, dGap + 1, { keysetId });
+    // Restore [T - d_gap, T] in batchSize chunks. The range is known up front, so chunks run
+    // through a bounded worker pool: full concurrency benefit, same total request count.
+    const starts: number[] = [];
+    for (let s = t - dGap; s <= t; s += batchSize) starts.push(s);
+    const results = await runPool(starts, BATCH_POOL_SIZE, (s) =>
+      this.restore(s, Math.min(batchSize, t - s + 1), { keysetId }),
+    );
+    const proofs: Proof[] = [];
+    let lastCounterWithSignature: number | undefined;
+    for (const result of results) {
+      proofs.push(...result.proofs);
+      if (result.lastCounterWithSignature !== undefined) {
+        lastCounterWithSignature = Math.max(
+          lastCounterWithSignature ?? 0,
+          result.lastCounterWithSignature,
+        );
+      }
+    }
+    return { proofs, lastCounterWithSignature };
   }
 
   /**
@@ -1837,9 +1908,24 @@ class Wallet {
    *
    * @returns One entry per counter with an issued signature, ascending.
    */
-  private async restoreSignatures(
+  private restoreSignatures(
     start: number,
     count: number,
+    keysetId?: string,
+  ): Promise<
+    Array<{ counter: number; signature: SerializedBlindedSignature; output: OutputDataLike }>
+  > {
+    return this.restoreSignaturesBatch([{ start, count }], keysetId);
+  }
+
+  /**
+   * Queries the NUT-09 restore endpoint for issued signatures over disjoint ascending counter
+   * ranges, all in a single request.
+   *
+   * @returns One entry per counter with an issued signature, ascending.
+   */
+  private async restoreSignaturesBatch(
+    ranges: CounterRange[],
     keysetId?: string,
   ): Promise<
     Array<{ counter: number; signature: SerializedBlindedSignature; output: OutputDataLike }>
@@ -1852,31 +1938,38 @@ class Wallet {
 
     // create deterministic blank outputs for unknown restore amounts
     // Note: zero amount + zero denomination passes splitAmount validation
-    const zeros = Array(count).fill(0);
-    const outputData = this._outputDataCreator.createDeterministicData(
-      0,
-      this._seed,
-      start,
-      keyset,
-      zeros,
-    );
+    const outputData: OutputDataLike[] = [];
+    const counters: number[] = [];
+    for (const range of ranges) {
+      const data = this._outputDataCreator.createDeterministicData(
+        0,
+        this._seed,
+        range.start,
+        keyset,
+        Array(range.count).fill(0),
+      );
+      data.forEach((d, i) => {
+        outputData.push(d);
+        counters.push(range.start + i);
+      });
+    }
 
     const { outputs, signatures } = await this.mint.restore({
       outputs: outputData.map((d) => d.blindedMessage),
     });
 
-    const signatureMap: { [sig: string]: SerializedBlindedSignature } = {};
-    outputs.forEach((o, i) => (signatureMap[o.B_] = signatures[i]));
+    const signaturesByB: { [b: string]: SerializedBlindedSignature } = {};
+    outputs.forEach((o, i) => (signaturesByB[o.B_] = signatures[i]));
 
     const found: Array<{
       counter: number;
       signature: SerializedBlindedSignature;
       output: OutputDataLike;
     }> = [];
-    for (let i = 0; i < outputData.length; i++) {
-      const signature = signatureMap[outputData[i].blindedMessage.B_];
-      if (signature) found.push({ counter: start + i, signature, output: outputData[i] });
-    }
+    outputData.forEach((d, i) => {
+      const signature = signaturesByB[d.blindedMessage.B_];
+      if (signature) found.push({ counter: counters[i], signature, output: d });
+    });
     return found;
   }
 

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -50,10 +50,21 @@ export type BatchRestoreConfig = {
 export type RestoreEfficientConfig = {
   keysetId?: string;
   /**
-   * Counters probed per binary-search request. Larger windows tolerate larger derivation gaps at
-   * the cost of revealing more nonces per probe. Default is `25`.
+   * Nonces per probe window; also the largest derivation gap the search tolerates. Larger windows
+   * are safer but reveal more nonces per probe round. Default is `25`.
    */
   probeWindow?: number;
+  /**
+   * Chunk size for the final window restore (mints cap request lengths); chunks are requested
+   * concurrently. Must be 1-1000. Default is `300`.
+   */
+  batchSize?: number;
+  /**
+   * Probe windows per search request (grid width). Larger budgets pin T in fewer rounds but land
+   * more probes in issued history, letting the mint link more old signatures to the recovery. Must
+   * be 2-40. Default is `12`.
+   */
+  probeBudget?: number;
   /**
    * Drop spent proofs (NUT-07) before returning. Default is `true`
    */

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -66,6 +66,13 @@ export type RestoreEfficientConfig = {
    */
   probeBudget?: number;
   /**
+   * Low ladder rungs to skip: the first search rung starts at `probeWindow * 2^ladderSkip`. Aged
+   * wallets have used every low counter, so skipping avoids linking them; a keyset living below the
+   * first rung triggers one extra request that fires the skipped rungs instead. Must be 0-20.
+   * Default is `0` (probe from counter 0).
+   */
+  ladderSkip?: number;
+  /**
    * Drop spent proofs (NUT-07) before returning. Default is `true`
    */
   filterSpent?: boolean;

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -56,7 +56,7 @@ export type RestoreEfficientConfig = {
   probeWindow?: number;
   /**
    * Chunk size for the final window restore (mints cap request lengths); chunks are requested
-   * concurrently. Must be 1-1000. Default is `300`.
+   * concurrently. Must be 1-1000. Default is `500`, matching `batchRestore`.
    */
   batchSize?: number;
   /**

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -556,6 +556,94 @@ describe('restoreEfficient (draft NUT-342)', () => {
 
     expect(mockBatch).toHaveBeenCalledTimes(1);
   });
+
+  test('falls back when both ladder stages find nothing (ladderSkip)', async () => {
+    use342Info();
+    const restoreCalls = useFakeRestoreMint(new Map());
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
+    await wallet.loadMint();
+    const mockBatch = vi
+      .spyOn(wallet, 'batchRestore')
+      .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
+
+    await wallet.restoreEfficient({ probeWindow: 5, ladderSkip: 2 });
+
+    expect(restoreCalls()).toBe(2); // high ladder, then the deferred low rungs
+    expect(mockBatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('pins T in the topmost ladder rung near the counter cap', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // legacy keyset caps counters at 2^31; with probeWindow 1 the highest rung
+    // is exactly 2^30, so T there leaves no rung above to bound the ceiling
+    const t = 2 ** 30;
+    const output = blank(seed, t);
+    const issued = new Map([
+      [output.blindedMessage.B_, { counter: t, d_gap: encryptDGap(3, output.blindingFactor) }],
+    ]);
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 1 });
+
+    expect(res.proofs).toHaveLength(1);
+    expect(res.lastCounterWithSignature).toBe(t);
+    // ladder + grid rounds over (2^30, 2^31) + recovery chunk, within the round cap
+    expect(restoreCalls()).toBeLessThanOrEqual(12);
+  });
+
+  test('keeps the old ceiling when T sits in the last grid cell', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // ladder pins (80, 160); with probeBudget 2 the first grid round probes
+    // [107,111] and [133,137], so T=134 is found in the final cell
+    const issued = new Map(
+      [80, 134].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, ...(c === 134 && { d_gap: encryptDGap(54, output.blindingFactor) }) },
+        ];
+      }),
+    );
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5, probeBudget: 2 });
+
+    // recovery window [80, 134] holds both issued counters
+    expect(res.proofs).toHaveLength(2);
+    expect(res.lastCounterWithSignature).toBe(134);
+    // ladder + grid + grid + tile + one recovery chunk
+    expect(restoreCalls()).toBe(5);
+  });
+
+  test('skips empty chunks inside a sparse recovery window', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // T=40 with d_gap spanning the whole history; batchSize 10 makes chunks
+    // [10,19], [20,29] and [30,39] answer with no signatures at all
+    const issued = new Map(
+      [0, 1, 2, 3, 4, 5, 40].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, ...(c === 40 && { d_gap: encryptDGap(40, output.blindingFactor) }) },
+        ];
+      }),
+    );
+    useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5, batchSize: 10 });
+
+    expect(res.proofs).toHaveLength(7);
+    expect(res.lastCounterWithSignature).toBe(40);
+  });
 });
 
 describe('recovery gap attachment (draft NUT-342)', () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -577,7 +577,7 @@ describe('restoreEfficient (draft NUT-342)', () => {
     // one linear-scan gap check fires just above T
     expect(mockBatch).toHaveBeenCalledTimes(1);
     expect(mockBatch).toHaveBeenCalledWith({
-      batchSize: 300,
+      batchSize: 500,
       counter: 2,
       keysetId: undefined,
       filterSpent: false,

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -457,6 +457,39 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(restoreCalls()).toBe(7);
   });
 
+  test('retries a failed window chunk once instead of falling back', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // Same shape as above: T=45, gap spanning the history, batchSize 10 forces 5 chunks
+    const issued = new Map(
+      Array.from({ length: 46 }, (_, c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          {
+            counter: c,
+            ...(c === 45 && { d_gap: encryptDGap(45, output.blindingFactor) }),
+          },
+        ] as const;
+      }),
+    );
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    // The first chunk fetch dies transiently; later calls run the real implementation
+    const chunkSpy = vi.spyOn(wallet, 'restore').mockRejectedValueOnce(new Error('transient'));
+    const scanSpy = vi.spyOn(wallet, 'batchRestore');
+    const res = await wallet.restoreEfficient({ probeWindow: 5, batchSize: 10 });
+
+    expect(res.proofs).toHaveLength(46);
+    expect(res.lastCounterWithSignature).toBe(45);
+    expect(chunkSpy).toHaveBeenCalledTimes(6); // 5 pool chunks + 1 retry
+    expect(scanSpy).not.toHaveBeenCalled(); // recovered without the full-scan fallback
+    // 2 search requests + 4 surviving pool chunks + 1 retried chunk
+    expect(restoreCalls()).toBe(7);
+  });
+
   test('fires the skipped low rungs when the keyset lives below the first rung', async () => {
     use342Info();
     const seed = randomBytes(64);

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -457,6 +457,32 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(restoreCalls()).toBe(7);
   });
 
+  test('fires the skipped low rungs when the keyset lives below the first rung', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // ladderSkip 5 with probeWindow 5 puts the first rung at counter 160, far
+    // above this wallet's T=3; stage two (the deferred low rungs) must find it
+    const issued = new Map(
+      [0, 1, 3].map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          { counter: c, d_gap: encryptDGap(c, output.blindingFactor) },
+        ];
+      }),
+    );
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5, ladderSkip: 5 });
+
+    expect(res.proofs).toHaveLength(3);
+    expect(res.lastCounterWithSignature).toBe(3);
+    // high ladder + deferred low rungs + tile + one recovery chunk
+    expect(restoreCalls()).toBe(4);
+  });
+
   test('rejects an out-of-range batchSize', async () => {
     const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
     await wallet.loadMint();

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -325,11 +325,11 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(mockStates).not.toHaveBeenCalled();
   });
 
-  test('re-probes the terminal window when T lies beyond window 0', async () => {
+  test('finds T beyond the first probe window', async () => {
     use342Info();
     const seed = randomBytes(64);
-    // counters span two probe windows (0..4 and 5..9), so the search converges
-    // on window 1 and must fetch the terminal window again for its d_gap
+    // counters span two probe windows (0..4 and 5..9), so the ladder alone
+    // cannot pin T and a refinement round must run
     const issued = new Map(
       [0, 1, 2, 6, 7].map((c) => {
         const output = blank(seed, c);
@@ -349,11 +349,11 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(res.lastCounterWithSignature).toBe(7);
   });
 
-  test('falls back when the terminal window vanishes mid-search', async () => {
+  test('falls back safely when the mint answers probes inconsistently', async () => {
     use342Info();
     const seed = randomBytes(64);
-    // counters 5..6 sit in window 1; the mint answers for them exactly once,
-    // so the terminal re-probe comes back empty (inconsistent mint)
+    // counters 5..6 answer exactly once; later probes of the same region come
+    // back empty (inconsistent mint), which must never produce a bogus result
     const window1 = new Map([5, 6].map((c) => [blank(seed, c).blindedMessage.B_, c] as const));
     const anchor = blank(seed, 0).blindedMessage.B_;
     let window1Answers = 1;
@@ -396,6 +396,73 @@ describe('restoreEfficient (draft NUT-342)', () => {
 
     expect(res.proofs).toHaveLength(3);
     expect(res.lastCounterWithSignature).toBe(2);
+  });
+
+  test('pins T with a handful of batched probe requests', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // a long history: every 2nd counter issued up to T=600 (in-window gaps of 1)
+    const counters: number[] = [];
+    for (let c = 0; c <= 600; c += 2) counters.push(c);
+    const issued = new Map(
+      counters.map((c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          {
+            counter: c,
+            ...(c === 600 && { d_gap: encryptDGap(40, output.blindingFactor) }),
+          },
+        ];
+      }),
+    );
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5 });
+
+    // recovery window [560, 600] holds the 21 issued even counters
+    expect(res.proofs).toHaveLength(21);
+    expect(res.lastCounterWithSignature).toBe(600);
+    // ladder + grid + tile + one recovery chunk — versus ~29 sequential bisection probes
+    expect(restoreCalls()).toBeLessThanOrEqual(5);
+  });
+
+  test('chunks the recovery window into concurrent batches', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    // T=45 with the gap spanning the whole history; batchSize 10 forces 5 chunks
+    const issued = new Map(
+      Array.from({ length: 46 }, (_, c) => {
+        const output = blank(seed, c);
+        return [
+          output.blindedMessage.B_,
+          {
+            counter: c,
+            ...(c === 45 && { d_gap: encryptDGap(45, output.blindingFactor) }),
+          },
+        ] as const;
+      }),
+    );
+    const restoreCalls = useFakeRestoreMint(issued);
+
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    const res = await wallet.restoreEfficient({ probeWindow: 5, batchSize: 10 });
+
+    expect(res.proofs).toHaveLength(46);
+    expect(res.lastCounterWithSignature).toBe(45);
+    // 2 search requests (ladder, tile) + ceil(46/10) = 5 recovery chunks
+    expect(restoreCalls()).toBe(7);
+  });
+
+  test('rejects an out-of-range batchSize', async () => {
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
+    await wallet.loadMint();
+    await expect(wallet.restoreEfficient({ batchSize: 2000 })).rejects.toThrow(
+      'batchSize must be an integer between 1 and 1000',
+    );
   });
 
   test('falls back to batchRestore when the mint lacks support', async () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -18,6 +18,10 @@ import { useTestServer, mint, unit, dummyKeysResp, mintUrl, mintInfoResp, logger
 
 const server = useTestServer();
 
+// NUT-342 search tests derive hundreds of deterministic outputs per run; slow CI
+// runners can exceed the default 5s budget.
+vi.setConfig({ testTimeout: 15_000 });
+
 const allUnspent = (n: number): ProofState[] =>
   Array(n).fill({ state: CheckStateEnum.UNSPENT }) as ProofState[];
 

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -519,7 +519,7 @@ describe('restoreEfficient (draft NUT-342)', () => {
     expect(mockBatch).toHaveBeenCalledTimes(1);
   });
 
-  test('falls back when the terminal signature carries no d_gap', async () => {
+  test('restores [0, T] and gap-checks above when T carries no d_gap', async () => {
     use342Info();
     const seed = randomBytes(64);
     const issued = new Map(
@@ -532,9 +532,40 @@ describe('restoreEfficient (draft NUT-342)', () => {
       .spyOn(wallet, 'batchRestore')
       .mockResolvedValue({ proofs: [], lastCounterWithSignature: undefined });
 
-    await wallet.restoreEfficient({ probeWindow: 5 });
+    const res = await wallet.restoreEfficient({ probeWindow: 5 });
 
+    // the probe pinned T=1, so the whole space below it is fetched, not rescanned linearly
+    expect(res.proofs.length).toBe(2);
+    expect(res.lastCounterWithSignature).toBe(1);
+    // one linear-scan gap check fires just above T
     expect(mockBatch).toHaveBeenCalledTimes(1);
+    expect(mockBatch).toHaveBeenCalledWith({
+      batchSize: 300,
+      counter: 2,
+      keysetId: undefined,
+      filterSpent: false,
+    });
+  });
+
+  test('merges tail proofs found above T during the no-d_gap gap check', async () => {
+    use342Info();
+    const seed = randomBytes(64);
+    const issued = new Map(
+      [0, 1].map((c) => [blank(seed, c).blindedMessage.B_, { counter: c }] as const),
+    );
+    useFakeRestoreMint(issued);
+    const wallet = new Wallet(mint, { unit, bip39seed: seed });
+    await wallet.loadMint();
+    vi.spyOn(wallet, 'batchRestore').mockResolvedValue({
+      proofs: [{ secret: 'tail' } as Proof],
+      lastCounterWithSignature: 5,
+    });
+
+    // filterSpent off: the mocked tail proof is a stub that a real state check would choke on
+    const res = await wallet.restoreEfficient({ probeWindow: 5, filterSpent: false });
+
+    expect(res.proofs.length).toBe(3);
+    expect(res.lastCounterWithSignature).toBe(5);
   });
 
   test('falls back when the mint returns an invalid d_gap', async () => {


### PR DESCRIPTION
## NUT

- https://github.com/cashubtc/nuts/pull/342

Draft spec experiment, stacked on #788

## Description

Speeds up NUT-342 recovery by changing how the wallet searches for its last used counter. The previous search (#788) asked the mint one question at a time, roughly 30 questions in a row using binary search.

This PR asks the same questions in bundles, using an exponential ladder, followed by a grid and tile, so a full recovery takes 4-8 requests at any wallet age.

## Why a ladder rather than pure binary search

Counters live in a vast space (2^32 positions), but real wallets cluster at the very bottom of it: every wallet starts at counter 0 and climbs only as it is used, so the last counter is typically in the hundreds or low thousands, and even a million would be remarkable.

Pure binary search ignores that shape. It treats every position as equally likely and spends the same ~31 questions whether the wallet is a day or a decade old. That purity has a real virtue: most of its probes land above T in never-used territory, where they reveal nothing, making it the most private search (see the Linked column below).

The **exponential *ladder*** instead bets on the actual distribution: it starts where wallets really are and doubles outward, so the cost of the search follows the wallet's true age rather than the size of the theoretical space. The bet trades a little privacy for a large win in round trips: its probes land in used territory more often, so the mint can link a few more old signatures. `probeBudget` tunes where between those two extremes the search sits.

## How it works, step by step:

1. **Bracket the wallet's high point.** The wallet asks the mint about a 25-counter window (`probeWindow`) at each of a spread of positions, all in one request: [0-24], [25-49], [50-74], [100-124], [200-224] and so on, the start doubling each time (in the code: the **exponential *ladder***). Positions the wallet once used come back with signatures; positions it never reached come back empty. The highest position with a signature and the lowest empty one above it fence in the wallet's true last counter, T. (An optional `ladderSkip` drops the lowest rungs, which aged wallets have always used; a keyset living below the first remaining rung triggers one extra request that fires the skipped rungs after all. The default is no skip.)
2. **Narrow the fence.** That fence can still be wide. The next request spreads twelve small probes evenly across it, shrinking the unknown range by roughly 13x (a ***grid* round**; width set by `probeBudget`). One or two of these rounds is enough for any realistic wallet.
3. **Find T exactly.** Once the remaining range is small, one request checks every counter in it (**the *tile* round**). That lands on T precisely, and the mint's reply for T already carries the encrypted recovery gap (`d_gap`), so nothing extra is fetched.
4. **Restore the window.** All unspent proofs are guaranteed to sit within `d_gap` counters below T. The wallet fetches that window in chunks of 500 (matching `batchRestore`), several chunks in flight at once (via the request pool from #789), then runs the usual NUT-07 state check.

Nothing changes on the wire or at the mint: NUT-09 already accepts any set of blinded messages per request, so this is compatible with the draft spec and with the Nutshell reference implementation as they stand. The aim is to prove the approach in code and then propose it as the recommended search in the cashubtc/nuts#342 discussion.

## Benchmark

`scripts/bench-nut342-recovery.ts` mirrors the Nutshell reference benchmark setup (probe batch 25, `d_gap`=100, one skipped counter every 137 derivations) against an in-process mock mint with 50 ms simulated network latency. Calls include the NUT-07 state check; "this PR" rows use the defaults (`probeBudget: 12`, `ladderSkip: 0`). "Linked" counts the previously issued signatures the mint can associate with the recovery session - the privacy cost; the final `d_gap + 1` recovery window is unavoidable for any strategy.

| Method            | T         | Calls | Messages | Linked | Proofs checked | Wall  |
| ----------------- | --------- | ----- | -------- | ------ | -------------- | ----- |
| NUT-09 scan       | 100       | 5     | 2,000    | 101    | 101            | 0.8s  |
| bisection (#788)  | 100       | 32    | 851      | 101    | 101            | 2.4s  |
| this PR           | 100       | 4     | 925      | 101    | 101            | 0.7s  |
| NUT-09 scan       | 1,000     | 6     | 2,000    | 994    | 994            | 2.3s  |
| bisection (#788)  | 1,000     | 31    | 826      | 125    | 100            | 2.4s  |
| this PR           | 1,000     | 5     | 1,160    | 289    | 100            | 0.8s  |
| NUT-09 scan       | 10,000    | 44    | 12,000   | 9,928  | 9,928          | 20.7s |
| bisection (#788)  | 10,000    | 31    | 826      | 201    | 101            | 2.4s  |
| this PR           | 10,000    | 6     | 1,451    | 523    | 101            | 0.9s  |
| NUT-09 scan       | 100,000   | 403   | 102,000  | 99,272 | 99,272         | 210.5s |
| bisection (#788)  | 100,000   | 32    | 851      | 226    | 101            | 2.5s  |
| this PR           | 100,000   | 6     | 1,718    | 821    | 101            | 1.0s  |
| this PR           | 1,000,000 | 8     | 2,028    | 1,048  | 100            | 1.3s  |

Scan and "this PR" rows are measured on this branch as it stands (the pooled 500-counter `batchRestore` from #795, 500-counter window chunks): the scan's call count benefits from #795's waves, at the price of some speculative overshoot in messages. The bisection rows predate that rebase and are kept as measured: they reproduce the Nutshell reference benchmark exactly (32/851, 31/826, 31/826, 32/851), independently validating the harness and confirming the two implementations behave identically.

Long-run trends: this PR's search adds one narrowing round per ~13x of wallet age, so requests cap at ~10 even at the counter-space maximum (the one-at-a-time search stays at 31-32). Linked signatures grow slowly with age and cap around ~2,000, versus the scan linking everything.

## d_gap is wallet policy

The search costs ~4 requests at any wallet age; the recovery window costs `d_gap`, and the wallet controls it. Three live runs of the bundled demo against the dockerized Nutshell mint (`input_fee_ppk` 100; each regime is an env knob on the demo) differ only in wallet policy:

| Wallet history | Method | Restore requests | Messages | Linked | Wall |
| --- | --- | --- | --- | --- | --- |
| unmanaged, small spends (T=4,409, d_gap = T) | this PR | 13 | 6,155 | 4,409 | 32s |
| | NUT-09 scan | 12 | 6,000 | 4,409 | 33s |
| pending token sent mid-history, refresh on (T=16,176, d_gap=8,489) | this PR | 22 | 10,377 | 8,739 | 60s |
| | NUT-09 scan | 36 | 18,000 | 16,176 | 115s |
| oldest-refresh policy (T=16,285, d_gap=135) | this PR | 5 | 1,510 | 586 | 1.8s |
| | NUT-09 scan | 36 | 18,000 | 16,285 | 114s |

(The 13 and 22 each include one extra request from a retried dropped connection.)

**Lump-sum funding plus small spends maximizes `d_gap`.** The window is set by the wallet's single oldest live proof, and nothing about normal usage moves it. Small spends never break a lump-funded wallet's large reserve proofs: in the first row the counter-0 reserve survived every round, the window is the whole history, and the search sits at its floor: scan cost plus three search requests.

**Unclaimed sends pin the window** at their own counter even while consolidation runs (second row: the refresh policy was active throughout), and dust that never clears its own fee pins it the same way.

**Randomized coin selection keeps old proofs in play indefinitely.** Only heavy turnover consolidates by accident (a run swapping ~half the balance per round landed at d_gap 172 with no policy at all).

**A cheap periodic refresh bounds `d_gap`** by the refresh cadence (the demo rolls its oldest proofs forward every 20 swaps): one extra swap per cycle, a few counters (third row).

Wallets should actively manage the window by periodically refreshing their oldest live proofs (folding dust in), rather than relying on spending patterns; long-unclaimed sends set a floor no wallet policy can cross. Proposed as wallet guidance in the cashubtc/nuts#342 discussion.

## Privacy comparison on a real wallet

The "binary search is more private" assertion, measured. Recovery runs per keyset, so a wallet pays the search cost once for every keyset it has ever used. This scenario replays the nine keysets of an actual daily-use wallet (last counters: 2024, 728, 69, 53, 19, 4, 4, 2, 2) through the same harness.

| Strategy | Requests | Linked signatures | Wall @50ms |
| --- | --- | --- | --- |
| bisection (#788) | 283 | 538 | 21.7s |
| this PR, defaults | 45 | 909 | 6.2s |
| this PR, privacy profile (`probeBudget: 4, ladderSkip: 3`) | 53 | 558 | 6.6s |

Three facts the totals hide:

- On seven of the nine keysets, every strategy links the identical signatures: those keysets' whole history sits inside the `d_gap` recovery window, which any strategy must fetch. There is no privacy to win on young keysets; binary search still pays ~31 requests each to tie.
- On the most-used keyset (T=2024) the privacy profile links fewer signatures than binary search (199 vs 225): skipping the low rungs (`ladderSkip`) removes exactly the probes that always land in an aged wallet's spent history.
- The wallet-wide difference comes to 20 signatures (558 vs 538), concentrated on one mid-size keyset. That is what binary search's 230 extra requests and 15 extra seconds buy.

`ladderSkip` is two-stage: a keyset living below the first rung triggers one extra request that fires the skipped rungs, so young keysets are never missed and cost a single extra round trip.

## Changes

- `restoreFromGapBackup` rewritten as the bundled search described above, with a 16-round safety cap and the existing linear NUT-09 scan fallback untouched.
- New `restoreSignaturesBatch` packs several counter windows into a single NUT-09 request; `restoreSignatures` becomes a thin wrapper over it.
- New config knobs on `RestoreEfficientConfig`: `batchSize` (recovery chunk size, 1-1000, default 300), `probeBudget` (probes per narrowing round, 2-40, default 12) and `ladderSkip` (low rungs to drop, 0-20, default 0). Defaults came from sweeping the benchmark: budget 12 keeps the minimum request count through T=100k while halving linked signatures versus a 30-probe round; `probeBudget: 4, ladderSkip: 3` is the measured privacy profile above.
- Tests: multi-window search, exact chunked-recovery call counts, search efficiency at T=600, out-of-range config rejection; all prior fallback and gap-tolerance tests pass unchanged.
- Benchmark script in `scripts/`, following the existing bench-* conventions.

## Reviewer Notes

- Same working assumption as #788 and Nutshell: a probe window covers 25 consecutive counters, so if a wallet ever skipped more than 25 counters in a row, an empty window could end the search early. The bundled search's early probes sit in the wallet's dense early history, which is if anything safer than bisection's arbitrary midpoints.
- The benchmark makes the underlying trade explicit: the one-at-a-time bisection sends the fewest messages and lets the mint link the fewest old signatures (its probes mostly land above T and reveal nothing); the bundled search wins on requests and wall-clock. `probeBudget` and `ladderSkip` span the space between them, and the spec discussion should present that axis rather than pick a single point.
- The live demo (`examples/nut342_recovery`) runs unchanged against the Nutshell reference branch mint and recovers a churned wallet in 3 requests.
- Draft, experimental, and stacked on #788: merge that first (or together); the `342` identifier remains provisional.







