### PR TITLE
fix(utils): bound splitAmount output count [backport v4-dev]

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -22,6 +22,7 @@ import { encodeBase64ToJson, encodeBase64toUint8, encodeUint8toBase64Url } from 
 import { Bytes } from './Bytes';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
+import { MAX_SPLIT_OUTPUTS } from './limits';
 
 /**
  * Splits the amount into denominations of the provided keyset.
@@ -34,7 +35,8 @@ import { JSONInt } from './JSONInt';
  * @param split? Optional custom split amounts.
  * @param order? Optional order for split amounts (if fill was required)
  * @returns Array of split amounts.
- * @throws Error if split sum is greater than value or mint does not have keys for requested split.
+ * @throws Error if split sum is greater than value, the keyset lacks requested denominations, or
+ *   the fill would exceed an internal output cap (coarse denominations over a large value).
  */
 export function splitAmount(
   value: AmountLike,
@@ -86,10 +88,18 @@ export function splitAmount(
   }
   for (const amtAsAmount of sortedKeyAmounts) {
     if (amtAsAmount.isZero()) continue;
-    // Calculate how many of this denomination fit into the remaining value
-    const requireCount = remainingValue.divideBy(amtAsAmount).toNumber();
-    // Add them to the split and reduce the target value by added amounts
-    normalizedSplit.push(...Array<Amount>(requireCount).fill(amtAsAmount));
+    // Calculate how many of this denomination fit into the remaining value.
+    // Guard requireCount: small keyset denom + large value could be millions of outputs.
+    // Compare against remaining budget, so an oversized count never reaches toNumber().
+    const requireCount = remainingValue.divideBy(amtAsAmount);
+    const budget = MAX_SPLIT_OUTPUTS - normalizedSplit.length;
+    if (budget <= 0 || requireCount.greaterThan(budget)) {
+      throw new CTSError(`Cannot split amount: fill would exceed ${MAX_SPLIT_OUTPUTS} outputs`);
+    }
+    const count = requireCount.toNumber();
+    for (let i = 0; i < count; i++) {
+      normalizedSplit.push(amtAsAmount);
+    }
     remainingValue = remainingValue.subtract(amtAsAmount.multiplyBy(requireCount));
     // Break early once target is satisfied
     if (remainingValue.isZero()) break;

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -6,6 +6,14 @@
 export const ABSOLUTE_MAX_PER_MINT = 100;
 
 /**
+ * Cap on outputs from the `splitAmount` denomination fill. A normal split over a power-of-two
+ * keyset is at most a few dozen; a coarse keyset (few, small denominations) over a large value
+ * could otherwise fill millions. 8x cdk's default max_outputs (1000): clears any real mint, and a
+ * request carrying that many outputs would be rejected for size anyway. Exceeding it throws.
+ */
+export const MAX_SPLIT_OUTPUTS = 8_192;
+
+/**
  * NUT-29: Hard ceiling for batch-mint size, the maximum number of quote entries a wallet may
  * include in a single `prepareBatchMint` call. Values advertised by a mint above this cap are
  * clamped.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -763,7 +763,7 @@ class Wallet {
    */
   private receiveFeeAmounts(nOutputs: number, keyset: Keyset): Amount[] {
     // Bound the +1 convergence; any realistic keyset converges in a few dozen steps.
-    const maxIters = 1 << 12;
+    const maxIters = 4_096;
     let receiveFee = this.getFeesForKeyset(nOutputs, keyset.id);
     let receiveFeeAmounts = splitAmount(receiveFee, keyset.keys);
     let iters = 0;

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -106,6 +106,29 @@ describe('test split custom amounts ', () => {
   });
 });
 
+describe('splitAmount output bound', () => {
+  const onlyOnes: Keys = { 1: 'deadbeef' };
+
+  test('fills a small coarse split (no spread push)', () => {
+    const chunks = utils.splitAmount(100, onlyOnes);
+    expect(chunks).toHaveLength(100);
+    expect(chunks.every((a) => a.toNumber() === 1)).toBe(true);
+  });
+
+  test('rejects a coarse split that would exceed the output cap', () => {
+    // Only a 1-denomination keyset over a large value: previously built a huge array via a spread
+    // push (stack overflow / memory sink). Now bounded and rejected before allocating.
+    expect(() => utils.splitAmount(200000, onlyOnes)).toThrow(/would exceed .* outputs/);
+  });
+
+  test('allows exactly the cap and rejects one past it (inclusive boundary)', () => {
+    // 8_192 ones is exactly the cap: still built (proves the loop push holds at scale).
+    expect(utils.splitAmount(8_192, onlyOnes)).toHaveLength(8_192);
+    // One more output must be rejected, not allocated.
+    expect(() => utils.splitAmount(8_193, onlyOnes)).toThrow(/would exceed .* outputs/);
+  });
+});
+
 describe('test split different key amount', () => {
   test('testing amount 68251', async () => {
     const chunks = utils.splitAmount(68251, keys_base10, undefined, 'desc');


### PR DESCRIPTION
# Description
Backport of #859 to `v4-dev`.