### PR TITLE
feat(model): add MintInfo.getMintMeltMethod and document offline rehydration

### DIFF
--- a/docs-src/usage/mint_capabilities.md
+++ b/docs-src/usage/mint_capabilities.md
@@ -11,15 +11,20 @@ const wallet = new Wallet('http://localhost:3338');
 await wallet.loadMint();
 
 const info = wallet.getMintInfo();
+
+// optional: persist the response for offline use later
+// (see "Work offline from a stored response" below)
+localStorage.setItem('mintInfo', JSON.stringify(info.cache));
 ```
 
-Three helpers cover the common questions:
+Four helpers cover the common questions:
 
-| I want to…                               | Use                                             | Returns        |
-| :--------------------------------------- | :---------------------------------------------- | :------------- |
-| list the methods I can mint or melt with | `info.supportedMethods(op)`                     | `SwapMethod[]` |
-| check one method/unit pair               | `info.supportsMintMeltMethod(op, method, unit)` | `boolean`      |
-| inspect raw support for any NUT          | `info.isSupported(num)`                         | varies by NUT  |
+| I want to…                               | Use                                             | Returns                   |
+| :--------------------------------------- | :---------------------------------------------- | :------------------------ |
+| list the methods I can mint or melt with | `info.supportedMethods(op)`                     | `SwapMethod[]`            |
+| check one method/unit pair               | `info.supportsMintMeltMethod(op, method, unit)` | `boolean`                 |
+| read one pair's settings and limits      | `info.getMintMeltMethod(op, method, unit)`      | `SwapMethod \| undefined` |
+| inspect raw support for any NUT          | `info.isSupported(num)`                         | varies by NUT             |
 
 ## List supported methods
 
@@ -50,6 +55,34 @@ if (info.supportsMintMeltMethod('melt', 'bolt11', 'sat')) {
   // safe to prepare a bolt11 melt in sats
 }
 ```
+
+When you also need the amount limits, `getMintMeltMethod` returns the matched `SwapMethod`
+directly (`undefined` means the pair is unsupported or the operation is disabled):
+
+```ts
+const melt = info.getMintMeltMethod('melt', 'bolt11', 'sat');
+if (melt) {
+  console.log('melt limits:', melt.min_amount, '-', melt.max_amount); // null = no bound
+}
+```
+
+## Work offline from a stored response
+
+`MintInfo` does not need a live connection: its constructor accepts any persisted
+`GetInfoResponse`. Store `info.cache` while online (as in the first example above), and rehydrate
+later to answer capability questions before (or without) contacting the mint.
+
+```ts
+import { MintInfo } from '@cashu/cashu-ts';
+
+// e.g. when building the send screen at startup
+const stored = JSON.parse(localStorage.getItem('mintInfo')!);
+const offline = new MintInfo(stored);
+offline.getMintMeltMethod('melt', 'bolt11', 'sat'); // no network round-trip
+```
+
+To seed a whole wallet from persisted data (mint info plus keysets) so it starts without any
+network calls, use [`wallet.loadMintFromCache(storedInfo, keyChainCache)`](./create_wallet.md).
 
 ## Inspect raw NUT support
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1104,7 +1104,7 @@ export type MintContactInfo = {
     info: string;
 };
 
