### PR TITLE
fix(wallet): tidy diagnostic log output

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -314,9 +314,7 @@ export class AuthManager implements AuthProvider {
       const exp = typeof obj.exp === 'number' ? obj.exp : Number(obj.exp);
       if (Number.isFinite(exp) && exp > 0) return exp;
     } catch {
-      this.logger.warn('JWT access token was malformed.', {
-        token,
-      });
+      this.logger.warn('JWT access token was malformed.');
     }
     return;
   }

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -350,7 +350,7 @@ export class OIDCAuth {
     formBody: string,
   ): Promise<TSuccess> {
     try {
-      this.logger.debug('OIDCAuth Request', { formBody });
+      this.logger.debug('OIDCAuth Request', { endpoint });
       const res = await this.fetch(endpoint, {
         method: 'POST',
         headers: {
@@ -373,7 +373,7 @@ export class OIDCAuth {
         const msg = err.error_description || err.error || `HTTP ${res.status}`;
         throw new CTSError(`OIDCAuth: ${msg}`, { cause: parseError });
       }
-      this.logger.debug('OIDCAuth Response', { json });
+      this.logger.debug('OIDCAuth Response', { status: res.status });
       return (json ?? {}) as TSuccess;
     } catch (err) {
       this.logger.error('OIDCAuth: postFormStrict failed', { err });
@@ -387,7 +387,7 @@ export class OIDCAuth {
     formBody: string,
   ): Promise<T | TokenResponse> {
     try {
-      this.logger.debug('OIDCAuth Request', { formBody });
+      this.logger.debug('OIDCAuth Request', { endpoint });
       const res = await this.fetch(endpoint, {
         method: 'POST',
         headers: {
@@ -403,7 +403,7 @@ export class OIDCAuth {
       } catch (err) {
         this.logger.warn('OIDCAuth: bad JSON (loose)', { err });
       }
-      this.logger.debug('OIDCAuth Response', { json });
+      this.logger.debug('OIDCAuth Response', { status: res.status });
       return json ?? {};
     } catch (err) {
       this.logger.error('OIDCAuth: postFormLoose network error', { err });

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3214,15 +3214,11 @@ class Wallet {
     // Create any change Proofs
     const change = this.createMeltChangeProofs(meltPreview.outputData, meltResponse.change ?? []);
 
+    const changeAmounts = change.map((p) => p.amount.toString());
     if (completeOptions.preferAsync) {
-      this._logger.debug('ASYNC MELT REQUESTED', {
-        state: meltResponse.state,
-        changeAmounts: change.map((p) => p.amount.toString()),
-      });
+      this._logger.debug('ASYNC MELT REQUESTED', { state: meltResponse.state, changeAmounts });
     } else {
-      this._logger.debug('MELT COMPLETED', {
-        changeAmounts: change.map((p) => p.amount.toString()),
-      });
+      this._logger.debug('MELT COMPLETED', { changeAmounts });
     }
 
     // Merge preview quote with response to protect against incomplete response.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2208,7 +2208,7 @@ class Wallet {
     const availableAmount = amountPaid.subtract(amountIssued);
     this.failIf(
       requestedAmount.greaterThan(availableAmount),
-      `Mint quote ${quote.quote} has only ${availableAmount.toString()} available to mint; requested ${requestedAmount.toString()}`,
+      `Mint quote has only ${availableAmount.toString()} available to mint; requested ${requestedAmount.toString()}`,
       {
         method,
         amount_paid: amountPaid.toString(),
@@ -2231,7 +2231,7 @@ class Wallet {
         typeof quote.expiry === 'number' &&
         quote.expiry > 0 && // some mints (e.g. CDK) emit 0 for "no expiry"; spec says null
         quote.expiry < Math.floor(Date.now() / 1000),
-      `Mint quote ${quote.quote} has expired`,
+      `Mint quote has expired`,
     );
   }
 
@@ -2445,7 +2445,7 @@ class Wallet {
       const quotePubkey = 'pubkey' in quote ? (quote.pubkey as string | undefined) : undefined;
       this.failIf(
         !quotePubkey && Array.isArray(privkey),
-        `prepareMint: multiple privkeys supplied for quote '${quote.quote}' without pubkey`,
+        `prepareMint: multiple privkeys supplied for a quote without pubkey`,
       );
       const signingKey = quotePubkey
         ? findSigningKey(quotePubkey, privkey)
@@ -2633,7 +2633,7 @@ class Wallet {
     const signatures: Array<string | null> = [];
     const legacySignatures: Array<string | null> = []; // Temporary legacy message support
     let hasSignatures = false;
-    for (const entry of entries) {
+    for (const [i, entry] of entries.entries()) {
       const quotePubkey = 'pubkey' in entry.quote ? entry.quote.pubkey : undefined;
       if (quotePubkey && privkey) {
         const signingKey = findSigningKey(quotePubkey, privkey);
@@ -2643,7 +2643,7 @@ class Wallet {
       } else {
         if (privkey && !quotePubkey) {
           this._logger.warn(
-            `prepareBatchMint: privkey supplied but quote '${entry.quote.quote}' has no pubkey — treating as unlocked`,
+            `prepareBatchMint: privkey supplied but quote #${i + 1} has no pubkey; treating as unlocked`,
           );
         }
         signatures.push(null);
@@ -3215,7 +3215,10 @@ class Wallet {
     const change = this.createMeltChangeProofs(meltPreview.outputData, meltResponse.change ?? []);
 
     if (completeOptions.preferAsync) {
-      this._logger.debug('ASYNC MELT REQUESTED', meltResponse);
+      this._logger.debug('ASYNC MELT REQUESTED', {
+        state: meltResponse.state,
+        changeAmounts: change.map((p) => p.amount.toString()),
+      });
     } else {
       this._logger.debug('MELT COMPLETED', {
         changeAmounts: change.map((p) => p.amount.toString()),

--- a/test/auth/OIDCAuth.node.test.ts
+++ b/test/auth/OIDCAuth.node.test.ts
@@ -641,7 +641,7 @@ describe('OIDCAuth: postFormLoose minimal success', () => {
     await o.loadConfig();
     const res = await o['postFormLoose'](TOKEN, 'grant_type=x');
     expect(res).toEqual({ ok: true });
-    expect(logger.debug).toHaveBeenCalledWith('OIDCAuth Response', { json: { ok: true } });
+    expect(logger.debug).toHaveBeenCalledWith('OIDCAuth Response', { status: 200 });
   });
 });
 

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -536,7 +536,7 @@ describe('requestTokens', () => {
       wallet.prepareMint('bolt11', 1, quote, {
         privkey: [pk1, pk2],
       }),
-    ).rejects.toThrow('multiple privkeys supplied for quote');
+    ).rejects.toThrow('multiple privkeys supplied for a quote without pubkey');
   });
 
   test('prepareBatchMint fails when no privkey matches locked quote pubkey', async () => {
@@ -1606,7 +1606,7 @@ describe('generic mint/melt methods', () => {
         wallet.prepareMint('bolt12', 3, quote, {
           privkey: '01'.repeat(32),
         }),
-      ).rejects.toThrow('Mint quote bolt12-partial has only 2 available to mint; requested 3');
+      ).rejects.toThrow('Mint quote has only 2 available to mint; requested 3');
     });
 
     test('prepareMint rejects amounts above paid minus issued for custom methods', async () => {
@@ -1621,7 +1621,7 @@ describe('generic mint/melt methods', () => {
           amount_paid: Amount.from(5),
           amount_issued: Amount.from(3),
         }),
-      ).rejects.toThrow('Mint quote bacs-partial has only 2 available to mint; requested 3');
+      ).rejects.toThrow('Mint quote has only 2 available to mint; requested 3');
     });
 
     test('prepareMint defers to the mint when the quote reports no payment activity', async () => {
@@ -1674,7 +1674,7 @@ describe('generic mint/melt methods', () => {
       };
 
       await expect(wallet.mintProofsOnchain(3, quote, '01'.repeat(32))).rejects.toThrow(
-        'Mint quote onchain-partial has only 2 available to mint; requested 3',
+        'Mint quote has only 2 available to mint; requested 3',
       );
     });
 

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -416,7 +416,7 @@ describe('validateMintQuote mutants', () => {
     const nowSec = Math.floor(Date.now() / 1000);
 
     expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec - 100 })).toThrow(
-      'Mint quote q has expired',
+      'Mint quote has expired',
     );
     // 0 means "no expiry" (CDK quirk); a future expiry is still valid.
     expect(() => wallet.validateMintQuote({ quote: 'q', expiry: 0 })).not.toThrow();


### PR DESCRIPTION
Aligns debug and warning logs across wallet and auth on the compact style already used by the completion logs (amounts, counts, states, endpoints), and simplifies the quote validation error messages. Test assertions updated to match.

- `prepareBatchMint`: the unlocked-quote warning now refers to the batch entry position
- quote validation messages read the same across methods
- async melt debug log now matches the sync path (state and change amounts)
- OIDC debug logs record endpoint and response status
- the malformed-JWT warning drops its context object

Note for the merger: keep the `Release-As: 5.0.0-rc.5` footer in the squash commit body so release-please bumps the rc.

Release-As: 5.0.0-rc.5