### PR TITLE
fix(wallet): verify the lock pubkey on generic mint quotes

### DIFF
--- a/src/crypto/curve_secp.ts
+++ b/src/crypto/curve_secp.ts
@@ -54,12 +54,15 @@ const VALIDATED_PUBKEYS = new Set<string>();
  * @throws {@link CTSError} If not 66-char 02/03 hex, or not a valid secp256k1 point.
  */
 export function normalizeSecpPubkey(pk: string): string {
-  const hex = pk.toLowerCase();
-  if (hex.length !== 66 || !(hex.startsWith('02') || hex.startsWith('03'))) {
+  // Check type, length, and prefix before lowercasing: a non-string or oversized input is rejected
+  // as a CTSError (per this function's contract), not a raw TypeError, and without a full copy/scan.
+  if (typeof pk !== 'string' || pk.length !== 66 || !(pk.startsWith('02') || pk.startsWith('03'))) {
+    const got = typeof pk === 'string' ? `length ${pk.length}` : typeof pk;
     throw new CTSError(
-      `Invalid pubkey: expected 33-byte compressed hex (66 chars); for an x-only (nostr) key, prepend '02', got length ${hex.length}`,
+      `Invalid pubkey: expected 33-byte compressed hex (66 chars); for an x-only (nostr) key, prepend '02', got ${got}`,
     );
   }
+  const hex = pk.toLowerCase();
   if (!VALIDATED_PUBKEYS.has(hex)) {
     try {
       pointFromHex(hex);

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1868,9 +1868,7 @@ class Wallet {
     // Custom methods are fine, but NUT-04 requires the mint to advertise them
     this.requireSupport('mint', method);
     this.requireMintableKeyset('createMintQuote');
-    // When the caller locks the quote (NUT-20), validate and normalize the pubkey like the typed
-    // helpers, send the normalized key, and echo-check the response so a mint that drops or
-    // substitutes the lock is caught before the caller pays.
+    // When the caller locks the quote (NUT-20), validate and normalize the pubkey.
     const rawPubkey = payload.pubkey;
     const normPubkey =
       typeof rawPubkey === 'string' && rawPubkey.length > 0

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1868,10 +1868,25 @@ class Wallet {
     // Custom methods are fine, but NUT-04 requires the mint to advertise them
     this.requireSupport('mint', method);
     this.requireMintableKeyset('createMintQuote');
-    const body = { ...payload, unit: this._unit };
+    // When the caller locks the quote (NUT-20), validate and normalize the pubkey like the typed
+    // helpers, send the normalized key, and echo-check the response so a mint that drops or
+    // substitutes the lock is caught before the caller pays.
+    const rawPubkey = payload.pubkey;
+    const normPubkey =
+      typeof rawPubkey === 'string' && rawPubkey.length > 0
+        ? normalizeSecpPubkey(rawPubkey)
+        : undefined;
+    const body = { ...payload, unit: this._unit, ...(normPubkey ? { pubkey: normPubkey } : {}) };
     const res = await this.mint.createMintQuote<TRes>(method, body, {
       normalize: options?.normalize,
     });
+    if (normPubkey) {
+      this.failIf(typeof res.pubkey !== 'string', 'Mint returned unlocked mint quote');
+      this.failIf(
+        res.pubkey!.toLowerCase() !== normPubkey,
+        'Mint quote is not locked to the requested pubkey',
+      );
+    }
     return { ...res, unit: res.unit || this._unit };
   }
 

--- a/test/crypto/curve_secp.test.ts
+++ b/test/crypto/curve_secp.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 
 import { normalizeSecpPubkey, isValidSecpPubkey } from '../../src';
 
@@ -19,6 +19,28 @@ describe('normalizeSecpPubkey', () => {
 
   test('rejects a well-formed hex value that is not on the curve', () => {
     expect(() => normalizeSecpPubkey('02' + 'f'.repeat(64))).toThrow(/not a valid secp256k1 point/);
+  });
+
+  test('rejects a non-string input as a CTSError, not a TypeError', () => {
+    for (const bad of [null, undefined, 123, {}, []]) {
+      expect(() => normalizeSecpPubkey(bad as string)).toThrow(/Invalid pubkey/);
+    }
+    expect(isValidSecpPubkey(null as unknown as string)).toBe(false);
+  });
+
+  test('rejects an oversized input on length, before lowercasing the whole string', () => {
+    const big = 'a'.repeat(1_000_000);
+    const spy = vi.spyOn(String.prototype, 'toLowerCase');
+    let threw = false;
+    try {
+      normalizeSecpPubkey(big);
+    } catch {
+      threw = true;
+    }
+    const lowercased = spy.mock.calls.length;
+    spy.mockRestore();
+    expect(threw).toBe(true);
+    expect(lowercased).toBe(0);
   });
 });
 

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -1085,6 +1085,64 @@ describe('generic mint/melt methods', () => {
       expect(quote.unit).toBe('sat');
     });
 
+    test('createMintQuote rejects a locked quote the mint echoes with the wrong pubkey', async () => {
+      const lockPubkey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+      server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
+        http.post(mintUrl + '/v1/mint/quote/bacs', () =>
+          HttpResponse.json({
+            quote: 'bacs-locked',
+            request: 'CASHU-REF',
+            unit: 'sat',
+            pubkey: '02dcba', // not the requested key
+            amount_paid: 0,
+            amount_issued: 0,
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit: 'sat' });
+      await wallet.loadMint();
+
+      await expect(
+        wallet.createMintQuote('bacs', { amount: 5000n, pubkey: lockPubkey }),
+      ).rejects.toThrow('Mint quote is not locked to the requested pubkey');
+    });
+
+    test('createMintQuote accepts a locked quote the mint echoes correctly', async () => {
+      const lockPubkey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+      server.use(
+        http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)),
+        http.post(mintUrl + '/v1/mint/quote/bacs', () =>
+          HttpResponse.json({
+            quote: 'bacs-locked-ok',
+            request: 'CASHU-REF',
+            unit: 'sat',
+            pubkey: lockPubkey,
+            amount_paid: 0,
+            amount_issued: 0,
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit: 'sat' });
+      await wallet.loadMint();
+
+      const quote = await wallet.createMintQuote('bacs', { amount: 5000n, pubkey: lockPubkey });
+      expect(quote.pubkey).toBe(lockPubkey);
+      expect(quote.quote).toBe('bacs-locked-ok');
+    });
+
+    test('createMintQuote rejects a malformed lock pubkey (x-only) before requesting', async () => {
+      server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithBacs)));
+      const wallet = new Wallet(mint, { unit: 'sat' });
+      await wallet.loadMint();
+
+      // 64-char x-only key: v5 requires 33-byte compressed, so normalization rejects it up front.
+      const xOnly = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+      await expect(
+        wallet.createMintQuote('bacs', { amount: 5000n, pubkey: xOnly }),
+      ).rejects.toThrow('Invalid pubkey');
+    });
+
     test('createMintQuote for bolt11 delegates correctly', async () => {
       server.use(
         http.post(mintUrl + '/v1/mint/quote/bolt11', () =>


### PR DESCRIPTION
The generic `createMintQuote` now validates and normalizes a caller-supplied pubkey via `normalizeSecpPubkey` and echo-checks it against the mint response, matching the typed helpers (`createLockedMintQuote`, bolt12, onchain). A malformed key is rejected up front, and a quote returned unlocked or locked to a different key is rejected before the caller acts on it. Previously the generic path passed the response straight through with no such check.

## Testing

Unit: a mismatched echoed pubkey rejects, a matching one passes, and an x-only key is rejected before any request. `npm run prtasks` green; no public API signature change.