### PR TITLE
feat(model): encode and decode NUT-18 payment payloads

### DIFF
--- a/docs-src/usage/payment_requests.md
+++ b/docs-src/usage/payment_requests.md
@@ -42,17 +42,19 @@ It returns the normal send builder, so further options (deterministic outputs, k
 
 ### 3. Deliver the payload
 
-Send the payee a `PaymentRequestPayload` over the request's transport (HTTP POST body, Nostr DM, or in-band if no transport is given):
+`encodePayload` packages the proofs into the default NUT-18 `PaymentRequestPayload`, serialized as bigint-safe JSON ready for the wire (plain `JSON.stringify` throws on proof amounts). It fills `id` and `unit` from the request and rejects a mint outside the request's strict mint list:
 
 ```typescript
-import type { PaymentRequestPayload } from '@cashu/cashu-ts';
+const { keep, send } = await wallet.ops.sendToRequest(pr, proofs).run();
+const body = pr.encodePayload(wallet.mint.mintUrl, send, { memo: 'thanks' });
 
-const payload: PaymentRequestPayload = {
-  id: pr.id,
-  mint: myMint,
-  unit: pr.unit ?? myUnit, // the requested unit, or the unit of what you send
-  proofs: send, // the locked/selected proofs
-};
+// HTTP POST transport; for a Nostr transport, send `body` as the DM content.
+const post = pr.getTransport('post');
+await fetch(post.target, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body,
+});
 ```
 
 > [!IMPORTANT]
@@ -101,6 +103,27 @@ const request = new PaymentRequest({
   mintsPreferred: true, // advisory list
   supportedMethods: [{ method: 'bolt11' }, { method: 'bolt12', fee: 5 }],
 });
+```
+
+### Receive the payload
+
+Payloads arrive as raw text from the payer's wallet, so parse with `decodePayload` rather than `JSON.parse` (which silently corrupts amounts above 2^53). It validates the shape and normalizes proof amounts to `bigint`; matching the payload to your request is your job:
+
+```typescript
+import { PaymentRequest, type PaymentRequestPayload } from '@cashu/cashu-ts';
+
+let payload: PaymentRequestPayload;
+try {
+  payload = PaymentRequest.decodePayload(body); // POST body or Nostr DM content
+} catch {
+  return; // malformed: ignore or 400
+}
+
+if (payload.id !== request.id) return; // not for this request
+// Accept only mints you chose: with a mint list on the request that is
+// `request.includesMint(payload.mint)`; without one, check against your own
+// accepted set. Never dial an unknown mint URL taken from a payload.
+if (!request.includesMint(payload.mint)) return;
 ```
 
 ### Validate a payment

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1650,8 +1650,13 @@ class PaymentRequest_2 {
     amount?: Amount;
     amountToSend(mint: string, meltMethods?: string[]): Amount;
     static builder(): PaymentRequestBuilder;
+    static decodePayload(json: string): PaymentRequestPayload;
     // (undocumented)
     description?: string;
+    encodePayload(mint: string, proofs: Proof[], opts?: {
+        memo?: string;
+        unit?: string;
+    }): string;
     feesFor(mint: string, meltMethods?: string[]): Amount;
     // (undocumented)
     static fromEncodedRequest(encodedRequest: string): PaymentRequest_2;

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -8,6 +8,7 @@ import {
 } from '../crypto/NUT11';
 import { encodeBase64toUint8, decodeCBOR, encodeCBOR, Bytes, normalizeMintUrl } from '../utils';
 import { decodeBech32mToBytes, encodeBech32m } from '../utils/bech32m';
+import { JSONInt } from '../utils/JSONInt';
 import { decodeTLV, encodeTLV } from '../utils/tlv';
 import type { DecodedTLVPaymentRequest } from '../utils/tlv';
 import { PaymentRequestTransportType } from '../wallet/types';
@@ -15,12 +16,14 @@ import type {
   RawPaymentRequest,
   RawTransport,
   NUT10Option,
+  PaymentRequestPayload,
   PaymentRequestTransport,
   SupportedMethod,
 } from '../wallet/types';
 
 import { Amount, type AmountLike } from './Amount';
 import { CTSError } from './Errors';
+import type { Proof } from './types/proof';
 
 /**
  * Constructor options for {@link PaymentRequest}. Keys mirror the class properties; `amount` and
@@ -166,6 +169,94 @@ export class PaymentRequest {
     };
     const target = norm(mintUrl);
     return this.mints?.some((m) => norm(m) === target) ?? false;
+  }
+
+  /**
+   * Serializes the default NUT-18 payment payload for this request.
+   *
+   * @remarks
+   * BigInt-safe JSON; plain `JSON.stringify` throws on proof amounts. Proofs must come from `mint`
+   * and net the request after fees: `wallet.ops.sendToRequest` produces both, this only packages.
+   * Send it as the POST body or Nostr DM content.
+   * @param mint - The mint the proofs are from.
+   * @param proofs - The proofs to send (eg the `send` half of a send flow).
+   * @param opts.memo - Optional memo for the payee.
+   * @param opts.unit - Unit when the request has none (default 'sat').
+   * @throws If the request has a strict mint list and `mint` is not in it.
+   */
+  encodePayload(mint: string, proofs: Proof[], opts?: { memo?: string; unit?: string }): string {
+    if (this.isMintListStrict && !this.includesMint(mint)) {
+      throw new CTSError("mint is not in the request's strict mint list");
+    }
+    const payload: PaymentRequestPayload = {
+      ...(this.id !== undefined && { id: this.id }),
+      ...(opts?.memo !== undefined && { memo: opts.memo }),
+      unit: this.unit ?? opts?.unit ?? 'sat',
+      mint,
+      proofs,
+    };
+    return JSONInt.stringify(payload)!;
+  }
+
+  /**
+   * Parses a default NUT-18 payment payload received from a payer.
+   *
+   * @remarks
+   * BigInt-safe: proof amounts are normalized to `bigint` whatever their JSON size. Validates shape
+   * only; matching the payload to a request (id, mint, netting the amount) is the payee's job.
+   * @param json - Raw payload text (POST body or Nostr DM content).
+   * @throws {@link CTSError} If the text is not valid JSON or not payload-shaped.
+   */
+  static decodePayload(json: string): PaymentRequestPayload {
+    let raw: unknown;
+    try {
+      raw = JSONInt.parse(json, undefined, { strict: true });
+    } catch (e) {
+      throw new CTSError('invalid payment payload: not valid JSON', { cause: e });
+    }
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      throw new CTSError('invalid payment payload: expected a JSON object');
+    }
+    const { id, memo, unit, mint, proofs } = raw as Record<string, unknown>;
+    if (typeof mint !== 'string' || !mint) {
+      throw new CTSError('invalid payment payload: missing mint');
+    }
+    if (typeof unit !== 'string' || !unit) {
+      throw new CTSError('invalid payment payload: missing unit');
+    }
+    if (id !== undefined && typeof id !== 'string') {
+      throw new CTSError('invalid payment payload: id must be a string');
+    }
+    if (memo !== undefined && typeof memo !== 'string') {
+      throw new CTSError('invalid payment payload: memo must be a string');
+    }
+    if (!Array.isArray(proofs) || proofs.length === 0) {
+      throw new CTSError('invalid payment payload: missing proofs');
+    }
+    const normalized = proofs.map((p: unknown, i: number) => {
+      if (
+        typeof p !== 'object' ||
+        p === null ||
+        Array.isArray(p) ||
+        typeof (p as Record<string, unknown>).id !== 'string' ||
+        typeof (p as Record<string, unknown>).secret !== 'string' ||
+        typeof (p as Record<string, unknown>).C !== 'string'
+      ) {
+        throw new CTSError(`invalid payment payload: malformed proof at index ${i}`);
+      }
+      const amount = (p as Record<string, unknown>).amount;
+      if (typeof amount !== 'number' && typeof amount !== 'bigint') {
+        throw new CTSError(`invalid payment payload: malformed proof amount at index ${i}`);
+      }
+      return { ...p, amount: Amount.from(amount).toBigInt() } as unknown as Proof;
+    });
+    return {
+      ...(id !== undefined && { id }),
+      ...(memo !== undefined && { memo }),
+      unit,
+      mint,
+      proofs: normalized,
+    };
   }
 
   toRawRequest() {

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -708,3 +708,105 @@ describe('payment requests', () => {
     });
   });
 });
+
+describe('NUT-18 payment payloads', () => {
+  const MINT = 'https://mint.example';
+  const makeProof = (amount: bigint) => ({
+    id: '009a1f293253e41e',
+    amount,
+    secret: 'secret-string',
+    C: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+  });
+
+  describe('encodePayload', () => {
+    test('round-trips through decodePayload, filling id and unit from the request', () => {
+      const pr = new PaymentRequest({ id: 'inv-1', unit: 'sat' });
+      const body = pr.encodePayload(MINT, [makeProof(9007199254740993n)], { memo: 'hi' });
+      expect(typeof body).toBe('string');
+
+      const payload = PaymentRequest.decodePayload(body);
+      expect(payload.id).toBe('inv-1');
+      expect(payload.unit).toBe('sat');
+      expect(payload.mint).toBe(MINT);
+      expect(payload.memo).toBe('hi');
+      // BigInt-safe: an amount beyond 2^53 survives exactly.
+      expect(payload.proofs[0].amount).toBe(9007199254740993n);
+    });
+
+    test('omits id and memo when absent and defaults the unit', () => {
+      const pr = new PaymentRequest({});
+      const payload = PaymentRequest.decodePayload(pr.encodePayload(MINT, [makeProof(1n)]));
+      expect(payload.id).toBeUndefined();
+      expect(payload.memo).toBeUndefined();
+      expect(payload.unit).toBe('sat');
+
+      const usd = new PaymentRequest({});
+      const p2 = PaymentRequest.decodePayload(
+        usd.encodePayload(MINT, [makeProof(1n)], { unit: 'usd' }),
+      );
+      expect(p2.unit).toBe('usd');
+    });
+
+    test('enforces a strict mint list but not a preferred one', () => {
+      const strict = new PaymentRequest({ mints: ['https://other.mint'] });
+      expect(() => strict.encodePayload(MINT, [makeProof(1n)])).toThrow(
+        "mint is not in the request's strict mint list",
+      );
+      // URL-normalized membership passes.
+      const listed = new PaymentRequest({ mints: [MINT + '/'] });
+      expect(() => listed.encodePayload(MINT, [makeProof(1n)])).not.toThrow();
+
+      const preferred = new PaymentRequest({ mints: ['https://other.mint'], mintsPreferred: true });
+      expect(() => preferred.encodePayload(MINT, [makeProof(1n)])).not.toThrow();
+    });
+  });
+
+  describe('decodePayload', () => {
+    const valid = () => ({
+      id: 'inv-1',
+      unit: 'sat',
+      mint: MINT,
+      proofs: [{ id: '009a1f293253e41e', amount: 2, secret: 's', C: '02ff' }],
+    });
+
+    test('normalizes small JSON number amounts to bigint', () => {
+      const payload = PaymentRequest.decodePayload(JSON.stringify(valid()));
+      expect(payload.proofs[0].amount).toBe(2n);
+    });
+
+    test('preserves unknown proof fields (witness, dleq)', () => {
+      const obj = valid();
+      (obj.proofs[0] as Record<string, unknown>).witness = '{"signatures":[]}';
+      const payload = PaymentRequest.decodePayload(JSON.stringify(obj));
+      expect(payload.proofs[0].witness).toBe('{"signatures":[]}');
+    });
+
+    test.each([
+      ['not JSON', 'nope{', /not valid JSON/],
+      ['a JSON array', '[]', /expected a JSON object/],
+      ['missing mint', JSON.stringify({ ...valid(), mint: undefined }), /missing mint/],
+      ['missing unit', JSON.stringify({ ...valid(), unit: 42 }), /missing unit/],
+      ['a non-string id', JSON.stringify({ ...valid(), id: 7 }), /id must be a string/],
+      ['a non-string memo', JSON.stringify({ ...valid(), memo: 7 }), /memo must be a string/],
+      ['missing proofs', JSON.stringify({ ...valid(), proofs: [] }), /missing proofs/],
+      [
+        'a malformed proof',
+        JSON.stringify({ ...valid(), proofs: [{ amount: 1 }] }),
+        /malformed proof at index 0/,
+      ],
+      [
+        'a non-numeric proof amount',
+        JSON.stringify({ ...valid(), proofs: [{ ...valid().proofs[0], amount: '2' }] }),
+        /malformed proof amount at index 0/,
+      ],
+    ])('rejects %s', (_name, input, expected) => {
+      expect(() => PaymentRequest.decodePayload(input)).toThrow(expected);
+    });
+
+    test('rejects a fractional proof amount', () => {
+      const obj = valid();
+      obj.proofs[0].amount = 1.5;
+      expect(() => PaymentRequest.decodePayload(JSON.stringify(obj))).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Adds `PaymentRequest.encodePayload` and static `PaymentRequest.decodePayload` for the default NUT-18 payment payload. Payers previously assembled the payload by hand and had to know to serialize with `JSONInt` (plain `JSON.stringify` throws on bigint proof amounts); receivers parsing with `JSON.parse` corrupt amounts above 2^53, and even `JSONInt.parse` leaves small amounts as `number` in the `bigint`-typed `Proof.amount` field.

`encodePayload` fills `id` and `unit` from the request, enforces a strict mint list (URL-normalized), and returns a wire-ready bigint-safe JSON string. It does not validate amount sufficiency: the required total is amount + `mf` + payee input fees, which needs mint info and keysets; `wallet.ops.sendToRequest` remains the sanctioned proof source and this method packages its output.

`decodePayload` is the receiver's trust boundary: strict bigint-safe parse, shape validation with actionable errors, and proof amounts normalized to `bigint`. Matching a payload to a request (id, mint, netting the amount) stays with the caller; the docs show the full receive flow including the accept-only-known-mints guard.

Docs: payer and receiver flows in `payment_requests.md` updated to use the pair.