### PR TITLE
fix(wallet): bound keyset denomination count at ingest

### DIFF
--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -5,6 +5,10 @@ import { type MintKeyset, type MintKeys } from '../model/types';
 import { isValidHex, deriveKeysetId, isBase64String } from '../utils';
 import { normalizeMintKeyset, normalizeMintKeys } from '../utils/normalizeNumbers';
 
+// Mint-supplied keysets are untrusted; bound the denomination count before any
+// per-key work. Real keysets carry ~64 keys (powers of two), so 256 is ample.
+const MAX_KEYSET_DENOMINATIONS = 256;
+
 export class Keyset {
   private _id: string;
   private _unit: string;
@@ -122,11 +126,13 @@ export class Keyset {
   /**
    * Verifies that a MintKeys DTO has a correct id for its keys/unit/expiry.
    *
-   * @returns True if verification succeeds, false otherwise (e.g: no keys or mismatch).
+   * @returns True if verification succeeds, false otherwise (e.g: no keys, too many keys, or
+   *   mismatch).
    */
   static verifyKeysetId(keys: MintKeys): boolean {
     try {
-      if (!keys.keys || Object.keys(keys.keys).length === 0) return false;
+      const count = keys.keys ? Object.keys(keys.keys).length : 0;
+      if (count === 0 || count > MAX_KEYSET_DENOMINATIONS) return false;
 
       const isDeprecatedBase64 = isBase64String(keys.id) && !isValidHex(keys.id);
       const versionByte = isValidHex(keys.id) ? hexToBytes(keys.id)[0] : 0;

--- a/test/wallet/Keyset.node.test.ts
+++ b/test/wallet/Keyset.node.test.ts
@@ -30,6 +30,11 @@ describe('Keyset.verifyKeysetId', () => {
     expect(Keyset.verifyKeysetId(mk)).toBe(false);
   });
 
+  test('returns false when the keys field is missing entirely', () => {
+    const mk = { id: GENUINE_ID, unit: 'sat', active: true } as MintKeys;
+    expect(Keyset.verifyKeysetId(mk)).toBe(false);
+  });
+
   test('returns false for a keyset with more than 256 denominations', () => {
     // Id derives genuinely for the oversized set, so rejection is due solely
     // to the denomination-count bound.

--- a/test/wallet/Keyset.node.test.ts
+++ b/test/wallet/Keyset.node.test.ts
@@ -30,6 +30,21 @@ describe('Keyset.verifyKeysetId', () => {
     expect(Keyset.verifyKeysetId(mk)).toBe(false);
   });
 
+  test('returns false for a keyset with more than 256 denominations', () => {
+    // Id derives genuinely for the oversized set, so rejection is due solely
+    // to the denomination-count bound.
+    const pubkey = (PUBKEYS as Keys)[1];
+    const oversized: Keys = {};
+    for (let i = 0; i < 257; i++) oversized[i + 1] = pubkey;
+    const mk: MintKeys = {
+      id: deriveKeysetId(oversized, { versionByte: 0 }),
+      unit: 'sat',
+      active: true,
+      keys: oversized,
+    };
+    expect(Keyset.verifyKeysetId(mk)).toBe(false);
+  });
+
   test('returns false when derived id does not match a tampered key', () => {
     const tampered: Keys = { ...(PUBKEYS as Keys), 1: (PUBKEYS as Keys)[2] };
     const mk: MintKeys = { id: GENUINE_ID, unit: 'sat', active: true, keys: tampered };


### PR DESCRIPTION
## Description

Caps the number of keys a keyset may carry at 256, checked in `Keyset.verifyKeysetId` before id derivation. All keyset ingest funnels through `verify()`, so the single check covers every path. Mint responses are untrusted input; per the contributing guidelines, any work they drive should be bounded. Real keysets carry ~64 denominations (powers of two up to 2^63), so the bound leaves ample headroom.

An oversized keyset now fails verification the same way a wrong-id keyset does: `verifyKeysetId` returns false and the keyset is rejected at load.

## Testing

New unit test: a 257-key keyset whose id genuinely derives is rejected, proving rejection is due to the count bound rather than an id mismatch. `npm run prtasks` is green; no public API change.