### PR TITLE
feat(wallet): prefer newest keyset version in getCheapestKeyset

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -790,6 +790,7 @@ export class Keyset {
     get unit(): string;
     verify(): boolean;
     static verifyKeysetId(keys: MintKeys): boolean;
+    get version(): number;
 }
 
 // @public

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -186,7 +186,7 @@ export class KeyChain {
   // ---------------------------------------------------------------------
 
   /**
-   * Get a keyset by ID or the cheapest keyset if no ID is provided.
+   * Get a keyset by ID, or the cheapest modern keyset if no ID is provided.
    *
    * @param id Optional keyset ID.
    * @returns Keyset with keys.
@@ -201,10 +201,11 @@ export class KeyChain {
   }
 
   /**
-   * Get the cheapest active keyset.
+   * Get the cheapest modern active keyset.
    *
    * @remarks
-   * Selects active keyset with lowest fee and hex ID.
+   * Prefers the highest keyset ID version, then the lowest fee, then the latest `final_expiry` (no
+   * expiry sorts as never expiring).
    * @returns Active Keyset.
    * @throws If none found or uninitialized.
    */
@@ -218,7 +219,10 @@ export class KeyChain {
     if (activeKeysets.length === 0) {
       throw new CTSError(`No active keyset found for unit: ${this.unit}`);
     }
-    return activeKeysets.sort((a, b) => a.fee - b.fee)[0];
+    const never = Number.MAX_SAFE_INTEGER;
+    return activeKeysets.sort(
+      (a, b) => b.version - a.version || a.fee - b.fee || (b.expiry ?? never) - (a.expiry ?? never),
+    )[0];
   }
 
   /**

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -55,6 +55,13 @@ export class Keyset {
     return isValidHex(this._id);
   }
 
+  /**
+   * Keyset ID version byte (`-1` for deprecated base64 IDs).
+   */
+  get version(): number {
+    return this.hasHexId ? hexToBytes(this._id)[0] : -1;
+  }
+
   get keys(): Record<number, string> {
     return this._keys;
   }

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -379,6 +379,10 @@ describe('Keyset', () => {
     const keyset = new Keyset('testid', 'sat', true, undefined, undefined);
     expect(keyset.fee).toBe(0);
   });
+  test('version should be -1 for deprecated base64 IDs', () => {
+    const keyset = new Keyset('yjzQhxghPdrr', 'sat', true, undefined, undefined);
+    expect(keyset.version).toBe(-1);
+  });
   test('verifyKeysetId should return false if verifying keyset with no keys', () => {
     const badKeyset = { ...dummyKeysResp.keysets[0], keys: {} };
     const verify = Keyset.verifyKeysetId(badKeyset);
@@ -491,6 +495,13 @@ describe('KeyChain.getCheapestKeyset prefers the newest keyset version', () => {
     const expiring = makeKeyset(1, 1, 2000);
     const forever = makeKeyset(1, 1);
     const chain = await initChainWith([expiring.keys, forever.keys]);
+    expect(chain.getCheapestKeyset().id).toBe(forever.meta.id);
+  });
+
+  test('same version and fee: no expiry wins regardless of insertion order', async () => {
+    const forever = makeKeyset(1, 1);
+    const expiring = makeKeyset(1, 1, 2000);
+    const chain = await initChainWith([forever.keys, expiring.keys]);
     expect(chain.getCheapestKeyset().id).toBe(forever.meta.id);
   });
 });

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -408,15 +408,26 @@ describe('Keyset', () => {
   });
 });
 
