### PR TITLE
feat(wallet): warn when a mint has deprecated legacy keysets

### DIFF
--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -12,6 +12,14 @@ Existing v0 (legacy base64), v1 (`00…`), and v2 (`01…`) keysets continue to 
 
 ---
 
+## Legacy (base64-id) keysets are deprecated, removal planned for v6
+
+Base64 keyset ids were removed from the Cashu spec in December 2023 and have never been supported by CDK-based mints and wallets. v5 keeps support for spending and restoring proofs on legacy keysets (see the output policy below), but this is the last major that will: **v6 removes legacy keyset support entirely**.
+
+The wallet now logs a warning at `loadMint()` when a mint lists legacy keysets. If your users may hold pre-2024 proofs (or seeds) from a nutshell mint, sweep them during the v5 cycle: restore and swap so the balance moves onto a hex-id keyset. Note that nutshell mints migrating to CDK drop their legacy keysets in the process, after which such proofs are unredeemable at the mint regardless of wallet library.
+
+---
+
 ## Keyset output policy: new proofs require an active, prefixed keyset
 
 Proofs on **any** keyset can still be spent, swapped, and restored. But v5 now enforces a policy on which keysets may be used to **create new proofs**: the output keyset must be active and have a hex-prefixed id (`00…`/`01…`/`02…`).

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -48,8 +48,8 @@ type SecretAndBlindingFactorDeriver = (counter: number) => DerivedSecretAndBlind
  * values together is faster because it avoids repeating the shared path derivation common to the
  * secret and blinding factor.
  *
- * The function supports legacy base64 keyset IDs, deprecated hex keyset IDs with the `00` prefix,
- * and modern hex keyset IDs with the `01` prefix.
+ * The function supports legacy base64 keyset IDs (deprecated, removal planned for v6), deprecated
+ * hex keyset IDs with the `00` prefix, and modern hex keyset IDs with the `01` prefix.
  * @param seed - Wallet seed used for deterministic derivation.
  * @param keysetId - Mint keyset ID that selects the derivation method.
  * @param counter - Deterministic counter for the output.

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -418,6 +418,9 @@ export type DeriveKeysetIdOptions = {
   input_fee_ppk?: number;
   unit?: string;
   versionByte?: number;
+  /**
+   * @deprecated Legacy base64 keyset ids will be removed in cashu-ts v6.
+   */
   isDeprecatedBase64?: boolean;
 };
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -59,6 +59,7 @@ import type { RequestFetch, RequestFn } from '../transport';
 import {
   getDecodedToken,
   invoiceHasAmountInHRP,
+  isValidHex,
   normalizeProofAmounts,
   normalizeUrl,
   splitAmount,
@@ -375,7 +376,17 @@ class Wallet {
    * Finishes wiring up the wallet instance and checks we are "Go for launch".
    */
   private finishInit(): void {
-    this._logger.debug('KeyChain', { keychain: this._keyChain.cache });
+    const keychainCache = this._keyChain.cache;
+    this._logger.debug('KeyChain', { keychain: keychainCache });
+
+    // Legacy keysets still load (spend/restore only), but their days are numbered.
+    const legacyIds = keychainCache.keysets.map((k) => k.id).filter((id) => !isValidHex(id));
+    if (legacyIds.length > 0) {
+      this._logger.warn(
+        'Mint has legacy (base64-id) keysets. Support is deprecated and will be removed in cashu-ts v6; sweep any proofs held on these keysets.',
+        { keysets: legacyIds },
+      );
+    }
 
     // Go Keychain?
     if (this._boundKeysetId === PENDING_KEYSET_ID) {

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
-import { test, describe, expect } from 'vitest';
+import { test, describe, expect, vi } from 'vitest';
 
-import { Wallet, type MintKeys, type MintKeyset } from '../../src';
+import { Wallet, type Logger, type MintKeys, type MintKeyset } from '../../src';
 import { deriveKeysetId, isValidHex, isBase64String } from '../../src/utils';
 import { DUMMY_TEST_KEYS, DUMMY_TEST_KEYSET, PUBKEYS } from '../consts';
 
@@ -59,6 +59,42 @@ describe('Legacy (pre-v1) keyset output gating', () => {
     const keyset = wallet.keyChain.getKeyset(legacyId);
     expect(keyset.hasKeys).toBe(true);
     expect(keyset.hasHexId).toBe(false);
+  });
+
+  test('loadMint warns about deprecated legacy keysets, naming them', async () => {
+    const logger: Logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+
+    useLegacyHandlers();
+    const wallet = new Wallet(mint, { logger });
+    await wallet.loadMint();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/legacy .*deprecated.*removed in cashu-ts v6/i),
+      { keysets: [legacyId] },
+    );
+  });
+
+  test('loadMint does not warn when the mint has no legacy keysets', async () => {
+    const logger: Logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+
+    const wallet = new Wallet(mint, { logger });
+    await wallet.loadMint();
+
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   test('prepareMint refuses to create proofs on a legacy keyset', async () => {


### PR DESCRIPTION
## Summary

Legacy (pre-v1, base64-id) keyset support is planned for removal in v6 (#800 carries the removal, parked for the v6 window). This PR gives consumers a full major cycle of notice:

- `loadMint()` / `loadMintFromCache()` now log a warning naming any legacy keysets the mint lists, so apps can prompt users to sweep old proofs during v5
- `DeriveKeysetIdOptions.isDeprecatedBase64` is marked `@deprecated`
- the v5 migration guide documents the deprecation and the v6 removal plan

No behaviour change otherwise: legacy keysets still load and remain spend/restore-only, exactly as before.

## Context

Base64 keyset ids left the spec in December 2023 and CDK has never supported them, but some nutshell mints (notably Minibits) still serve them and may keep a redemption path alive long-term. Removing support at v5 GA would strand redeemable proofs and give affected wallets a reason not to upgrade; warn-now-remove-in-v6 gives everyone a clean runway.