### PR TITLE
feat(crypto): public secp pubkey validation in curve_secp

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -715,6 +715,9 @@ export function isMintOperationError(e: unknown): e is MintOperationError;
 export function isP2PKSpendAuthorised(proof: Proof, logger?: Logger, message?: string): boolean;
 
 // @public
+export function isValidSecpPubkey(pk: string): boolean;
+
+// @public
 export const JSONInt: JSONIntApi;
 
 // @public (undocumented)
@@ -1379,6 +1382,9 @@ export function normalizeMintUrl(url: string): string;
 
 // @public
 export function normalizeProofAmounts(raw: ProofLike[]): Proof[];
+
+// @public
+export function normalizeSecpPubkey(pk: string): string;
 
 // @public
 export type NUT10Option = {

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -8,7 +8,7 @@ import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
 import { type NUT10Option } from '../wallet/types/payment-requests';
 
 import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
-import { pointFromHex } from './curve_secp';
+import { normalizePubkey } from './curve_secp';
 import {
   getTagInt,
   getTagScalar,
@@ -184,39 +184,6 @@ export function parseP2PKSecret(secret: string | Secret): Secret {
 // ------------------------------
 // Normalizer Functions
 // ------------------------------
-
-// Decompression-validated keys; proofs typically share lock keys, so repeat parses are
-// common. Naive clear-on-full, swap for LRU if churn ever matters.
-const VALIDATED_PUBKEYS = new Set<string>();
-
-/**
- * Validates and lowercases a P2PK pubkey (NUT-11: 33-byte compressed hex).
- *
- * @remarks
- * Strict: x-only input is rejected so a 64-hex value can only ever be a hashlock, and the key must
- * decompress to a curve point. A non-compliant key burns funds when authored and is unspendable on
- * spec-conformant mints when parsed.
- * @throws If not 66-char 02/03 hex, or not a valid secp256k1 point.
- * @internal
- */
-export function normalizePubkey(pk: string): string {
-  const hex = pk.toLowerCase();
-  if (hex.length !== 66 || !(hex.startsWith('02') || hex.startsWith('03'))) {
-    throw new CTSError(
-      `Invalid pubkey: expected 33-byte compressed hex (66 chars); for an x-only (nostr) key, prepend '02', got length ${hex.length}`,
-    );
-  }
-  if (!VALIDATED_PUBKEYS.has(hex)) {
-    try {
-      pointFromHex(hex);
-    } catch (e) {
-      throw new CTSError('Invalid pubkey: not a valid secp256k1 point', { cause: e });
-    }
-    if (VALIDATED_PUBKEYS.size >= 1024) VALIDATED_PUBKEYS.clear();
-    VALIDATED_PUBKEYS.add(hex);
-  }
-  return hex;
-}
 
 /**
  * Validate and canonicalise an HTLC hashlock (a SHA-256 digest).

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -8,7 +8,7 @@ import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
 import { type NUT10Option } from '../wallet/types/payment-requests';
 
 import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
-import { normalizePubkey } from './curve_secp';
+import { normalizeSecpPubkey } from './curve_secp';
 import {
   getTagInt,
   getTagScalar,
@@ -215,7 +215,7 @@ export function dedupeP2PKPubkeys(keys: string[]): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
   for (const raw of keys) {
-    const k = normalizePubkey(raw);
+    const k = normalizeSecpPubkey(raw);
     const xOnly = k.slice(-64);
     if (!seen.has(xOnly)) {
       seen.add(xOnly);
@@ -901,7 +901,7 @@ function assertSpendingConditionRules(params: {
 function getP2PKWitnessPubkeys(secret: Secret): string[] {
   const data = getSecretKind(secret) === 'P2PK' ? getDataField(secret) : '';
   const pubkeys = getTag(secret, 'pubkeys') ?? [];
-  const keys = (data ? [data, ...pubkeys] : pubkeys).map((key) => normalizePubkey(key));
+  const keys = (data ? [data, ...pubkeys] : pubkeys).map((key) => normalizeSecpPubkey(key));
   if (dedupeP2PKPubkeys(keys).length !== keys.length) {
     throw new CTSError('Duplicate main pubkeys are not allowed');
   }
@@ -909,7 +909,7 @@ function getP2PKWitnessPubkeys(secret: Secret): string[] {
 }
 
 function getP2PKWitnessRefundkeys(secret: Secret): string[] {
-  const keys = (getTag(secret, 'refund') ?? []).map((key) => normalizePubkey(key));
+  const keys = (getTag(secret, 'refund') ?? []).map((key) => normalizeSecpPubkey(key));
   if (dedupeP2PKPubkeys(keys).length !== keys.length) {
     throw new CTSError('Duplicate refund pubkeys are not allowed');
   }

--- a/src/crypto/curve_secp.ts
+++ b/src/crypto/curve_secp.ts
@@ -41,6 +41,38 @@ export function pointFromHex(hex: string) {
   return secp256k1.Point.fromHex(hex);
 }
 
+// Decompression-validated keys; callers typically share keys, so repeat parses are common. Naive
+// clear-on-full, swap for LRU if churn ever matters.
+const VALIDATED_PUBKEYS = new Set<string>();
+
+/**
+ * Validates and lowercases a compressed secp256k1 public key (33-byte, 66-hex, 02/03 prefix).
+ *
+ * @remarks
+ * Strict: x-only input is rejected, and the key must decompress to a curve point. Used for P2PK
+ * locks and NUT-20 quote-lock keys; a non-compliant key is unspendable on spec-conformant mints.
+ * @throws If not 66-char 02/03 hex, or not a valid secp256k1 point.
+ * @internal
+ */
+export function normalizePubkey(pk: string): string {
+  const hex = pk.toLowerCase();
+  if (hex.length !== 66 || !(hex.startsWith('02') || hex.startsWith('03'))) {
+    throw new CTSError(
+      `Invalid pubkey: expected 33-byte compressed hex (66 chars); for an x-only (nostr) key, prepend '02', got length ${hex.length}`,
+    );
+  }
+  if (!VALIDATED_PUBKEYS.has(hex)) {
+    try {
+      pointFromHex(hex);
+    } catch (e) {
+      throw new CTSError('Invalid pubkey: not a valid secp256k1 point', { cause: e });
+    }
+    if (VALIDATED_PUBKEYS.size >= 1024) VALIDATED_PUBKEYS.clear();
+    VALIDATED_PUBKEYS.add(hex);
+  }
+  return hex;
+}
+
 export function getPubKeyFromPrivKey(privKey: Uint8Array): Uint8Array<ArrayBufferLike> {
   return secp256k1.getPublicKey(privKey, true);
 }

--- a/src/crypto/curve_secp.ts
+++ b/src/crypto/curve_secp.ts
@@ -46,15 +46,14 @@ export function pointFromHex(hex: string) {
 const VALIDATED_PUBKEYS = new Set<string>();
 
 /**
- * Validates and lowercases a compressed secp256k1 public key (33-byte, 66-hex, 02/03 prefix).
+ * Validates a compressed secp256k1 pubkey and returns it lowercased (canonical form).
  *
  * @remarks
- * Strict: x-only input is rejected, and the key must decompress to a curve point. Used for P2PK
- * locks and NUT-20 quote-lock keys; a non-compliant key is unspendable on spec-conformant mints.
- * @throws If not 66-char 02/03 hex, or not a valid secp256k1 point.
- * @internal
+ * Strict: 66-char 02/03 hex that decompresses to a curve point; x-only is rejected. Throwing
+ * companion to {@link isValidSecpPubkey}.
+ * @throws {@link CTSError} If not 66-char 02/03 hex, or not a valid secp256k1 point.
  */
-export function normalizePubkey(pk: string): string {
+export function normalizeSecpPubkey(pk: string): string {
   const hex = pk.toLowerCase();
   if (hex.length !== 66 || !(hex.startsWith('02') || hex.startsWith('03'))) {
     throw new CTSError(
@@ -71,6 +70,19 @@ export function normalizePubkey(pk: string): string {
     VALIDATED_PUBKEYS.add(hex);
   }
   return hex;
+}
+
+/**
+ * True if `pk` is a valid compressed secp256k1 pubkey. Non-throwing companion to
+ * {@link normalizeSecpPubkey}.
+ */
+export function isValidSecpPubkey(pk: string): boolean {
+  try {
+    normalizeSecpPubkey(pk);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getPubKeyFromPrivKey(privKey: Uint8Array): Uint8Array<ArrayBufferLike> {

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -1,4 +1,4 @@
-import { normalizePubkey } from '../crypto/curve_secp';
+import { normalizeSecpPubkey } from '../crypto/curve_secp';
 import { getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
 import type { P2PKOptions, P2PKTag } from '../crypto/NUT11';
 import { P2PK_KNOWN_TAG_KEYS, p2pkOptionsToPRNut10, parseP2PKSecret } from '../crypto/NUT11';
@@ -392,17 +392,17 @@ export class PaymentRequest {
     ]);
     // `data` is the NUT-10 data slot (hashlock for HTLC, primary pubkey for P2PK);
     // the `pubkeys` tag carries the optional additional / receiver keys for either kind.
-    const taggedPubkeys = (getTag(secret, 'pubkeys') ?? []).map(normalizePubkey);
+    const taggedPubkeys = (getTag(secret, 'pubkeys') ?? []).map(normalizeSecpPubkey);
     const options: P2PKOptions = {
       kind: isHTLC ? 'HTLC' : 'P2PK',
-      data: isHTLC ? nut10.data : normalizePubkey(nut10.data),
+      data: isHTLC ? nut10.data : normalizeSecpPubkey(nut10.data),
       ...(taggedPubkeys.length ? { pubkeys: taggedPubkeys } : {}),
     };
 
     // Optional fields pass straight through: the accessors return undefined when
     // absent, and the builder ignores undefined options. getTag never yields [].
     options.locktime = getTagInt(secret, 'locktime');
-    options.refundKeys = getTag(secret, 'refund')?.map(normalizePubkey);
+    options.refundKeys = getTag(secret, 'refund')?.map(normalizeSecpPubkey);
     options.requiredSignatures = getTagInt(secret, 'n_sigs');
     options.requiredRefundSignatures = getTagInt(secret, 'n_sigs_refund');
     if (getTagScalar(secret, 'sigflag') === 'SIG_ALL') {

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -1,11 +1,7 @@
+import { normalizePubkey } from '../crypto/curve_secp';
 import { getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
 import type { P2PKOptions, P2PKTag } from '../crypto/NUT11';
-import {
-  P2PK_KNOWN_TAG_KEYS,
-  normalizePubkey,
-  p2pkOptionsToPRNut10,
-  parseP2PKSecret,
-} from '../crypto/NUT11';
+import { P2PK_KNOWN_TAG_KEYS, p2pkOptionsToPRNut10, parseP2PKSecret } from '../crypto/NUT11';
 import { encodeBase64toUint8, decodeCBOR, encodeCBOR, Bytes, normalizeMintUrl } from '../utils';
 import { decodeBech32mToBytes, encodeBech32m } from '../utils/bech32m';
 import { JSONInt } from '../utils/JSONInt';

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -20,7 +20,7 @@ import {
   parseSecret,
 } from '../crypto';
 // Internal transitional fallback — not part of crypto/index.ts
-import { normalizePubkey } from '../crypto/NUT11';
+import { normalizePubkey } from '../crypto/curve_secp';
 import { signMintQuoteLegacy } from '../crypto/NUT20';
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -20,7 +20,7 @@ import {
   parseSecret,
 } from '../crypto';
 // Internal transitional fallback — not part of crypto/index.ts
-import { normalizePubkey } from '../crypto/curve_secp';
+import { normalizeSecpPubkey } from '../crypto/curve_secp';
 import { signMintQuoteLegacy } from '../crypto/NUT20';
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';
@@ -1917,7 +1917,7 @@ class Wallet {
     this.requireSupport('mint', 'bolt11');
     this.requireMintableKeyset('createLockedMintQuote');
     this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
-    const normPubkey = normalizePubkey(pubkey);
+    const normPubkey = normalizeSecpPubkey(pubkey);
     const mintAmount = this.parseAmount(amount, 'createLockedMintQuote');
     const { supported } = this.getMintInfo().isSupported(20);
     this.failIf(!supported, 'Mint does not support NUT-20');
@@ -1958,7 +1958,7 @@ class Wallet {
     this.requireSupport('mint', 'bolt12');
     this.requireMintableKeyset('createMintQuoteBolt12');
     this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
-    const normPubkey = normalizePubkey(pubkey);
+    const normPubkey = normalizeSecpPubkey(pubkey);
     // Check if mint supports description for bolt12
     const mintInfo = this.getMintInfo();
     if (options?.description && !mintInfo.supportsNut04Description('bolt12', this._unit)) {
@@ -1997,7 +1997,7 @@ class Wallet {
     this.requireSupport('mint', 'onchain');
     this.requireMintableKeyset('createMintQuoteOnchain');
     this.failIf(typeof pubkey !== 'string', 'A pubkey is required to lock the mint quote');
-    const normPubkey = normalizePubkey(pubkey);
+    const normPubkey = normalizeSecpPubkey(pubkey);
     const res = await this.mint.createMintQuoteOnchain({ unit: this._unit, pubkey: normPubkey });
     this.failIf(
       typeof res.pubkey !== 'string' || res.pubkey.toLowerCase() !== normPubkey,

--- a/test/crypto/curve_secp.test.ts
+++ b/test/crypto/curve_secp.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest';
+
+import { normalizeSecpPubkey, isValidSecpPubkey } from '../../src';
+
+// A valid compressed secp256k1 point (the generator).
+const VALID = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+
+describe('normalizeSecpPubkey', () => {
+  test('validates and lowercases a compressed pubkey to canonical form', () => {
+    expect(normalizeSecpPubkey(VALID.toUpperCase())).toBe(VALID);
+    expect(normalizeSecpPubkey(VALID)).toBe(VALID);
+  });
+
+  test('rejects malformed input (whitespace, empty, wrong length, x-only, non-hex)', () => {
+    for (const bad of [' ', '', 'hello', '02', VALID.slice(2) /* 64-hex x-only */]) {
+      expect(() => normalizeSecpPubkey(bad)).toThrow(/Invalid pubkey/);
+    }
+  });
+
+  test('rejects a well-formed hex value that is not on the curve', () => {
+    expect(() => normalizeSecpPubkey('02' + 'f'.repeat(64))).toThrow(/not a valid secp256k1 point/);
+  });
+});
+
+describe('isValidSecpPubkey', () => {
+  test('mirrors normalizeSecpPubkey without throwing', () => {
+    expect(isValidSecpPubkey(VALID)).toBe(true);
+    expect(isValidSecpPubkey(VALID.toUpperCase())).toBe(true);
+    expect(isValidSecpPubkey(' ')).toBe(false);
+    expect(isValidSecpPubkey('02' + 'f'.repeat(64))).toBe(false);
+  });
+});

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -32,7 +32,7 @@ import {
 const server = useTestServer();
 
 const KEYSET_ID = '00bd033559de27d0';
-// A valid compressed secp256k1 point (the generator), accepted by normalizePubkey.
+// A valid compressed secp256k1 point (the generator), accepted by normalizeSecpPubkey.
 const LOCK_PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
 const SIG_C = '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625';
 const SEED = hexToBytes(
@@ -1043,7 +1043,7 @@ describe('createLockedMintQuote mutants', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    // normalizePubkey runs before the NUT-20 support check, so this fails on the pubkey.
+    // normalizeSecpPubkey runs before the NUT-20 support check, so this fails on the pubkey.
     await expect(wallet.createLockedMintQuote(100, ' ')).rejects.toThrow('Invalid pubkey');
   });
 });


### PR DESCRIPTION
`normalizePubkey` was general compressed-secp256k1 validation living in NUT-11 and marked `@internal`, yet already used across payment requests and mint quote locks. This:

- Moves it beside its dependency `pointFromHex` in `curve_secp`.
- Renames it `normalizeSecpPubkey` (the old name implied any curve; this only handles compressed secp256k1, distinct from v3/BLS keys).
- Adds a non-throwing companion `isValidSecpPubkey`, implemented via the normalizer so the two can't drift.
- Exports both from the public API (they were reachable but hidden by `@internal`).

The memoization cache stays private: it's an internal perf detail, and exposing a mutable set that gates the on-curve check would be a validation-bypass footgun. Main only.