### PR TITLE
fix(utils): return false from isValidHex for non-string input [backport v4-dev]

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -163,12 +163,15 @@ export function numberToHexPadded64(scalar: bigint): string {
 }
 
 /**
- * Returns `true` if the string is byte-decodable hex (even length, hex chars only).
+ * Returns `true` if the value is byte-decodable hex (a string, even length, hex chars only).
  *
+ * @remarks
+ * Accepts `unknown`: IDs reach here from decoded tokens and mint responses, so a non-string must
+ * return `false`, not throw.
  * @internal
  */
-export function isValidHex(str: string) {
-  return str.length % 2 === 0 && /^[a-f0-9]+$/i.test(str);
+export function isValidHex(str: unknown): str is string {
+  return typeof str === 'string' && str.length % 2 === 0 && /^[a-f0-9]+$/i.test(str);
 }
 
 function hasNonHexId(p: Proof | Proof[]) {

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1112,6 +1112,35 @@ describe('getEncodedToken edge cases', () => {
     };
     expect(() => utils.getEncodedToken(token)).toThrow(/legacy keyset ID/);
   });
+  test('rejects a proof with a nullish id as legacy, not with a TypeError', () => {
+    // A hand-built or JSON-parsed token may carry id: undefined/null. The id checks must
+    // classify it as legacy and reject, not read .length off a nullish value.
+    for (const id of [undefined, null]) {
+      const token: Token = {
+        mint: 'http://localhost:3338',
+        proofs: [
+          { id: id as unknown as string, amount: Amount.from(1), secret: 'abc', C: '02abc' },
+        ],
+        unit: 'sat',
+      };
+      expect(() => utils.getEncodedToken(token)).toThrow(/legacy keyset ID/);
+    }
+  });
+});
+
+describe('isValidHex', () => {
+  test('returns false for non-string input without throwing', () => {
+    expect(utils.isValidHex(undefined as unknown as string)).toBe(false);
+    expect(utils.isValidHex(null)).toBe(false);
+    expect(utils.isValidHex(1234)).toBe(false);
+  });
+  test('returns false for empty and odd-length strings', () => {
+    expect(utils.isValidHex('')).toBe(false);
+    expect(utils.isValidHex('abc')).toBe(false);
+  });
+  test('returns true for even-length hex', () => {
+    expect(utils.isValidHex('00abcd')).toBe(true);
+  });
 });
 
 describe('getDecodedTokenBinary edge cases', () => {

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -390,6 +390,17 @@ describe('Keyset', () => {
     const keyset = new Keyset('a', 'sat', true, undefined, undefined);
     expect(keyset.hasHexId).toBe(false);
   });
+  test('hasHexId and version resolve without throwing for a null id', () => {
+    // A mint response with id: null must classify as legacy, not crash on the id checks.
+    const keyset = new Keyset(null as unknown as string, 'sat', true, undefined, undefined);
+    expect(keyset.hasHexId).toBe(false);
+    expect(keyset.version).toBe(-1);
+  });
+  test('hasHexId and version resolve without throwing for an undefined id', () => {
+    const keyset = new Keyset(undefined as unknown as string, 'sat', true, undefined, undefined);
+    expect(keyset.hasHexId).toBe(false);
+    expect(keyset.version).toBe(-1);
+  });
   test('verifyKeysetId should return false if verifying keyset with no keys', () => {
     const badKeyset = { ...dummyKeysResp.keysets[0], keys: {} };
     const verify = Keyset.verifyKeysetId(badKeyset);


### PR DESCRIPTION
Backport of #843 to v4-dev.

`isValidHex` read `str.length` before running the regex, so a non-string id threw a `TypeError` instead of returning `false`. IDs reach this check from decoded tokens (`getEncodedToken` -> `hasNonHexId`) and from mint responses (`Keyset.hasHexId`), i.e. untrusted input that can be `null`/`undefined`.

The function now takes `unknown` and narrows with a type guard, so a non-string value returns `false` (classified as a legacy/unparseable id, which every caller already handles) rather than throwing.

`isValidHex` is `@internal`, so this is not a public API change.

Tests: direct `isValidHex(null | undefined | number | '' | odd-length)` cases, plus the two integration paths (encode with a nullish proof id, and `Keyset` with a nullish id).