### PR TITLE
fix(model): preserve Amount instances through MintInfo snapshot [backport v4-dev]

### DIFF
--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -3,6 +3,7 @@ import { nullIfUndefined } from '../utils/core';
 import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
+import { Amount } from './Amount';
 import { CTSError } from './Errors';
 import {
   type GetInfoResponse,
@@ -348,10 +349,13 @@ export class MintInfo {
 
   /**
    * Deep-copies a plain data value so accessors return snapshots, never internal references.
-   * Preserves bigints, which AmountLike fields may hold; JSON round-trips would not.
+   * Preserves bigints (AmountLike fields may hold them; JSON round-trips would not) and Amount
+   * instances (which AmountLike also admits): Amount is frozen and immutable, so sharing the
+   * reference is safe and structural copying would strip its prototype into a bare `{value}`.
    */
   private static snapshot<T>(value: T): T {
     if (value === null || typeof value !== 'object') return value;
+    if (value instanceof Amount) return value;
     if (Array.isArray(value)) {
       return (value as unknown[]).map((v) => MintInfo.snapshot(v)) as T;
     }

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
+import { Amount } from '../../src/model/Amount';
 import { MintInfo } from '../../src/model/MintInfo';
 import { MINTINFORESP } from '../consts';
 
@@ -455,6 +456,26 @@ describe('MintInfo snapshot accessors', () => {
     info.isSupported(4).params[0].method = 'bogus';
 
     expect(info.supportsMintMeltMethod('mint', 'bolt11', 'sat')).toBe(true);
+  });
+
+  it('preserves Amount instances (AmountLike) through the snapshot', () => {
+    // AmountLike admits Amount; a snapshot must not strip its prototype into {value}
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        4: {
+          disabled: false,
+          methods: [
+            { method: 'bolt11', unit: 'sat', min_amount: Amount.from(100), max_amount: null },
+          ],
+        },
+      },
+    });
+
+    const min = info.isSupported(4).params[0].min_amount;
+    expect(min).toBeInstanceOf(Amount);
+    expect(() => Amount.from(min!)).not.toThrow();
+    expect(Amount.from(min!).toBigInt()).toBe(100n);
   });
 
   it('cache, nuts and contact return snapshots', () => {


### PR DESCRIPTION
Backport of #826 to v4-dev (which carries the same snapshot via #825). The `snapshot()` deep-copy strips class prototypes, so an `Amount` in an `AmountLike` field (`min_amount`/`max_amount`) came back as a bare `{ value }` and threw in `Amount.from()`. `Amount` is frozen and immutable, so it is now returned by reference: safe and prototype-faithful. No wire/persistence path is affected (those carry number/bigint); the trigger is a hand-built response embedding `Amount`, which `AmountLike` permits. Test adapted to v4's surface (`isSupported(4).params`, no `getMintMeltMethod`). prtasks green on v4 (4764 passing).