### PR TITLE
fix(crypto): harden P2PK witness edge cases

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -471,6 +471,8 @@ export function parseWitnessData(witness: Proof['witness']): WitnessData | undef
     console.error('Failed to parse witness string:', e);
     return undefined;
   }
+  // A parsed primitive (eg "null", "1", "true") is not a witness; treat it as absent.
+  if (!parsed || typeof parsed !== 'object') return undefined;
   const data: WitnessData = {
     // always normalize signatures to an array (untrusted witness may carry a non-array value)
     signatures: Array.isArray(parsed.signatures) ? parsed.signatures : [],
@@ -558,6 +560,14 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
 
   if (alreadySigned) {
     throw new CTSError(`Proof already signed by [02|03]${pubkey}`);
+  }
+
+  // Appending must not push the witness past the cap the verify path enforces,
+  // else we'd hand back a proof getP2PKWitnessSignatures then rejects.
+  if (signatures.length >= MAX_P2PK_SIGNATURES) {
+    throw new CTSError(
+      `Cannot sign: witness already at the ${MAX_P2PK_SIGNATURES}-signature limit`,
+    );
   }
 
   // Add new signature

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -79,6 +79,19 @@ describe('test create p2pk secret', () => {
     expect(isP2PKSpendAuthorised(proof)).toBe(false);
   });
 
+  test('a JSON-primitive witness (eg "null") verifies as false, not a thrown TypeError', () => {
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}"}]`,
+      witness: 'null', // JSON.parse("null") === null, not an object
+    };
+    expect(isP2PKSpendAuthorised(proof)).toBe(false);
+    expect(parseWitnessData('null')).toBeUndefined();
+    expect(parseWitnessData('1')).toBeUndefined();
+  });
+
   test('accepts a SIG_ALL-sized witness (multiple signatures per signer)', () => {
     // SIG_ALL signs each message variant per signer, so a legitimate witness carries well over
     // the 11-slot lock size; the cap must not reject it.
@@ -91,6 +104,22 @@ describe('test create p2pk secret', () => {
   test('a witness with too many signatures is rejected with a CTSError', () => {
     const many = JSON.stringify({ signatures: Array.from({ length: 65 }, () => 'ab'.repeat(64)) });
     expect(() => getP2PKWitnessSignatures(many)).toThrow(/Too many witness signatures/);
+  });
+
+  test('signing a witness already at the cap throws instead of producing an over-cap proof', () => {
+    // A hostile proof arrives locked to our key with the maximum witness signatures already set.
+    // Appending our signature would make the verify path reject the proof we just produced.
+    const witness = JSON.stringify({
+      signatures: Array.from({ length: 64 }, () => 'ab'.repeat(64)),
+    });
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}"}]`,
+      witness,
+    };
+    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY))).toThrow(/signature limit/);
   });
 
   test('a secret with too many pubkeys is rejected before per-key work', () => {


### PR DESCRIPTION
Follows up #874 with two edge-case behaviours on the P2PK witness path:

- `parseWitnessData` treats a JSON-primitive witness (eg `"null"`) as
  absent instead of throwing a `TypeError` when reading its fields.
- `signP2PKProof` refuses to append a signature to a witness already at
  the signature limit, so signing cannot produce a proof the verify path
  then rejects.

## Testing

Regression tests beside the #874 witness bound tests: a `"null"` witness
verifies as false, and signing an at-cap witness throws a `CTSError`.
`npm run prtasks` green; no public API change.