### PR TITLE
feat(utils): rename normalizeUrl to normalizeMintUrl and make it public

### DIFF
--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -1,0 +1,28 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Helpers**
+
+# Helpers
+
+Small, standalone utility functions that are part of the supported public API. These need no
+`Wallet` or `Mint` instance — import and call. This page grows as more helpers are promoted
+into core.
+
+## `normalizeMintUrl`
+
+Parses and normalizes a mint URL into its canonical form: validates the scheme (http/https
+only), rejects credentials, query parameters, fragments, and encoded path delimiters, lowercases
+the host, and strips trailing slashes. Throws `CTSError` on invalid input.
+
+Use it anywhere a mint URL acts as an identity or cache key — two URLs that normalize
+identically refer to the same mint. `Wallet` and `Mint` already apply it internally to the
+URLs you pass them; call it yourself when you key storage, deduplicate mints, or compare a
+token's mint URL against your own records.
+
+```ts
+import { normalizeMintUrl } from '@cashu/cashu-ts';
+
+normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
+normalizeMintUrl('https://mint.example.com///'); // 'https://mint.example.com'
+normalizeMintUrl('http://abc123.onion/path'); // 'http://abc123.onion/path'
+normalizeMintUrl('ftp://mint.example.com'); // throws CTSError
+normalizeMintUrl('https://mint.example.com?x=1'); // throws CTSError
+```

--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -9,8 +9,8 @@ into core.
 ## `normalizeMintUrl`
 
 Parses and normalizes a mint URL into its canonical form: validates the scheme (http/https
-only), rejects credentials, query parameters, fragments, and encoded path delimiters, lowercases
-the host, and strips trailing slashes. Throws `CTSError` on invalid input.
+only), rejects credentials, query parameters, fragments, and percent-encoded characters in the
+path, lowercases the host, and strips trailing slashes. Throws `CTSError` on invalid input.
 
 Use it anywhere a mint URL acts as an identity or cache key, two URLs that normalize
 identically refer to the same mint. `Wallet` and `Mint` already apply it internally to the

--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -12,7 +12,7 @@ Parses and normalizes a mint URL into its canonical form: validates the scheme (
 only), rejects credentials, query parameters, fragments, and encoded path delimiters, lowercases
 the host, and strips trailing slashes. Throws `CTSError` on invalid input.
 
-Use it anywhere a mint URL acts as an identity or cache key — two URLs that normalize
+Use it anywhere a mint URL acts as an identity or cache key, two URLs that normalize
 identically refer to the same mint. `Wallet` and `Mint` already apply it internally to the
 URLs you pass them; call it yourself when you key storage, deduplicate mints, or compare a
 token's mint URL against your own records.

--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -2,27 +2,18 @@
 
 # Helpers
 
-Small, standalone utility functions that are part of the supported public API. These need no
-`Wallet` or `Mint` instance — import and call. This page grows as more helpers are promoted
-into core.
+Standalone utility functions in the public API. No `Wallet` or `Mint` instance needed.
 
 ## `normalizeMintUrl`
 
