### PR TITLE
feat(wallet): add getFeesToInclude fee helper

### DIFF
--- a/docs-src/usage/fees.md
+++ b/docs-src/usage/fees.md
@@ -1,0 +1,76 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Fees**
+
+# Fees
+
+Two separate costs apply when spending proofs:
+
+- **Input fees** (NUT-02): each keyset advertises `input_fee_ppk` (parts per thousand, per input).
+  Spending N proofs from that keyset costs `ceil(N * ppk / 1000)`, rounded up once per transaction.
+- **Lightning costs** (melt only): a melt quote's `fee_reserve` is the ceiling the mint holds back
+  for routing, not an estimate. When the mint supports NUT-08, unused reserve comes back as change.
+
+Most flows need no fee arithmetic at all: pass `includeFees: true` to `send` (or
+`.includeFees(true)` on the `wallet.ops` builders) and the wallet inflates the outputs so the
+receiver nets the requested amount. The helpers below are for when you budget, validate, or plan
+outputs yourself.
+
+## Which helper, when
+
+| Question                                                       | Helper                                                  |
+| :------------------------------------------------------------- | :------------------------------------------------------ |
+| What does it cost to spend these exact proofs?                 | `Wallet.getFeesForProofs(proofs)`                       |
+| What would N inputs of a keyset cost?                          | `Wallet.getFeesForKeyset(nInputs, keysetId)`            |
+| Receiver must net `amount`: what does the sender add on top?   | `Wallet.getFeesToInclude(amount, opts?)`                |
+| What is the most this proof set can send or melt, after fees?  | `Wallet.maxSpendableAfterFees(proofs, feeReserve?)`     |
+| Payee: do these received proofs net a NUT-18 request?          | `Wallet.isPaymentRequestSatisfied(pr, proofs, amount?)` |
+| Payer: what do I owe on a NUT-18 request, method fee included? | `PaymentRequest.amountToSend(mintUrl, methods)`         |
+
+## Exact-target: the receiver nets a fixed amount
+
+`getFeesToInclude` returns the amount `includeFees` would add: the input fee for spending the
+planned outputs, including the fee outputs themselves (fee outputs also incur fees, so the wallet
+iterates until the total is stable). Use it to budget before selecting, or to price a custom
+denomination plan:
+
+```ts
+// Price a sender-pays-fees send before committing to it
+const fee = wallet.getFeesToInclude(1000); // eg 2 on a 1000 ppk keyset
+// wallet.send(1000, proofs, { includeFees: true }) creates outputs totalling 1000 + fee
+
+// Custom denomination sets: pass the planned output count instead of the default split
+wallet.getFeesToInclude(1000, { nOutputs: 4 });
+```
+
+`getFeesForProofs` prices a concrete proof set (eg inputs you are about to melt).
+`getFeesForKeyset` prices a count when the proofs do not exist yet (eg outputs a swap will create).
+
+## Send-max: "melt everything"
+
+`maxSpendableAfterFees` works in the opposite direction: given a proof set, the largest amount that
+remains after input fees and, optionally, a melt quote's `fee_reserve`. Because `fee_reserve`
+shrinks with the amount, iterate until the quote stabilizes:
+
+```ts
+let target = wallet.maxSpendableAfterFees(proofs); // before any quote: input fees only
+let quote;
+for (let attempt = 0; attempt < 3; attempt++) {
+  const invoice = await getInvoiceFor(target); // from the receiving Lightning wallet
+  quote = await wallet.createMeltQuoteBolt11(invoice);
+  target = wallet.maxSpendableAfterFees(proofs, quote.fee_reserve);
+  if (target.greaterThanOrEqual(quote.amount)) break; // proofs cover amount + fees: pay this quote
+  quote = undefined; // reserve ate into the amount: re-quote smaller
+}
+if (!quote) throw new Error('Melt-all did not converge');
+```
+
+## NUT-18 payment requests
+
+The payee checks that incoming proofs net the requested amount after the input fees they will cost
+to swap (`Wallet.isPaymentRequestSatisfied`); the payer totals the request amount plus the applicable
+method fee (`PaymentRequest.amountToSend`). Both are covered in [Payment Requests](./payment_requests.md).
+
+## Related docs
+
+- [Melt Token](./melt_token.md) for budgeting melts with `amount + fee_reserve` and `includeFees`.
+- [Send](../wallet_ops/send.md) for sender-pays-fees via the ops builder.
+- [Amounts](./amounts.md) for the `Amount` value object used throughout.

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -37,6 +37,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [NUT-19 Cached Responses](./nut19.md)               | Understand cached endpoint retries and timeout behavior.                        |
 | [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |
 | [Amounts](./amounts.md)                             | Work with the `Amount` and `AmountWithUnit` value objects.                      |
+| [Fees](./fees.md)                                   | Pick the right fee helper: input fees, sender-pays-fees, send-max, NUT-18.      |
 | [Helpers](./helpers.md)                             | Standalone public utility functions — currently mint URL normalization.         |
 
 ## Related docs

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2347,6 +2347,10 @@ export class Wallet {
     defaultOutputType(): OutputType;
     getFeesForKeyset(nInputs: number, keysetId: string): Amount;
     getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount;
+    getFeesToInclude(amount: AmountLike, opts?: {
+        keysetId?: string;
+        nOutputs?: number;
+    }): Amount;
     getKeyset(id?: string): Keyset;
     getMintInfo(): MintInfo;
     groupProofsByState<T extends ProofLike = Proof>(proofs: T[]): Promise<{

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -771,21 +771,28 @@ class Wallet {
     // If includeFees, we create additional output amounts to cover the
     // fee the receiver will pay when they spend the proofs (ie sender pays fees)
     if (includeFees) {
-      let receiveFee = this.getFeesForKeyset(denominations.length, keyset.id);
-      let receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
-      while (
-        this.getFeesForKeyset(
-          denominations.length + receiveFeeAmounts.length,
-          keyset.id,
-        ).greaterThan(receiveFee)
-      ) {
-        receiveFee = receiveFee.add(1);
-        receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
-      }
-      newAmount = newAmount.add(receiveFee);
+      const receiveFeeAmounts = this.receiveFeeAmounts(denominations.length, keyset);
+      newAmount = newAmount.add(Amount.sum(receiveFeeAmounts));
       denominations = [...denominations, ...receiveFeeAmounts];
     }
     return { ...outputType, denominations };
+  }
+
+  /**
+   * Extra denominations that cover the input fee for spending `nOutputs` outputs plus themselves.
+   *
+   * Iterates until the fee is stable, since fee outputs also incur fees.
+   */
+  private receiveFeeAmounts(nOutputs: number, keyset: Keyset): Amount[] {
+    let receiveFee = this.getFeesForKeyset(nOutputs, keyset.id);
+    let receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
+    while (
+      this.getFeesForKeyset(nOutputs + receiveFeeAmounts.length, keyset.id).greaterThan(receiveFee)
+    ) {
+      receiveFee = receiveFee.add(1);
+      receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
+    }
+    return receiveFeeAmounts;
   }
 
   /**
@@ -1573,6 +1580,26 @@ class Wallet {
       this._logger.error(message, { e });
       throw new CTSError(message, { cause: e });
     }
+  }
+
+  /**
+   * Fee to add on top of `amount` so the resulting outputs can later be spent at no cost to the
+   * receiver (ie sender pays fees). This is the amount `includeFees` adds.
+   *
+   * @remarks
+   * The fee depends on the output count, taken from the default denomination split of `amount`.
+   * Pass `nOutputs` when pricing up custom denomination sets.
+   * @param amount The amount the receiver should net after swap fees.
+   * @param opts.keysetId Optional `keysetId` to price against (default: the wallet's bound keyset)
+   * @param opts.nOutputs Optional Override the output count for custom denoms (default: optimal
+   *   split).
+   * @returns The fee, zero when the keyset charges no input fees.
+   */
+  getFeesToInclude(amount: AmountLike, opts?: { keysetId?: string; nOutputs?: number }): Amount {
+    const keyset = this.getKeyset(opts?.keysetId);
+    const parsed = this.parseAmount(amount, 'getFeesToInclude', true);
+    const nOutputs = opts?.nOutputs ?? splitAmount(parsed, keyset.keys).length;
+    return Amount.sum(this.receiveFeeAmounts(nOutputs, keyset));
   }
 
   /**

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -122,6 +122,56 @@ describe('wallet.maxSpendableAfterFees', () => {
   });
 });
 
+describe('wallet.getFeesToInclude', () => {
+  test('returns zero when the keyset charges no input fees', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    expect(wallet.getFeesToInclude(100).isZero()).toBe(true);
+  });
+
+  test('converges on the fee for the fee outputs themselves', async () => {
+    // 1000 ppk = 1 sat per proof.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 1000 }],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // Fixture keys are {1,2}. Amount 2 is one output (naive fee 1), but the fee
+    // output itself incurs a fee: two inputs cost 2, so the converged fee is 2.
+    expect(wallet.getFeesToInclude(2).toString()).toBe('2');
+  });
+
+  test('nOutputs overrides the count derived from the default split', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 1000 }],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // Caller plans 3 outputs (custom denominations): 3 fee outputs converge on 6.
+    expect(wallet.getFeesToInclude(2, { nOutputs: 3 }).toString()).toBe('6');
+  });
+
+  test('throws when the keyset id is unknown', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    expect(() => wallet.getFeesToInclude(100, { keysetId: '00missingkeyset' })).toThrow(
+      /not found/,
+    );
+  });
+});
+
 describe('wallet.isPaymentRequestSatisfied', () => {
   test('enforces the net-of-input-fees formula (NUT-18)', async () => {
     // Keyset charges 1 sat per proof (1000 ppk), the spec's dust-protection scenario.

--- a/typedoc.json
+++ b/typedoc.json
@@ -23,6 +23,7 @@
     "docs-src/usage/payment_requests.md",
     "docs-src/usage/nut19.md",
     "docs-src/usage/logging.md",
+    "docs-src/usage/fees.md",
     "docs-src/usage/helpers.md",
     "docs-src/wallet_ops/wallet_ops.md",
     "docs-src/wallet_ops/send.md",


### PR DESCRIPTION
## Summary

Adds `Wallet.getFeesToInclude(amount, opts?)`: the fee that `includeFees` adds on top of an amount so the resulting outputs can later be spent at no cost to the receiver (sender pays fees). The fee-inflation loop moves out of `configureOutputs` into a shared private helper, so the existing path and the new method use the same arithmetic. `opts.nOutputs` overrides the output count for custom denomination sets; `opts.keysetId` prices against a specific keyset.

Consumers that plan outputs themselves (persist-then-execute wallets) currently have to reimplement this loop or over-select with a buffer, eg coco's `calculateSendAmountWithFees` and the selection FIXME in its swap-then-melt handler.

Also adds a Fees usage recipe (`docs-src/usage/fees.md`) mapping each fee helper to its use case: `getFeesForProofs`, `getFeesForKeyset`, `getFeesToInclude`, `maxSpendableAfterFees`, `isPaymentRequestSatisfied` and `PaymentRequest.amountToSend`.

## Test plan

- New unit tests: zero-fee keyset, fee convergence (fee outputs incur their own fee), `nOutputs` override, unknown keyset throws.
- `npm run prtasks` passes; `etc/cashu-ts.api.md` regenerated.