### PR TITLE
fix(utils): bound splitAmount output count

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -34,6 +34,12 @@ import { Bytes } from './Bytes';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
 
+// Cap on outputs from the denomination fill. A normal split over a power-of-two keyset is at most a
+// few dozen; a coarse keyset (few, small denominations) over a large value could otherwise fill
+// millions. 8x cdk's default max_outputs (1000): clears any real mint, and a request carrying that
+// many outputs would be rejected for size anyway.
+const MAX_SPLIT_OUTPUTS = 8_192;
+
 /**
  * Splits the amount into denominations of the provided keyset.
  *
@@ -45,7 +51,8 @@ import { JSONInt } from './JSONInt';
  * @param split? Optional custom split amounts.
  * @param order? Optional order for split amounts (if fill was required)
  * @returns Array of split amounts.
- * @throws Error if split sum is greater than value or mint does not have keys for requested split.
+ * @throws Error if split sum is greater than value, the keyset lacks requested denominations, or
+ *   the fill would exceed an internal output cap (coarse denominations over a large value).
  */
 export function splitAmount(
   value: AmountLike,
@@ -97,10 +104,19 @@ export function splitAmount(
   }
   for (const amtAsAmount of sortedKeyAmounts) {
     if (amtAsAmount.isZero()) continue;
-    // Calculate how many of this denomination fit into the remaining value
-    const requireCount = remainingValue.divideBy(amtAsAmount).toNumber();
-    // Add them to the split and reduce the target value by added amounts
-    normalizedSplit.push(...Array<Amount>(requireCount).fill(amtAsAmount));
+    // How many of this denomination fit into the remaining value. Guard the running total before
+    // building the array: a coarse keyset over a large value would otherwise fill millions of
+    // outputs (and a spread push of that many overflows the call stack). Compare against the
+    // remaining budget so an oversized count never reaches toNumber().
+    const requireCount = remainingValue.divideBy(amtAsAmount);
+    const budget = MAX_SPLIT_OUTPUTS - normalizedSplit.length;
+    if (budget <= 0 || requireCount.greaterThan(budget)) {
+      throw new CTSError(`Cannot split amount: fill would exceed ${MAX_SPLIT_OUTPUTS} outputs`);
+    }
+    const count = requireCount.toNumber();
+    for (let i = 0; i < count; i++) {
+      normalizedSplit.push(amtAsAmount);
+    }
     remainingValue = remainingValue.subtract(amtAsAmount.multiplyBy(requireCount));
     // Break early once target is satisfied
     if (remainingValue.isZero()) break;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -99,10 +99,9 @@ export function splitAmount(
   }
   for (const amtAsAmount of sortedKeyAmounts) {
     if (amtAsAmount.isZero()) continue;
-    // How many of this denomination fit into the remaining value. Guard the running total before
-    // building the array: a coarse keyset over a large value would otherwise fill millions of
-    // outputs (and a spread push of that many overflows the call stack). Compare against the
-    // remaining budget so an oversized count never reaches toNumber().
+    // Calculate how many of this denomination fit into the remaining value.
+    // Guard requireCount: small keyset denom + large value could be millions of outputs.
+    // Compare against remaining budget, so an oversized count never reaches toNumber().
     const requireCount = remainingValue.divideBy(amtAsAmount);
     const budget = MAX_SPLIT_OUTPUTS - normalizedSplit.length;
     if (budget <= 0 || requireCount.greaterThan(budget)) {

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -33,12 +33,7 @@ import { encodeBase64ToJson, encodeBase64toUint8, encodeUint8toBase64Url } from 
 import { Bytes } from './Bytes';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
-
-// Cap on outputs from the denomination fill. A normal split over a power-of-two keyset is at most a
-// few dozen; a coarse keyset (few, small denominations) over a large value could otherwise fill
-// millions. 8x cdk's default max_outputs (1000): clears any real mint, and a request carrying that
-// many outputs would be rejected for size anyway.
-const MAX_SPLIT_OUTPUTS = 8_192;
+import { MAX_SPLIT_OUTPUTS } from './limits';
 
 /**
  * Splits the amount into denominations of the provided keyset.

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -6,6 +6,14 @@
 export const ABSOLUTE_MAX_PER_MINT = 100;
 
 /**
+ * Cap on outputs from the `splitAmount` denomination fill. A normal split over a power-of-two
+ * keyset is at most a few dozen; a coarse keyset (few, small denominations) over a large value
+ * could otherwise fill millions. 8x cdk's default max_outputs (1000): clears any real mint, and a
+ * request carrying that many outputs would be rejected for size anyway. Exceeding it throws.
+ */
+export const MAX_SPLIT_OUTPUTS = 8_192;
+
+/**
  * NUT-29: Hard ceiling for batch-mint size, the maximum number of quote entries a wallet may
  * include in a single `prepareBatchMint` call. Values advertised by a mint above this cap are
  * clamped.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -785,7 +785,7 @@ class Wallet {
    */
   private receiveFeeAmounts(nOutputs: number, keyset: Keyset): Amount[] {
     // Bound the +1 convergence; any realistic keyset converges in a few dozen steps.
-    const maxIters = 1 << 12;
+    const maxIters = 4_096;
     let receiveFee = this.getFeesForKeyset(nOutputs, keyset.id);
     let receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
     let iters = 0;

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -108,6 +108,29 @@ describe('test split custom amounts ', () => {
   });
 });
 
+describe('splitAmount output bound', () => {
+  const onlyOnes: Keys = { 1: 'deadbeef' };
+
+  test('fills a small coarse split (no spread push)', () => {
+    const chunks = utils.splitAmount(100, onlyOnes);
+    expect(chunks).toHaveLength(100);
+    expect(chunks.every((a) => a.toNumber() === 1)).toBe(true);
+  });
+
+  test('rejects a coarse split that would exceed the output cap', () => {
+    // Only a 1-denomination keyset over a large value: previously built a huge array via a spread
+    // push (stack overflow / memory sink). Now bounded and rejected before allocating.
+    expect(() => utils.splitAmount(200000, onlyOnes)).toThrow(/would exceed .* outputs/);
+  });
+
+  test('allows exactly the cap and rejects one past it (inclusive boundary)', () => {
+    // 8_192 ones is exactly the cap: still built (proves the loop push holds at scale).
+    expect(utils.splitAmount(8_192, onlyOnes)).toHaveLength(8_192);
+    // One more output must be rejected, not allocated.
+    expect(() => utils.splitAmount(8_193, onlyOnes)).toThrow(/would exceed .* outputs/);
+  });
+});
+
 describe('test split different key amount', () => {
   test('testing amount 68251', async () => {
     const chunks = utils.splitAmount(68251, keys_base10, undefined, 'desc');


### PR DESCRIPTION
`splitAmount` fills a value from a keyset's denominations. When a keyset offers only small denominations relative to the value, the denomination fill could build a very large output array, previously via a spread push that also overflows the call stack at high counts.

Bound the fill to a sane maximum (8192, 8x cdk's default `max_outputs`) and reject before allocating, comparing the required count against the remaining budget so an oversized count never reaches `toNumber()`. Normal splits over a power-of-two keyset are unaffected (a few dozen outputs). Adds an inclusive-boundary test.

Also swaps a bit-shift literal in the fee-convergence cap (`1 << 12` -> `4_096`) for readability, no behaviour change.