### PR TITLE
fix(wallet): return -1 from Keyset.version for unparseable ids

### DIFF
--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -56,10 +56,10 @@ export class Keyset {
   }
 
   /**
-   * Keyset ID version byte (`-1` for deprecated base64 IDs).
+   * Keyset ID version byte (`-1` for base64 or unparseable IDs).
    */
   get version(): number {
-    return this.hasHexId ? hexToBytes(this._id)[0] : -1;
+    return this.hasHexId && this._id.length % 2 === 0 ? hexToBytes(this._id)[0] : -1;
   }
 
   get keys(): Record<number, string> {

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -383,6 +383,10 @@ describe('Keyset', () => {
     const keyset = new Keyset('yjzQhxghPdrr', 'sat', true, undefined, undefined);
     expect(keyset.version).toBe(-1);
   });
+  test('version should be -1 for odd-length hex IDs', () => {
+    const keyset = new Keyset('a', 'sat', true, undefined, undefined);
+    expect(keyset.version).toBe(-1);
+  });
   test('verifyKeysetId should return false if verifying keyset with no keys', () => {
     const badKeyset = { ...dummyKeysResp.keysets[0], keys: {} };
     const verify = Keyset.verifyKeysetId(badKeyset);


### PR DESCRIPTION
Follow-up to #835.

`isValidHex` accepts odd-length strings, but `hexToBytes` rejects them, so `Keyset.version` threw on such ids. Treat them as versionless (-1), matching base64 ids.

Not reachable from mint data (keysets that fail verification are dropped before the version sort); only manually constructed Keysets were affected.