### PR TITLE
fix(model): preserve Amount instances through MintInfo snapshot

### DIFF
--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -3,6 +3,7 @@ import { nullIfUndefined } from '../utils/core';
 import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT, MAX_METHOD_LENGTH } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
+import { Amount } from './Amount';
 import { CTSError } from './Errors';
 import {
   type GetInfoResponse,
@@ -364,10 +365,13 @@ export class MintInfo {
 
   /**
    * Deep-copies a plain data value so accessors return snapshots, never internal references.
-   * Preserves bigints, which AmountLike fields may hold; JSON round-trips would not.
+   * Preserves bigints (AmountLike fields may hold them; JSON round-trips would not) and Amount
+   * instances (which AmountLike also admits): Amount is frozen and immutable, so sharing the
+   * reference is safe and structural copying would strip its prototype into a bare `{value}`.
    */
   private static snapshot<T>(value: T): T {
     if (value === null || typeof value !== 'object') return value;
+    if (value instanceof Amount) return value;
     if (Array.isArray(value)) {
       return (value as unknown[]).map((v) => MintInfo.snapshot(v)) as T;
     }

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
+import { Amount } from '../../src/model/Amount';
 import { MintInfo } from '../../src/model/MintInfo';
 import { MAX_METHOD_LENGTH } from '../../src/utils/limits';
 import { MINTINFORESP } from '../consts';
@@ -804,6 +805,26 @@ describe('MintInfo snapshot accessors', () => {
       min_amount: null,
       options: { description: true },
     });
+  });
+
+  it('preserves Amount instances (AmountLike) through the snapshot', () => {
+    // AmountLike admits Amount; a snapshot must not strip its prototype into {value}
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        4: {
+          disabled: false,
+          methods: [
+            { method: 'bolt11', unit: 'sat', min_amount: Amount.from(100), max_amount: null },
+          ],
+        },
+      },
+    });
+
+    const min = info.getMintMeltMethod('mint', 'bolt11', 'sat')!.min_amount;
+    expect(min).toBeInstanceOf(Amount);
+    expect(() => Amount.from(min!)).not.toThrow();
+    expect(Amount.from(min!).toBigInt()).toBe(100n);
   });
 
   it('supportedMethods and isSupported(4).params return copies', () => {


### PR DESCRIPTION
## Summary

Follow-up to #824. The `snapshot()` deep-copy rebuilds plain objects via `Object.entries`, which strips the prototype of class instances. `SwapMethod.min_amount`/`max_amount` are typed `AmountLike | null`, and `AmountLike` includes `Amount` — so an `Amount` embedded in a response came back as a bare `{ value: 100n }`, and `Amount.from()` on it threw `Unsupported amount input type`.

The fix returns `Amount` instances by reference from `snapshot()`. `Amount` is `Object.freeze`d and immutable, so sharing the reference is safe (nothing can mutate it) and prototype-faithful — deep-copying an immutable was pointless destruction to begin with.

## Scope

- No wire or persistence path is affected: a mint sends JSON, and a persisted `cache` is JSON, so `min_amount`/`max_amount` normally arrive as `number` or `bigint`, which pass through the snapshot unchanged. No library code reads these fields via `Amount.from`.
- The trigger is a hand-built `GetInfoResponse` that embeds `Amount` instances — type-legal under `AmountLike`, so worth making sound even though it is unusual.
- No public signature change; `snapshot` is private.

## Testing

New test embeds `Amount.from(100)` in a response and asserts the accessor returns an `Amount` that `Amount.from` accepts. Full suite and prtasks green (6524 passing).