### PR TITLE
ci: nest backport conflict_resolution under experimental input

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,7 +43,13 @@ jobs:
           # a DRAFT PR (finish it in place: resolve, regenerate the api report,
           # push). The action comments resolution steps on the original PR and
           # the open-issue job below still files a tracking issue.
-          conflict_resolution: draft_commit_conflicts
+          # In backport-action v4 this option lives under `experimental`; passed
+          # top-level it is silently ignored and the action falls back to
+          # fail-on-conflict (no draft PR pushed, as happened on #806/#807).
+          experimental: |
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }
           # Ignore merge commits from "update branch" syncs
           merge_commits: skip
           # Backport marker goes at the END of the title: the default


### PR DESCRIPTION
## What

Moves `conflict_resolution: draft_commit_conflicts` from a top-level `with:` key into the `experimental` JSON input on `korthout/backport-action@v4.6.0`.

## Why

In v4 of the action, `conflict_resolution` is a property of the `experimental` input, not a top-level input. Passed top-level it is silently ignored (warning only) and the action uses the `experimental` default `{"conflict_resolution": "fail"}`. So on a cherry-pick conflict the action aborts, comments "cherry-pick locally", and pushes no draft PR, defeating the `draft_commit_conflicts` behaviour the workflow intends.

This surfaced on #806: its backport to `v4-dev` hit a conflict, no draft PR was created (see #807), and it had to be cherry-picked by hand (#808).

Run log from the #806 backport:

```
##[warning]Unexpected input(s) 'conflict_resolution', valid inputs are [... 'experimental' ...]
"conflict_resolution": "fail"
```

## Verification

Config-only, so no repo test exercises it. Confirmed against the `action.yml` for the pinned `v4.6.0` tag: `conflict_resolution` is documented under the `experimental` input with values `fail` and `draft_commit_conflicts`. The next conflicting backport should now open a draft PR instead of failing.