### PR TITLE
fix(wallet): classify odd-length hex keyset ids as legacy

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -773,7 +773,6 @@ export class Keyset {
     // (undocumented)
     get fee(): number;
     static fromMintApi(meta: MintKeyset, keys?: MintKeys): Keyset;
-    // (undocumented)
     get hasHexId(): boolean;
     // (undocumented)
     get hasKeys(): boolean;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -174,12 +174,12 @@ export function numberToHexPadded64(scalar: bigint): string {
 }
 
 /**
- * Returns `true` if the string contains only hexadecimal characters (case-insensitive).
+ * Returns `true` if the string is byte-decodable hex (even length, hex chars only).
  *
  * @internal
  */
 export function isValidHex(str: string) {
-  return /^[a-f0-9]+$/i.test(str);
+  return str.length % 2 === 0 && /^[a-f0-9]+$/i.test(str);
 }
 
 function hasNonHexId(p: Proof | Proof[]) {

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -51,6 +51,9 @@ export class Keyset {
     return Object.keys(this._keys).length > 0;
   }
 
+  /**
+   * True if the ID is modern byte-encoded hex.
+   */
   get hasHexId(): boolean {
     return isValidHex(this._id);
   }
@@ -59,7 +62,7 @@ export class Keyset {
    * Keyset ID version byte (`-1` for base64 or unparseable IDs).
    */
   get version(): number {
-    return this.hasHexId && this._id.length % 2 === 0 ? hexToBytes(this._id)[0] : -1;
+    return this.hasHexId ? hexToBytes(this._id)[0] : -1;
   }
 
   get keys(): Record<number, string> {

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1501,6 +1501,14 @@ describe('getEncodedToken edge cases', () => {
     };
     expect(() => utils.getEncodedToken(token)).toThrow(/legacy keyset ID/);
   });
+  test('throws for proofs with odd-length hex keyset IDs', () => {
+    const token: Token = {
+      mint: 'http://localhost:3338',
+      proofs: [{ id: '00abc', amount: Amount.from(1), secret: 'abc', C: '02abc' }],
+      unit: 'sat',
+    };
+    expect(() => utils.getEncodedToken(token)).toThrow(/legacy keyset ID/);
+  });
 });
 
 describe('getDecodedTokenBinary edge cases', () => {

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -387,6 +387,10 @@ describe('Keyset', () => {
     const keyset = new Keyset('a', 'sat', true, undefined, undefined);
     expect(keyset.version).toBe(-1);
   });
+  test('hasHexId should be false for odd-length hex IDs', () => {
+    const keyset = new Keyset('a', 'sat', true, undefined, undefined);
+    expect(keyset.hasHexId).toBe(false);
+  });
   test('verifyKeysetId should return false if verifying keyset with no keys', () => {
     const badKeyset = { ...dummyKeysResp.keysets[0], keys: {} };
     const verify = Keyset.verifyKeysetId(badKeyset);


### PR DESCRIPTION
Follow-up to #837.

Internal `isValidHex` accepted odd-length strings, so consumers disagreed on how to classify such ids: `Keyset.version` returned -1 while proof-selection ranking parsed a version byte from them, the output-keyset guard let them through, and token encoding failed deep inside hex decoding with a raw error. Requiring byte-decodable (even-length) hex in `isValidHex` makes every consumer treat them as legacy consistently: rotation-aware selection ranks them in the legacy bucket, new outputs refuse them, and `getEncodedToken` raises the proper legacy-keyset CTSError.

The NUT-13 derivation paths keep their own local hex checks unchanged, preserving historical derivation semantics. No behavior change for well-formed ids.