### PR TITLE
fix(transport): retry idempotent requests once on network errors

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1843,6 +1843,7 @@ export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 // @public (undocumented)
 export type RequestOptions = RequestArgs & Omit<RequestInit, 'body' | 'headers'> & Partial<Nut19Policy> & {
     requestTimeout?: number;
+    idempotent?: boolean;
     onResponseMeta?: (meta: ResponseMeta) => void;
     fetch?: RequestFetch;
 };

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -945,7 +945,7 @@ class Mint {
     const data = await this.requestWithAuth<CheckStateResponse>(
       'POST',
       '/v1/checkstate',
-      { requestBody: checkPayload },
+      { requestBody: checkPayload, idempotent: true },
       customRequest,
     );
 
@@ -1041,6 +1041,7 @@ class Mint {
       endpoint: joinUrls(this._mintUrl, '/v1/restore'),
       method: 'POST',
       requestBody: restorePayload,
+      idempotent: true,
       onResponseMeta: this._captureResponseMetadata,
     });
 

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -142,6 +142,12 @@ export type RequestOptions = RequestArgs &
      */
     requestTimeout?: number;
     /**
+     * Marks the request as safe to replay (read-only, no side effects). Idempotent requests retry
+     * once on a network-level failure, recovering from dropped keep-alive sockets. GET requests
+     * default to `true`; POSTs must opt in.
+     */
+    idempotent?: boolean;
+    /**
      * Optional callback invoked on every HTTP response with structured rate-limit metadata. Fires
      * before the promise resolves (on success) or rejects (on error), so consumers always receive
      * metadata even when the request fails.
@@ -312,7 +318,19 @@ async function requestWithRetry(options: RequestOptions): Promise<unknown> {
     !!ttl;
 
   if (!isCachable) {
-    return await _request(options);
+    const idempotent = options.idempotent ?? requestMethod === 'GET';
+    if (!idempotent) {
+      return await _request(options);
+    }
+    try {
+      return await _request(options);
+    } catch (e) {
+      // One immediate retry on a connection-level failure (a dropped keep-alive socket is the
+      // common case); HTTP errors mean the server answered and are never retried here.
+      if (e instanceof CallerAbortError || !(e instanceof NetworkError)) throw e;
+      requestLogger.info('Network error on an idempotent request, retrying once', { e });
+      return await _request(options);
+    }
   }
 
   let retries = 0;
@@ -376,6 +394,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
     // consumed by requestWithRetry, excluded from raw fetch options
     cached_endpoints,
     ttl,
+    idempotent,
     logger,
     ...fetchOptions
   } = options;
@@ -383,6 +402,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
   // Intentionally unused vars (extracted from fetchOptions)
   void cached_endpoints;
   void ttl;
+  void idempotent;
   void logger;
 
   const requestFetch = fetchImpl ?? fetch;

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1154,7 +1154,7 @@ describe('CDK Mint NUT-19 Cache Tests', () => {
     }
   }, 30500); // cdk mint has 30s ttl by default
 
-  test('Requests to endpoints not specified in NUT19 in MintInfo should not be replayed', async () => {
+  test('Requests to endpoints not specified in NUT19 in MintInfo skip the cache backoff', async () => {
     if (!(await shouldRunCDKTests())) {
       console.log('Skipping test - not CDK mint');
       return;
@@ -1172,7 +1172,8 @@ describe('CDK Mint NUT-19 Cache Tests', () => {
 
     try {
       await expect(wallet.mint.getKeys()).rejects.toThrow(NetworkError);
-      expect(fetchCallCount).toBe(1); // single request, without retries
+      // one attempt plus the single idempotent GET retry; no NUT-19 backoff loop
+      expect(fetchCallCount).toBe(2);
     } finally {
       globalThis.fetch = ogFetch;
     }

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -357,7 +357,7 @@ describe('requests', { timeout: 7500 }, () => {
     afterEach(() => {
       vi.restoreAllMocks();
     });
-    test('does not retry for non-cached endpoints', async () => {
+    test('does not enter the NUT-19 backoff loop for non-cached endpoints', async () => {
       const endpoint = mintUrl + '/v1/mint/quote';
 
       let requestCount = 0;
@@ -371,11 +371,12 @@ describe('requests', { timeout: 7500 }, () => {
       await expect(
         request({
           endpoint,
-          // no cached_endpoints specified - should not retry
+          // no cached_endpoints specified - should not enter the backoff loop
         }),
       ).rejects.toThrow(NetworkError);
 
-      expect(requestCount).toBe(1);
+      // one attempt plus the single idempotent GET retry, no backoff beyond that
+      expect(requestCount).toBe(2);
     });
 
     test('handles relative endpoints with normal request behavior', async () => {
@@ -457,7 +458,8 @@ describe('requests', { timeout: 7500 }, () => {
         .mockRejectedValue(new TypeError('Failed to parse URL from v1/keys'));
 
       await expect(request({ endpoint, ...retryPolicy })).rejects.toThrow(NetworkError);
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // no NUT-19 backoff; just the single idempotent GET retry
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     test('retries cached endpoints on NetworkError', async () => {
@@ -895,7 +897,8 @@ describe('requests', { timeout: 7500 }, () => {
 
       let thrown: unknown;
       try {
-        await request({ endpoint, signal: ac.signal, requestTimeout: 10 });
+        // idempotent off: a retry would race the caller abort and blur which error surfaces
+        await request({ endpoint, signal: ac.signal, requestTimeout: 10, idempotent: false });
       } catch (err) {
         thrown = err;
       } finally {
@@ -943,7 +946,8 @@ describe('requests', { timeout: 7500 }, () => {
         }),
       ).rejects.toThrow(NetworkError);
 
-      expect(getRequestCount).toBe(1);
+      // the GET misses the POST-only cache entry: one attempt plus the idempotent retry
+      expect(getRequestCount).toBe(2);
       expect(postRequestCount).toBeGreaterThan(1);
     });
 
@@ -1038,6 +1042,82 @@ describe('requests', { timeout: 7500 }, () => {
         vi.useRealTimers();
       }
     });
+  });
+});
+
+describe('idempotent single retry (non-cached endpoints)', () => {
+  test('GET retries once on NetworkError and succeeds', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    let requestCount = 0;
+    server.use(
+      http.get(endpoint, () => {
+        requestCount++;
+        return requestCount === 1 ? Response.error() : HttpResponse.json({ ok: true });
+      }),
+    );
+    const data = await request<{ ok: boolean }>({ endpoint });
+    expect(data.ok).toBe(true);
+    expect(requestCount).toBe(2);
+  });
+
+  test('GET retries only once', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    let requestCount = 0;
+    server.use(
+      http.get(endpoint, () => {
+        requestCount++;
+        return Response.error();
+      }),
+    );
+    await expect(request({ endpoint })).rejects.toThrow(NetworkError);
+    expect(requestCount).toBe(2);
+  });
+
+  test('POST does not retry by default', async () => {
+    const endpoint = mintUrl + '/v1/swap';
+    let requestCount = 0;
+    server.use(
+      http.post(endpoint, () => {
+        requestCount++;
+        return Response.error();
+      }),
+    );
+    await expect(request({ endpoint, method: 'POST', requestBody: {} })).rejects.toThrow(
+      NetworkError,
+    );
+    expect(requestCount).toBe(1);
+  });
+
+  test('an idempotent POST retries once on NetworkError', async () => {
+    const endpoint = mintUrl + '/v1/restore';
+    let requestCount = 0;
+    server.use(
+      http.post(endpoint, () => {
+        requestCount++;
+        return requestCount === 1 ? Response.error() : HttpResponse.json({ ok: true });
+      }),
+    );
+    const data = await request<{ ok: boolean }>({
+      endpoint,
+      method: 'POST',
+      requestBody: {},
+      idempotent: true,
+    });
+    expect(data.ok).toBe(true);
+    expect(requestCount).toBe(2);
+  });
+
+  test('HTTP errors are not retried, even when idempotent', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    let requestCount = 0;
+    server.use(
+      http.get(endpoint, () => {
+        requestCount++;
+        return new HttpResponse(JSON.stringify({ error: 'Service Unavailable' }), { status: 503 });
+      }),
+    );
+    await expect(request({ endpoint })).rejects.toThrow(HttpResponseError);
+    expect(requestCount).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Description

Node's fetch (undici) does not retry a POST that fails at the connection level, so a request sent on a keep-alive socket the mint has meanwhile closed dies with `UND_ERR_SOCKET: other side closed`. Browsers retry this case transparently, which is why it mostly surfaces in Node consumers. Wallet flows that pause between requests (a recovery deriving thousands of outputs, or any wallet idling past the mint's keep-alive timeout before a state check) hit it reliably against a directly-exposed uvicorn mint and occasionally behind proxies.

This adds a single immediate retry for requests that are safe to replay:

- GETs are treated as idempotent by default (matching browser behaviour); a new `idempotent` request option opts out.
- The read-only POSTs, `/v1/restore` and `/v1/checkstate`, opt in at their call sites.
- Only network-level failures retry (no response received). HTTP error responses are never retried on this path, caller aborts are respected, and the NUT-19 cached-endpoint backoff is unchanged; non-idempotent POSTs keep their exact current behaviour.

Tests cover the retry-once-and-succeed path for GET and idempotent POST, the single-retry cap, the POST default, and that HTTP errors stay single-shot. Existing NUT-19 tests updated where their attempt counts now include the one idempotent retry.