### PR TITLE
perf(crypto): cache the keyset parent node in the BIP-32 deriver

### DIFF
--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, numberToBytesBE } from '@noble/curves/utils.js';
 import { hmac } from '@noble/hashes/hmac.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { HDKey } from '@scure/bip32';
+import { HDKey, HARDENED_OFFSET } from '@scure/bip32';
 
 import { CTSError } from '../model/Errors';
 import { Bytes, isBase64String } from '../utils';
@@ -138,8 +138,9 @@ export function createKeyPairDeriver(
  * Creates a deterministic deriver function for a seed/keyset pair.
  *
  * @remarks
- * For deprecated BIP-32 derivation this caches the master key once, so callers that derive many
- * counters can reuse the expensive seed setup.
+ * For deprecated BIP-32 derivation this caches the shared keyset parent node once, so each counter
+ * costs three child derivations instead of a full path walk from the master. Constructing an HDKey
+ * node computes its public key, so fewer nodes means fewer EC multiplications.
  * @internal
  */
 export function createSecretAndBlindingFactorDeriver(
@@ -148,8 +149,11 @@ export function createSecretAndBlindingFactorDeriver(
 ): SecretAndBlindingFactorDeriver {
   switch (getDerivationKind(keysetId)) {
     case DerivationKind.DEPRECATED_BIP32: {
-      const masterKey = HDKey.fromMasterSeed(seed);
-      return (counter: number) => deriveBip32SecretAndBlindingFactor(masterKey, keysetId, counter);
+      const keysetIdInt = getKeysetIdInt(keysetId);
+      const parentKey = HDKey.fromMasterSeed(seed).derive(
+        `${STANDARD_DERIVATION_PATH}/${keysetIdInt}'`,
+      );
+      return (counter: number) => deriveBip32SecretAndBlindingFactor(parentKey, counter);
     }
     case DerivationKind.HMAC_SHA256:
       return (counter: number) => deriveHmacSecretAndBlindingFactor(seed, keysetId, counter);
@@ -172,13 +176,10 @@ function getDerivationKind(keysetId: string): DerivationKind {
 }
 
 function deriveBip32SecretAndBlindingFactor(
-  hdKey: HDKey,
-  keysetId: string,
+  parentKey: HDKey,
   counter: number,
 ): DerivedSecretAndBlindingFactor {
-  const keysetIdInt = getKeysetIdInt(keysetId);
-  const baseDerivationPath = `${STANDARD_DERIVATION_PATH}/${keysetIdInt}'/${counter}'`;
-  const baseKey = hdKey.derive(baseDerivationPath);
+  const baseKey = parentKey.deriveChild(HARDENED_OFFSET + counter);
   const secret = baseKey.deriveChild(0).privateKey;
   const blindingFactor = baseKey.deriveChild(1).privateKey;
   /* c8 ignore next */


### PR DESCRIPTION
## Summary

Profiling restore-scale blank creation showed 1.33ms per counter on `00` keysets, 75% of it in NUT-13 BIP-32 derivation. Two compounding causes: `createSecretAndBlindingFactorDeriver` cached only the master key, so every counter re-walked the three constant hardened levels of `m/129372'/0'/{keysetIdInt}'`; and `@scure/bip32` computes each node's public key (plus its hash160) eagerly in the constructor, so every derived node costs an EC multiplication this code path never reads. Six nodes per counter, one public key actually needed.

Caching the keyset-level parent once per deriver (the pattern `createKeyPairDeriver` already uses) leaves three child derivations per counter: **1.33 -> 0.83ms per counter** on an M-series laptop, so a 10k-counter restore drops from ~13s to ~8s of CPU. v1/v2 (`01`/`02`) keysets use HMAC derivation and are unaffected.

## Changes

- The `DEPRECATED_BIP32` arm derives `m/129372'/0'/{keysetIdInt}'` once when the deriver is created; each counter is `deriveChild(HARDENED_OFFSET + counter)` plus the two non-hardened children, exactly the path the old string walk produced.
- `getKeysetIdInt` moved out of the per-counter path into the factory.
- No new tests: the existing NUT-13 vectors pin byte-identical output for both hex and base64 keysets, and the base64 test builds its expectation from a raw hardened-counter path string independently of the deriver.

