### PR TITLE
fix(transport): stop pool claims after a failure

### DIFF
--- a/src/transport/pool.ts
+++ b/src/transport/pool.ts
@@ -13,8 +13,8 @@ export const BATCH_POOL_SIZE = 4;
  *
  * @remarks
  * Not chunked: `limit` workers pull from a shared cursor, so a slow item never stalls the rest.
- * Lock-free because `next++` claims are synchronous; workers only interleave at the await. Rejects
- * on the first `fn` rejection (Promise.all); later rejections are absorbed.
+ * Lock-free because `next++` claims are synchronous; workers only interleave at the await. A
+ * failure stops new claims; in-flight items settle, then the pool rejects with that failure.
  * @internal
  */
 export async function runPool<T, R>(
@@ -30,10 +30,19 @@ export async function runPool<T, R>(
     // `next++` reads-then-bumps in one synchronous step, so every index is claimed exactly
     // once; the worker claims whatever is next by the time its await settles.
     for (let i = next++; i < items.length; i = next++) {
-      // Write by slot, so output order matches input order however workers finish.
-      results[i] = await fn(items[i], i);
+      try {
+        // Write by slot, so output order matches input order however workers finish.
+        results[i] = await fn(items[i], i);
+      } catch (e) {
+        // Poison the cursor so no worker claims another item after a failure.
+        next = items.length;
+        throw e;
+      }
     }
   });
-  await Promise.all(workers);
+  // Settle every worker before rejecting, so a rejection never leaves requests in flight.
+  const settled = await Promise.allSettled(workers);
+  const failed = settled.find((s): s is PromiseRejectedResult => s.status === 'rejected');
+  if (failed) throw failed.reason;
   return results;
 }

--- a/test/transport/pool.test.ts
+++ b/test/transport/pool.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+
+import { runPool } from '../../src/transport/pool';
+
+describe('runPool', () => {
+  test('runs items with bounded concurrency and keeps result order', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const results = await runPool([30, 10, 20], 2, async (ms) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, ms));
+      inFlight--;
+      return ms;
+    });
+    expect(results).toEqual([30, 10, 20]);
+    expect(peak).toBe(2);
+  });
+
+  test('a failure stops new claims and settles in-flight work before rejecting', async () => {
+    const claimed: number[] = [];
+    let inFlight = 0;
+    const pool = runPool([0, 1, 2, 3, 4], 2, async (item) => {
+      claimed.push(item);
+      inFlight++;
+      try {
+        await new Promise((r) => setTimeout(r, item === 0 ? 5 : 25));
+        if (item === 0) throw new Error('boom');
+        return item;
+      } finally {
+        inFlight--;
+      }
+    });
+    await expect(pool).rejects.toThrow('boom');
+    expect(inFlight).toBe(0); // rejection waited for the in-flight item
+    expect(claimed).toEqual([0, 1]); // items queued behind the failure were never claimed
+  });
+});


### PR DESCRIPTION
## Description

`runPool` (#789) rejects on the first failure via `Promise.all`, but its remaining workers keep claiming and sending requests in the background. A caller that starts fallback work in its catch block then overlaps orphaned pool traffic, paying for both.

A failure now poisons the claim cursor so no further items are claimed, in-flight items settle, and the pool rejects afterwards. When `runPool` rejects, the pool is quiet.

Retry policy stays with callers: the pool reports the failure rather than requeueing, since it cannot know what is idempotent or how many attempts are sane.

Tests cover bounded concurrency with result ordering, and that a failure stops new claims and settles in-flight work before rejecting.
