### PR TITLE
fix(wallet): bound fee convergence loop

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -784,11 +784,19 @@ class Wallet {
    * Iterates until the fee is stable, since fee outputs also incur fees.
    */
   private receiveFeeAmounts(nOutputs: number, keyset: Keyset): Amount[] {
+    // Bound the +1 convergence; any realistic keyset converges in a few dozen steps.
+    const maxIters = 1 << 12;
     let receiveFee = this.getFeesForKeyset(nOutputs, keyset.id);
     let receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
+    let iters = 0;
     while (
       this.getFeesForKeyset(nOutputs + receiveFeeAmounts.length, keyset.id).greaterThan(receiveFee)
     ) {
+      if (iters++ > maxIters) {
+        throw new CTSError(
+          `Fee calculation for keyset ${keyset.id} did not converge (input_fee_ppk too high for its denominations)`,
+        );
+      }
       receiveFee = receiveFee.add(1);
       receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
     }

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -2,8 +2,28 @@ import { HttpResponse, http } from 'msw';
 import { test, describe, expect } from 'vitest';
 
 import { Wallet, Amount, CTSError, PaymentRequest, type Proof } from '../../src';
+import { deriveKeysetId } from '../../src/utils';
+import { PUBKEYS } from '../consts';
 
 import { mint, unit, mintUrl, useTestServer } from './_setup';
+
+// Full power-of-two denomination set, a realistic set for fee convergence. A v0 keyset id hashes
+// only the pubkeys (not the fee), so one id is valid for any advertised fee.
+const FULL_DENOM_ID = deriveKeysetId(PUBKEYS, { versionByte: 0 });
+
+// Advertise a full-denomination keyset with a given input fee, so fee convergence sees a realistic
+// denomination set rather than the {1,2} default fixture.
+const useKeysetWithFee = (server: ReturnType<typeof useTestServer>, input_fee_ppk: number) => {
+  const id = FULL_DENOM_ID;
+  const withKeys = { id, unit: 'sat', active: true, input_fee_ppk, keys: PUBKEYS };
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () =>
+      HttpResponse.json({ keysets: [{ id, unit: 'sat', active: true, input_fee_ppk }] }),
+    ),
+    http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [withKeys] })),
+    http.get(mintUrl + '/v1/keys/' + id, () => HttpResponse.json({ keysets: [withKeys] })),
+  );
+};
 
 const server = useTestServer();
 
@@ -169,6 +189,25 @@ describe('wallet.getFeesToInclude', () => {
     expect(() => wallet.getFeesToInclude(100, { keysetId: '00missingkeyset' })).toThrow(
       /not found/,
     );
+  });
+
+  test('converges on the minimal (fewest-output) fee, not an overshoot', async () => {
+    // 3000 ppk = 3 sat per input. Spending 1 real output plus its fee outputs, a single 8 output
+    // is minimal: it covers the two-input fee (fee(2) = 6) with the fewest outputs. A convergence
+    // that jumps past the low-popcount value would settle on 9 (two outputs) instead.
+    useKeysetWithFee(server, 3000);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    expect(wallet.getFeesToInclude(1).toString()).toBe('8');
+  });
+
+  test('fails fast instead of hanging when input_fee_ppk is degenerately large', async () => {
+    useKeysetWithFee(server, 10_000_000_000);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    expect(() => wallet.getFeesToInclude(1)).toThrow(/did not converge/);
   });
 });
 


### PR DESCRIPTION
`receiveFeeAmounts` converges on the fee that covers its own fee outputs by advancing one unit at a time. The number of steps scales with `input_fee_ppk`, and the loop does not converge at all when the per-input fee exceeds the keyset's largest denomination, so a keyset advertising an extreme `input_fee_ppk` could make fee calculation (any `includeFees` path, or `getFeesToInclude`) run for a very long time.

Bounds the loop and throws a clear error past the cap. Any realistic keyset converges in a few dozen steps (even 10 sat/input is ~23), so the bound only trips on degenerate fee metadata; the minimal-fee result is unchanged for every converging case.

Adds regression tests: minimal (fewest-output) convergence at 3 sat/input, and a fail-fast throw for an extreme fee.