### PR TITLE
fix(wallet): compute NUT-08 blank count in bigint [backport v4-dev]

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -61,7 +61,7 @@ import {
   ABSOLUTE_MAX_BATCH_SIZE,
 } from '../utils';
 
-import { getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
+import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
 import {
   type CounterSource,
   EphemeralCounterSource,
@@ -2937,9 +2937,10 @@ class Wallet {
         { keyset: keyset.id },
       );
       keyset = this.getOutputKeyset(keysetId);
-      let count = Math.ceil(Math.log2(feeReserve.toNumberUnsafe())) || 1;
-      if (count < 0) count = 0; // Prevents: -Infinity
-      const denominations: number[] = count ? new Array<number>(count).fill(0) : [];
+      // NUT-08 blank outputs: ceil(log2(feeReserve)) blinded messages, at least one.
+      // Computed on bigint so a u64-scale reserve cannot lose precision to a float.
+      const count = Math.max(ceilLog2(feeReserve.toBigInt()), 1);
+      const denominations: number[] = new Array<number>(count).fill(0);
       this._logger.debug('Creating NUT-08 blanks for fee reserve', {
         feeReserve: feeReserve,
         denominations,

--- a/src/wallet/_internal.ts
+++ b/src/wallet/_internal.ts
@@ -7,6 +7,14 @@ import { splitAmount } from '../utils/core';
 
 import { type OutputType } from './types';
 
+/**
+ * Exact `ceil(log2(n))` for n >= 1, computed on bigint so u64-scale inputs never lose precision.
+ * Returns 0 for n <= 1. Used for NUT-08 blank output counts.
+ */
+export function ceilLog2(n: bigint): number {
+  return n <= 1n ? 0 : (n - 1n).toString(2).length;
+}
+
 function getKeysetAmountsAsc(keys: Keys): Amount[] {
   const amounts = Object.keys(keys).map((k) => Amount.from(k));
   amounts.sort((a, b) => a.compareTo(b));

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -2,8 +2,33 @@ import { test, describe, expect } from 'vitest';
 
 import { Amount, type Keys, type Proof, type OutputType } from '../../src';
 import { OutputData } from '../../src/model/OutputData';
-import { getKeepAmounts, stringifyOutputTypeForLog } from '../../src/wallet/_internal';
+import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from '../../src/wallet/_internal';
 import { PUBKEYS } from '../consts';
+
+describe('ceilLog2', () => {
+  test('matches Math.ceil(Math.log2(n)) for small values', () => {
+    for (const [n, want] of [
+      [1n, 0],
+      [2n, 1],
+      [3n, 2],
+      [4n, 2],
+      [5n, 3],
+      [8n, 3],
+      [9n, 4],
+      [16n, 4],
+    ] as const) {
+      expect(ceilLog2(n)).toBe(want);
+    }
+  });
+
+  test('is exact above Number.MAX_SAFE_INTEGER (float log2 would truncate)', () => {
+    // 2^53 is a power of two; 2^53 + 1 needs one more bit. The old
+    // toNumberUnsafe path truncated 2^53+1 back to 2^53 and returned 53.
+    expect(ceilLog2(2n ** 53n)).toBe(53);
+    expect(ceilLog2(2n ** 53n + 1n)).toBe(54);
+    expect(ceilLog2(2n ** 64n)).toBe(64);
+  });
+});
 
 describe('getKeepAmounts', () => {
   const amountsWeHave = [1, 2, 4, 4, 4, 8];


### PR DESCRIPTION
Backport of #828. v4's melt path has the identical `Math.ceil(Math.log2(feeReserve.toNumberUnsafe()))`, the last silent number truncation on a money-bearing amount; a u64-scale fee reserve near a power-of-2 boundary could yield one too few NUT-08 blank outputs. Replaced with the exact bigint `ceilLog2` helper in `_internal.ts` (not public API). Also keeps `Wallet.ts`/`_internal.ts` converged with main for clean future cherry-picks. Node suite and lint/format green on v4 (1592 passing); browser project omitted here (sandbox flakiness), CI will run it.