### PR TITLE
fix(model): cap Amount at the u64 range [backport v4-dev]

### DIFF
--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -32,6 +32,12 @@ export class Amount {
   private readonly value: bigint;
 
   private constructor(value: bigint) {
+    // Single choke point for the u64 ceiling: every Amount, including arithmetic results, is
+    // <= u64 max. Muldiv helpers keep their wide intermediate in bigint and only construct the
+    // divided-down result, so a valid `a*n/d` still works while an out-of-range result throws.
+    if (value > U64_MAX) {
+      throw new AmountError(`Amount exceeds u64 max, got ${value}`);
+    }
     this.value = value;
     Object.freeze(this);
   }
@@ -53,10 +59,7 @@ export class Amount {
       if (input < 0n) {
         throw new AmountError(`Amount must be >= 0, got ${input}`);
       }
-      if (input > U64_MAX) {
-        throw new AmountError(`Amount exceeds u64 max, got ${input}`);
-      }
-      return new Amount(input);
+      return new Amount(input); // constructor enforces the u64 ceiling
     }
 
     if (typeof input === 'number') {
@@ -86,11 +89,7 @@ export class Amount {
           `Invalid amount string "${input}". Expected non-negative decimal integer.`,
         );
       }
-      const value = BigInt(input);
-      if (value > U64_MAX) {
-        throw new AmountError(`Amount exceeds u64 max, got ${value}`);
-      }
-      return new Amount(value);
+      return new Amount(BigInt(input)); // constructor enforces the u64 ceiling
     }
 
     // Unknown type
@@ -219,10 +218,10 @@ export class Amount {
         `ceilPercent: denominator must be a positive integer, got ${denominator}`,
       );
     }
-    // ceil(a * n / d) = floor((a * n + d - 1) / d)
-    return this.multiplyBy(numerator)
-      .add(denominator - 1)
-      .divideBy(denominator);
+    // ceil(a * n / d) = floor((a * n + d - 1) / d); the a*n intermediate stays in bigint
+    const num = BigInt(numerator);
+    const den = BigInt(denominator);
+    return new Amount((this.value * num + (den - 1n)) / den);
   }
 
   /**
@@ -247,7 +246,10 @@ export class Amount {
         `floorPercent: denominator must be a positive integer, got ${denominator}`,
       );
     }
-    return this.multiplyBy(numerator).divideBy(denominator);
+    // floor(a * n / d); the a*n intermediate stays in bigint
+    const num = BigInt(numerator);
+    const den = BigInt(denominator);
+    return new Amount((this.value * num) / den);
   }
 
   /**
@@ -306,14 +308,14 @@ export class Amount {
    * @throws If numerator or denominator are zero or negative.
    */
   scaledBy(numerator: AmountLike, denominator: AmountLike): Amount {
-    const n = Amount.from(numerator);
-    const d = Amount.from(denominator);
-    if (n.isZero()) return Amount.zero();
-    if (d.isZero()) {
+    const n = Amount.from(numerator).value;
+    const d = Amount.from(denominator).value;
+    if (n === 0n) return Amount.zero();
+    if (d === 0n) {
       throw new AmountError('scaledBy: denominator must be > 0');
     }
-    // round(a × n / d) = floor((2 × a × n + d) / (2 × d))
-    return this.multiplyBy(n).multiplyBy(2).add(d).divideBy(d.multiplyBy(2));
+    // round(a × n / d) = floor((2 × a × n + d) / (2 × d)); the 2*a*n intermediate stays in bigint
+    return new Amount((2n * this.value * n + d) / (2n * d));
   }
 
   // -----------------------------------------------------------------

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -13,8 +13,8 @@ export const ABSOLUTE_MAX_PER_MINT = 100;
 export const ABSOLUTE_MAX_BATCH_SIZE = 100;
 
 /**
- * Max u64 (2^64 - 1): upper bound for amount and other u64 integer fields as they arrive from the
- * wire or an API caller. Enforced on ingest (`Amount.from`), not on arithmetic: Amount math
- * (percent, scale) intentionally uses intermediates above u64.
+ * Max u64 (2^64 - 1): the ceiling every Amount is held to. Enforced in the Amount constructor, so
+ * arithmetic results are bounded too; muldiv helpers keep their wide intermediate in bigint and
+ * only construct the divided-down result.
  */
 export const U64_MAX = 2n ** 64n - 1n;

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -49,6 +49,18 @@ describe('Amount.from validation', () => {
     // 90M-digit string must be refused up front, not run through regex/BigInt (DoS guard)
     expect(() => Amount.from('1' + '0'.repeat(90_000_000))).toThrow('exceeds u64 max');
   });
+
+  it('caps arithmetic results at u64, throwing on overflow', () => {
+    const max = Amount.from(2n ** 64n - 1n);
+    expect(() => max.add(1)).toThrow('exceeds u64 max');
+    expect(() => max.multiplyBy(2)).toThrow('exceeds u64 max');
+  });
+
+  it('scaledBy holds the wide intermediate in bigint and returns an in-range result', () => {
+    // a * n = 2.4e19 overflows u64, but round(a * n / d) = 3e9 is a valid amount
+    const result = Amount.from(6_000_000_000n).scaledBy(4_000_000_000n, 8_000_000_000n);
+    expect(result.toBigInt()).toBe(3_000_000_000n);
+  });
 });
 
 describe('Amount conversions', () => {


### PR DESCRIPTION
Backport of #832 to `v4-dev`.

`Amount` now enforces the u64 ceiling in its private constructor, so every Amount, parsed or computed, is <= u64 max, matching the wire type used across NUT-01 units (sat, msat, etc.).

The muldiv helpers (`scaledBy`, `ceilPercent`, `floorPercent`) keep their `a*n` / `2*a*n` intermediate in bigint and construct only the divided-down result, so exact proportional math still works; only an out-of-range *result* throws.

Behaviour change: arithmetic now throws on u64 overflow (was bigint-unbounded). It never fires for real amounts (~9x total msat supply of headroom) and fails fast on a bug rather than carrying a bad value to serialization.

`limits.ts` adapted: `MAX_METHOD_LENGTH` is v5-only, so `U64_MAX` sits after `ABSOLUTE_MAX_BATCH_SIZE`.
