### PR TITLE
fix(wallet): reject a missing pubkey in locked mint quotes [backport v4-dev]

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1812,6 +1812,10 @@ class Wallet {
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
     this.requireMintableKeyset('createLockedMintQuote');
+    this.failIf(
+      typeof pubkey !== 'string' || pubkey.length === 0,
+      'A pubkey is required to lock the mint quote',
+    );
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1851,6 +1855,10 @@ class Wallet {
   ): Promise<MintQuoteBolt12Response> {
     this.requireSupport('mint', 'bolt12');
     this.requireMintableKeyset('createMintQuoteBolt12');
+    this.failIf(
+      typeof pubkey !== 'string' || pubkey.length === 0,
+      'A pubkey is required to lock the mint quote',
+    );
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1888,6 +1896,10 @@ class Wallet {
   async createMintQuoteOnchain(pubkey: string): Promise<MintQuoteOnchainResponse> {
     this.requireSupport('mint', 'onchain');
     this.requireMintableKeyset('createMintQuoteOnchain');
+    this.failIf(
+      typeof pubkey !== 'string' || pubkey.length === 0,
+      'A pubkey is required to lock the mint quote',
+    );
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
     this.failIf(
       typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -312,6 +312,16 @@ describe('createMintQuoteBolt12 mutants', () => {
       'Mint quote is not locked to the requested pubkey',
     );
   });
+
+  test('rejects a missing pubkey with a clear error, not a TypeError', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // A loosely-typed JS caller can omit the required pubkey; fail fast, not on `.toLowerCase()`.
+    await expect(wallet.createMintQuoteBolt12(undefined as unknown as string)).rejects.toThrow(
+      'A pubkey is required to lock the mint quote',
+    );
+  });
 });
 
 describe('createMintQuoteOnchain mutants', () => {
@@ -357,6 +367,15 @@ describe('createMintQuoteOnchain mutants', () => {
 
     await expect(wallet.createMintQuoteOnchain('02abcd')).rejects.toThrow(
       'Mint quote is not locked to the requested pubkey',
+    );
+  });
+
+  test('rejects a missing pubkey with a clear error, not a TypeError', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteOnchain(undefined as unknown as string)).rejects.toThrow(
+      'A pubkey is required to lock the mint quote',
     );
   });
 });
@@ -988,6 +1007,15 @@ describe('createLockedMintQuote mutants', () => {
 
     const quote = await wallet.createLockedMintQuote(100, PUBKEY);
     expect(quote.pubkey.toLowerCase()).toBe(PUBKEY);
+  });
+
+  test('rejects a missing pubkey with a clear error, not a TypeError', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createLockedMintQuote(100, undefined as unknown as string)).rejects.toThrow(
+      'A pubkey is required to lock the mint quote',
+    );
   });
 });
 


### PR DESCRIPTION
# Description
Backport of #856 to `v4-dev`.