### PR TITLE
test(crypto): refresh amended mint-quote vector to a uuid-v7 quote id

### DIFF
--- a/test/crypto/NUT20.test.ts
+++ b/test/crypto/NUT20.test.ts
@@ -15,6 +15,7 @@ describe('mint quote signatures (amended message)', () => {
   const pubkey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
   const privkey = '0000000000000000000000000000000000000000000000000000000000000001';
   const keysetId = '010000000000000000000000000000000000000000000000000000000000000000';
+  const quote = '019e6d5a-2347-7000-8c81-a1e0dbf3299f';
 
   const allOutputs = [
     {
@@ -31,52 +32,50 @@ describe('mint quote signatures (amended message)', () => {
 
   // Canonical results from the spec test vector.
   const expectedMsgToSign =
-    '43617368755f4d696e7451756f74655369675f76310000000c6c6f636b65642d71756f7465' +
+    '43617368755f4d696e7451756f74655369675f76310000002430313965366435612d323334372d373030302d386338312d613165306462663332393966' +
     '000000010100000021036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2' +
     '000000010100000021021f8a566c205633d029094747d2e18f44e05993dda7a5f88f496078205f656e59';
-  const expectedMsgHash = '03dc68d6617bba502d8648efd0965bf393841082cf04fd03e5de4bcb5777cdfc';
+  const expectedMsgHash = 'dad25acc587637206d73398894d337f983a0ca644746e8673727eaa0b29fa9b4';
   const expectedSignature =
-    'a913e48177027d87e0e38c6f2021763c46997ff4866a4b63ebca800b0776b28519eab37377cf9bc1869e489d7b25747b7a998eaa1c33c2cac7fa168449d8267a';
+    '0c39431338a0202568b9a1d4215c99f179cbb8ee5472ac5ae7133fbb8f99cafbb9e425ad33c60224c96b8f9f984f004379a18e9558468d129b6b03f0da6de162';
 
   test('canonical msg_to_sign hashes to the test vector', () => {
     expect(bytesToHex(sha256(hexToBytes(expectedMsgToSign)))).toBe(expectedMsgHash);
   });
 
   test('test vector signature verifies correctly', () => {
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', allOutputs, expectedSignature)).toBe(
-      true,
-    );
+    expect(verifyMintQuoteSignature(pubkey, quote, allOutputs, expectedSignature)).toBe(true);
   });
 
   test('signMintQuote over all outputs produces a valid signature', () => {
-    const signature = signMintQuote(privkey, 'locked-quote', allOutputs);
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', allOutputs, signature)).toBe(true);
+    const signature = signMintQuote(privkey, quote, allOutputs);
+    expect(verifyMintQuoteSignature(pubkey, quote, allOutputs, signature)).toBe(true);
   });
 
   test('signature over per-quote subset is invalid against full output set', () => {
-    const perQuoteSig = signMintQuote(privkey, 'locked-quote', [allOutputs[0]]);
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', allOutputs, perQuoteSig)).toBe(false);
+    const perQuoteSig = signMintQuote(privkey, quote, [allOutputs[0]]);
+    expect(verifyMintQuoteSignature(pubkey, quote, allOutputs, perQuoteSig)).toBe(false);
   });
 
   test('signature is bound to output amounts', () => {
-    const signature = signMintQuote(privkey, 'locked-quote', allOutputs);
+    const signature = signMintQuote(privkey, quote, allOutputs);
     const reValued = [{ ...allOutputs[0], amount: Amount.from(2) }, allOutputs[1]];
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', reValued, signature)).toBe(false);
+    expect(verifyMintQuoteSignature(pubkey, quote, reValued, signature)).toBe(false);
   });
 
   test('normalizes a raw JSON number amount (Amount instances pass through)', () => {
     // A server may pass outputs straight from JSON.parse, where amount is a primitive number.
     const numberOutputs = allOutputs.map((o) => ({ ...o, amount: o.amount.toNumber() }));
     const cast = numberOutputs as unknown as typeof allOutputs;
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', cast, expectedSignature)).toBe(true);
-    const sig = signMintQuote(privkey, 'locked-quote', cast);
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', allOutputs, sig)).toBe(true);
+    expect(verifyMintQuoteSignature(pubkey, quote, cast, expectedSignature)).toBe(true);
+    const sig = signMintQuote(privkey, quote, cast);
+    expect(verifyMintQuoteSignature(pubkey, quote, allOutputs, sig)).toBe(true);
   });
 
   test('signature is bound to output order', () => {
-    const signature = signMintQuote(privkey, 'locked-quote', allOutputs);
+    const signature = signMintQuote(privkey, quote, allOutputs);
     const reordered = [allOutputs[1], allOutputs[0]];
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', reordered, signature)).toBe(false);
+    expect(verifyMintQuoteSignature(pubkey, quote, reordered, signature)).toBe(false);
   });
 
   test('encodes amounts canonically (0 -> empty, even-length hex unpadded)', () => {
@@ -84,20 +83,16 @@ describe('mint quote signatures (amended message)', () => {
       { ...allOutputs[0], amount: Amount.from(0) },
       { ...allOutputs[1], amount: Amount.from(16) },
     ];
-    const signature = signMintQuote(privkey, 'locked-quote', outputs);
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', outputs, signature)).toBe(true);
-    expect(verifyMintQuoteSignature(pubkey, 'locked-quote', allOutputs, signature)).toBe(false);
+    const signature = signMintQuote(privkey, quote, outputs);
+    expect(verifyMintQuoteSignature(pubkey, quote, outputs, signature)).toBe(true);
+    expect(verifyMintQuoteSignature(pubkey, quote, allOutputs, signature)).toBe(false);
   });
 
   test('rejects pubkeys that are not 33-byte compressed', () => {
     const xOnly = pubkey.slice(2);
-    expect(verifyMintQuoteSignature(xOnly, 'locked-quote', allOutputs, expectedSignature)).toBe(
-      false,
-    );
-    const legacySig = signMintQuoteLegacy(privkey, 'locked-quote', allOutputs);
-    expect(verifyMintQuoteSignatureLegacy(xOnly, 'locked-quote', allOutputs, legacySig)).toBe(
-      false,
-    );
+    expect(verifyMintQuoteSignature(xOnly, quote, allOutputs, expectedSignature)).toBe(false);
+    const legacySig = signMintQuoteLegacy(privkey, quote, allOutputs);
+    expect(verifyMintQuoteSignatureLegacy(xOnly, quote, allOutputs, legacySig)).toBe(false);
   });
 
   test('each quote in a batch signs over the same output set, bound to its quote ID', () => {


### PR DESCRIPTION
# NUT
- https://github.com/cashubtc/nuts/pull/401

The canonical NUT-29 batch-mint signature vector in `nuts/tests/29-tests.md` was updated to use a realistic uuid-v7 quote id (`019e6d5a-...`) in place of the `locked-quote` placeholder, with a correspondingly new `msg_to_sign`, `msg_hash`, and `signature`.

This updates the mirrored vector in `NUT20.test.ts` (the amended-message block, shared by NUT-20 single and NUT-29 batch minting) to match, and hoists the quote id to a `const` so the calls stay on one line. The signing construction is unchanged: I confirmed CTS already verifies the new signature and that the vector is internally consistent (`msg_to_sign` hashes to `msg_hash`) before pinning it.

Test-only; `npm run prtasks` green.