### PR TITLE
fix(auth): tidy the OIDC debug logging [backport v4-dev]

### DIFF
--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -336,7 +336,7 @@ export class OIDCAuth {
     formBody: string,
   ): Promise<TSuccess> {
     try {
-      this.logger.debug('OIDCAuth Request', { endpoint });
+      // this.logger.debug('OIDCAuth Request', { endpoint });
       const res = await fetch(endpoint, {
         method: 'POST',
         headers: {
@@ -373,7 +373,7 @@ export class OIDCAuth {
     formBody: string,
   ): Promise<T | TokenResponse> {
     try {
-      this.logger.debug('OIDCAuth Request', { endpoint });
+      // this.logger.debug('OIDCAuth Request', { endpoint });
       const res = await fetch(endpoint, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Backport of #883 to v4-dev.

Follow-up to #882: comments out the OIDC request debug entries, matching the wallet debug log treatment (kept for local debugging); the response status entry stays.

Note for the merger: strip the `[backport v4-dev]` suffix from the squash subject.