### PR TITLE
refactor(model): return snapshots from MintInfo accessors

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1107,7 +1107,6 @@ export type MintContactInfo = {
 // @public
 export class MintInfo {
     constructor(info: GetInfoResponse, logger?: Logger);
-    // (undocumented)
     get cache(): GetInfoResponse;
     // (undocumented)
     get contact(): MintContactInfo[];

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -37,7 +37,8 @@ type ProtectedIndex = {
  * Wraps a mint's `/v1/info` response with capability helpers.
  *
  * Constructable from any `GetInfoResponse`, including one persisted from an earlier session; no
- * live connection is needed. Persist `cache` and rehydrate with `new MintInfo(stored)`.
+ * live connection is needed. Persist `cache` and rehydrate with `new MintInfo(stored)`. Accessors
+ * return snapshots, never internal references.
  */
 export class MintInfo {
   // Full mint info response
@@ -256,21 +257,21 @@ export class MintInfo {
   private checkMintMelt(num: 4 | 5) {
     const mintMeltInfo = this._mintInfo.nuts[num];
     if (mintMeltInfo && mintMeltInfo.methods.length > 0 && !mintMeltInfo.disabled) {
-      return { disabled: false, params: mintMeltInfo.methods };
+      return { disabled: false, params: MintInfo.snapshot(mintMeltInfo.methods) };
     }
-    return { disabled: true, params: mintMeltInfo?.methods ?? [] };
+    return { disabled: true, params: MintInfo.snapshot(mintMeltInfo?.methods ?? []) };
   }
 
   private checkNut17() {
     if (this._mintInfo.nuts[17] && this._mintInfo.nuts[17].supported.length > 0) {
-      return { supported: true, params: this._mintInfo.nuts[17].supported };
+      return { supported: true, params: MintInfo.snapshot(this._mintInfo.nuts[17].supported) };
     }
     return { supported: false };
   }
 
   private checkNut15() {
     if (this._mintInfo.nuts[15] && this._mintInfo.nuts[15].methods.length > 0) {
-      return { supported: true, params: this._mintInfo.nuts[15].methods };
+      return { supported: true, params: MintInfo.snapshot(this._mintInfo.nuts[15].methods) };
     }
     return { supported: false };
   }
@@ -285,7 +286,7 @@ export class MintInfo {
           // map null to infinity, if not null map seconds to milliseconds.
           // this way ttl is always a number
           ttl: ttlSeconds === null ? Infinity : Math.max(ttlSeconds, 0) * 1000,
-          cached_endpoints: rawPolicy.cached_endpoints,
+          cached_endpoints: MintInfo.snapshot(rawPolicy.cached_endpoints),
         },
       };
     }
@@ -295,7 +296,7 @@ export class MintInfo {
   private checkNut29() {
     const nut29 = this._mintInfo.nuts?.[29];
     if (nut29) {
-      return { supported: true, params: nut29 };
+      return { supported: true, params: MintInfo.snapshot(nut29) };
     }
     return { supported: false };
   }
@@ -361,11 +362,30 @@ export class MintInfo {
 
   // ---------- getters ----------
 
+  /**
+   * Deep-copies a plain data value so accessors return snapshots, never internal references.
+   * Preserves bigints, which AmountLike fields may hold; JSON round-trips would not.
+   */
+  private static snapshot<T>(value: T): T {
+    if (value === null || typeof value !== 'object') return value;
+    if (Array.isArray(value)) {
+      return (value as unknown[]).map((v) => MintInfo.snapshot(v)) as T;
+    }
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = MintInfo.snapshot(v);
+    }
+    return out as T;
+  }
+
+  /**
+   * Snapshot of the full mint info response, safe to mutate or persist.
+   */
   get cache(): GetInfoResponse {
-    return this._mintInfo;
+    return MintInfo.snapshot(this._mintInfo);
   }
   get contact() {
-    return this._mintInfo.contact;
+    return MintInfo.snapshot(this._mintInfo.contact);
   }
   get description() {
     return this._mintInfo.description;
@@ -380,7 +400,7 @@ export class MintInfo {
     return this._mintInfo.pubkey;
   }
   get nuts() {
-    return this._mintInfo.nuts;
+    return MintInfo.snapshot(this._mintInfo.nuts);
   }
   get version() {
     return this._mintInfo.version;

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -790,3 +790,49 @@ describe('MintInfo method/unit capability checks', () => {
     expect(info.supportsAmountless()).toBe(false);
   });
 });
+
+describe('MintInfo snapshot accessors', () => {
+  it('mutating a getMintMeltMethod result cannot pollute the cache', () => {
+    const info = new MintInfo(MINTINFORESP);
+    const method = info.getMintMeltMethod('mint', 'bolt11', 'sat')!;
+
+    method.min_amount = 10n; // type-legal via AmountLike; must not reach the cache
+    method.options!.description = false;
+
+    expect(() => JSON.stringify(info.cache)).not.toThrow();
+    expect(info.getMintMeltMethod('mint', 'bolt11', 'sat')).toMatchObject({
+      min_amount: null,
+      options: { description: true },
+    });
+  });
+
+  it('supportedMethods and isSupported(4).params return copies', () => {
+    const info = new MintInfo(MINTINFORESP);
+
+    info.supportedMethods('mint')[0].unit = 'zzz';
+    info.isSupported(4).params[0].method = 'bogus';
+
+    expect(info.supportsMintMeltMethod('mint', 'bolt11', 'sat')).toBe(true);
+  });
+
+  it('cache, nuts and contact return snapshots', () => {
+    const info = new MintInfo(MINTINFORESP);
+
+    (info.cache as any).nuts = {};
+    (info.nuts as any)[4] = undefined;
+    info.contact.length = 0;
+
+    expect(info.isSupported(4).disabled).toBe(false);
+    expect(info.cache.nuts?.[4]).toBeDefined();
+    expect(info.contact).toHaveLength(3);
+  });
+
+  it('nut17 and nut29 params are copies', () => {
+    const info = new MintInfo(MINTINFORESP);
+
+    const ws = info.isSupported(17);
+    if (ws.params) ws.params.length = 0;
+
+    expect(info.isSupported(17).params).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary

`MintInfo` accessors returned references into the normalized internal response, so an in-place edit by a consumer (or a plugin sharing the instance) could alter later reads and the persisted `cache`. Because `AmountLike` fields legally accept `bigint`, such an edit is even type-legal, and the damage only surfaces later, for example when serializing the cache. The class now has a one-line contract, stated in its TSDoc: accessors return snapshots, never internal references.

- A private structural `snapshot()` helper deep-copies plain data, preserving `bigint` values exactly. A JSON round-trip was considered and rejected: `JSON.stringify` cannot serialize bigints, and `JSONInt` canonicalizes by magnitude (small bigints come back as numbers), which is right for wire serialization but wrong for a faithful copy.
- Applied at every reference-returning surface: the `cache`, `nuts` and `contact` getters, `checkMintMelt` (covering `isSupported(4|5)`, `supportedMethods` and `getMintMeltMethod`), the NUT-15/17 params arrays, NUT-19's embedded `cached_endpoints`, and NUT-29's params object.
- String getters (`name`, `description`, `version`, ...) are deliberately unchanged: primitives cannot leak references, so the presence of `snapshot()` marks exactly which returns used to be shared.

## Behavior notes

- Returned objects are now safe to mutate or persist; edits no longer feed back into the instance. Object identity across calls is no longer stable (it was never contractual).
- Perf: the cloned values are small (mint info sized); the only internal consumer of an affected getter is a one-shot auth lookup.

## Testing

Four new tests: a type-legal `min_amount = 10n` write-back followed by cache serialization, copy verification for `supportedMethods`/`isSupported(4).params`, mutation isolation for `cache`/`nuts`/`contact`, and the NUT-17 params array. The existing suite's bigint-preservation tests validated the snapshot fidelity choice. Full suite and prtasks green (6520 passing).