### PR TITLE
fix(wallet): throw from sendOffline when no offline selection matches

### DIFF
--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -203,6 +203,34 @@ If your consumer was already wrapping the loop in `try/catch` (e.g. to handle ab
 
 ---
 
+## `sendOffline` throws when no offline selection matches
+
+`wallet.sendOffline` documents that it throws when the send cannot be completed offline, and already threw on insufficient funds and on selection timeout. But when funds were sufficient and no selection matched the requested amount (e.g. an exact-match `sendOffline(3, [2, 4])`), v4 returned an empty `send` instead. v5 throws in that case too, so every "cannot complete offline" outcome is a single failure mode.
+
+`send()` is unaffected: its offline attempt already wraps `sendOffline` in `try/catch` and falls back to an online swap.
+
+### Migration
+
+Wrap direct `sendOffline` calls in `try/catch`, or pass `exactMatch: false` to accept a close match:
+
+```ts
+// Before: empty send on no match
+const { send } = wallet.sendOffline(3, proofs);
+if (send.length === 0) {
+  // fall back to an online swap yourself
+}
+
+// After: throws on no match
+try {
+  const { send } = wallet.sendOffline(3, proofs);
+  // ...
+} catch {
+  // no exact offline match: swap online, or retry with { exactMatch: false }
+}
+```
+
+---
+
 ## `deriveSecret` and `deriveBlindingFactor` removed
 
 The single-value NUT-13 derivation helpers `deriveSecret` and `deriveBlindingFactor` are removed. Use `deriveSecretAndBlindingFactor`, which derives both values for a counter in one call (and, for legacy BIP-32 keysets, avoids repeating the shared path derivation).

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1105,7 +1105,7 @@ class Wallet {
    * @param proofs Array of proofs (must sum >= amount; pre-sign if P2PK-locked).
    * @param config Optional parameters for the send.
    * @returns SendResponse with keep/send proofs.
-   * @throws Throws if the send cannot be completed offline.
+   * @throws If funds are insufficient, or no offline selection matches the amount.
    */
   sendOffline(amount: AmountLike, proofs: ProofLike[], config?: SendOfflineConfig): SendResponse {
     const sendAmount = this.parseAmount(amount, 'sendOffline');
@@ -1128,6 +1128,12 @@ class Wallet {
       sendAmount,
       includeFees,
       exactMatch,
+    );
+    // No selection covers the amount: fail rather than return an empty send. send() catches this
+    // and falls back to a swap; direct callers get a clear failure instead of a silent no-op.
+    this.failIf(
+      !sendAmount.isZero() && send.length === 0,
+      'Send cannot be completed offline for the requested amount',
     );
     // Ensure witnesses are serialized, strip DLEQ if not required, keep p2pk_e
     const sendPrepared = this._prepareInputsForMint(send, requireDleq, true);

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -120,6 +120,19 @@ describe('sendOffline witness normalization', () => {
     expect(send[0].witness).toBeUndefined();
   });
 
+  test('throws when no offline selection matches, rather than returning an empty send', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // Enough funds (6 >= 3) but no exact subset of {2, 4} sums to 3.
+    const proofs: Proof[] = [
+      { id: '00bd033559de27d0', amount: Amount.from(2), secret: 's1', C: 'C1' },
+      { id: '00bd033559de27d0', amount: Amount.from(4), secret: 's2', C: 'C2' },
+    ];
+
+    expect(() => wallet.sendOffline(3, proofs)).toThrow(/cannot be completed offline/);
+  });
+
   test('preserves witness on NUT-10 unknown secret kind', async () => {
     const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();


### PR DESCRIPTION
`sendOffline` documents `@throws` if the send cannot be completed offline, and already throws on insufficient funds and on selection timeout. But when funds were sufficient and no selection matched the amount (e.g. exact-match `sendOffline(3, [2, 4])`), it returned an empty `send` instead. That left a direct caller having to both `try/catch` and check `send.length`.

It now throws consistently in that case, matching the documented contract and the `prepareSwapToSend`/`completeSwap` throw-on-failure convention. `send()`'s offline attempt already wraps `sendOffline` in `try/catch` and falls back to a swap, so the internal path is unchanged (verified: the fallback now catches the throw where it previously saw the empty return).

**Breaking vs v4** (v5 only, not backported): a direct caller that branched on an empty `send` will now get a throw. Such callers should wrap the call in `try/catch`, or use `exactMatch: false`.

## Testing

New unit test: sufficient funds but no exact subset now throws rather than returning an empty send. `npm run prtasks` green; no public API signature change.