-Parses and normalizes a mint URL into its canonical form: validates the scheme (http/https
-only), rejects credentials, query parameters, fragments, and percent-encoded characters in the
-path, lowercases the host, and strips trailing slashes. Throws `CTSError` on invalid input.
-
-Use it anywhere a mint URL acts as an identity or cache key, two URLs that normalize
-identically refer to the same mint. `Wallet` and `Mint` already apply it internally to the
-URLs you pass them; call it yourself when you key storage, deduplicate mints, or compare a
-token's mint URL against your own records.
+Returns the canonical form of a mint URL, or throws `CTSError` if it is not a clean
+http(s) URL (exact rules in the API reference). `Wallet` and `Mint` already normalize
+the URLs you pass them; call it yourself when a mint URL is a storage key, or when
+comparing a token's mint against your own records.
 
 ```ts
 import { normalizeMintUrl } from '@cashu/cashu-ts';
 
 normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
-normalizeMintUrl('https://mint.example.com///'); // 'https://mint.example.com'
-normalizeMintUrl('http://abc123.onion/path'); // 'http://abc123.onion/path'
 normalizeMintUrl('ftp://mint.example.com'); // throws CTSError
-normalizeMintUrl('https://mint.example.com?x=1'); // throws CTSError
 ```

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -37,6 +37,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [NUT-19 Cached Responses](./nut19.md)               | Understand cached endpoint retries and timeout behavior.                        |
 | [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |
 | [Amounts](./amounts.md)                             | Work with the `Amount` and `AmountWithUnit` value objects.                      |
+| [Helpers](./helpers.md)                             | Standalone public utility functions — currently mint URL normalization.         |
 
 ## Related docs
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1375,6 +1375,9 @@ export class NetworkError extends CTSError {
 }
 
 // @public
+export function normalizeMintUrl(url: string): string;
+
+// @public
 export function normalizeProofAmounts(raw: ProofLike[]): Proof[];
 
 // @public

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -393,16 +393,16 @@ Several functions that were intended for internal use have been removed from the
 
 The following are still exported but are excluded from the trimmed type definitions and not part of the supported public API. Remove any external dependencies on them.
 
-| Function                | Notes                                          |
-| ----------------------- | ---------------------------------------------- |
-| `isValidHex`            | Internal helper.                               |
-| `hexToNumber`           | Crypto scalar helper (hex → bigint).           |
-| `numberToHexPadded64`   | Crypto scalar helper (bigint → 64-char hex).   |
-| `isObj`                 | HTTP response type guard.                      |
-| `joinUrls`              | Mint URL path builder.                         |
-| `sanitizeUrl`           | Renamed to `normalizeUrl` (internal).          |
-| `invoiceHasAmountInHRP` | BOLT-11 HRP amount detector.                   |
-| `bigIntStringify`       | `JSON.stringify` replacer for `bigint` values. |
+| Function                | Notes                                                     |
+| ----------------------- | --------------------------------------------------------- |
+| `isValidHex`            | Internal helper.                                          |
+| `hexToNumber`           | Crypto scalar helper (hex → bigint).                      |
+| `numberToHexPadded64`   | Crypto scalar helper (bigint → 64-char hex).              |
+| `isObj`                 | HTTP response type guard.                                 |
+| `joinUrls`              | Mint URL path builder.                                    |
+| `sanitizeUrl`           | Renamed to `normalizeMintUrl` and made public — see main. |
+| `invoiceHasAmountInHRP` | BOLT-11 HRP amount detector.                              |
+| `bigIntStringify`       | `JSON.stringify` replacer for `bigint` values.            |
 
 ### `handleTokens` no longer exported
 

--- a/migration-4.0.0.md
+++ b/migration-4.0.0.md
@@ -393,16 +393,19 @@ Several functions that were intended for internal use have been removed from the
 
 The following are still exported but are excluded from the trimmed type definitions and not part of the supported public API. Remove any external dependencies on them.
 
-| Function                | Notes                                                     |
-| ----------------------- | --------------------------------------------------------- |
-| `isValidHex`            | Internal helper.                                          |
-| `hexToNumber`           | Crypto scalar helper (hex → bigint).                      |
-| `numberToHexPadded64`   | Crypto scalar helper (bigint → 64-char hex).              |
-| `isObj`                 | HTTP response type guard.                                 |
-| `joinUrls`              | Mint URL path builder.                                    |
-| `sanitizeUrl`           | Renamed to `normalizeMintUrl` and made public — see main. |
-| `invoiceHasAmountInHRP` | BOLT-11 HRP amount detector.                              |
-| `bigIntStringify`       | `JSON.stringify` replacer for `bigint` values.            |
+| Function                | Notes                                          |
+| ----------------------- | ---------------------------------------------- |
+| `isValidHex`            | Internal helper.                               |
+| `hexToNumber`           | Crypto scalar helper (hex → bigint).           |
+| `numberToHexPadded64`   | Crypto scalar helper (bigint → 64-char hex).   |
+| `isObj`                 | HTTP response type guard.                      |
+| `joinUrls`              | Mint URL path builder.                         |
+| `invoiceHasAmountInHRP` | BOLT-11 HRP amount detector.                   |
+| `bigIntStringify`       | `JSON.stringify` replacer for `bigint` values. |
+
+### `sanitizeUrl` renamed to `normalizeMintUrl`
+
+`sanitizeUrl` has been renamed to `normalizeMintUrl` and made part of the public API. It now also parses and validates the URL, rejecting invalid schemes, credentials, query parameters, fragments, and percent-encoded path characters, rather than only sanitizing it.
 
 ### `handleTokens` no longer exported
 

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -54,8 +54,8 @@ import {
   joinUrls,
   normalizeMintKeys,
   normalizeMintKeyset,
+  normalizeMintUrl,
   normalizeSafeIntegerMetadata,
-  normalizeUrl,
   nullIfUndefined,
 } from '../utils';
 
@@ -102,7 +102,7 @@ class Mint {
       logger?: Logger;
     },
   ) {
-    this._mintUrl = normalizeUrl(mintUrl);
+    this._mintUrl = normalizeMintUrl(mintUrl);
     if (options?.customRequest) {
       this._request = options.customRequest;
     } else if (options?.requestFetch) {

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -6,7 +6,7 @@ import {
   p2pkOptionsToPRNut10,
   parseP2PKSecret,
 } from '../crypto/NUT11';
-import { encodeBase64toUint8, decodeCBOR, encodeCBOR, Bytes, normalizeUrl } from '../utils';
+import { encodeBase64toUint8, decodeCBOR, encodeCBOR, Bytes, normalizeMintUrl } from '../utils';
 import { decodeBech32mToBytes, encodeBech32m } from '../utils/bech32m';
 import { decodeTLV, encodeTLV } from '../utils/tlv';
 import type { DecodedTLVPaymentRequest } from '../utils/tlv';
@@ -159,7 +159,7 @@ export class PaymentRequest {
   includesMint(mintUrl: string): boolean {
     const norm = (u: string) => {
       try {
-        return normalizeUrl(u);
+        return normalizeMintUrl(u);
       } catch {
         return u;
       }
@@ -485,7 +485,7 @@ export class PaymentRequestBuilder {
   addMint(mint: string | string[]): this {
     const arr = Array.isArray(mint) ? mint : [mint];
     for (const m of arr) {
-      const normalized = normalizeUrl(m);
+      const normalized = normalizeMintUrl(m);
       if (!this._mints.includes(normalized)) this._mints.push(normalized);
     }
     return this;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -544,9 +544,12 @@ export function joinUrls(...parts: string[]): string {
  * Parses and normalizes a mint URL: validates the scheme (http/https only), rejects credentials,
  * query parameters, fragments, and encoded path delimiters, and strips any trailing slashes.
  *
- * @internal
+ * @example normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
+ *
+ * @throws CTSError if the URL is invalid, non-http(s), or contains credentials, query, fragment, or
+ *   encoded path delimiters.
  */
-export function normalizeUrl(url: string): string {
+export function normalizeMintUrl(url: string): string {
   let parsed: URL;
   try {
     parsed = new URL(url);

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -542,14 +542,15 @@ export function joinUrls(...parts: string[]): string {
 
 /**
  * Parses and normalizes a mint URL: validates the scheme (http/https only), rejects credentials,
- * query parameters, fragments, and encoded path delimiters, and strips any trailing slashes.
+ * query parameters, fragments, and percent-encoded characters in the path, and strips any trailing
+ * slashes.
  *
  * @example
  *
  *     normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
  *
  * @throws CTSError if the URL is invalid, non-http(s), or contains credentials, query, fragment, or
- *   encoded path delimiters.
+ *   percent-encoded characters in the path.
  */
 export function normalizeMintUrl(url: string): string {
   let parsed: URL;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -544,7 +544,9 @@ export function joinUrls(...parts: string[]): string {
  * Parses and normalizes a mint URL: validates the scheme (http/https only), rejects credentials,
  * query parameters, fragments, and encoded path delimiters, and strips any trailing slashes.
  *
- * @example normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
+ * @example
+ *
+ *     normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
  *
  * @throws CTSError if the URL is invalid, non-http(s), or contains credentials, query, fragment, or
  *   encoded path delimiters.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -60,8 +60,8 @@ import type { RequestFetch, RequestFn } from '../transport';
 import {
   getDecodedToken,
   invoiceHasAmountInHRP,
+  normalizeMintUrl,
   normalizeProofAmounts,
-  normalizeUrl,
   splitAmount,
   sumProofs,
   verifyProofsForReceive,
@@ -1007,7 +1007,7 @@ class Wallet {
       proofs = normalizeProofAmounts(token);
     } else {
       const decodedToken: Token = typeof token === 'string' ? this.decodeToken(token) : token;
-      const tokenMintUrl = normalizeUrl(decodedToken.mint);
+      const tokenMintUrl = normalizeMintUrl(decodedToken.mint);
       this.failIf(tokenMintUrl !== this.mint.mintUrl, 'Token belongs to a different mint', {
         token: tokenMintUrl,
         wallet: this.mint.mintUrl,

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -24,7 +24,7 @@ import {
   deserializeProofs,
   normalizeProofAmounts,
   sortProofsById,
-  normalizeUrl,
+  normalizeMintUrl,
 } from '../../src/utils';
 import {
   NUT02_V1_VECTOR1_KEYS,
@@ -1714,70 +1714,72 @@ describe('mapShortKeysetIds full-length pass-through (non-conformant tokens)', (
   });
 });
 
-describe('normalizeUrl', () => {
+describe('normalizeMintUrl', () => {
   test('strips trailing slash', () => {
-    expect(normalizeUrl('https://mint.example.com/')).toBe('https://mint.example.com');
+    expect(normalizeMintUrl('https://mint.example.com/')).toBe('https://mint.example.com');
   });
   test('strips multiple trailing slashes', () => {
-    expect(normalizeUrl('https://mint.example.com///')).toBe('https://mint.example.com');
+    expect(normalizeMintUrl('https://mint.example.com///')).toBe('https://mint.example.com');
   });
   test('preserves path', () => {
-    expect(normalizeUrl('https://mint.example.com/v1/mint')).toBe(
+    expect(normalizeMintUrl('https://mint.example.com/v1/mint')).toBe(
       'https://mint.example.com/v1/mint',
     );
   });
   test('throws on malformed URL', () => {
-    expect(() => normalizeUrl('not-a-url')).toThrow('Invalid mint URL: not-a-url');
+    expect(() => normalizeMintUrl('not-a-url')).toThrow('Invalid mint URL: not-a-url');
   });
   test('throws on non-http scheme', () => {
-    expect(() => normalizeUrl('ftp://mint.example.com')).toThrow('Invalid mint URL scheme: ftp:');
+    expect(() => normalizeMintUrl('ftp://mint.example.com')).toThrow(
+      'Invalid mint URL scheme: ftp:',
+    );
   });
   test('accepts http', () => {
-    expect(normalizeUrl('http://localhost:3338')).toBe('http://localhost:3338');
+    expect(normalizeMintUrl('http://localhost:3338')).toBe('http://localhost:3338');
   });
   test('accepts .onion', () => {
-    expect(normalizeUrl('http://abc123.onion/path')).toBe('http://abc123.onion/path');
+    expect(normalizeMintUrl('http://abc123.onion/path')).toBe('http://abc123.onion/path');
   });
   test('rejects query parameters', () => {
-    expect(() => normalizeUrl('https://mint.example.com?token=abc')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com?token=abc')).toThrow(
       'Mint URL must not contain query parameters',
     );
   });
   test('rejects trailing ? with no query value', () => {
-    expect(() => normalizeUrl('https://mint.example.com/path?')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com/path?')).toThrow(
       'Mint URL must not contain query parameters',
     );
   });
   test('rejects fragment', () => {
-    expect(() => normalizeUrl('https://mint.example.com#section')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com#section')).toThrow(
       'Mint URL must not contain a fragment',
     );
   });
   test('rejects trailing # with no fragment value', () => {
-    expect(() => normalizeUrl('https://mint.example.com/path#')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com/path#')).toThrow(
       'Mint URL must not contain a fragment',
     );
   });
   test('rejects credentials', () => {
-    expect(() => normalizeUrl('https://user:pass@mint.example.com')).toThrow(
+    expect(() => normalizeMintUrl('https://user:pass@mint.example.com')).toThrow(
       'Mint URL must not contain credentials',
     );
-    expect(() => normalizeUrl('https://user@mint.example.com')).toThrow(
+    expect(() => normalizeMintUrl('https://user@mint.example.com')).toThrow(
       'Mint URL must not contain credentials',
     );
   });
   test('rejects percent-encoded path characters', () => {
-    expect(() => normalizeUrl('https://mint.example.com/path%3Ftoken=abc')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com/path%3Ftoken=abc')).toThrow(
       'Mint URL path must not contain percent-encoded characters',
     );
-    expect(() => normalizeUrl('https://mint.example.com/path%23fragment')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com/path%23fragment')).toThrow(
       'Mint URL path must not contain percent-encoded characters',
     );
-    expect(() => normalizeUrl('https://mint.example.com/path%2Fadmin')).toThrow(
+    expect(() => normalizeMintUrl('https://mint.example.com/path%2Fadmin')).toThrow(
       'Mint URL path must not contain percent-encoded characters',
     );
   });
   test('lowercases hostname', () => {
-    expect(normalizeUrl('https://Mint.Example.COM')).toBe('https://mint.example.com');
+    expect(normalizeMintUrl('https://Mint.Example.COM')).toBe('https://mint.example.com');
   });
 });

--- a/typedoc.json
+++ b/typedoc.json
@@ -23,6 +23,7 @@
     "docs-src/usage/payment_requests.md",
     "docs-src/usage/nut19.md",
     "docs-src/usage/logging.md",
+    "docs-src/usage/helpers.md",
     "docs-src/wallet_ops/wallet_ops.md",
     "docs-src/wallet_ops/send.md",
     "docs-src/wallet_ops/receive.md",


### PR DESCRIPTION
## Description

A review of downstream cashu wallets surfaced that different teams, ended up writing the exact same lines of code to clean up mint web addresses, lowercasing them, stripping default ports, trimming trailing slashes, so that "https://mint.example.com" and "https://mint.example.com/" are recognized as the same mint. Neither team needed to write that code. CTS already has it and already uses it internally, it just isn't visible to the wallets because it was marked internal-only.

---

## Changes

- Renames `normalizeUrl` to `normalizeMintUrl`, removes its `@internal` tag so it ships in the published type definitions.
- Adds a `docs-src/usage/helpers.md` page
- Updates the `migration-4.0.0.md` note per the backport plan
- `etc/cashu-ts.api.md` diff shows the single new public export.
- No behavior change; existing test block renamed as-is, zero assertion changes.

---

## Alignment & Discussion

- Was an issue opened prior to this PR? [No]
- Does this PR align with the current project direction and scope? [Yes]

---

## Reviewer Notes

- Helpers page is deliberately single-entry for now; structured to grow as further audit issues land.
- Old name is not aliased, it was `@internal`, so no compatibility promise, but it *was* runtime-reachable via `export *`; happy to add a deprecated alias if you'd prefer.
