### PR TITLE
fix(wallet): compute NUT-08 blank count in bigint

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -67,7 +67,7 @@ import {
   ABSOLUTE_MAX_BATCH_SIZE,
 } from '../utils';
 
-import { getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
+import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
 import {
   type CounterSource,
   EphemeralCounterSource,
@@ -3008,9 +3008,10 @@ class Wallet {
         { keyset: keyset.id },
       );
       keyset = this.getOutputKeyset(keysetId);
-      let count = Math.ceil(Math.log2(feeReserve.toNumberUnsafe())) || 1;
-      if (count < 0) count = 0; // Prevents: -Infinity
-      const denominations: number[] = count ? new Array<number>(count).fill(0) : [];
+      // NUT-08 blank outputs: ceil(log2(feeReserve)) blinded messages, at least one.
+      // Computed on bigint so a u64-scale reserve cannot lose precision to a float.
+      const count = Math.max(ceilLog2(feeReserve.toBigInt()), 1);
+      const denominations: number[] = new Array<number>(count).fill(0);
       this._logger.debug('Creating NUT-08 blanks for fee reserve', {
         feeReserve: feeReserve,
         denominations,

--- a/src/wallet/_internal.ts
+++ b/src/wallet/_internal.ts
@@ -7,6 +7,14 @@ import { splitAmount } from '../utils/core';
 
 import { type OutputType } from './types';
 
+/**
+ * Exact `ceil(log2(n))` for n >= 1, computed on bigint so u64-scale inputs never lose precision.
+ * Returns 0 for n <= 1. Used for NUT-08 blank output counts.
+ */
+export function ceilLog2(n: bigint): number {
+  return n <= 1n ? 0 : (n - 1n).toString(2).length;
+}
+
 function getKeysetAmountsAsc(keys: Keys): Amount[] {
   const amounts = Object.keys(keys).map((k) => Amount.from(k));
   amounts.sort((a, b) => a.compareTo(b));

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -2,8 +2,33 @@ import { test, describe, expect } from 'vitest';
 
 import { Amount, type Keys, type Proof, type OutputType } from '../../src';
 import { OutputData } from '../../src/model/OutputData';
-import { getKeepAmounts, stringifyOutputTypeForLog } from '../../src/wallet/_internal';
+import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from '../../src/wallet/_internal';
 import { PUBKEYS } from '../consts';
+
+describe('ceilLog2', () => {
+  test('matches Math.ceil(Math.log2(n)) for small values', () => {
+    for (const [n, want] of [
+      [1n, 0],
+      [2n, 1],
+      [3n, 2],
+      [4n, 2],
+      [5n, 3],
+      [8n, 3],
+      [9n, 4],
+      [16n, 4],
+    ] as const) {
+      expect(ceilLog2(n)).toBe(want);
+    }
+  });
+
+  test('is exact above Number.MAX_SAFE_INTEGER (float log2 would truncate)', () => {
+    // 2^53 is a power of two; 2^53 + 1 needs one more bit. The old
+    // toNumberUnsafe path truncated 2^53+1 back to 2^53 and returned 53.
+    expect(ceilLog2(2n ** 53n)).toBe(53);
+    expect(ceilLog2(2n ** 53n + 1n)).toBe(54);
+    expect(ceilLog2(2n ** 64n)).toBe(64);
+  });
+});
 
 describe('getKeepAmounts', () => {
   const amountsWeHave = [1, 2, 4, 4, 4, 8];


### PR DESCRIPTION
## Summary

Final follow-up to the selection bigint migration (#822). A sweep for number-arithmetic on money paths found one remaining silent truncation: the NUT-08 melt-change path derived its blank-output count with

```js
Math.ceil(Math.log2(feeReserve.toNumberUnsafe()))
```

`toNumberUnsafe()` truncates above `Number.MAX_SAFE_INTEGER`, so a u64-scale fee reserve near a power-of-2 boundary could round to one *too few* blank outputs, leaving a sliver of overpaid fee change that the mint cannot return. It's the last money-bearing value in the library computed through a float.

Replaced with an exact bigint helper `ceilLog2(n)` (in `src/wallet/_internal.ts`, not public API). Behaviour is unchanged for all realistic fee reserves; it just stays exact for large ones. `feeReserve.greaterThan(0)` already guards the branch, so the count is always at least one, same as before.

## Testing

`ceilLog2` is unit-tested against `Math.ceil(Math.log2(n))` for small values, plus the boundary case `2^53 + 1 → 54` where the old float path returned 53. Full node and browser suites green.

## Note

The sweep found the rest of the money paths clean: `sumProofs`, `Amount.sum`, `getFeesForProofs`, quote round-tripping, and CBOR/JSONInt token serialization are all bigint/Amount-backed. The one other `toNumber()` (in `splitAmount`) is the throwing variant guarding a pathological split and was left as-is.