### PR TITLE
fix(model): bound Amount.from to the u64 range

### DIFF
--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -1,3 +1,5 @@
+import { U64_MAX } from '../utils/limits';
+
 import { CTSError } from './Errors';
 
 export class AmountError extends CTSError {
@@ -41,8 +43,8 @@ export class Amount {
   /**
    * Parse/normalize supported inputs into an Amount.
    *
-   * @throws If input is negative, or if a `number` input exceeds the safe integer limit, or if
-   *   input is not a finite integer.
+   * @throws If input is negative, exceeds the u64 range, is a non-finite/non-integer `number`, or
+   *   is above the safe integer limit for a `number`.
    */
   static from(input: AmountLike): Amount {
     if (input instanceof Amount) return input;
@@ -50,6 +52,9 @@ export class Amount {
     if (typeof input === 'bigint') {
       if (input < 0n) {
         throw new AmountError(`Amount must be >= 0, got ${input}`);
+      }
+      if (input > U64_MAX) {
+        throw new AmountError(`Amount exceeds u64 max, got ${input}`);
       }
       return new Amount(input);
     }
@@ -69,13 +74,23 @@ export class Amount {
     }
 
     if (typeof input === 'string') {
+      // Length-gate before regex/BigInt: u64 max is 20 digits, so a longer amount string is
+      // out of range by definition. Refuse it up front rather than run O(n) parsing on unbounded
+      // input.
+      if (input.length > 20) {
+        throw new AmountError(`Amount exceeds u64 max: "${input.slice(0, 20)}..."`);
+      }
       // Decimal-only canonical form
       if (!/^(0|[1-9]\d*)$/.test(input)) {
         throw new AmountError(
           `Invalid amount string "${input}". Expected non-negative decimal integer.`,
         );
       }
-      return new Amount(BigInt(input));
+      const value = BigInt(input);
+      if (value > U64_MAX) {
+        throw new AmountError(`Amount exceeds u64 max, got ${value}`);
+      }
+      return new Amount(value);
     }
 
     // Unknown type

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -19,3 +19,10 @@ export const ABSOLUTE_MAX_BATCH_SIZE = 100;
  * (split/map/join) on a multi-megabyte string, which a malicious mint could use to exhaust memory.
  */
 export const MAX_METHOD_LENGTH = 255;
+
+/**
+ * Max u64 (2^64 - 1): upper bound for amount and other u64 integer fields as they arrive from the
+ * wire or an API caller. Enforced on ingest (`Amount.from`), not on arithmetic: Amount math
+ * (percent, scale) intentionally uses intermediates above u64.
+ */
+export const U64_MAX = 2n ** 64n - 1n;

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -29,6 +29,26 @@ describe('Amount.from validation', () => {
   it('rejects unsupported input types', () => {
     expect(() => Amount.from({} as unknown as Amount)).toThrow('Unsupported amount input type');
   });
+
+  it('accepts the u64 max at the boundary', () => {
+    const u64Max = 2n ** 64n - 1n;
+    expect(Amount.from(u64Max).toBigInt()).toBe(u64Max);
+    expect(Amount.from(u64Max.toString()).toBigInt()).toBe(u64Max);
+  });
+
+  it('rejects bigints above the u64 range', () => {
+    expect(() => Amount.from(2n ** 64n)).toThrow('exceeds u64 max');
+  });
+
+  it('rejects decimal strings above the u64 range', () => {
+    // 20 digits but numerically above u64 max (needs the post-parse check, not just length)
+    expect(() => Amount.from('20000000000000000000')).toThrow('exceeds u64 max');
+  });
+
+  it('rejects over-long amount strings without parsing them', () => {
+    // 90M-digit string must be refused up front, not run through regex/BigInt (DoS guard)
+    expect(() => Amount.from('1' + '0'.repeat(90_000_000))).toThrow('exceeds u64 max');
+  });
 });
 
 describe('Amount conversions', () => {


### PR DESCRIPTION
`Amount.from` now rejects values above the u64 max (2^64-1), the protocol range for wire amounts. This completes the u64 amount support from #822 by validating the upper bound on ingest.

The string path length-gates before regex/`BigInt`, so an over-long numeric string is refused without O(n) parsing.

Arithmetic is deliberately unchanged: percent and scale intermediates may legitimately exceed u64, so the bound sits at ingest rather than on the operators.

Technically a breaking change (`Amount.from(2n**64n)` now throws), but no real amount reaches u64.
