### PR TITLE
refactor(wallet): make RGLI exFee an integer sort key

### DIFF
--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -141,7 +141,10 @@ export function selectProofsRGLI(
     }
     const ppkfee = feeForProof(p);
     const amountNum = p.amount.toNumber(); // safe: guarded above
-    const exFee = includeFees ? amountNum - ppkfee / 1000 : amountNum;
+    // Floor the proof's own fee: keeps exFee an integer sort key, and the economical
+    // filter decides identically (amount > floor(ppk/1000) iff 1000 * amount > ppk);
+    // set-level fee accounting (sumExFees) is untouched
+    const exFee = includeFees ? amountNum - Math.floor(ppkfee / 1000) : amountNum;
     const obj = { proof: p, amountNum, exFee, ppkfee };
     // Sum all economical proofs (filtered below)
     if (!includeFees || exFee > 0) {
@@ -158,9 +161,9 @@ export function selectProofsRGLI(
   spendableProofs.sort((a, b) => a.exFee - b.exFee);
 
   // Remove proofs too large to be useful and adjust totals
-  // Exact Match: Keep proofs where exFee <= amountToSend + 1. Fees round up
-  // once per selection, not per proof, so the real net can be up to a sat
-  // below the exFee sum: a 6 sat proof at 500ppk has exFee 5.5 yet nets
+  // Exact Match: Keep proofs where exFee <= amountToSend + 1. exFee floors the
+  // proof's own fee while the real fee ceils once per selection, so the net can
+  // sit up to a sat below exFee: a 6 sat proof at 500ppk has exFee 6 yet nets
   // 6 - 1 = 5, an exact match that a bound of exFee <= amountToSend misses
   // Close Match: Keep proofs where exFee <= nextBiggerExFee
   if (spendableProofs.length > 0) {

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -354,6 +354,32 @@ describe('selectProofsRGLI, invariants', () => {
     }
   });
 
+  test('sub-sat fee proofs are kept and aggregate into a spendable sat', () => {
+    // 1 sat at 999ppk nets 0.001 alone; one thousand of them net exactly 1
+    const proofs: Proof[] = Array.from({ length: 1000 }, (_, i) => ({
+      id: 'A',
+      amount: Amount.from(1),
+      secret: `s${i}`,
+      C: `C${i}`,
+    }));
+    const kc = keychainStub({ A: 999 });
+
+    const res = selectProofsRGLI(proofs, 1, kc, true, false);
+
+    expect(res.send).toHaveLength(1000);
+    expect(res.keep).toHaveLength(0);
+  });
+
+  test('a 1 sat proof at 1000ppk is uneconomical and never selected', () => {
+    const proofs: Proof[] = [{ id: 'A', amount: Amount.from(1), secret: 's1', C: 'C1' }];
+    const kc = keychainStub({ A: 1000 });
+
+    const res = selectProofsRGLI(proofs, 1, kc, true, false);
+
+    expect(res.send).toHaveLength(0);
+    expect(res.keep).toHaveLength(1);
+  });
+
   test('exact match finds a proof whose exFee is above target but whose net hits it', () => {
     // 6 sat at 500ppk: exFee 5.5 but net alone is 6 - ceil(500/1000) = 5
     const proofs: Proof[] = [{ id: 'A', amount: Amount.from(6), secret: 's1', C: 'C1' }];


### PR DESCRIPTION
This is a stepping stone to Bigint aware RGLI.

## Summary

`exFee` is only ever a sort key: it drives the ordering, binary searches, trims and the economical filter, never the fee accounting. This change floors each proof's own fee in the `exFee` calculation so the key is an integer instead of a fine-grained double.

- The economical filter decides identically: fractional keeps a proof iff `1000*amount > ppk`, floored keeps iff `amount > floor(ppk/1000)`, and for integers those are the same predicate.
- Set-level fee accounting (`sumExFees`, one ceil per selection) is untouched, so nothing about acceptance changes.
- Ordering coarsens by sub-sat distinctions only, which can shift which of two delta-equal solutions a trial finds, never validity. The full suite passes unchanged.
- The `target + 1` exact-match trim bound from #814 composes: members of an exact solution have integer `exFee <= target + 1`, and the trim comment's example gets cleaner (a 6 sat proof at 500ppk has `exFee` 6 yet nets 5).

This removes the last fractional layer from the selection hot path, which is what makes a future bigint port of RGLI mechanical rather than a rewrite.

## Testing

Two new boundary tests: one thousand 1 sat proofs at 999ppk aggregate into exactly one spendable sat (fails under any per-proof fee rounding, protecting the aggregation rebate), and a 1 sat proof at 1000ppk remains uneconomical. Full suite and prtasks green.