### PR TITLE
fix(auth): tidy the OIDC debug logging

### DIFF
--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -350,7 +350,7 @@ export class OIDCAuth {
     formBody: string,
   ): Promise<TSuccess> {
     try {
-      this.logger.debug('OIDCAuth Request', { endpoint });
+      // this.logger.debug('OIDCAuth Request', { endpoint });
       const res = await this.fetch(endpoint, {
         method: 'POST',
         headers: {
@@ -387,7 +387,7 @@ export class OIDCAuth {
     formBody: string,
   ): Promise<T | TokenResponse> {
     try {
-      this.logger.debug('OIDCAuth Request', { endpoint });
+      // this.logger.debug('OIDCAuth Request', { endpoint });
       const res = await this.fetch(endpoint, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Follow-up to #881: comments out the OIDC request debug entries, matching the wallet debug log treatment (kept for local debugging); the response status entry stays.