### PR TITLE
docs(wallet): note sendOffline throws in v5 on no offline match

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1084,11 +1084,15 @@ class Wallet {
    * If proofs are P2PK-locked to your public key, call signP2PKProofs first to sign them. The
    * default config uses exact match selection, and does not includeFees or requireDleq. Because the
    * send is offline, the user will unlock the signed proofs when they receive them online.
+   *
+   * When no offline selection matches the amount, this returns an empty `send`. In v5 it throws
+   * instead; wrap calls in try/catch to stay forward-compatible.
    * @param amount Amount to send.
    * @param proofs Array of proofs (must sum >= amount; pre-sign if P2PK-locked).
    * @param config Optional parameters for the send.
-   * @returns SendResponse with keep/send proofs.
-   * @throws Throws if the send cannot be completed offline.
+   * @returns SendResponse with keep/send proofs (`send` is empty when no offline match; see
+   *   remarks).
+   * @throws If funds are insufficient or proof selection times out.
    */
   sendOffline(amount: AmountLike, proofs: ProofLike[], config?: SendOfflineConfig): SendResponse {
     const sendAmount = this.parseAmount(amount, 'sendOffline');


### PR DESCRIPTION
Doc-only, no behaviour change. The v4 `sendOffline` `@throws` line claimed it throws whenever the send can't complete offline, but when funds are sufficient and no selection matches the amount it returns an empty `send`. This corrects the tag to what v4 actually does (throws on insufficient funds or selection timeout) and adds a forward-compatibility note: v5 throws in the no-match case (#871), so callers should wrap `sendOffline` in try/catch.

No API signature change; `npm run prtasks` green.