### PR TITLE
fix(crypto): bound untrusted P2PK witness and CBOR decode input

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -30,6 +30,14 @@ export const SigFlags = {
 export type SigFlag = (typeof SigFlags)[keyof typeof SigFlags];
 const VALID_SIG_FLAGS: ReadonlySet<SigFlag> = new Set(Object.values(SigFlags));
 
+// Upper bounds on untrusted P2PK/HTLC secret and witness sizes, applied on the verify/sign path so
+// per-key and per-signature work stays bounded rather than scaling with input. NUT-28 caps a lock
+// at 11 slots (data + pubkeys + refund); SIG_ALL adds a signature per message variant per signer,
+// so signatures need more headroom than keys. These are work bounds, not the exact NUT-28 rule
+// (still enforced at build).
+const MAX_P2PK_PUBKEYS = 16;
+const MAX_P2PK_SIGNATURES = 64;
+
 export type LockState = 'PERMANENT' | 'ACTIVE' | 'EXPIRED';
 
 export type P2PKSpendingPath = 'MAIN' | 'REFUND' | 'UNLOCKED' | 'FAILED';
@@ -437,7 +445,11 @@ export function getP2PKSigFlag(secretStr: string | Secret): SigFlag {
  * @returns Array of witness signatures.
  */
 export function getP2PKWitnessSignatures(witness: Proof['witness']): string[] {
-  return parseWitnessData(witness)?.signatures ?? [];
+  const signatures = parseWitnessData(witness)?.signatures ?? [];
+  if (signatures.length > MAX_P2PK_SIGNATURES) {
+    throw new CTSError(`Too many witness signatures: ${signatures.length}`);
+  }
+  return signatures;
 }
 
 /**
@@ -460,8 +472,8 @@ export function parseWitnessData(witness: Proof['witness']): WitnessData | undef
     return undefined;
   }
   const data: WitnessData = {
-    // always normalize signatures to an array
-    signatures: parsed.signatures ?? [],
+    // always normalize signatures to an array (untrusted witness may carry a non-array value)
+    signatures: Array.isArray(parsed.signatures) ? parsed.signatures : [],
   };
 
   // Only set preimage if it is a non empty string
@@ -901,6 +913,10 @@ function assertSpendingConditionRules(params: {
 function getP2PKWitnessPubkeys(secret: Secret): string[] {
   const data = getSecretKind(secret) === 'P2PK' ? getDataField(secret) : '';
   const pubkeys = getTag(secret, 'pubkeys') ?? [];
+  // Bound EC decompression before mapping over untrusted keys.
+  if (pubkeys.length > MAX_P2PK_PUBKEYS) {
+    throw new CTSError(`Too many pubkeys: ${pubkeys.length}`);
+  }
   const keys = (data ? [data, ...pubkeys] : pubkeys).map((key) => normalizeSecpPubkey(key));
   if (dedupeP2PKPubkeys(keys).length !== keys.length) {
     throw new CTSError('Duplicate main pubkeys are not allowed');
@@ -909,7 +925,11 @@ function getP2PKWitnessPubkeys(secret: Secret): string[] {
 }
 
 function getP2PKWitnessRefundkeys(secret: Secret): string[] {
-  const keys = (getTag(secret, 'refund') ?? []).map((key) => normalizeSecpPubkey(key));
+  const refund = getTag(secret, 'refund') ?? [];
+  if (refund.length > MAX_P2PK_PUBKEYS) {
+    throw new CTSError(`Too many refund pubkeys: ${refund.length}`);
+  }
+  const keys = refund.map((key) => normalizeSecpPubkey(key));
   if (dedupeP2PKPubkeys(keys).length !== keys.length) {
     throw new CTSError('Duplicate refund pubkeys are not allowed');
   }

--- a/src/utils/cbor.ts
+++ b/src/utils/cbor.ts
@@ -314,7 +314,14 @@ export function decodeCBOR(data: Uint8Array): ResultValue {
   return result.value;
 }
 
-function decodeItem(view: DataView, offset: number): DecodeResult<ResultValue> {
+// Bound decode recursion so a deeply nested (hostile) payload fails with a CTSError instead of
+// overflowing the stack. Real tokens and payment requests nest only a few levels.
+const MAX_CBOR_DEPTH = 64;
+
+function decodeItem(view: DataView, offset: number, depth = 0): DecodeResult<ResultValue> {
+  if (depth > MAX_CBOR_DEPTH) {
+    throw new CTSError('CBOR nesting exceeds the maximum depth');
+  }
   if (offset >= view.byteLength) {
     throw new CTSError('Unexpected end of data');
   }
@@ -332,9 +339,9 @@ function decodeItem(view: DataView, offset: number): DecodeResult<ResultValue> {
     case 3:
       return decodeString(view, offset, additionalInfo);
     case 4:
-      return decodeArray(view, offset, additionalInfo);
+      return decodeArray(view, offset, additionalInfo, depth);
     case 5:
-      return decodeMap(view, offset, additionalInfo);
+      return decodeMap(view, offset, additionalInfo, depth);
     case 7:
       return decodeSimpleAndFloat(view, offset, additionalInfo);
     default:
@@ -442,13 +449,14 @@ function decodeArray(
   view: DataView,
   offset: number,
   additionalInfo: number,
+  depth: number,
 ): DecodeResult<ResultValue[]> {
   const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
   const len = Number(length);
   const array = [];
   let currentOffset = newOffset;
   for (let i = 0; i < len; i++) {
-    const result = decodeItem(view, currentOffset);
+    const result = decodeItem(view, currentOffset, depth + 1);
     array.push(result.value);
     currentOffset = result.offset;
   }
@@ -459,17 +467,18 @@ function decodeMap(
   view: DataView,
   offset: number,
   additionalInfo: number,
+  depth: number,
 ): DecodeResult<Record<string, ResultValue>> {
   const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
   const len = Number(length);
   const map: { [key: string]: ResultValue } = {};
   let currentOffset = newOffset;
   for (let i = 0; i < len; i++) {
-    const keyResult = decodeItem(view, currentOffset);
+    const keyResult = decodeItem(view, currentOffset, depth + 1);
     if (!isResultKeyType(keyResult.value)) {
       throw new CTSError('Invalid key type');
     }
-    const valueResult = decodeItem(view, keyResult.offset);
+    const valueResult = decodeItem(view, keyResult.offset, depth + 1);
     map[String(keyResult.value)] = valueResult.value;
     currentOffset = valueResult.offset;
   }

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -68,6 +68,54 @@ describe('test create p2pk secret', () => {
     expect(verify).toBe(true);
   });
 
+  test('non-array witness signatures verify as false, not a thrown TypeError', () => {
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}"}]`,
+      witness: JSON.stringify({ signatures: 'not-an-array' }),
+    };
+    expect(isP2PKSpendAuthorised(proof)).toBe(false);
+  });
+
+  test('accepts a SIG_ALL-sized witness (multiple signatures per signer)', () => {
+    // SIG_ALL signs each message variant per signer, so a legitimate witness carries well over
+    // the 11-slot lock size; the cap must not reject it.
+    const sigAll = JSON.stringify({
+      signatures: Array.from({ length: 33 }, () => 'ab'.repeat(64)),
+    });
+    expect(getP2PKWitnessSignatures(sigAll)).toHaveLength(33);
+  });
+
+  test('a witness with too many signatures is rejected with a CTSError', () => {
+    const many = JSON.stringify({ signatures: Array.from({ length: 65 }, () => 'ab'.repeat(64)) });
+    expect(() => getP2PKWitnessSignatures(many)).toThrow(/Too many witness signatures/);
+  });
+
+  test('a secret with too many pubkeys is rejected before per-key work', () => {
+    const tag = Array.from({ length: 65 }, () => `"${PUBKEY}"`).join(',');
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}","tags":[["pubkeys",${tag}]]}]`,
+    };
+    expect(() => verifyP2PKSpendingConditions(proof)).toThrow(/Too many pubkeys/);
+  });
+
+  test('a secret with too many refund pubkeys is rejected before per-key work', () => {
+    const tag = Array.from({ length: 65 }, () => `"${PUBKEY}"`).join(',');
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      // A normal main key passes its cap; the oversized refund tag trips the refund cap.
+      secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}","tags":[["refund",${tag}]]}]`,
+    };
+    expect(() => verifyP2PKSpendingConditions(proof)).toThrow(/Too many refund pubkeys/);
+  });
+
   test('sign and verify proofs', async () => {
     const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${PUBKEY}"}]`;
     const proof1: Proof = {

--- a/test/utils/cbor.test.ts
+++ b/test/utils/cbor.test.ts
@@ -89,6 +89,16 @@ describe('cbor decoder', () => {
     expect(v).toBe(0x10);
   });
 
+  test('deeply nested input fails with a CTSError, not a stack overflow', () => {
+    // 0x81 = "array of length 1"; nesting it far past the depth cap must throw a CTSError
+    // rather than a RangeError that a decode-on-paste consumer would not catch.
+    const depth = 60000;
+    const buf = new Uint8Array(depth + 1);
+    buf.fill(0x81, 0, depth);
+    buf[depth] = 0x00;
+    expect(() => decodeCBOR(buf)).toThrow(/nesting exceeds the maximum depth/);
+  });
+
   test('decode float16 (0xf9) and float32 (0xfa) paths', () => {
     // float16 0x3c00 -> 1.0
     const f16 = new Uint8Array([0xf9, 0x3c, 0x00]);


### PR DESCRIPTION
Bounds a few untrusted inputs on the P2PK/HTLC and CBOR paths so work stays proportional to a sane maximum rather than to input size:

- Cap pubkey and signature counts on the P2PK/HTLC verify, sign, and P2BK-derive paths (the two key extractors are the shared chokepoint). Signatures get more headroom than keys because SIG_ALL carries a signature per message variant per signer.
- Treat a non-array witness `signatures` value as an empty array.
- Bound CBOR decode recursion to a fixed depth, returning a `CTSError` for input nested beyond it.

## Testing

Unit: over-cap pubkeys/signatures throw a CTSError, a SIG_ALL-sized (33-signature) witness is accepted, a non-array `signatures` verifies as false, and deeply nested CBOR throws a CTSError instead of overflowing. `npm run prtasks` green; no public API signature change.