### PR TITLE
fix(wallet): validate pubkey in locked mint quote responses

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1919,6 +1919,10 @@ class Wallet {
     const res = await this.mint.createMintQuoteBolt11(mintQuotePayload);
     this.failIf(typeof res.pubkey !== 'string', 'Mint returned unlocked mint quote');
     const resPubkey = res.pubkey!;
+    this.failIf(
+      resPubkey.toLowerCase() !== pubkey.toLowerCase(),
+      'Mint quote is not locked to the requested pubkey',
+    );
     return { ...res, pubkey: resPubkey, unit: res.unit || this._unit };
   }
 
@@ -1960,7 +1964,12 @@ class Wallet {
       description: options?.description,
     };
 
-    return this.mint.createMintQuoteBolt12(mintQuotePayload);
+    const res = await this.mint.createMintQuoteBolt12(mintQuotePayload);
+    this.failIf(
+      typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),
+      'Mint quote is not locked to the requested pubkey',
+    );
+    return res;
   }
 
   /**
@@ -1975,6 +1984,10 @@ class Wallet {
     this.requireSupport('mint', 'onchain');
     this.requireMintableKeyset('createMintQuoteOnchain');
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
+    this.failIf(
+      typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),
+      'Mint quote is not locked to the requested pubkey',
+    );
     return { ...res, unit: res.unit || this._unit };
   }
 

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -289,6 +289,29 @@ describe('createMintQuoteBolt12 mutants', () => {
     expect(body.amount).toBeUndefined();
     expect(body.description).toBeUndefined();
   });
+
+  test('rejects when the mint returns a quote locked to a different pubkey', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/mint/quote/bolt12', () =>
+        HttpResponse.json({
+          quote: 'q-bolt12-other',
+          request: 'lno1offer...',
+          unit: 'sat',
+          pubkey: '02dcba',
+          state: MintQuoteState.UNPAID,
+          expiry: null,
+          amount_paid: 0,
+          amount_issued: 0,
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteBolt12('02abcd')).rejects.toThrow(
+      'Mint quote is not locked to the requested pubkey',
+    );
+  });
 });
 
 describe('createMintQuoteOnchain mutants', () => {
@@ -312,6 +335,29 @@ describe('createMintQuoteOnchain mutants', () => {
 
     const quote = await wallet.createMintQuoteOnchain('02abcd');
     expect(quote.unit).toBe('sat');
+  });
+
+  test('rejects when the mint returns a quote locked to a different pubkey', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/mint/quote/onchain', () =>
+        HttpResponse.json({
+          quote: 'onchain-q-other',
+          request: 'bc1qdeposit',
+          unit: 'sat',
+          pubkey: '02dcba',
+          state: MintQuoteState.UNPAID,
+          expiry: null,
+          amount_paid: 0,
+          amount_issued: 0,
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteOnchain('02abcd')).rejects.toThrow(
+      'Mint quote is not locked to the requested pubkey',
+    );
   });
 });
 
@@ -902,6 +948,51 @@ describe('createLockedMintQuote mutants', () => {
     await expect(wallet.createLockedMintQuote(100, PUBKEY)).rejects.toThrow(
       'Mint returned unlocked mint quote',
     );
+  });
+
+  test('rejects when the mint returns a quote locked to a different pubkey', async () => {
+    useNut20();
+    server.use(
+      http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+        HttpResponse.json({
+          quote: 'locked-elsewhere',
+          request: 'lnbc...',
+          unit: 'sat',
+          amount: 100,
+          state: MintQuoteState.UNPAID,
+          expiry: null,
+          pubkey: '03' + PUBKEY.slice(2),
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createLockedMintQuote(100, PUBKEY)).rejects.toThrow(
+      'Mint quote is not locked to the requested pubkey',
+    );
+  });
+
+  test('accepts a case-variant echo of the requested pubkey', async () => {
+    useNut20();
+    server.use(
+      http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+        HttpResponse.json({
+          quote: 'locked-upper',
+          request: 'lnbc...',
+          unit: 'sat',
+          amount: 100,
+          state: MintQuoteState.UNPAID,
+          expiry: null,
+          pubkey: PUBKEY.toUpperCase(),
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const quote = await wallet.createLockedMintQuote(100, PUBKEY);
+    expect(quote.pubkey.toLowerCase()).toBe(PUBKEY);
   });
 });
 


### PR DESCRIPTION
`createLockedMintQuote` accepted any pubkey in the mint's response as long as one was present; `createMintQuoteBolt12` and `createMintQuoteOnchain` did not inspect the echoed pubkey at all. All three now verify the response pubkey matches the requested one (case-insensitive) and fail fast with an actionable error at quote creation. Adds mutant tests for the three paths.