### PR TITLE
fix(wallet): compute keyset fees with integer arithmetic

### DIFF
--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -207,11 +207,13 @@ export class Amount {
    *     amount.ceilPercent(1, 200); // ceil(0.5% of amount)
    *     amount.ceilPercent(15, 10); // ceil(1.5% of amount)
    *
-   * @throws If numerator or denominator are not positive integers.
+   * @throws If numerator is a negative or non-integer, or denominator is not a positive integer.
    */
   ceilPercent(numerator: number, denominator: number = 100): Amount {
-    if (!Number.isInteger(numerator) || numerator <= 0) {
-      throw new AmountError(`ceilPercent: numerator must be a positive integer, got ${numerator}`);
+    if (!Number.isInteger(numerator) || numerator < 0) {
+      throw new AmountError(
+        `ceilPercent: numerator must be a non-negative integer, got ${numerator}`,
+      );
     }
     if (!Number.isInteger(denominator) || denominator <= 0) {
       throw new AmountError(
@@ -235,11 +237,13 @@ export class Amount {
    *     amount.floorPercent(98); // floor(98% of amount)
    *     amount.floorPercent(1, 200); // floor(0.5% of amount)
    *
-   * @throws If numerator or denominator are not positive integers.
+   * @throws If numerator is a negative or non-integer, or denominator is not a positive integer.
    */
   floorPercent(numerator: number, denominator: number = 100): Amount {
-    if (!Number.isInteger(numerator) || numerator <= 0) {
-      throw new AmountError(`floorPercent: numerator must be a positive integer, got ${numerator}`);
+    if (!Number.isInteger(numerator) || numerator < 0) {
+      throw new AmountError(
+        `floorPercent: numerator must be a non-negative integer, got ${numerator}`,
+      );
     }
     if (!Number.isInteger(denominator) || denominator <= 0) {
       throw new AmountError(

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1580,15 +1580,18 @@ class Wallet {
    * @returns Fee amount.
    */
   getFeesForKeyset(nInputs: number, keysetId: string): Amount {
+    let feePPK: number;
     try {
       // We must NOT fallback to wallet's keyset
-      const feePPK = this._keyChain.getKeyset(keysetId).fee;
-      return Amount.from(Math.floor(Math.max((nInputs * feePPK + 999) / 1000, 0)));
+      feePPK = this._keyChain.getKeyset(keysetId).fee;
     } catch (e) {
       const message = `No keyset found with ID ${keysetId}`;
       this._logger.error(message, { e });
       throw new CTSError(message, { cause: e });
     }
+    // fee = ceil(nInputs * feePPK / 1000). ceilPercent keeps the product in bigint, so a large
+    // (ingest-bounded) fee cannot lose integer precision the way number math would.
+    return Amount.from(nInputs).ceilPercent(feePPK, 1000);
   }
 
   /**

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -114,8 +114,8 @@ describe('Amount.floorPercent', () => {
   it('returns zero for amounts smaller than the percentage unit', () => {
     expect(Amount.from(1).floorPercent(2).toBigInt()).toBe(0n);
   });
-  it('throws for non-positive numerator or denominator', () => {
-    expect(() => Amount.from(100).floorPercent(0)).toThrow('floorPercent');
+  it('returns zero for a zero numerator, throws for negative or zero denominator', () => {
+    expect(Amount.from(100).floorPercent(0).toBigInt()).toBe(0n);
     expect(() => Amount.from(100).floorPercent(2, 0)).toThrow('floorPercent');
     expect(() => Amount.from(100).floorPercent(-1)).toThrow('floorPercent');
   });
@@ -145,8 +145,8 @@ describe('Amount.ceilPercent', () => {
   it('returns at least 1 for any positive amount', () => {
     expect(Amount.from(1).ceilPercent(2).toBigInt()).toBe(1n);
   });
-  it('throws for non-positive numerator or denominator', () => {
-    expect(() => Amount.from(100).ceilPercent(0)).toThrow('ceilPercent');
+  it('returns zero for a zero numerator, throws for negative or zero denominator', () => {
+    expect(Amount.from(100).ceilPercent(0).toBigInt()).toBe(0n);
     expect(() => Amount.from(100).ceilPercent(2, 0)).toThrow('ceilPercent');
     expect(() => Amount.from(100).ceilPercent(-1)).toThrow('ceilPercent');
   });

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -126,6 +126,24 @@ describe('wallet.maxSpendableAfterFees', () => {
     }
   });
 
+  test('computes an exact integer fee for a huge input_fee_ppk', async () => {
+    // nInputs * feePPK + 999 lands past Number.MAX_SAFE_INTEGER; number math would round up 1 sat.
+    useKeysetWithFee(server, 9007199254740000);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // ceil(1 * 9007199254740000 / 1000) = 9007199254740, not ...741
+    expect(wallet.getFeesForKeyset(1, FULL_DENOM_ID).toBigInt()).toBe(9007199254740n);
+  });
+
+  test('returns a zero fee for a zero-fee keyset', async () => {
+    useKeysetWithFee(server, 0);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    expect(wallet.getFeesForKeyset(5, FULL_DENOM_ID).isZero()).toBe(true);
+  });
+
   test('throws with cause when a keyset fee lookup fails', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();


### PR DESCRIPTION
`getFeesForKeyset` computed the fee in JS `number` space (`Math.floor((nInputs * feePPK + 999) / 1000)`). For a large `input_fee_ppk` the `nInputs * feePPK + 999` intermediate crosses `Number.MAX_SAFE_INTEGER` and the result can be one off. It now uses `Amount.ceilPercent`, which keeps the product in bigint, so the fee is exact for any value the ingest bound admits.

Alongside, `ceilPercent`/`floorPercent` now accept a zero numerator (ceil/floor of 0% is 0), which the fee path needs for zero-fee keysets rather than special-casing them. Negative and non-integer numerators still throw.

## Testing

- Unit: zero-numerator now returns 0 for both helpers; negative/zero-denominator still throw.
- Wallet: a large `input_fee_ppk` yields the exact integer fee (the `number` path was off by one sat), and a zero-fee keyset returns zero.
- `npm run prtasks` green; no public API change.