### PR TITLE
fix(wallet): widen exact-match trim bound for selection-level fee rounding [backport v4-dev]

### DIFF
--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -157,12 +157,15 @@ export function selectProofsRGLI(
   spendableProofs.sort((a, b) => a.exFee - b.exFee);
 
   // Remove proofs too large to be useful and adjust totals
-  // Exact Match: Keep proofs where exFee <= amountToSend
+  // Exact Match: Keep proofs where exFee <= amountToSend + 1. Fees round up
+  // once per selection, not per proof, so the real net can be up to a sat
+  // below the exFee sum: a 6 sat proof at 500ppk has exFee 5.5 yet nets
+  // 6 - 1 = 5, an exact match that a bound of exFee <= amountToSend misses
   // Close Match: Keep proofs where exFee <= nextBiggerExFee
   if (spendableProofs.length > 0) {
     let endIndex;
     if (exactMatch) {
-      const rightIndex = binarySearchIndex(spendableProofs, targetAmountNumber, true);
+      const rightIndex = binarySearchIndex(spendableProofs, targetAmountNumber + 1, true);
       endIndex = rightIndex !== null ? rightIndex + 1 : 0;
     } else {
       const biggerIndex = binarySearchIndex(spendableProofs, targetAmountNumber, false);

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -184,3 +184,17 @@ describe('selectProofsRGLI, focused unit tests', () => {
     );
   });
 });
+
+describe('selectProofsRGLI, invariants', () => {
+  test('exact match finds a proof whose exFee is above target but whose net hits it', () => {
+    // 6 sat at 500ppk: exFee 5.5 but net alone is 6 - ceil(500/1000) = 5
+    const proofs: Proof[] = [{ id: 'A', amount: Amount.from(6), secret: 's1', C: 'C1' }];
+    const kc = keychainStub({ A: 500 });
+
+    const res = selectProofsRGLI(proofs, 5, kc, true, true);
+
+    expect(res.send).toHaveLength(1);
+    expect(res.send[0].amount.toNumber()).toBe(6);
+    expect(res.keep).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# Description
Backport of #814 to `v4-dev`.