### PR TITLE
fix(wallet): validate the lock pubkey in mint quote methods

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -20,6 +20,7 @@ import {
   parseSecret,
 } from '../crypto';
 // Internal transitional fallback — not part of crypto/index.ts
+import { normalizePubkey } from '../crypto/NUT11';
 import { signMintQuoteLegacy } from '../crypto/NUT20';
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';
@@ -1915,10 +1916,8 @@ class Wallet {
   ): Promise<MintQuoteBolt11Response> {
     this.requireSupport('mint', 'bolt11');
     this.requireMintableKeyset('createLockedMintQuote');
-    this.failIf(
-      typeof pubkey !== 'string' || pubkey.length === 0,
-      'A pubkey is required to lock the mint quote',
-    );
+    this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
+    pubkey = normalizePubkey(pubkey);
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1958,10 +1957,8 @@ class Wallet {
   ): Promise<MintQuoteBolt12Response> {
     this.requireSupport('mint', 'bolt12');
     this.requireMintableKeyset('createMintQuoteBolt12');
-    this.failIf(
-      typeof pubkey !== 'string' || pubkey.length === 0,
-      'A pubkey is required to lock the mint quote',
-    );
+    this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
+    pubkey = normalizePubkey(pubkey);
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1999,10 +1996,8 @@ class Wallet {
   async createMintQuoteOnchain(pubkey: string): Promise<MintQuoteOnchainResponse> {
     this.requireSupport('mint', 'onchain');
     this.requireMintableKeyset('createMintQuoteOnchain');
-    this.failIf(
-      typeof pubkey !== 'string' || pubkey.length === 0,
-      'A pubkey is required to lock the mint quote',
-    );
+    this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
+    pubkey = normalizePubkey(pubkey);
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
     this.failIf(
       typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1917,7 +1917,7 @@ class Wallet {
     this.requireSupport('mint', 'bolt11');
     this.requireMintableKeyset('createLockedMintQuote');
     this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
-    pubkey = normalizePubkey(pubkey);
+    const normPubkey = normalizePubkey(pubkey);
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1925,13 +1925,13 @@ class Wallet {
       unit: this._unit,
       amount: mintAmount,
       description: description,
-      pubkey: pubkey,
+      pubkey: normPubkey,
     };
     const res = await this.mint.createMintQuoteBolt11(mintQuotePayload);
     this.failIf(typeof res.pubkey !== 'string', 'Mint returned unlocked mint quote');
     const resPubkey = res.pubkey!;
     this.failIf(
-      resPubkey.toLowerCase() !== pubkey.toLowerCase(),
+      resPubkey.toLowerCase() !== normPubkey,
       'Mint quote is not locked to the requested pubkey',
     );
     return { ...res, pubkey: resPubkey, unit: res.unit || this._unit };
@@ -1958,7 +1958,7 @@ class Wallet {
     this.requireSupport('mint', 'bolt12');
     this.requireMintableKeyset('createMintQuoteBolt12');
     this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
-    pubkey = normalizePubkey(pubkey);
+    const normPubkey = normalizePubkey(pubkey);
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1971,7 +1971,7 @@ class Wallet {
         : undefined;
 
     const mintQuotePayload: MintQuoteBolt12Request = {
-      pubkey: pubkey,
+      pubkey: normPubkey,
       unit: this._unit,
       amount,
       description: options?.description,
@@ -1979,7 +1979,7 @@ class Wallet {
 
     const res = await this.mint.createMintQuoteBolt12(mintQuotePayload);
     this.failIf(
-      typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),
+      typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== normPubkey,
       'Mint quote is not locked to the requested pubkey',
     );
     return res;
@@ -1997,10 +1997,10 @@ class Wallet {
     this.requireSupport('mint', 'onchain');
     this.requireMintableKeyset('createMintQuoteOnchain');
     this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
-    pubkey = normalizePubkey(pubkey);
-    const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey });
+    const normPubkey = normalizePubkey(pubkey);
+    const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey: normPubkey });
     this.failIf(
-      typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== pubkey.toLowerCase(),
+      typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== normPubkey,
       'Mint quote is not locked to the requested pubkey',
     );
     return { ...res, unit: res.unit || this._unit };

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -387,13 +387,15 @@ describe('Mint (BOLT12) – instance methods', () => {
 
 describe('Wallet (BOLT12) – wrappers', () => {
   it('wallet.createMintQuoteBolt12 delegates to mint', async () => {
+    // A valid compressed secp256k1 point (the generator); the wallet validates the lock pubkey.
+    const pk = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
     const response = {
       quote: 'q1',
       request: 'lno1offer...',
       amount: 21,
       unit: 'sat',
       expiry: null,
-      pubkey: '02abcd',
+      pubkey: pk,
       amount_paid: 0,
       amount_issued: 0,
     };
@@ -401,14 +403,14 @@ describe('Wallet (BOLT12) – wrappers', () => {
     const mint = new Mint(mintUrl, { customRequest: req });
     const wallet = new Wallet(mint);
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
-    const res = await wallet.createMintQuoteBolt12('02abcd', { amount: 21, description: 'desc' });
+    const res = await wallet.createMintQuoteBolt12(pk, { amount: 21, description: 'desc' });
     expect(res.quote).toBe(response.quote);
     expect(res.amount).toEqual(Amount.from(response.amount));
     expect(res.amount_paid).toEqual(Amount.from(response.amount_paid));
     expect(res.amount_issued).toEqual(Amount.from(response.amount_issued));
     expect(calls).toHaveLength(1);
     expect(calls[0].requestBody).toEqual({
-      pubkey: '02abcd',
+      pubkey: pk,
       unit: 'sat',
       amount: 21n,
       description: 'desc',

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -32,6 +32,8 @@ import {
 const server = useTestServer();
 
 const KEYSET_ID = '00bd033559de27d0';
+// A valid compressed secp256k1 point (the generator), accepted by normalizePubkey.
+const LOCK_PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
 const SIG_C = '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625';
 const SEED = hexToBytes(
   'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
@@ -258,7 +260,7 @@ describe('createMintQuoteBolt12 mutants', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
     // Default fixture advertises bolt12 mint for sat but not description.
-    await expect(wallet.createMintQuoteBolt12('02abcd', { description: 'x' })).rejects.toThrow(
+    await expect(wallet.createMintQuoteBolt12(LOCK_PUBKEY, { description: 'x' })).rejects.toThrow(
       'Mint does not support description for bolt12',
     );
   });
@@ -272,7 +274,7 @@ describe('createMintQuoteBolt12 mutants', () => {
           quote: 'q-bolt12',
           request: 'lno1offer...',
           unit: 'sat',
-          pubkey: '02abcd',
+          pubkey: LOCK_PUBKEY,
           state: MintQuoteState.UNPAID,
           expiry: null,
           amount_paid: 0,
@@ -283,9 +285,9 @@ describe('createMintQuoteBolt12 mutants', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    const quote = await wallet.createMintQuoteBolt12('02abcd');
+    const quote = await wallet.createMintQuoteBolt12(LOCK_PUBKEY);
     expect(quote.quote).toBe('q-bolt12');
-    expect(body.pubkey).toBe('02abcd');
+    expect(body.pubkey).toBe(LOCK_PUBKEY);
     expect(body.amount).toBeUndefined();
     expect(body.description).toBeUndefined();
   });
@@ -308,7 +310,7 @@ describe('createMintQuoteBolt12 mutants', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    await expect(wallet.createMintQuoteBolt12('02abcd')).rejects.toThrow(
+    await expect(wallet.createMintQuoteBolt12(LOCK_PUBKEY)).rejects.toThrow(
       'Mint quote is not locked to the requested pubkey',
     );
   });
@@ -322,6 +324,13 @@ describe('createMintQuoteBolt12 mutants', () => {
       'A pubkey is required to lock the mint quote',
     );
   });
+
+  test('rejects a malformed pubkey (e.g. whitespace) before any request', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteBolt12(' ')).rejects.toThrow('Invalid pubkey');
+  });
 });
 
 describe('createMintQuoteOnchain mutants', () => {
@@ -332,7 +341,7 @@ describe('createMintQuoteOnchain mutants', () => {
           quote: 'onchain-q',
           request: 'bc1qdeposit',
           unit: '', // empty → wallet fills its unit
-          pubkey: '02abcd',
+          pubkey: LOCK_PUBKEY,
           state: MintQuoteState.UNPAID,
           expiry: null,
           amount_paid: 0,
@@ -343,7 +352,7 @@ describe('createMintQuoteOnchain mutants', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    const quote = await wallet.createMintQuoteOnchain('02abcd');
+    const quote = await wallet.createMintQuoteOnchain(LOCK_PUBKEY);
     expect(quote.unit).toBe('sat');
   });
 
@@ -365,7 +374,7 @@ describe('createMintQuoteOnchain mutants', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    await expect(wallet.createMintQuoteOnchain('02abcd')).rejects.toThrow(
+    await expect(wallet.createMintQuoteOnchain(LOCK_PUBKEY)).rejects.toThrow(
       'Mint quote is not locked to the requested pubkey',
     );
   });
@@ -377,6 +386,13 @@ describe('createMintQuoteOnchain mutants', () => {
     await expect(wallet.createMintQuoteOnchain(undefined as unknown as string)).rejects.toThrow(
       'A pubkey is required to lock the mint quote',
     );
+  });
+
+  test('rejects a malformed pubkey (e.g. whitespace) before any request', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMintQuoteOnchain(' ')).rejects.toThrow('Invalid pubkey');
   });
 });
 
@@ -1021,6 +1037,14 @@ describe('createLockedMintQuote mutants', () => {
     await expect(wallet.createLockedMintQuote(100, undefined as unknown as string)).rejects.toThrow(
       'A pubkey is required to lock the mint quote',
     );
+  });
+
+  test('rejects a malformed pubkey (e.g. whitespace) before any request', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // normalizePubkey runs before the NUT-20 support check, so this fails on the pubkey.
+    await expect(wallet.createLockedMintQuote(100, ' ')).rejects.toThrow('Invalid pubkey');
   });
 });
 


### PR DESCRIPTION
`createLockedMintQuote`, `createMintQuoteBolt12`, and `createMintQuoteOnchain` accepted any non-empty string as the lock pubkey and forwarded it to the mint. A caller passing a malformed value (not a valid compressed secp256k1 point) could (possibly) create a quote locked to a key it cannot later sign for if mint did not check.

Validate the argument with `normalizePubkey` at method entry and send the normalized (canonical, lowercase compressed) form, failing fast with a clear error before any request. Tests use real points and add a rejection case per method.