### PR TITLE
fix(wallet): more debug log tidy-up

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -937,11 +937,11 @@ class Wallet {
     const sortedOutputData: OutputDataLike[] = indices.map((i) => mergedBlindingData[i]);
     const sortedKeepVector: boolean[] = indices.map((i) => keepVector[i]);
     const outputs = sortedOutputData.map((d) => d.blindedMessage);
-    this._logger.debug('createSwapTransaction:', {
-      indices,
-      sortedKeepVector,
-      // outputs, // <-- removed for security
-    });
+    // this._logger.debug('createSwapTransaction:', {
+    //   indices,
+    //   sortedKeepVector,
+    //   outputs,
+    // });
     const payload: SwapRequest = {
       inputs,
       outputs,

--- a/src/wallet/_internal.ts
+++ b/src/wallet/_internal.ts
@@ -84,12 +84,23 @@ export function stringifyOutputTypeForLog(ot: OutputType): string {
         counter: ot.counter,
         denominations: (ot.denominations ?? []).map((d) => Amount.from(d).toString()),
       });
-    case 'p2pk':
+    case 'p2pk': {
+      // P2BK: the natural keys are only blinded later, so log placeholders instead
+      const opts = ot.options;
+      const options = opts.blindKeys
+        ? {
+            ...opts,
+            data: opts.kind === 'P2PK' ? '[redacted]' : opts.data,
+            pubkeys: opts.pubkeys?.map(() => '[redacted]'),
+            refundKeys: opts.refundKeys?.map(() => '[redacted]'),
+          }
+        : opts;
       return JSON.stringify({
         type: 'p2pk',
-        options: ot.options,
+        options,
         denominations: (ot.denominations ?? []).map((d) => Amount.from(d).toString()),
       });
+    }
     case 'random':
       return JSON.stringify({
         type: 'random',

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -109,6 +109,26 @@ describe('stringifyOutputTypeForLog', () => {
     );
   });
 
+  test('logs placeholders for the natural keys when blindKeys is enabled', () => {
+    const lockKey = '02'.padEnd(66, 'a');
+    const additionalKey = '02'.padEnd(66, 'b');
+    const refundKey = '02'.padEnd(66, 'c');
+    const result = stringifyOutputTypeForLog({
+      type: 'p2pk',
+      options: {
+        kind: 'P2PK',
+        data: lockKey,
+        pubkeys: [additionalKey],
+        refundKeys: [refundKey],
+        blindKeys: true,
+      },
+    });
+    expect(result).not.toContain(lockKey);
+    expect(result).not.toContain(additionalKey);
+    expect(result).not.toContain(refundKey);
+    expect(result).toContain('blindKeys');
+  });
+
   test('formats custom outputs as amount strings without serializing bigint internals', () => {
     const data = OutputData.createRandomData(3, keyset, [1, 2]);
     const result = stringifyOutputTypeForLog({

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -892,13 +892,21 @@ describe('async melt preference body', () => {
       }),
     );
 
-    const wallet = new Wallet(mint, { unit });
+    const debug = vi.fn();
+    const wallet = new Wallet(mint, {
+      unit,
+      logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug, trace: vi.fn() },
+    });
     await wallet.loadMint();
     const meltTxn = await wallet.prepareMelt('bolt11', meltQuote, proofs);
     const res = await wallet.completeMelt(meltTxn, undefined, { preferAsync: true });
 
     expect(res.quote.quote).toBe(meltQuote.quote);
     expect(res.change).toHaveLength(0);
+    expect(debug).toHaveBeenCalledWith('ASYNC MELT REQUESTED', {
+      state: 'UNPAID',
+      changeAmounts: [],
+    });
   });
 
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {


### PR DESCRIPTION
Follow-up to #879: mutes the chatty `createSwapTransaction` debug entry (kept commented out for local debugging, like `PROOFS SELECTED`) and reworks the p2pk output type log formatting. Pins the async melt debug context in the existing preferAsync test.