### PR TITLE
fix(crypto): validate counter range in BIP-32 secret derivation

### DIFF
--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -179,6 +179,11 @@ function deriveBip32SecretAndBlindingFactor(
   parentKey: HDKey,
   counter: number,
 ): DerivedSecretAndBlindingFactor {
+  // HARDENED_OFFSET + counter must stay in the hardened range; a counter outside [0, 2^31) would
+  // wrap to a different index and derive the wrong key rather than fail.
+  if (!Number.isInteger(counter) || counter < 0 || counter >= 0x80000000) {
+    throw new CTSError('Counter must be an integer in the range 0 <= counter < 2^31');
+  }
   const baseKey = parentKey.deriveChild(HARDENED_OFFSET + counter);
   const secret = baseKey.deriveChild(0).privateKey;
   const blindingFactor = baseKey.deriveChild(1).privateKey;

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -83,6 +83,15 @@ describe('derivation kind selection', () => {
     expect(bytesToHex(blindingFactor)).toBe(bytesToHex(expectedR as Uint8Array));
   });
 
+  test('rejects a negative counter on the deprecated BIP-32 path', () => {
+    // -1 is the boundary case: HARDENED_OFFSET + (-1) is a valid non-hardened index, so without the
+    // guard derivation would silently succeed with the wrong key instead of throwing.
+    const base64KeysetId = '0NI3TUAs1Sfa';
+    expect(() => deriveSecretAndBlindingFactor(seed, base64KeysetId, -1)).toThrow(
+      /Counter must be an integer/,
+    );
+  });
+
   test('throws for an unrecognized keyset id version, naming only the version byte', () => {
     // A pure-hex id with an unknown version prefix must throw; the message reports the 2-char
     // version slice exactly (anchored), pinning both the slice bounds and the message text.


### PR DESCRIPTION
Adds a range check to the deprecated BIP-32 secret/blinding-factor deriver so a non-integer or out-of-range `counter` (outside `[0, 2^31)`) throws instead of deriving an unintended child index.

## Why

#796 replaced the string-path derivation with `HARDENED_OFFSET + counter` arithmetic. The string path implicitly rejected out-of-range counters via the path regex; the arithmetic form does not, so a value below zero resolves to a valid child index and derives silently. This restores the fail-fast behavior and matches the guard already present on `createKeyPairDeriver`.

## Test

Adds a case asserting a negative counter throws on the deprecated BIP-32 path. `npm run prtasks` passes locally.