### PR TITLE
feat(wallet): restore every keyset in one call with restoreAll

### DIFF
--- a/docs-src/deterministic_counters.md
+++ b/docs-src/deterministic_counters.md
@@ -39,12 +39,11 @@ wallet.on.countersReserved(({ keysetId, start, count, next }) => {
 // 3) Inspect current state, what will be reserved next
 const nextCounter = await wallet.counters.peekNext('0111111'); // 128
 
-// 4) After a restore or cross device sync, bump the cursor forward
-const { lastCounterWithSignature } = await wallet.batchRestore();
-if (lastCounterWithSignature != null) {
-  const next = lastCounterWithSignature + 1; // e.g. 137
-  await wallet.counters.advanceToAtLeast('0111111', next);
-  await saveNextToDb('0111111', next);
+// 4) After a restore or cross device sync, bump the cursors forward
+const { lastCounters } = await wallet.restoreAll();
+for (const [keysetId, last] of Object.entries(lastCounters)) {
+  await wallet.counters.advanceToAtLeast(keysetId, last + 1);
+  await saveNextToDb(keysetId, last + 1);
 }
 
 // 5) Parallel keysets without mutation

--- a/docs-src/deterministic_counters.md
+++ b/docs-src/deterministic_counters.md
@@ -40,6 +40,7 @@ wallet.on.countersReserved(({ keysetId, start, count, next }) => {
 const nextCounter = await wallet.counters.peekNext('0111111'); // 128
 
 // 4) After a restore or cross device sync, bump the cursors forward
+// (see usage/restore_proofs.md for the full restore flow)
 const { lastCounters } = await wallet.restoreAll();
 for (const [keysetId, last] of Object.entries(lastCounters)) {
   await wallet.counters.advanceToAtLeast(keysetId, last + 1);

--- a/docs-src/usage/restore_proofs.md
+++ b/docs-src/usage/restore_proofs.md
@@ -1,0 +1,62 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Restore Proofs**
+
+# Restore proofs from a seed
+
+Wallets that create outputs deterministically (see [Deterministic Counters](../deterministic_counters.md)) can rebuild their proofs from nothing but the seed: the wallet re-derives the blinded messages for each counter ([NUT-13](https://github.com/cashubtc/nuts/blob/main/13.md)) and asks the mint to replay its signatures for them ([NUT-09](https://github.com/cashubtc/nuts/blob/main/09.md)). Only deterministic outputs are recoverable; proofs created with random secrets are not.
+
+## Quick start: restore everything
+
+`restoreAll` scans every keyset in the wallet's unit (inactive keysets included) and merges the results. Afterwards, bump each keyset's counter past the restored range so new outputs cannot collide with already-signed ones.
+
+```typescript
+const wallet = new Wallet(mintUrl, { bip39seed: seed });
+await wallet.loadMint();
+
+const { proofs, lastCounters } = await wallet.restoreAll();
+
+// proofs are unspent (spent ones are filtered out by default) - store them
+for (const [keysetId, last] of Object.entries(lastCounters)) {
+  await wallet.counters.advanceToAtLeast(keysetId, last + 1);
+}
+```
+
+`lastCounters` maps each keyset id to the highest counter that returned a signature. Keysets with no signatures are absent. Counter advancement uses all found signatures, including any whose proofs were filtered out as spent, so it is always safe to resume from `last + 1`.
+
+## Single keyset and options
+
+`batchRestore` scans one keyset. Both it and `restoreAll` accept the same scan options (`restoreAll` forwards them to every keyset):
+
+```typescript
+const { proofs, lastCounterWithSignature } = await wallet.batchRestore({
+  keysetId: '00bd033559de27d0', // defaults to the wallet's keyset
+  gapLimit: 300, // consecutive empty counters that end the scan
+  batchSize: 500, // counters per request (mint caps are typically 1000)
+  counter: 0, // starting counter
+  filterSpent: true, // drop spent proofs via NUT-07 before returning
+});
+```
+
+Semantics worth knowing:
+
+- **`gapLimit` is a floor, not an exact ceiling.** Batches are fetched through a small request pool, so a few batches are already in flight when the gap closes. Their results are still processed: proofs sitting shortly past the gap limit are recovered rather than dropped, and the scan may probe up to three extra batches of counters past the gap.
+- **`filterSpent` drops SPENT proofs and keeps PENDING ones** (a pending melt can fail and return them to spendable). Pass `filterSpent: false` for the raw output, e.g. for auditing. `lastCounterWithSignature` is never affected by filtering.
+- **`maxCounter` bounds the scan** (inclusive); nothing above it is probed. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall:
+
+```typescript
+// You know the last used counter (e.g. from a backup) - skip the gap search entirely
+const { proofs } = await wallet.batchRestore({ maxCounter: lastKnown, gapLimit: Infinity });
+```
+
+## Low-level: one exact range
+
+`restore(start, count)` performs a single NUT-09 request with no gap logic and no spent filtering. Use it to build custom scan strategies:
+
+```typescript
+const { proofs, lastCounterWithSignature } = await wallet.restore(0, 100, { keysetId });
+```
+
+## Notes
+
+- Restore replays **issued signatures**, so without `filterSpent` the result includes proofs you have long since spent. Filter before crediting a balance.
+- Restoring reveals the derived blinded messages for every scanned counter to the mint. The gap limit exists to bound that reveal; raise it only when you expect large counter gaps.
+- Upgrading from v4: `batchRestore` took positional arguments and returned spent proofs. See the [v5 migration guide](https://github.com/cashubtc/cashu-ts/blob/main/migration-5.0.0.md) for the config-object signature and the `filterSpent` default.

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -17,6 +17,7 @@ If you are building a wallet integration from scratch, read these in order:
 3. [Create Token](./create_token.md) or [Create P2PK](./create_p2pk.md) to send value.
 4. [Get Token](./get_token.md) to inspect or decode tokens safely.
 5. [Melt Token](./melt_token.md) to pay invoices with proofs.
+6. [Restore Proofs](./restore_proofs.md) to recover a wallet from its seed.
 
 ## Recipes
 
@@ -30,6 +31,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [Derive Keys](./derive_keys.md)                     | Derive recoverable P2PK / NUT-20 keys deterministically from the wallet seed.   |
 | [Get Token](./get_token.md)                         | Inspect token metadata before wallet creation or decode it after load.          |
 | [Melt Token](./melt_token.md)                       | Pay BOLT11 invoices or other payment methods with wallet proofs.                |
+| [Restore Proofs](./restore_proofs.md)               | Recover deterministic proofs from the wallet seed across keysets.               |
 | [Bolt12](./bolt12.md)                               | Work with reusable BOLT12 offers for minting and melting.                       |
 | [NUT-19 Cached Responses](./nut19.md)               | Understand cached endpoint retries and timeout behavior.                        |
 | [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1857,6 +1857,9 @@ export type ResponseMeta = {
     headers: Headers;
 };
 
+// @public
+export type RestoreAllConfig = Omit<BatchRestoreConfig, 'counter' | 'keysetId'>;
+
 // @public (undocumented)
 export type RestoreConfig = {
     keysetId?: string;
@@ -2312,6 +2315,10 @@ export class Wallet {
     restore(start: number, count: number, config?: RestoreConfig): Promise<{
         proofs: Proof[];
         lastCounterWithSignature?: number;
+    }>;
+    restoreAll(config?: RestoreAllConfig): Promise<{
+        proofs: Proof[];
+        lastCounters: Record<string, number>;
     }>;
     selectProofsToSend(proofs: ProofLike[], amountToSend: AmountLike, includeFees?: boolean, exactMatch?: boolean): SendResponse;
     send(amount: AmountLike, proofs: ProofLike[], config?: SendConfig, outputConfig?: OutputConfig): Promise<SendResponse>;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -93,6 +93,7 @@ import {
   type SendResponse,
   type RestoreConfig,
   type BatchRestoreConfig,
+  type RestoreAllConfig,
   type SecretsPolicy,
   type SwapPreview,
   type MintPreview,
@@ -1668,6 +1669,33 @@ class Wallet {
       restoredProofs = restoredProofs.filter((_, i) => states[i].state !== CheckStateEnum.SPENT);
     }
     return { proofs: restoredProofs, lastCounterWithSignature };
+  }
+
+  /**
+   * Restores deterministic proofs for every keyset in the wallet's unit.
+   *
+   * @remarks
+   * Runs `batchRestore` per keyset, inactive keysets included, and merges the results. After
+   * restoring, advance each keyset's counter from `lastCounters`.
+   */
+  async restoreAll(
+    config?: RestoreAllConfig,
+  ): Promise<{ proofs: Proof[]; lastCounters: Record<string, number> }> {
+    const keysetIds = this._keyChain
+      .getAllKeysetIds()
+      .filter((id) => this._keyChain.getKeyset(id).unit === this.unit);
+    let proofs: Proof[] = [];
+    const lastCounters: Record<string, number> = {};
+    for (const keysetId of keysetIds) {
+      const res = await this.batchRestore({ ...config, keysetId });
+      // concat, not push-spread: a keyset's result is unbounded and spread
+      // arguments hit V8's call-size limit around ~65k elements.
+      proofs = proofs.concat(res.proofs);
+      if (res.lastCounterWithSignature !== undefined) {
+        lastCounters[keysetId] = res.lastCounterWithSignature;
+      }
+    }
+    return { proofs, lastCounters };
   }
 
   /**

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -45,6 +45,11 @@ export type BatchRestoreConfig = {
 };
 
 /**
+ * Configuration for `restoreAll`: `batchRestore` options minus the per-keyset fields.
+ */
+export type RestoreAllConfig = Omit<BatchRestoreConfig, 'counter' | 'keysetId'>;
+
+/**
  * Shared properties for most `OutputType` variants (except 'custom').
  */
 export interface SharedOutputTypeProps {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1063,6 +1063,18 @@ describe('Wallet Restore', () => {
     expect(sumProofs(restoredProofs).equals(70)).toBeTruthy();
     expect(lastCounterWithSignature).toBe(7);
   });
+  test('Using restoreAll', async () => {
+    const seed = randomBytes(64);
+    const wallet = new Wallet(mintUrl, { bip39seed: seed });
+    await wallet.loadMint();
+    const mintQuote = await wallet.createMintQuoteBolt11(70);
+    await untilMintQuotePaid(wallet, mintQuote);
+    const proofs = await wallet.ops.mintBolt11(70, mintQuote.quote).asDeterministic(5).run();
+    const { proofs: restoredProofs, lastCounters } = await wallet.restoreAll();
+    expect(restoredProofs).toEqual(proofs);
+    expect(sumProofs(restoredProofs).equals(70)).toBeTruthy();
+    expect(lastCounters[wallet.keysetId]).toBe(7);
+  });
 });
 
 describe('CDK Mint NUT-19 Cache Tests', () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -142,6 +142,55 @@ describe('Restoring deterministic proofs', () => {
   });
 });
 
+describe('restoreAll', () => {
+  // Minimal Keyset-shaped stub; only `unit` is read by restoreAll's filter.
+  const ks = (unitStr: string) => ({ unit: unitStr }) as never;
+
+  test('restores every keyset in the wallet unit and merges results', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    vi.spyOn(wallet.keyChain, 'getAllKeysetIds').mockReturnValue(['A', 'B', 'C']);
+    vi.spyOn(wallet.keyChain, 'getKeyset').mockImplementation((id) =>
+      id === 'C' ? ks('eur') : ks('sat'),
+    );
+    const batchSpy = vi.spyOn(wallet, 'batchRestore').mockImplementation(async (config) => {
+      if (config?.keysetId === 'A') {
+        return {
+          proofs: [{ secret: 'a1' }, { secret: 'a2' }] as Proof[],
+          lastCounterWithSignature: 12,
+        };
+      }
+      return { proofs: [] }; // keyset B: nothing found
+    });
+
+    const { proofs, lastCounters } = await wallet.restoreAll();
+
+    expect(proofs.map((p) => p.secret)).toEqual(['a1', 'a2']);
+    // per-keyset counters: B absent (no signatures), C never scanned (wrong unit)
+    expect(lastCounters).toEqual({ A: 12 });
+    expect(batchSpy).toHaveBeenCalledTimes(2);
+    expect(batchSpy).toHaveBeenCalledWith({ keysetId: 'A' });
+    expect(batchSpy).toHaveBeenCalledWith({ keysetId: 'B' });
+  });
+
+  test('forwards scan options to every keyset', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    vi.spyOn(wallet.keyChain, 'getAllKeysetIds').mockReturnValue(['A']);
+    vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks('sat'));
+    const batchSpy = vi.spyOn(wallet, 'batchRestore').mockResolvedValue({ proofs: [] });
+
+    await wallet.restoreAll({ gapLimit: 100, batchSize: 50, filterSpent: false });
+
+    expect(batchSpy).toHaveBeenCalledWith({
+      gapLimit: 100,
+      batchSize: 50,
+      filterSpent: false,
+      keysetId: 'A',
+    });
+  });
+});
+
 describe('restore', () => {
   test('sends zero-amount blanks and maps signatures to proofs', async () => {
     const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32), logger });


### PR DESCRIPTION
## Summary

A full wallet restore has to scan every keyset the mint has rotated through, and today each consumer writes that loop themselves (cashu.me's restore store is the canonical example). `wallet.restoreAll()` does it in one call: it enumerates the keychain, filters to the wallet's unit (inactive keysets included, since restore is not gated on active), runs the pooled `batchRestore` from #795 per keyset, and merges the proofs plus a `lastCounters: Record<keysetId, number>` map, since counter advancement is per keyset.

Keysets run sequentially by design: each keyset's scan already saturates the 4-slot request pool, so cross-keyset interleaving would add complexity for little wall-clock.

## Changes

- `Wallet.restoreAll(config?: RestoreAllConfig)` after `batchRestore`; `RestoreAllConfig = Omit<BatchRestoreConfig, 'counter' | 'keysetId'>`, so `gapLimit`, `batchSize`, `maxCounter`, and `filterSpent` pass through to every keyset scan.
- Keysets that return no signatures are absent from `lastCounters`; wrong-unit keysets are never scanned.
- Per-keyset results merge via `concat` rather than push-spread: a keyset's result is unbounded and spread arguments hit V8's call-size limit around ~65k elements.
- Docs: new usage recipe page `docs-src/usage/restore_proofs.md` covering `restoreAll`, the `batchRestore` options (gap floor semantics, `maxCounter` + `gapLimit: Infinity`, spent filtering), and the low-level range call; indexed in usage examples, and the deterministic counters recipe now shows the cross-keyset cursor bump and links over. `etc/cashu-ts.api.md` regenerated.
- Tests: unit coverage for unit filtering, result merging, and option pass-through; integration test verified against a fresh CDK mint alongside the existing batch restore test.

## Reviewer Notes

- Memory profile: with the default `filterSpent: true` the cross-keyset accumulation holds unspent proofs only; a keyset's full issued history exists transiently one keyset at a time inside `batchRestore`. `filterSpent: false` reverts to accumulating everything, which is the caller's explicit choice.
- No seed guard: `batchRestore -> restore` already fails fast without a seed.
- Non-breaking addition on top of #795; deliberate non-goals: cross-keyset pool interleaving, per-keyset start counters, cross-unit restore (one Wallet per unit remains the app pattern), progress events.
