### PR TITLE
feat(wallet)!: pooled batch restore with config object and spent filtering

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -217,6 +217,7 @@ export type BatchMintRequest = {
 // @public
 export type BatchRestoreConfig = {
     gapLimit?: number;
+    maxCounter?: number;
     batchSize?: number;
     counter?: number;
     keysetId?: string;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -215,6 +215,15 @@ export type BatchMintRequest = {
 };
 
 // @public
+export type BatchRestoreConfig = {
+    gapLimit?: number;
+    batchSize?: number;
+    counter?: number;
+    keysetId?: string;
+    filterSpent?: boolean;
+};
+
+// @public
 export function batchVerifyUnblindedSignatureBls(items: Array<{
     K2: G2Point;
     C: G1Point;
@@ -2215,7 +2224,7 @@ export class Wallet {
         requestFetch?: RequestFetch;
         logger?: Logger;
     });
-    batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{
+    batchRestore(config?: BatchRestoreConfig): Promise<{
         proofs: Proof[];
         lastCounterWithSignature?: number;
     }>;

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -116,6 +116,7 @@ If you were already passing full `Proof` objects (the normal case — `wallet.ch
 - `batchSize` defaults to 500 (was 300), matching the request size `checkProofsStates` already uses against reference mint caps.
 - Spent proofs are dropped by default via a NUT-07 state check before returning; pending proofs are kept. Pass `filterSpent: false` for the old raw output. `lastCounterWithSignature` always reflects all found signatures, so counter advancement is unaffected by filtering.
 - `gapLimit` is now a floor rather than an exact ceiling: batches already in flight when the gap closes are still processed, so proofs sitting shortly past the gap limit may still be recovered.
+- New `maxCounter` option: an inclusive scan ceiling, nothing above it is probed. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall.
 
 ### Migration
 

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -108,6 +108,36 @@ If you were already passing full `Proof` objects (the normal case — `wallet.ch
 
 ---
 
+## `batchRestore` takes an options object and filters spent proofs
+
+`Wallet.batchRestore(gapLimit?, batchSize?, counter?, keysetId?)` is now `batchRestore(config?: BatchRestoreConfig)`. Behavior changes ride along:
+
+- Batches are fetched through a bounded request pool (4 in flight), cutting restore wall-clock to roughly a quarter; the request count is nearly unchanged.
+- `batchSize` defaults to 500 (was 300), matching the request size `checkProofsStates` already uses against reference mint caps.
+- Spent proofs are dropped by default via a NUT-07 state check before returning; pending proofs are kept. Pass `filterSpent: false` for the old raw output. `lastCounterWithSignature` always reflects all found signatures, so counter advancement is unaffected by filtering.
+- `gapLimit` is now a floor rather than an exact ceiling: batches already in flight when the gap closes are still processed, so proofs sitting shortly past the gap limit may still be recovered.
+
+### Migration
+
+```ts
+// Before
+const { proofs } = await wallet.batchRestore(300, 100, 0, keysetId);
+// ...followed by a manual checkProofsStates to drop spent proofs
+
+// After (spent filtering is built in)
+const { proofs } = await wallet.batchRestore({
+  gapLimit: 300,
+  batchSize: 100,
+  counter: 0,
+  keysetId,
+});
+
+// Bare calls need no change
+await wallet.batchRestore();
+```
+
+---
+
 ## `verifyDleqIfPresent` removed; `hasValidDleq` default flipped to spec semantics
 
 `verifyDleqIfPresent` is removed. Its NUT-12 "verify-if-present" semantic is now the default behavior of `hasValidDleq`, which gains an optional `{ require?: boolean }` argument for the stricter opt-in policy.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1611,6 +1611,10 @@ class Wallet {
   /**
    * Restores batches of deterministic proofs until no more signatures are returned from the mint.
    *
+   * @remarks
+   * Batches are fetched through a bounded request pool and every batch in flight is processed, so
+   * the scan can probe (and recover proofs) up to `(BATCH_POOL_SIZE - 1) * batchSize` counters past
+   * the gap limit before it stops.
    * @param [gapLimit=300] The amount of empty counters that should be returned before restoring
    *   ends (defaults to 300). Default is `300`
    * @param [batchSize=300] The amount of proofs that should be restored at a time (defaults to
@@ -1632,16 +1636,25 @@ class Wallet {
     let lastCounterWithSignature: undefined | number;
     let emptyBatchesFound = 0;
 
+    // Batch positions are fixed, so each wave speculatively fetches the next BATCH_POOL_SIZE
+    // batches concurrently; only the stop decision is data-dependent. Results are consumed in
+    // counter order, and a non-empty batch past the gap limit resets the gap count: the reveal
+    // is already spent at request time, so proofs in flight are recovered rather than dropped.
     while (emptyBatchesFound < requiredEmptyBatches) {
-      const restoreRes = await this.restore(counter, batchSize, { keysetId });
-      if (restoreRes.proofs.length > 0) {
-        emptyBatchesFound = 0;
-        restoredProofs.push(...restoreRes.proofs);
-        lastCounterWithSignature = restoreRes.lastCounterWithSignature;
-      } else {
-        emptyBatchesFound++;
+      const starts = Array.from({ length: BATCH_POOL_SIZE }, (_, i) => counter + i * batchSize);
+      const wave = await runPool(starts, BATCH_POOL_SIZE, (start) =>
+        this.restore(start, batchSize, { keysetId }),
+      );
+      for (const restoreRes of wave) {
+        if (restoreRes.proofs.length > 0) {
+          emptyBatchesFound = 0;
+          restoredProofs.push(...restoreRes.proofs);
+          lastCounterWithSignature = restoreRes.lastCounterWithSignature;
+        } else {
+          emptyBatchesFound++;
+        }
       }
-      counter += batchSize;
+      counter += batchSize * BATCH_POOL_SIZE;
     }
     return { proofs: restoredProofs, lastCounterWithSignature };
   }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1618,7 +1618,10 @@ class Wallet {
    * the gap limit before it stops. `lastCounterWithSignature` always reflects all signatures found,
    * including those of proofs removed by `filterSpent`.
    * @param [config.gapLimit=300] Consecutive empty counters that end the scan. A floor, not an
-   *   exact ceiling: batches already in flight past it are still processed. Default is `300`
+   *   exact ceiling: batches already in flight past it are still processed. `Infinity` disables the
+   *   gap rule (use with `maxCounter`). Default is `300`
+   * @param [config.maxCounter] Inclusive scan ceiling; no counter above it is probed. Default is
+   *   unbounded.
    * @param [config.batchSize=500] Counters per restore request. Default is `500`
    * @param [config.counter=0] Starting counter. Default is `0`
    * @param [config.keysetId] Keyset to restore; defaults to the wallet's.
@@ -1629,6 +1632,7 @@ class Wallet {
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
     const { gapLimit = 300, batchSize = 500, keysetId, filterSpent = true } = config ?? {};
     let counter = config?.counter ?? 0;
+    const bound = config?.maxCounter ?? Number.MAX_SAFE_INTEGER;
     const requiredEmptyBatches = Math.ceil(gapLimit / batchSize);
     let restoredProofs: Proof[] = [];
 
@@ -1639,10 +1643,13 @@ class Wallet {
     // batches concurrently; only the stop decision is data-dependent. Results are consumed in
     // counter order, and a non-empty batch past the gap limit resets the gap count: the reveal
     // is already spent at request time, so proofs in flight are recovered rather than dropped.
-    while (emptyBatchesFound < requiredEmptyBatches) {
-      const starts = Array.from({ length: BATCH_POOL_SIZE }, (_, i) => counter + i * batchSize);
+    while (emptyBatchesFound < requiredEmptyBatches && counter <= bound) {
+      const starts = Array.from(
+        { length: BATCH_POOL_SIZE },
+        (_, i) => counter + i * batchSize,
+      ).filter((s) => s <= bound);
       const wave = await runPool(starts, BATCH_POOL_SIZE, (start) =>
-        this.restore(start, batchSize, { keysetId }),
+        this.restore(start, Math.min(batchSize, bound - start + 1), { keysetId }),
       );
       for (const restoreRes of wave) {
         if (restoreRes.proofs.length > 0) {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -92,6 +92,7 @@ import {
   type MeltProofsResponse,
   type SendResponse,
   type RestoreConfig,
+  type BatchRestoreConfig,
   type SecretsPolicy,
   type SwapPreview,
   type MintPreview,
@@ -1614,24 +1615,22 @@ class Wallet {
    * @remarks
    * Batches are fetched through a bounded request pool and every batch in flight is processed, so
    * the scan can probe (and recover proofs) up to `(BATCH_POOL_SIZE - 1) * batchSize` counters past
-   * the gap limit before it stops.
-   * @param [gapLimit=300] The amount of empty counters that should be returned before restoring
-   *   ends (defaults to 300). Default is `300`
-   * @param [batchSize=300] The amount of proofs that should be restored at a time (defaults to
-   *   300). Default is `300`
-   * @param [counter=0] The counter that should be used as a starting point (defaults to 0). Default
-   *   is `0`
-   * @param [keysetId] Which keysetId to use for the restoration. If none is passed the instance's
-   *   default one will be used.
+   * the gap limit before it stops. `lastCounterWithSignature` always reflects all signatures found,
+   * including those of proofs removed by `filterSpent`.
+   * @param [config.gapLimit=300] Consecutive empty counters that end the scan. A floor, not an
+   *   exact ceiling: batches already in flight past it are still processed. Default is `300`
+   * @param [config.batchSize=500] Counters per restore request. Default is `500`
+   * @param [config.counter=0] Starting counter. Default is `0`
+   * @param [config.keysetId] Keyset to restore; defaults to the wallet's.
+   * @param [config.filterSpent=true] Drop spent proofs (NUT-07) before returning. Default is `true`
    */
   async batchRestore(
-    gapLimit = 300,
-    batchSize = 300,
-    counter = 0,
-    keysetId?: string,
+    config?: BatchRestoreConfig,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
+    const { gapLimit = 300, batchSize = 500, keysetId, filterSpent = true } = config ?? {};
+    let counter = config?.counter ?? 0;
     const requiredEmptyBatches = Math.ceil(gapLimit / batchSize);
-    const restoredProofs: Proof[] = [];
+    let restoredProofs: Proof[] = [];
 
     let lastCounterWithSignature: undefined | number;
     let emptyBatchesFound = 0;
@@ -1655,6 +1654,11 @@ class Wallet {
         }
       }
       counter += batchSize * BATCH_POOL_SIZE;
+    }
+
+    if (filterSpent && restoredProofs.length > 0) {
+      const states = await this.checkProofsStates(restoredProofs);
+      restoredProofs = restoredProofs.filter((_, i) => states[i].state !== CheckStateEnum.SPENT);
     }
     return { proofs: restoredProofs, lastCounterWithSignature };
   }

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -11,6 +11,33 @@ export type RestoreConfig = {
 };
 
 /**
+ * Configuration for `batchRestore`.
+ */
+export type BatchRestoreConfig = {
+  /**
+   * Consecutive empty counters that end the scan. A floor, not an exact ceiling: batches already in
+   * flight past it are still processed. Default is `300`
+   */
+  gapLimit?: number;
+  /**
+   * Counters per restore request. Default is `500`
+   */
+  batchSize?: number;
+  /**
+   * Starting counter. Default is `0`
+   */
+  counter?: number;
+  /**
+   * Keyset to restore; defaults to the wallet's.
+   */
+  keysetId?: string;
+  /**
+   * Drop spent proofs (NUT-07) before returning. Default is `true`
+   */
+  filterSpent?: boolean;
+};
+
+/**
  * Shared properties for most `OutputType` variants (except 'custom').
  */
 export interface SharedOutputTypeProps {

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -16,9 +16,16 @@ export type RestoreConfig = {
 export type BatchRestoreConfig = {
   /**
    * Consecutive empty counters that end the scan. A floor, not an exact ceiling: batches already in
-   * flight past it are still processed. Default is `300`
+   * flight past it are still processed. `Infinity` disables the gap rule (use with `maxCounter`).
+   * Default is `300`
    */
   gapLimit?: number;
+  /**
+   * Inclusive scan ceiling: no counter above it is probed and the scan stops there even without a
+   * gap. Combine with `gapLimit: Infinity` to fetch a known range wall to wall. Default is
+   * unbounded.
+   */
+  maxCounter?: number;
   /**
    * Counters per restore request. Default is `500`
    */

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -1155,13 +1155,22 @@ describe('batchRestore mutants', () => {
     const restoreSpy = vi
       .spyOn(wallet, 'restore')
       .mockResolvedValueOnce({ proofs: [fakeProof], lastCounterWithSignature: 0 })
+      .mockResolvedValueOnce({ proofs: [fakeProof], lastCounterWithSignature: 1 })
+      .mockResolvedValueOnce({ proofs: [fakeProof], lastCounterWithSignature: 2 })
+      .mockResolvedValueOnce({ proofs: [fakeProof], lastCounterWithSignature: 3 })
       .mockResolvedValue({ proofs: [] });
 
-    await wallet.batchRestore(1, 1, 0, KEYSET_ID);
+    await wallet.batchRestore({
+      gapLimit: 1,
+      batchSize: 1,
+      keysetId: KEYSET_ID,
+      filterSpent: false,
+    });
 
-    // First non-empty batch resets the empty run, then one empty batch ends it: two calls.
+    // Wave 1 probes counters 0-3 in order (a `-` mutant in the start math would probe -1).
     expect(restoreSpy).toHaveBeenNthCalledWith(1, 0, 1, { keysetId: KEYSET_ID });
-    // Counter must advance by batchSize (a `-=` mutant would call restore with -1).
     expect(restoreSpy).toHaveBeenNthCalledWith(2, 1, 1, { keysetId: KEYSET_ID });
+    // Wave 1 was all non-empty, so wave 2 must start at counter 4 (a `-=` advance mutant goes negative).
+    expect(restoreSpy).toHaveBeenNthCalledWith(5, 4, 1, { keysetId: KEYSET_ID });
   });
 });

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -12,35 +12,30 @@ describe('Restoring deterministic proofs', () => {
   test('Batch restore', async () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
-    let rounds = 0;
     const mockRestore = vi
       .spyOn(wallet, 'restore')
-      .mockImplementation(async (): Promise<{ proofs: Proof[] }> => {
-        if (rounds === 0) {
-          rounds++;
+      .mockImplementation(async (start): Promise<{ proofs: Proof[] }> => {
+        if (start === 0) {
           return { proofs: Array(21).fill(1) as Proof[] };
         }
-        rounds++;
         return { proofs: [] };
       });
     const { proofs: restoredProofs } = await wallet.batchRestore();
     expect(restoredProofs.length).toBe(21);
-    expect(mockRestore).toHaveBeenCalledTimes(2);
+    // one pooled wave of 4 batches covers the gap limit
+    expect(mockRestore).toHaveBeenCalledTimes(4);
     mockRestore.mockClear();
   });
   test('Batch restore with custom values', async () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
-    let rounds = 0;
     const mockRestore = vi
       .spyOn(wallet, 'restore')
       .mockImplementation(
-        async (): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> => {
-          if (rounds === 0) {
-            rounds++;
+        async (start): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> => {
+          if (start === 0) {
             return { proofs: Array(42).fill(1) as Proof[], lastCounterWithSignature: 41 };
           }
-          rounds++;
           return { proofs: [] };
         },
       );
@@ -50,8 +45,33 @@ describe('Restoring deterministic proofs', () => {
       0,
     );
     expect(restoredProofs.length).toBe(42);
-    expect(mockRestore).toHaveBeenCalledTimes(3);
+    expect(mockRestore).toHaveBeenCalledTimes(4);
     expect(lastCounterWithSignature).toBe(41);
+    mockRestore.mockClear();
+  });
+  test('Batch restore recovers proofs found past the gap limit in the same wave', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    // the gap limit is reached at start 300, but the batch at 600 is already in flight in
+    // the same wave; its proofs reset the gap count and are kept, not dropped.
+    const mockRestore = vi
+      .spyOn(wallet, 'restore')
+      .mockImplementation(
+        async (start): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> => {
+          if (start === 0) {
+            return { proofs: Array(5).fill(1) as Proof[], lastCounterWithSignature: 4 };
+          }
+          if (start === 600) {
+            return { proofs: Array(3).fill(1) as Proof[], lastCounterWithSignature: 602 };
+          }
+          return { proofs: [] };
+        },
+      );
+    const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore();
+    expect(restoredProofs.length).toBe(8);
+    expect(lastCounterWithSignature).toBe(602);
+    // the empty batch at 900 closes the gap again, so one wave suffices
+    expect(mockRestore).toHaveBeenCalledTimes(4);
     mockRestore.mockClear();
   });
 });

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -2,11 +2,14 @@ import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
-import { Wallet, Amount, type Proof } from '../../src';
+import { Wallet, Amount, CheckStateEnum, type Proof, type ProofState } from '../../src';
 
 import { useTestServer, mint, unit, dummyKeysResp, mintUrl, logger } from './_setup';
 
 const server = useTestServer();
+
+const allUnspent = (n: number): ProofState[] =>
+  Array(n).fill({ state: CheckStateEnum.UNSPENT }) as ProofState[];
 
 describe('Restoring deterministic proofs', () => {
   test('Batch restore', async () => {
@@ -20,11 +23,15 @@ describe('Restoring deterministic proofs', () => {
         }
         return { proofs: [] };
       });
+    const mockStates = vi.spyOn(wallet, 'checkProofsStates').mockResolvedValue(allUnspent(21));
     const { proofs: restoredProofs } = await wallet.batchRestore();
     expect(restoredProofs.length).toBe(21);
     // one pooled wave of 4 batches covers the gap limit
     expect(mockRestore).toHaveBeenCalledTimes(4);
+    // spent filtering is on by default
+    expect(mockStates).toHaveBeenCalledTimes(1);
     mockRestore.mockClear();
+    mockStates.mockClear();
   });
   test('Batch restore with custom values', async () => {
     const wallet = new Wallet(mint);
@@ -39,11 +46,11 @@ describe('Restoring deterministic proofs', () => {
           return { proofs: [] };
         },
       );
-    const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore(
-      100,
-      50,
-      0,
-    );
+    const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore({
+      gapLimit: 100,
+      batchSize: 50,
+      filterSpent: false,
+    });
     expect(restoredProofs.length).toBe(42);
     expect(mockRestore).toHaveBeenCalledTimes(4);
     expect(lastCounterWithSignature).toBe(41);
@@ -67,12 +74,44 @@ describe('Restoring deterministic proofs', () => {
           return { proofs: [] };
         },
       );
-    const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore();
+    const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore({
+      batchSize: 300,
+      filterSpent: false,
+    });
     expect(restoredProofs.length).toBe(8);
     expect(lastCounterWithSignature).toBe(602);
     // the empty batch at 900 closes the gap again, so one wave suffices
     expect(mockRestore).toHaveBeenCalledTimes(4);
     mockRestore.mockClear();
+  });
+  test('Batch restore drops spent proofs but keeps pending, counter unfiltered', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    const found = [{ secret: 'a' }, { secret: 'b' }, { secret: 'c' }, { secret: 'd' }] as Proof[];
+    const mockRestore = vi
+      .spyOn(wallet, 'restore')
+      .mockImplementation(
+        async (start): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> => {
+          if (start === 0) {
+            return { proofs: found, lastCounterWithSignature: 3 };
+          }
+          return { proofs: [] };
+        },
+      );
+    const mockStates = vi
+      .spyOn(wallet, 'checkProofsStates')
+      .mockResolvedValue([
+        { state: CheckStateEnum.UNSPENT },
+        { state: CheckStateEnum.SPENT },
+        { state: CheckStateEnum.PENDING },
+        { state: CheckStateEnum.UNSPENT },
+      ] as ProofState[]);
+    const { proofs: restoredProofs, lastCounterWithSignature } = await wallet.batchRestore();
+    expect(restoredProofs.map((p) => p.secret)).toEqual(['a', 'c', 'd']);
+    expect(lastCounterWithSignature).toBe(3);
+    expect(mockStates).toHaveBeenCalledWith(found);
+    mockRestore.mockClear();
+    mockStates.mockClear();
   });
 });
 

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -113,6 +113,33 @@ describe('Restoring deterministic proofs', () => {
     mockRestore.mockClear();
     mockStates.mockClear();
   });
+  test('Batch restore treats maxCounter as an inclusive ceiling and ends there', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    const calls: Array<[number, number]> = [];
+    const mockRestore = vi
+      .spyOn(wallet, 'restore')
+      .mockImplementation(async (start, count): Promise<{ proofs: Proof[] }> => {
+        calls.push([start, count]);
+        return { proofs: [1] as unknown as Proof[] };
+      });
+    // gapLimit Infinity: the gap rule never fires, so only the bound can end the scan
+    const { proofs } = await wallet.batchRestore({
+      gapLimit: Infinity,
+      batchSize: 100,
+      maxCounter: 349,
+      filterSpent: false,
+    });
+    // 350 counters in 100-batches; the last is clamped, nothing probes past the bound
+    expect(calls).toEqual([
+      [0, 100],
+      [100, 100],
+      [200, 100],
+      [300, 50],
+    ]);
+    expect(proofs.length).toBe(4);
+    mockRestore.mockClear();
+  });
 });
 
 describe('restore', () => {


### PR DESCRIPTION
## Summary

Two changes to `batchRestore`, using the v5 window to fix both its speed and its ergonomics.

**Pooling:** the linear scan fetched one batch per round trip, so an aged wallet paid hundreds of sequential requests. Batch positions are fixed (batch k always covers the same counter range) and only the stop decision is data-dependent, so the scan can speculate: each wave fetches the next `BATCH_POOL_SIZE` batches through the request pool from #789 and consumes results in counter order through the unchanged gap logic. With the batch size raised to 500, a wallet with its last used counter near 100k drops from ~336 round trips to ~50.

**v5 API (breaking):** the positional signature becomes `batchRestore(config?: BatchRestoreConfig)`, and spent proofs are filtered out by default before returning. The filter mirrors the manual post-pass reference wallets run today (cashu.me: restore, then `checkProofsStates`, drop SPENT, keep PENDING), so consumers can delete that code. `lastCounterWithSignature` always reflects all found signatures, so counter advancement is unaffected by filtering.

## The trade-off: counters in flight vs revealed messages

Speed and reveal are the same quantity here. Covering more counters per round trip means more speculative batches in flight when the scan hits the gap, and every batch sent reveals its deterministic blinded messages to the mint whether or not it was needed. At the defaults (pool of 4, batch 500) the scan may probe up to `(BATCH_POOL_SIZE - 1) * batchSize` = 1500 counters past the gap limit, once per restore (typical ~750, comparable to the ~800 non-contiguous messages a probe-search restore reveals). Shrinking the batch size would shrink that reveal in exact proportion to the speed given up, so the pool width and batch size are the dial. The extra reveal is empty counters only, inside a restore session the mint can already link, which is why ~7x speed for a bounded tail seemed the right side of the trade.

## Changes

- `batchRestore` fetches waves of `BATCH_POOL_SIZE` (4) batches via `runPool`; the empty/reset/stop state machine is unchanged and consumes results in counter order.
- The gap limit is checked at wave boundaries, so a non-empty batch already in flight past the limit is kept rather than dropped: the reveal is spent at request time, and discarding received proofs protects nothing. `gapLimit` is therefore a floor on gap tolerance rather than an exact ceiling (a gap that ends inside the current wave is bridged; one straddling a wave boundary still stops the scan).
- Breaking: `batchRestore(gapLimit?, batchSize?, counter?, keysetId?)` is now `batchRestore(config?: BatchRestoreConfig)`, with per-option TSDoc.
- `batchSize` default 300 -> 500, matching the request size `checkProofsStates` already uses against nutshell/CDK caps (1000).
- `filterSpent: true` by default: one pooled NUT-07 state check over the restored proofs, dropping SPENT and keeping PENDING. `filterSpent: false` returns the raw output.
- New `maxCounter` option: an inclusive scan ceiling, nothing above it is probed and the scan ends there even without a gap. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall (e.g. when T is known out of band).
- `migration-5.0.0.md` gains a section with before/after and the behavior notes; `etc/cashu-ts.api.md` regenerated.
- Tests: restore tests moved to the config form, a new test pins drop-SPENT/keep-PENDING/counter-unfiltered, another pins the in-flight rescue case, and the `batchRestore` mutant test now forces a second wave so the counter-advance mutant stays caught under pooling.

## Reviewer Notes

- Request count is nearly unchanged (up to 3 extra batches at the tail, plus the state check that consumers previously made themselves), so the rate-limit reasoning from #789 carries over: pool of 4 sits under browser connection caps, and nutshell/CDK per-minute limits see the same request budget spent faster but not larger.
- Behavior differs from v4 in two ways beyond the signature: spent proofs are no longer returned by default, and wallets with a counter gap larger than `gapLimit` may now recover proofs past it when the far side of the gap sits inside the in-flight wave.
- Public API change: `BatchRestoreConfig` added and the `batchRestore` signature updated in `etc/cashu-ts.api.md`.
