### PR TITLE
refactor(wallet): move MAX_KEYSET_DENOMINATIONS to limits

### DIFF
--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -13,6 +13,13 @@ export const ABSOLUTE_MAX_PER_MINT = 100;
 export const ABSOLUTE_MAX_BATCH_SIZE = 100;
 
 /**
+ * NUT-02: Hard ceiling on the number of denominations a mint-supplied keyset may carry, checked
+ * before any per-key work (id derivation hashes every pubkey). Real keysets carry ~64 keys (powers
+ * of two to 2^63), so 256 is ample headroom. Oversized keysets fail id verification.
+ */
+export const MAX_KEYSET_DENOMINATIONS = 256;
+
+/**
  * NUT-04/05: Upper bound on the length of a mint-advertised payment `method` string we will derive
  * a default `method_name` from. Real methods are short identifiers (`bolt11`, `onchain`); a value
  * beyond this is malformed/hostile, so we skip derivation rather than run unbounded string work

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -2,12 +2,8 @@ import { hexToBytes } from '@noble/curves/utils.js';
 
 import { CTSError } from '../model/Errors';
 import { type MintKeyset, type MintKeys } from '../model/types';
-import { isValidHex, deriveKeysetId, isBase64String } from '../utils';
+import { isValidHex, deriveKeysetId, isBase64String, MAX_KEYSET_DENOMINATIONS } from '../utils';
 import { normalizeMintKeyset, normalizeMintKeys } from '../utils/normalizeNumbers';
-
-// Mint-supplied keysets are untrusted; bound the denomination count before any
-// per-key work. Real keysets carry ~64 keys (powers of two), so 256 is ample.
-const MAX_KEYSET_DENOMINATIONS = 256;
 
 export class Keyset {
   private _id: string;


### PR DESCRIPTION
Relocates `MAX_KEYSET_DENOMINATIONS` from `Keyset.ts` into `src/utils/limits.ts`, alongside the other hard ceilings on mint-supplied input. No behavior change.

Note for merge order: this should merge after #865 so the backport applies onto the relocated constant's origin. #859 makes the matching move for `MAX_SPLIT_OUTPUTS`.