### PR TITLE
feat(wallet): prefer stale keysets in default proof selection

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1903,6 +1903,9 @@ export type SelectProofs = (proofs: ProofLike[], amountToSelect: AmountLike, key
 export function selectProofsRGLI(proofs: ProofLike[], amountToSelect: AmountLike, keyChain: KeyChain, includeFees?: boolean, exactMatch?: boolean, _logger?: Logger): SendResponse;
 
 // @public
+export function selectProofsRotating(proofs: ProofLike[], amountToSelect: AmountLike, keyChain: KeyChain, includeFees?: boolean, exactMatch?: boolean, _logger?: Logger): SendResponse;
+
+// @public
 export class SendBuilder {
     constructor(wallet: Wallet, amount: AmountLike, proofs: ProofLike[]);
     asCustom(data: OutputDataLike[]): this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export { Mint } from './mint';
 export { KeyChain } from './wallet/KeyChain';
 export { Keyset } from './wallet/Keyset';
 export { P2PKBuilder } from './wallet/P2PKBuilder';
-export { type SelectProofs, selectProofsRGLI } from './wallet/SelectProofs';
+export { type SelectProofs, selectProofsRGLI, selectProofsRotating } from './wallet/SelectProofs';
 export { Wallet } from './wallet/Wallet';
 export { WalletCounters } from './wallet/WalletCounters';
 export { WalletEvents } from './wallet/WalletEvents';

--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -337,3 +337,122 @@ export function selectProofsRGLI(
   }
   return { keep: normalizedProofs, send: [] };
 }
+
+/**
+ * Keyset-rotation-aware proof selection. Wraps {@link selectProofsRGLI}.
+ *
+ * @remarks
+ * Prefers stale keysets (base64 first, then older versions, inactive before active),
+ * force-including whole stale buckets, dust and all, so balances rotate onto the current keyset.
+ * Falls back to plain RGLI when the biased attempt has no solution.
+ */
+export function selectProofsRotating(
+  proofs: ProofLike[],
+  amountToSelect: AmountLike,
+  keyChain: KeyChain,
+  includeFees: boolean = false,
+  exactMatch: boolean = false,
+  _logger: Logger = NULL_LOGGER,
+): SendResponse {
+  const normalizedProofs = normalizeProofAmounts(proofs);
+  const targetAmount = Amount.from(amountToSelect);
+  const target = targetAmount.toBigInt();
+
+  // Net sum under unified fee arithmetic (single ceil over the whole set).
+  // Bigint keeps the wrapper exact at u64 scale; only pools delegated to RGLI
+  // carry its number-arithmetic guard. Bigint not Amount because dust proofs
+  // can netOf() negative (eg: 1 sat proof at 2000ppk).
+  const netOf = (gross: bigint, ppk: bigint): bigint =>
+    gross - (includeFees ? (ppk + 999n) / 1000n : 0n);
+  // Partition the full set around a chosen send subset (proof secrets are unique)
+  const toSendResponse = (send: Proof[]): SendResponse => {
+    const sendSet = new Set(send.map((p) => p.secret));
+    return { keep: normalizedProofs.filter((p) => !sendSet.has(p.secret)), send };
+  };
+
+  // Bucket by staleness: version rank (base64 = 0, else first id byte + 1), with
+  // inactive before active within a version. Lower keys are staler.
+  const buckets = new Map<number, { proofs: Proof[]; gross: bigint; ppk: bigint }>();
+  for (const p of normalizedProofs) {
+    const ks = keyChain.getKeyset(p.id); // throws for unknown keyset ids
+    const rank = ks.hasHexId ? parseInt(p.id.slice(0, 2), 16) + 1 : 0;
+    const key = rank * 2 + (ks.isActive ? 1 : 0);
+    const bucket = buckets.get(key) ?? { proofs: [], gross: 0n, ppk: 0n };
+    bucket.proofs.push(p);
+    bucket.gross += p.amount.toBigInt();
+    bucket.ppk += BigInt(ks.fee);
+    buckets.set(key, bucket);
+  }
+  const order = [...buckets.keys()].sort((a, b) => a - b);
+
+  // Fast path: nothing to rotate
+  if (targetAmount.isZero() || order.length <= 1) {
+    return selectProofsRGLI(
+      normalizedProofs,
+      targetAmount,
+      keyChain,
+      includeFees,
+      exactMatch,
+      _logger,
+    );
+  }
+
+  // Walk stalest first, forcing whole buckets while the running net stays below target
+  const forced: Proof[] = [];
+  let fGross = 0n;
+  let fPpk = 0n;
+  let i = 0;
+  for (; i < order.length; i++) {
+    const b = buckets.get(order[i])!;
+    const candidateNet = netOf(fGross + b.gross, fPpk + b.ppk);
+    if (candidateNet > target) break; // boundary bucket (we will RGLI this one)
+    // the whole bucket is needed: add all its proofs and continue to next bucket
+    // push singly: spreading a huge bucket into push() can overflow the call stack
+    for (const q of b.proofs) forced.push(q);
+    fGross += b.gross;
+    fPpk += b.ppk;
+    if (candidateNet === target) return toSendResponse(forced); // forced buckets cover it exactly
+  }
+
+  // Delegate the residual to RGLI: boundary bucket first, then boundary plus fresher
+  // The walk forced buckets only while strictly below target (equality returned
+  // early), so the residual handed to RGLI is always at least 1
+  if (i < order.length) {
+    const residual = target - netOf(fGross, fPpk);
+    const boundary = buckets.get(order[i])!.proofs;
+    const fresher = order.slice(i + 1).flatMap((k) => buckets.get(k)!.proofs);
+    const pools = fresher.length ? [boundary, boundary.concat(fresher)] : [boundary];
+    for (const pool of pools) {
+      let attempt: SendResponse;
+      try {
+        attempt = selectProofsRGLI(pool, residual, keyChain, includeFees, exactMatch, _logger);
+      } catch (error) {
+        _logger.debug('selectProofsRotating: biased attempt failed', { error });
+        continue; // RGLI could not handle this pool (timeout or scale); widen or fall back
+      }
+      if (attempt.send.length === 0) continue;
+      // Splitting forced/residual can overstate fees by one, so verify the merged
+      // solution with a single ceil before accepting it
+      let mergedGross = fGross;
+      let mergedPpk = fPpk;
+      for (const p of attempt.send) {
+        mergedGross += p.amount.toBigInt();
+        mergedPpk += BigInt(keyChain.getKeyset(p.id).fee);
+      }
+      const mergedNet = netOf(mergedGross, mergedPpk);
+      if (exactMatch ? mergedNet === target : mergedNet >= target) {
+        return toSendResponse(forced.concat(attempt.send));
+      }
+    }
+  }
+
+  // No biased solution, or every bucket forced without covering the target: plain RGLI
+  return selectProofsRGLI(
+    normalizedProofs,
+    targetAmount,
+    keyChain,
+    includeFees,
+    exactMatch,
+    _logger,
+  );
+}

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -76,7 +76,7 @@ import {
 } from './CounterSource';
 import { KeyChain } from './KeyChain';
 import { type Keyset } from './Keyset';
-import { selectProofsRGLI, type SelectProofs } from './SelectProofs';
+import { selectProofsRotating, type SelectProofs } from './SelectProofs';
 import {
   type MeltPreview,
   type OutputType,
@@ -199,7 +199,7 @@ class Wallet {
    * @param options.counterInit Seed values for the built-in EphemeralCounterSource. Ignored if
    *   counterSource is also provided.
    * @param options.denominationTarget Target proofs per denomination, default 3.
-   * @param options.selectProofs Custom proof selection function.
+   * @param options.selectProofs Custom proof selection function. Default: selectProofsRotating.
    * @param options.outputDataCreator Custom OutputDataCreator implementation. The canonical and
    *   maintained implementation is the default Noble Curves based behavior exposed by
    *   `OutputData.create*()`. Custom creators are an escape hatch for runtime-specific needs, and
@@ -238,7 +238,7 @@ class Wallet {
     this.ops = new WalletOps(this);
     this.on = new WalletEvents(this);
     this._logger = options?.logger ?? NULL_LOGGER; // init early (seed can throw)
-    this._selectProofs = options?.selectProofs ?? selectProofsRGLI; // vital
+    this._selectProofs = options?.selectProofs ?? selectProofsRotating; // vital
     this._outputDataCreator = options?.outputDataCreator ?? new DefaultOutputDataCreator();
     this.mint =
       typeof mint === 'string'
@@ -1407,7 +1407,9 @@ class Wallet {
    *
    * @remarks
    * Uses an adapted Randomized Greedy with Local Improvement (RGLI) algorithm, which has a time
-   * complexity O(n log n) and space complexity O(n).
+   * complexity O(n log n) and space complexity O(n). The default selector prefers stale keysets
+   * (base64, older versions, inactive) so balances rotate onto the current keyset; pass
+   * `selectProofs: selectProofsRGLI` in the Wallet options for keyset-neutral selection.
    * @param proofs Array of proofs available to select from. Accepts {@link ProofLike} so proofs
    *   loaded from storage (with `amount: number`) work without manual conversion.
    * @param amountToSend The target amount to send.

--- a/test/wallet/selectProofsRotating.test.ts
+++ b/test/wallet/selectProofsRotating.test.ts
@@ -1,0 +1,262 @@
+import { describe, test, expect } from 'vitest';
+
+import { CTSError } from '../../src';
+import { Amount } from '../../src/model/Amount';
+import { type Proof } from '../../src/model/types';
+import { selectProofsRotating } from '../../src/wallet/SelectProofs';
+
+// -----------------------------------------------------------------
+// Unit tests for the keyset-rotation wrapper. RGLI internals are
+// covered by selectProofsRGLI.test.ts and the wallet tests.
+// -----------------------------------------------------------------
+
+// Keyset ids: one per staleness class used in tests
+const B64 = 'RQvZXp8f'; // non-hex, legacy base64 (v0)
+const V1A = '00aa111111111111';
+const V1B = '00bb222222222222';
+const V2A = '01cc333333333333';
+
+// Minimal keychain stub with fee and active flag per keyset
+function keychainStub(keysets: Record<string, { fee?: number; active?: boolean }>) {
+  const entry = (id: string) => ({
+    id,
+    fee: keysets[id]?.fee ?? 0,
+    isActive: keysets[id]?.active ?? true,
+    hasHexId: /^[0-9a-fA-F]+$/.test(id),
+  });
+  return {
+    getKeyset: (id: string) => {
+      if (!keysets[id]) throw new CTSError(`Keyset '${id}' not found`);
+      return entry(id);
+    },
+    getKeysets: () => Object.keys(keysets).map(entry),
+  } as any;
+}
+
+let n = 0;
+const P = (id: string, amount: number | bigint): Proof => ({
+  id,
+  amount: Amount.from(amount),
+  secret: `s${++n}`,
+  C: `C${n}`,
+});
+
+const secrets = (proofs: Proof[]) => proofs.map((p) => p.secret).sort();
+const total = (proofs: Proof[]) => proofs.reduce((a, p) => a + p.amount.toNumber(), 0);
+
+describe('selectProofsRotating', () => {
+  test('base64 outranks inactive hex keysets regardless of active status', () => {
+    // Active base64 must be forced ahead of the inactive v1 bucket
+    const b64 = P(B64, 2);
+    const v1 = P(V1A, 4);
+    const v2 = P(V2A, 64);
+    const kc = keychainStub({ [B64]: {}, [V1A]: { active: false }, [V2A]: {} });
+
+    const res = selectProofsRotating([b64, v1, v2], 3, kc);
+
+    expect(res.send.map((p) => p.secret)).toContain(b64.secret);
+    expect(res.send.every((p) => p.id !== V2A)).toBe(true);
+    expect(total(res.send)).toBe(6); // forced 2 + boundary 4
+  });
+
+  test('inactive before active within the same version', () => {
+    const inactive = P(V1A, 4);
+    const active = P(V1B, 4);
+    const kc = keychainStub({ [V1A]: { active: false }, [V1B]: {} });
+
+    const res = selectProofsRotating([inactive, active], 4, kc);
+
+    expect(secrets(res.send)).toEqual([inactive.secret]);
+    expect(secrets(res.keep)).toEqual([active.secret]);
+  });
+
+  test('stale dust below target is always force-included', () => {
+    const dust = [P(B64, 1), P(B64, 1), P(B64, 1)];
+    const fresh = [P(V2A, 8), P(V2A, 4), P(V2A, 2), P(V2A, 1)];
+    const kc = keychainStub({ [B64]: {}, [V2A]: {} });
+
+    const res = selectProofsRotating([...dust, ...fresh], 10, kc);
+
+    const sent = new Set(res.send.map((p) => p.secret));
+    for (const d of dust) expect(sent.has(d.secret)).toBe(true);
+    expect(total(res.send)).toBeGreaterThanOrEqual(10);
+  });
+
+  test('large stale boundary bucket satisfies the send without fresh proofs', () => {
+    const stale = [P(V1A, 16), P(V1A, 8), P(V1A, 4), P(V1A, 2), P(V1A, 1)];
+    const fresh = [P(V2A, 64), P(V2A, 32)];
+    const kc = keychainStub({ [V1A]: { active: false }, [V2A]: {} });
+
+    const res = selectProofsRotating([...stale, ...fresh], 10, kc);
+
+    expect(res.send.length).toBeGreaterThan(0);
+    expect(res.send.every((p) => p.id === V1A)).toBe(true);
+    for (const f of fresh) expect(res.keep.map((p) => p.secret)).toContain(f.secret);
+  });
+
+  test('exact match widens to fresher buckets when the boundary has no exact subset', () => {
+    const b64 = P(B64, 3);
+    const v1 = P(V1A, 4);
+    const v2 = P(V2A, 2);
+    const kc = keychainStub({ [B64]: {}, [V1A]: {}, [V2A]: {} });
+
+    // Forced 3, residual 2. Boundary {4} has no exact subset; attempt 2 finds {2}.
+    const res = selectProofsRotating([b64, v1, v2], 5, kc, false, true);
+
+    expect(secrets(res.send)).toEqual(secrets([b64, v2]));
+    expect(total(res.send)).toBe(5);
+  });
+
+  test('exact match falls back to plain RGLI when forcing makes exactness impossible', () => {
+    const b64 = P(B64, 3);
+    const v1a = P(V1A, 4);
+    const v1b = P(V1A, 3);
+    const kc = keychainStub({ [B64]: {}, [V1A]: {} });
+
+    // Forced 3 leaves residual 1, which nothing satisfies. Plain RGLI finds {4}.
+    const res = selectProofsRotating([b64, v1a, v1b], 4, kc, false, true);
+
+    expect(secrets(res.send)).toEqual([v1a.secret]);
+    expect(res.keep.map((p) => p.secret)).toContain(b64.secret);
+  });
+
+  test('unified fee verification rejects a split-computed off-by-one exact match', () => {
+    // Forced: 1 sat at 400ppk nets 0 alone (residual 5). Boundary {3, 3} at 250ppk
+    // nets exactly 5 split (6 - ceil(500/1000)), but merged nets 6 (7 - ceil(900/1000)),
+    // so attempts 1 and 2 must be rejected and plain RGLI returns {3, 3} alone.
+    const b64 = P(B64, 1);
+    const v1a = P(V1A, 3);
+    const v1b = P(V1A, 3);
+    const kc = keychainStub({ [B64]: { fee: 400 }, [V1A]: { fee: 250 } });
+
+    const res = selectProofsRotating([b64, v1a, v1b], 5, kc, true, true);
+
+    expect(secrets(res.send)).toEqual(secrets([v1a, v1b]));
+    expect(res.keep.map((p) => p.secret)).toContain(b64.secret);
+  });
+
+  test('uneconomical stale dust is forced and the residual expands to cover it', () => {
+    const dust = P(B64, 1); // exFee -1 at 2000ppk, plain RGLI would filter it
+    const fresh = [P(V2A, 8), P(V2A, 4), P(V2A, 2), P(V2A, 1)];
+    const kc = keychainStub({ [B64]: { fee: 2000 }, [V2A]: {} });
+
+    const res = selectProofsRotating([dust, ...fresh], 10, kc, true);
+
+    expect(res.send.map((p) => p.secret)).toContain(dust.secret);
+    // Merged net (gross - ceil(ppk/1000)) still covers the target
+    const gross = total(res.send);
+    const ppk = res.send.reduce((a, p) => a + (p.id === B64 ? 2000 : 0), 0);
+    expect(gross - Math.ceil(ppk / 1000)).toBeGreaterThanOrEqual(10);
+  });
+
+  test('forced dust that makes the target infeasible falls back to plain RGLI', () => {
+    const dust = P(B64, 1);
+    const fresh = P(V1A, 4);
+    const kc = keychainStub({ [B64]: { fee: 2000 }, [V1A]: {} });
+
+    // Forcing dust nets 3 of a 4 target across the whole wallet; attempt 3 drops it.
+    const res = selectProofsRotating([dust, fresh], 4, kc, true);
+
+    expect(secrets(res.send)).toEqual([fresh.secret]);
+    expect(res.keep.map((p) => p.secret)).toContain(dust.secret);
+  });
+
+  test('single bucket fast path behaves like plain RGLI', () => {
+    const proofs = [P(V2A, 8), P(V2A, 4), P(V2A, 2), P(V2A, 1)];
+    const kc = keychainStub({ [V2A]: {} });
+
+    const res = selectProofsRotating(proofs, 6, kc);
+
+    expect(total(res.send)).toBeGreaterThanOrEqual(6);
+    expect(res.send.length + res.keep.length).toBe(4);
+  });
+
+  test('zero target returns keep all', () => {
+    const proofs = [P(V2A, 4), P(B64, 2)];
+    const kc = keychainStub({ [V2A]: {}, [B64]: {} });
+
+    const res = selectProofsRotating(proofs, 0, kc);
+
+    expect(res.send).toHaveLength(0);
+    expect(res.keep).toHaveLength(2);
+  });
+
+  test('target above spendable total returns keep all', () => {
+    const proofs = [P(V2A, 4), P(B64, 2)];
+    const kc = keychainStub({ [V2A]: {}, [B64]: {} });
+
+    const res = selectProofsRotating(proofs, 100, kc);
+
+    expect(res.send).toHaveLength(0);
+    expect(res.keep).toHaveLength(2);
+  });
+
+  test('unknown keyset id throws CTSError', () => {
+    const kc = keychainStub({ [V2A]: {} });
+    expect(() => selectProofsRotating([P(V1A, 4)], 2, kc)).toThrow(CTSError);
+  });
+
+  test('two stale buckets are forced in sequence before the boundary supplies the residual', () => {
+    const dust = [P(B64, 1), P(B64, 1)];
+    const stale = P(V1A, 4);
+    const fresh = [P(V2A, 16), P(V2A, 8), P(V2A, 4), P(V2A, 2), P(V2A, 1)];
+    const kc = keychainStub({ [B64]: {}, [V1A]: { active: false }, [V2A]: {} });
+
+    // Forced: base64 (2) then inactive v1 (4); boundary v2 covers the residual 4
+    const res = selectProofsRotating([...dust, stale, ...fresh], 10, kc);
+
+    const sent = new Set(res.send.map((p) => p.secret));
+    for (const d of dust) expect(sent.has(d.secret)).toBe(true);
+    expect(sent.has(stale.secret)).toBe(true);
+    expect(total(res.send)).toBe(10);
+  });
+
+  test('equality return after forcing two buckets sends exactly those buckets', () => {
+    const b64 = P(B64, 2);
+    const stale = P(V1A, 4);
+    const fresh = P(V2A, 32);
+    const kc = keychainStub({ [B64]: {}, [V1A]: { active: false }, [V2A]: {} });
+
+    const res = selectProofsRotating([b64, stale, fresh], 6, kc);
+
+    expect(secrets(res.send)).toEqual(secrets([b64, stale]));
+    expect(secrets(res.keep)).toEqual([fresh.secret]);
+  });
+
+  test('u64-scale amounts flush via the forced walk without touching RGLI', () => {
+    // Both proofs exceed Number.MAX_SAFE_INTEGER; equality return needs no RGLI call
+    const b64 = P(B64, 2n ** 60n);
+    const stale = P(V1A, 2n ** 60n);
+    const kc = keychainStub({ [B64]: {}, [V1A]: { active: false } });
+
+    const res = selectProofsRotating([b64, stale], 2n ** 61n, kc);
+
+    expect(secrets(res.send)).toEqual(secrets([b64, stale]));
+    expect(res.keep).toHaveLength(0);
+  });
+
+  test('u64-scale forced bucket combines with a safe RGLI residual', () => {
+    const huge = P(B64, 2n ** 60n);
+    const fresh = [P(V2A, 8), P(V2A, 4), P(V2A, 2), P(V2A, 1)];
+    const kc = keychainStub({ [B64]: {}, [V2A]: {} });
+
+    const res = selectProofsRotating([huge, ...fresh], 2n ** 60n + 10n, kc);
+
+    expect(res.send.map((p) => p.secret)).toContain(huge.secret);
+    const sent = res.send.reduce((a, p) => a + p.amount.toBigInt(), 0n);
+    expect(sent).toBeGreaterThanOrEqual(2n ** 60n + 10n);
+  });
+
+  test('copes with a huge forced dust bucket (50k proofs)', () => {
+    const dust: Proof[] = [];
+    for (let i = 0; i < 50000; i++) dust.push(P(B64, 1));
+    const fresh = P(V2A, 100000);
+    const kc = keychainStub({ [B64]: {}, [V2A]: {} });
+
+    const res = selectProofsRotating([...dust, fresh], 50001, kc);
+
+    expect(res.send).toHaveLength(50001);
+    expect(total(res.send)).toBe(150000);
+    expect(res.keep).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `selectProofsRotating`, a wrapper around `selectProofsRGLI` that preferentially spends proofs on stale keysets, and makes it the Wallet default. Balances migrate onto the mint's current keyset during normal sends, swaps and melts.

- Buckets proofs by staleness: legacy base64 ids first (whatever their status), then older version bytes, inactive before active within a version. An old version never queues behind a newer version's rotation churn.
- Force-includes whole stale buckets, uneconomical dust included. The set-level fee ceil makes aggregation cost at most about a sat per dust proof, and flushing beats stranding the value when legacy formats are eventually dropped.
- Delegates the residual to RGLI: boundary bucket first, then boundary plus fresher buckets, then plain full-set RGLI as the fallback. Merged results are verified under a single fee ceil, so split accounting can never overpay an exact match.
- Wrapper arithmetic is bigint, so u64-scale proofs on stale keysets flush without hitting RGLI's number guard.

## Behavior changes

- The default selector now prefers stale keysets. Opt out with `selectProofs: selectProofsRGLI` in the Wallet options. `selectProofsRGLI` is unchanged, and the fallback path reproduces current behavior exactly.
- Wallets holding uneconomical dust (fee at or above value) now deliberately spend it to drain old keysets, a one-off cost of up to about a sat per dust proof.

## Why

Base64 keyset ids left the spec long ago but some remain in use, and NUT-02 says wallets SHOULD swap proofs off inactive keysets. Draining old keysets as a side effect of normal spending also keeps unspent proofs clustered on recent keysets, which benefits wallet restore schemes.

## Testing

18 unit tests cover bucket ordering, forced-walk invariants, exact-match fallbacks, unified fee verification (including rejection of a split-computed off-by-one exact match), u64-scale flushing, and a 50k-proof scale case. Full suite and prtasks green.