-// @public (undocumented)
+// @public
 export class MintInfo {
     constructor(info: GetInfoResponse, logger?: Logger);
     // (undocumented)
@@ -1115,6 +1115,7 @@ export class MintInfo {
     get description(): string | undefined;
     // (undocumented)
     get description_long(): string | undefined;
+    getMintMeltMethod(op: 'mint' | 'melt', method: string, unit: string): SwapMethod | undefined;
     // (undocumented)
     isSupported(num: 4 | 5): {
         disabled: boolean;

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -33,6 +33,12 @@ type ProtectedIndex = {
   prefix: Record<Method, string[]>;
 };
 
+/**
+ * Wraps a mint's `/v1/info` response with capability helpers.
+ *
+ * Constructable from any `GetInfoResponse`, including one persisted from an earlier session; no
+ * live connection is needed. Persist `cache` and rehydrate with `new MintInfo(stored)`.
+ */
 export class MintInfo {
   // Full mint info response
   private readonly _mintInfo: GetInfoResponse;
@@ -402,7 +408,8 @@ export class MintInfo {
   /**
    * Lists the method-unit settings the mint advertises for an operation (`'mint'` → NUT-4, `'melt'`
    * → NUT-5), or `[]` when that operation is disabled. Use this to discover what a consumer can
-   * mint or melt with; to test a single pair use `supportsMintMeltMethod`.
+   * mint or melt with; to test a single pair use `supportsMintMeltMethod`, or `getMintMeltMethod`
+   * to read its settings.
    */
   supportedMethods(op: 'mint' | 'melt'): SwapMethod[] {
     const { disabled, params } = this.isSupported(op === 'mint' ? 4 : 5);
@@ -410,13 +417,20 @@ export class MintInfo {
   }
 
   /**
+   * Returns the mint's advertised settings for a (method, unit) pair for the given operation
+   * (`'mint'` → NUT-4, `'melt'` → NUT-5), or `undefined` when the pair is unsupported or the
+   * operation is disabled. The result carries the `min_amount`/`max_amount` limits and `options`.
+   */
+  getMintMeltMethod(op: 'mint' | 'melt', method: string, unit: string): SwapMethod | undefined {
+    return this.supportedMethods(op).find((m) => m.method === method && m.unit === unit);
+  }
+
+  /**
    * Checks if the mint advertises the given (method, unit) pair for the given operation (`'mint'` →
    * NUT-4, `'melt'` → NUT-5).
    */
   supportsMintMeltMethod(op: 'mint' | 'melt', method: string, unit: string): boolean {
-    const { disabled, params } = this.isSupported(op === 'mint' ? 4 : 5);
-    if (disabled) return false;
-    return params.some((m) => m.method === method && m.unit === unit);
+    return this.getMintMeltMethod(op, method, unit) !== undefined;
   }
 
   supportsAmountless(method: string = 'bolt11', unit: string = 'sat'): boolean {

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -728,6 +728,40 @@ describe('MintInfo method/unit capability checks', () => {
     expect(info.supportsMintMeltMethod('melt', 'bolt11', 'sat')).toBe(false);
   });
 
+  it('getMintMeltMethod returns the matched settings, also after a JSON round-trip', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        5: {
+          disabled: false,
+          methods: [{ method: 'bolt11', unit: 'sat', min_amount: 1, max_amount: 10_000 }],
+        },
+      },
+    });
+
+    const rehydrated = new MintInfo(JSON.parse(JSON.stringify(info.cache)));
+    for (const i of [info, rehydrated]) {
+      expect(i.getMintMeltMethod('melt', 'bolt11', 'sat')).toMatchObject({
+        min_amount: 1,
+        max_amount: 10_000,
+      });
+      expect(i.getMintMeltMethod('melt', 'bolt11', 'usd')).toBeUndefined();
+    }
+  });
+
+  it('getMintMeltMethod returns undefined when the operation is disabled', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        5: {
+          disabled: true,
+          methods: [{ method: 'bolt11', unit: 'sat', min_amount: null, max_amount: null }],
+        },
+      },
+    });
+    expect(info.getMintMeltMethod('melt', 'bolt11', 'sat')).toBeUndefined();
+  });
+
   it('supportsAmountless defaults to bolt11/sat and requires an exact method/unit match', () => {
     const info = new MintInfo({
       ...MINTINFORESP,


### PR DESCRIPTION
## Motivation

A review of downstream wallets (cashu.me, minibits, coco) found each one reimplements (method, unit) capability resolution by hand over a raw `GetInfoResponse` kept in local storage, walking `nuts[4]`/`nuts[5]` blocks directly. `MintInfo` already answers these questions and is constructable from a persisted response with no live connection, but nothing documents that, and no helper returns the matched method settings with its amount limits.

## Changes

- New `MintInfo.getMintMeltMethod(op, method, unit)`: returns the matched `SwapMethod` (carrying `min_amount`/`max_amount` and `options`), or `undefined` when the pair is unsupported or the operation is disabled. `supportsMintMeltMethod` now delegates to it.
- Class-level TSDoc on `MintInfo` noting it rehydrates from any persisted `GetInfoResponse`.
- Usage guide (`docs-src/usage/mint_capabilities.md`): persist `info.cache` in the opening example, plus a "Work offline from a stored response" section with the rehydrate recipe and a pointer to `wallet.loadMintFromCache` for a full no-network wallet start.
- Tests: matched settings survive a JSON round-trip through `info.cache`; disabled operations return `undefined`.
- `etc/cashu-ts.api.md` regenerated.

No breaking changes; `npm run prtasks` passes.