### PR TITLE
fix(wallet): reject a missing pubkey in locked mint quotes

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1915,6 +1915,10 @@ class Wallet {
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
     this.requireMintableKeyset('createLockedMintQuote');
+    this.failIf(
+      typeof pubkey !== 'string' || pubkey.length === 0,
+      'A pubkey is required to lock the mint quote',
+    );
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1954,6 +1958,10 @@ class Wallet {
   ): Promise<MintQuoteBolt12Response> {
     this.requireSupport('mint', 'bolt12');
     this.requireMintableKeyset('createMintQuoteBolt12');
+    this.failIf(
+      typeof pubkey !== 'string' || pubkey.length === 0,
+      'A pubkey is required to lock the mint quote',
+    );
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1991,6 +1999,10 @@ class Wallet {
   async createMintQuoteOnchain(pubkey: string): Promise<MintQuoteOnchainResponse> {
     this.requireSupport('mint', 'onchain');
     this.requireMintableKeyset('createMintQuoteOnchain');
+    this.failIf(
+      typeof pubkey !== 'string' || pubkey.length === 0,
+      'A pubkey is required to lock the mint quote',
+    );
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
     this.failIf(
       typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -312,6 +312,16 @@ describe('createMintQuoteBolt12 mutants', () => {
       'Mint quote is not locked to the requested pubkey',
     );
   });
+
+  test('rejects a missing pubkey with a clear error, not a TypeError', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // A loosely-typed JS caller can omit the required pubkey; fail fast, not on `.toLowerCase()`.
+    await expect(wallet.createMintQuoteBolt12(undefined as unknown as string)).rejects.toThrow(
+      'A pubkey is required to lock the mint quote',
+    );
+  });
 });
 
 describe('createMintQuoteOnchain mutants', () => {
@@ -357,6 +367,15 @@ describe('createMintQuoteOnchain mutants', () => {
 
     await expect(wallet.createMintQuoteOnchain('02abcd')).rejects.toThrow(
       'Mint quote is not locked to the requested pubkey',
+    );
+  });
+
+  test('rejects a missing pubkey with a clear error, not a TypeError', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteOnchain(undefined as unknown as string)).rejects.toThrow(
+      'A pubkey is required to lock the mint quote',
     );
   });
 });
@@ -993,6 +1012,15 @@ describe('createLockedMintQuote mutants', () => {
 
     const quote = await wallet.createLockedMintQuote(100, PUBKEY);
     expect(quote.pubkey.toLowerCase()).toBe(PUBKEY);
+  });
+
+  test('rejects a missing pubkey with a clear error, not a TypeError', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createLockedMintQuote(100, undefined as unknown as string)).rejects.toThrow(
+      'A pubkey is required to lock the mint quote',
+    );
   });
 });
 


### PR DESCRIPTION
The locked mint quote methods (`createLockedMintQuote`, `createMintQuoteBolt12`, `createMintQuoteOnchain`) type `pubkey` as a required string, but a loosely-typed JavaScript caller can omit it. When the mint then returns a string pubkey, the response echo check called `pubkey.toLowerCase()` on `undefined` and threw a raw `TypeError` instead of a clear error.

Validate the argument at method entry (`typeof pubkey !== 'string' || empty`) and fail fast with an actionable message, before any request is sent. Adds a test per method.