### PR TITLE
fix(crypto): validate counter range in BIP-32 secret derivation [backport v4-dev]

### DIFF
--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -118,6 +118,11 @@ function deriveBip32SecretAndBlindingFactor(
   parentKey: HDKey,
   counter: number,
 ): DerivedSecretAndBlindingFactor {
+  // HARDENED_OFFSET + counter must stay in the hardened range; a counter outside [0, 2^31) would
+  // wrap to a different index and derive the wrong key rather than fail.
+  if (!Number.isInteger(counter) || counter < 0 || counter >= 0x80000000) {
+    throw new CTSError('Counter must be an integer in the range 0 <= counter < 2^31');
+  }
   const baseKey = parentKey.deriveChild(HARDENED_OFFSET + counter);
   const secret = baseKey.deriveChild(0).privateKey;
   const blindingFactor = baseKey.deriveChild(1).privateKey;

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -13,4 +13,13 @@ describe('deriveBlindingFactor', () => {
     expect(r).toHaveLength(32);
     expect(bytesToHex(r)).toBe('008464578dd0553eda2793249681ca2996587a6118b0974bf295fc946b4e5911');
   });
+
+  test('rejects a negative counter on the deprecated BIP-32 path', () => {
+    // -1 is the boundary case: HARDENED_OFFSET + (-1) is a valid non-hardened index, so without the
+    // guard derivation would silently succeed with the wrong key instead of throwing.
+    const seed = new TextEncoder().encode('test seed for regression');
+    expect(() => deriveBlindingFactor(seed, '0NI3TUAs1Sfa', -1)).toThrow(
+      /Counter must be an integer/,
+    );
+  });
 });


### PR DESCRIPTION
# Closes #807 

Backport of #806 to `v4-dev`.