-// Build a genuinely-verifying v1 keyset for PUBKEYS at a given fee.
-// Fee is part of the v1 id preimage, so distinct fees give distinct ids.
-function makeV1Keyset(fee: number): { meta: MintKeyset; keys: MintKeys } {
+// Build a genuinely-verifying keyset for PUBKEYS at a given fee.
+// Fee and expiry are part of the v1+ id preimage, so distinct values give distinct ids.
+function makeKeyset(
+  fee: number,
+  versionByte = 1,
+  expiry?: number,
+): { meta: MintKeyset; keys: MintKeys } {
   const id = deriveKeysetId(PUBKEYS, {
-    versionByte: 1,
+    versionByte,
     unit: 'sat',
     input_fee_ppk: fee,
+    expiry,
   });
-  const meta: MintKeyset = { id, unit: 'sat', active: true, input_fee_ppk: fee };
+  const meta: MintKeyset = {
+    id,
+    unit: 'sat',
+    active: true,
+    input_fee_ppk: fee,
+    final_expiry: expiry,
+  };
   return { meta, keys: { ...meta, keys: PUBKEYS } };
 }
 
@@ -434,8 +445,8 @@ async function initChainWith(keysets: MintKeys[]): Promise<KeyChain> {
 
 describe('KeyChain.getCheapestKeyset picks the lowest fee regardless of order', () => {
   test('returns cheapest when the cheap keyset is not first in insertion order', async () => {
-    const expensive = makeV1Keyset(100);
-    const cheap = makeV1Keyset(1);
+    const expensive = makeKeyset(100);
+    const cheap = makeKeyset(1);
     // Insert expensive first: an unsorted / no-op comparator would wrongly pick it.
     const chain = await initChainWith([expensive.keys, cheap.keys]);
     const active = chain.getCheapestKeyset();
@@ -444,13 +455,43 @@ describe('KeyChain.getCheapestKeyset picks the lowest fee regardless of order', 
   });
 
   test('returns cheapest when the cheap keyset is first in insertion order', async () => {
-    const cheap = makeV1Keyset(1);
-    const expensive = makeV1Keyset(100);
+    const cheap = makeKeyset(1);
+    const expensive = makeKeyset(100);
     // Insert cheap first: a fee-summing comparator would wrongly reverse and pick expensive.
     const chain = await initChainWith([cheap.keys, expensive.keys]);
     const active = chain.getCheapestKeyset();
     expect(active.id).toBe(cheap.meta.id);
     expect(active.fee).toBe(1);
+  });
+});
+
+describe('KeyChain.getCheapestKeyset prefers the newest keyset version', () => {
+  test('picks a newer, dearer keyset over an older, cheaper one', async () => {
+    const oldCheap = makeKeyset(1, 0);
+    const newDear = makeKeyset(100, 1);
+    const chain = await initChainWith([oldCheap.keys, newDear.keys]);
+    expect(chain.getCheapestKeyset().id).toBe(newDear.meta.id);
+  });
+
+  test('same version: fee beats expiry', async () => {
+    const cheapExpiring = makeKeyset(1, 1, 1000);
+    const dearForever = makeKeyset(100, 1);
+    const chain = await initChainWith([dearForever.keys, cheapExpiring.keys]);
+    expect(chain.getCheapestKeyset().id).toBe(cheapExpiring.meta.id);
+  });
+
+  test('same version and fee: prefers the keyset expiring last', async () => {
+    const dyingSoon = makeKeyset(1, 1, 1000);
+    const dyingLater = makeKeyset(1, 1, 2000);
+    const chain = await initChainWith([dyingSoon.keys, dyingLater.keys]);
+    expect(chain.getCheapestKeyset().id).toBe(dyingLater.meta.id);
+  });
+
+  test('same version and fee: prefers no expiry over any expiry', async () => {
+    const expiring = makeKeyset(1, 1, 2000);
+    const forever = makeKeyset(1, 1);
+    const chain = await initChainWith([expiring.keys, forever.keys]);
+    expect(chain.getCheapestKeyset().id).toBe(forever.meta.id);
   });
 });
 


### PR DESCRIPTION
Rotation-aware proof selection drains old-keyset proofs, but a fee-only default keyset choice can mint change straight back onto them. This orders active keysets by ID version first, then fee, then `final_expiry` (latest wins; none sorts as never expiring), so new outputs land on the mint's newest keyset generation. Tie-breaks are now deterministic (previously insertion order).

- Adds `Keyset.version` (ID version byte, `-1` for deprecated base64 IDs)
- `getCheapestKeyset()` keeps its name for v4 backportability; TSDoc now documents the "cheapest modern" ordering
- Tests cover version-over-fee, fee-over-expiry, latest-expiry and no-expiry ties

Note for merge: keep the `Release-As: 5.0.0-rc.4` footer in the squash commit body (repins the pending release after the NUT-18 major bump).