### PR TITLE
fix(wallet): widen exact-match trim bound for selection-level fee rounding

### DIFF
--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -158,12 +158,15 @@ export function selectProofsRGLI(
   spendableProofs.sort((a, b) => a.exFee - b.exFee);
 
   // Remove proofs too large to be useful and adjust totals
-  // Exact Match: Keep proofs where exFee <= amountToSend
+  // Exact Match: Keep proofs where exFee <= amountToSend + 1. Fees round up
+  // once per selection, not per proof, so the real net can be up to a sat
+  // below the exFee sum: a 6 sat proof at 500ppk has exFee 5.5 yet nets
+  // 6 - 1 = 5, an exact match that a bound of exFee <= amountToSend misses
   // Close Match: Keep proofs where exFee <= nextBiggerExFee
   if (spendableProofs.length > 0) {
     let endIndex;
     if (exactMatch) {
-      const rightIndex = binarySearchIndex(spendableProofs, targetAmountNumber, true);
+      const rightIndex = binarySearchIndex(spendableProofs, targetAmountNumber + 1, true);
       endIndex = rightIndex !== null ? rightIndex + 1 : 0;
     } else {
       const biggerIndex = binarySearchIndex(spendableProofs, targetAmountNumber, false);

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -353,4 +353,16 @@ describe('selectProofsRGLI, invariants', () => {
       expect(sumProofs(res.send).toNumber()).toBeGreaterThanOrEqual(5);
     }
   });
+
+  test('exact match finds a proof whose exFee is above target but whose net hits it', () => {
+    // 6 sat at 500ppk: exFee 5.5 but net alone is 6 - ceil(500/1000) = 5
+    const proofs: Proof[] = [{ id: 'A', amount: Amount.from(6), secret: 's1', C: 'C1' }];
+    const kc = keychainStub({ A: 500 });
+
+    const res = selectProofsRGLI(proofs, 5, kc, true, true);
+
+    expect(res.send).toHaveLength(1);
+    expect(res.send[0].amount.toNumber()).toBe(6);
+    expect(res.keep).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

`selectProofsRGLI`'s exact-match pre-trim discarded candidates at `exFee <= target`, but fees round up once per selection rather than per proof, so the real net can sit up to a sat below the fractional `exFee` sum. A proof whose `exFee` is just above the target can therefore still net the target exactly, and the old bound made such solutions unreachable: a wallet holding a single 6 sat proof at 500ppk could never exact-match a 5 sat send (`exFee` 5.5, net `6 - ceil(500/1000) = 5`).

The trim bound is now `target + 1`. Solution acceptance (`sumExFees`, true fee ceil) is unchanged, so nothing new can be wrongly accepted; the only behavior change is that previously missed exact matches are found, meaning fewer needless swaps where an offline exact send was possible.

## Scope note

Close match has a milder analog (a candidate just past the `nextBiggerExFee` cutoff can carry a marginally lower-ppk delta), but close match always finds a valid solution and the realized fee after the ceil is essentially identical, so that trim is deliberately left alone.

## Testing

One regression test proving the previously missed exact match is found; full suite and prtasks green.