### PR TITLE
fix: tidy response reads and number-token parsing

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1913,6 +1913,7 @@ export type RequestFn = <T = unknown>(args: RequestOptions) => Promise<T>;
 // @public (undocumented)
 export type RequestOptions = RequestArgs & Omit<RequestInit, 'body' | 'headers'> & Partial<Nut19Policy> & {
     requestTimeout?: number;
+    maxResponseBytes?: number;
     idempotent?: boolean;
     onResponseMeta?: (meta: ResponseMeta) => void;
     fetch?: RequestFetch;

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -171,9 +171,9 @@ export class PaymentRequest {
    * Serializes the default NUT-18 payment payload for this request.
    *
    * @remarks
-   * BigInt-safe JSON; plain `JSON.stringify` throws on proof amounts. Proofs must come from `mint`
-   * and net the request after fees: `wallet.ops.sendToRequest` produces both, this only packages.
-   * Send it as the POST body or Nostr DM content.
+   * Plain `JSON.stringify` can't serialize the bigint proof amounts, so use this. Proofs must come
+   * from `mint` and net the request after fees: `wallet.ops.sendToRequest` produces both, this only
+   * packages. Send it as the POST body or Nostr DM content.
    * @param mint - The mint the proofs are from.
    * @param proofs - The proofs to send (eg the `send` half of a send flow).
    * @param opts.memo - Optional memo for the payee.
@@ -198,8 +198,9 @@ export class PaymentRequest {
    * Parses a default NUT-18 payment payload received from a payer.
    *
    * @remarks
-   * BigInt-safe: proof amounts are normalized to `bigint` whatever their JSON size. Validates shape
-   * only; matching the payload to a request (id, mint, netting the amount) is the payee's job.
+   * Validates payload shape only. To confirm the payment settles the request, pass the result to
+   * {@link Wallet.isPaymentRequestSatisfied}. Imposes no size limit of its own: cap the raw text at
+   * the transport (POST body, DM) before decoding.
    * @param json - Raw payload text (POST body or Nostr DM content).
    * @throws {@link CTSError} If the text is not valid JSON or not payload-shaped.
    */
@@ -241,6 +242,13 @@ export class PaymentRequest {
         throw new CTSError(`invalid payment payload: malformed proof at index ${i}`);
       }
       const amount = (p as Record<string, unknown>).amount;
+      if (typeof amount === 'string') {
+        // A quoted amount is the tell-tale of plain JSON.stringify over bigint proofs (or an
+        // Amount VO via toJSON). NUT-18 amounts are JSON numbers: point the payer at the encoder.
+        throw new CTSError(
+          `invalid payment payload: proof amount at index ${i} is a string; amounts must be JSON numbers (serialize with encodePayload() or JSONInt.stringify, not JSON.stringify)`,
+        );
+      }
       if (typeof amount !== 'number' && typeof amount !== 'bigint') {
         throw new CTSError(`invalid payment payload: malformed proof amount at index ${i}`);
       }

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -108,16 +108,20 @@ export async function readBodyText(
   maxBytes: number,
   signal?: AbortSignal,
 ): Promise<string> {
+  const body = response.body;
   const contentLength = Number(response.headers.get('Content-Length') ?? '');
   if (contentLength > maxBytes) {
+    if (body && typeof body.cancel === 'function') {
+      body.cancel().catch(() => undefined);
+    }
     throw new CTSError(`response body exceeds ${maxBytes} bytes`);
   }
 
-  const body = response.body;
   if (!body || typeof body.getReader !== 'function') {
     // No stream to cancel (eg React Native): race the whole-body read against the signal once,
     // then size-check (utf8 bytes >= string length, so the cheap length check catches gross
     // oversize without re-encoding).
+    if (signal?.aborted) throw new CTSError('response body read aborted');
     const text = await raceAbort(response.text(), signal);
     if (text.length > maxBytes || new TextEncoder().encode(text).length > maxBytes) {
       throw new CTSError(`response body exceeds ${maxBytes} bytes`);

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -152,7 +152,13 @@ export async function readBodyText(
       }
       chunks.push(result.value);
     }
-    return Bytes.toString(Bytes.concat(...chunks));
+    const bytes = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return Bytes.toString(bytes);
   } finally {
     if (onAbort) signal?.removeEventListener('abort', onAbort);
     reader.cancel().catch(() => undefined); // release the connection; no-op if already closed
@@ -465,7 +471,13 @@ async function requestWithRetry(options: RequestOptions): Promise<unknown> {
     } catch (e) {
       // One immediate retry on a connection-level failure (a dropped keep-alive socket is the
       // common case); HTTP errors mean the server answered and are never retried here.
-      if (e instanceof CallerAbortError || !(e instanceof NetworkError)) throw e;
+      if (
+        e instanceof CallerAbortError ||
+        e instanceof UncancellableReadError ||
+        !(e instanceof NetworkError)
+      ) {
+        throw e;
+      }
       requestLogger.info('Network error on an idempotent request, retrying once', { e });
       return await _request(options);
     }

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -7,6 +7,7 @@ import {
   RateLimitError,
 } from '../model/Errors';
 import { type Nut19Policy } from '../model/types';
+import { Bytes } from '../utils/Bytes';
 import { JSONInt } from '../utils/JSONInt';
 
 /**
@@ -91,6 +92,123 @@ export function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
 }
 
+/**
+ * Reads a response body as text, failing once it exceeds `maxBytes`.
+ *
+ * @remarks
+ * With a readable stream (`response.body`) the read is bounded as it arrives (the cap rejects
+ * before over-allocating) and an abort cancels the reader, unblocking a pending read. The fallback
+ * (`response.text()`, eg React Native / custom transports with no stream) reads the whole body
+ * raced against `signal`, then size-checks the decoded text, so strict pre-allocation enforcement
+ * needs a streaming transport.
+ * @internal
+ */
+export async function readBodyText(
+  response: Response,
+  maxBytes: number,
+  signal?: AbortSignal,
+): Promise<string> {
+  const contentLength = Number(response.headers.get('Content-Length') ?? '');
+  if (contentLength > maxBytes) {
+    throw new CTSError(`response body exceeds ${maxBytes} bytes`);
+  }
+
+  const body = response.body;
+  if (!body || typeof body.getReader !== 'function') {
+    // No stream to cancel (eg React Native): race the whole-body read against the signal once,
+    // then size-check (utf8 bytes >= string length, so the cheap length check catches gross
+    // oversize without re-encoding).
+    const text = await raceAbort(response.text(), signal);
+    if (text.length > maxBytes || new TextEncoder().encode(text).length > maxBytes) {
+      throw new CTSError(`response body exceeds ${maxBytes} bytes`);
+    }
+    return text;
+  }
+
+  // Wire the signal to cancel the reader once, rather than racing every read() against a
+  // never-settling abort promise (which piles a reaction onto it per chunk). Cancelling unblocks a
+  // pending read; real fetch streams also reject the read on abort directly.
+  const reader = body.getReader();
+  let aborted = false;
+  let onAbort: (() => void) | undefined;
+  if (signal) {
+    onAbort = () => {
+      aborted = true;
+      reader.cancel().catch(() => undefined);
+    };
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
+  try {
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    for (;;) {
+      const result = await reader.read();
+      if (aborted) throw new CTSError('response body read aborted');
+      if (result.done) break;
+      received += result.value.byteLength;
+      if (received > maxBytes) {
+        throw new CTSError(`response body exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(result.value);
+    }
+    return Bytes.toString(Bytes.concat(...chunks));
+  } finally {
+    if (onAbort) signal?.removeEventListener('abort', onAbort);
+    reader.cancel().catch(() => undefined); // release the connection; no-op if already closed
+  }
+}
+
+/**
+ * Awaits `promise`, rejecting early if `signal` aborts. For whole-body reads that cannot be
+ * cancelled (the no-stream fallback); a single race, not one per chunk.
+ *
+ * @internal
+ */
+function raceAbort(promise: Promise<string>, signal?: AbortSignal): Promise<string> {
+  if (!signal) return promise;
+  promise.catch(() => undefined); // settles after we abort: keep it from going unhandled
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    // A whole-body read has no reader to cancel: mark it so a timeout is not retried (the native
+    // read may still be consuming the body).
+    onAbort = () => reject(new UncancellableReadError('response body read aborted'));
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  });
+  aborted.catch(() => undefined);
+  return Promise.race([promise, aborted]).finally(() => {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  });
+}
+
+/**
+ * Maps a body-read failure that happened under an armed timeout or caller signal to the matching
+ * abort error. A cancellable (streaming) read retries like a stalled connection; a read that could
+ * not be cancelled ({@link UncancellableReadError} from the no-stream fallback) does not, so retry
+ * cannot start a second read against a body the first is still consuming. Returns `undefined` when
+ * neither signal aborted.
+ *
+ * @internal
+ */
+function abortError(
+  err: unknown,
+  timeoutController: AbortController | undefined,
+  requestTimeout: number | undefined,
+  callerSignal: AbortSignal | undefined,
+): NetworkError | undefined {
+  if (timeoutController?.signal.aborted) {
+    const message = `Request timed out after ${requestTimeout}ms`;
+    return err instanceof UncancellableReadError
+      ? new UncancellableReadError(message, { cause: err })
+      : new NetworkError(message, { cause: err });
+  }
+  if (callerSignal?.aborted) {
+    return new CallerAbortError(errorMessage(err, 'Request aborted by caller'));
+  }
+  return undefined;
+}
+
 export type RequestArgs = {
   endpoint: string;
   requestBody?: Record<string, unknown>;
@@ -136,11 +254,17 @@ export type RequestOptions = RequestArgs &
   Omit<RequestInit, 'body' | 'headers'> &
   Partial<Nut19Policy> & {
     /**
-     * Per-request timeout in milliseconds. If a single fetch hangs longer than this, it is aborted
-     * and treated as a NetworkError (triggering retry on cached endpoints). Without this, a hung
-     * connection can consume the entire TTL retry window.
+     * Per-request timeout in milliseconds. If a single fetch hangs longer than this (connecting,
+     * waiting, or reading the body), it is aborted and treated as a NetworkError (triggering retry
+     * on cached endpoints). Without this, a hung connection can consume the entire TTL retry
+     * window.
      */
     requestTimeout?: number;
+    /**
+     * Maximum response body size in bytes (default 8_388_608 = 8 MiB). Bodies over the cap fail the
+     * request; reads are streamed and stop at the cap where the runtime supports it.
+     */
+    maxResponseBytes?: number;
     /**
      * Marks the request as safe to replay (read-only, no side effects). Idempotent requests retry
      * once on a network-level failure, recovering from dropped keep-alive sockets. GET requests
@@ -232,6 +356,7 @@ export function setRequestLogger(logger: Logger): void {
 const MAX_CACHED_RETRIES = 9; // 10 requests total
 const MAX_DELAY = 1000; // 1 sec
 const BASE_DELAY = 100; // 100 ms
+const DEFAULT_MAX_RESPONSE_BYTES = 8_388_608; // 8 MiB; >10x any realistic mint response
 
 class CallerAbortError extends NetworkError {
   constructor(message: string) {
@@ -242,16 +367,29 @@ class CallerAbortError extends NetworkError {
 }
 
 /**
+ * A timeout that fired while reading a response body that could not be cancelled (the no-stream
+ * fallback). The underlying read may still be consuming the body, so this is NOT retried: another
+ * attempt would start a second uncancellable read against the same (possibly unbounded) body.
+ */
+class UncancellableReadError extends NetworkError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'UncancellableReadError';
+    Object.setPrototypeOf(this, UncancellableReadError.prototype);
+  }
+}
+
+/**
  * Returns true if the error warrants a retry on NUT-19 cached endpoints:
  *
  * - NetworkError: network-level failures (DNS, connection refused, AbortError/timeout)
  * - HttpResponseError with 5xx status: server-side transient errors (503, 502, etc.)
  *
  * 4xx errors (including 429 Too Many Requests) are NOT retried — they are bounced back to the
- * caller immediately.
+ * caller immediately. Caller aborts and uncancellable body-read timeouts are never retried.
  */
 function isRetryableError(e: unknown): boolean {
-  if (e instanceof CallerAbortError) return false;
+  if (e instanceof CallerAbortError || e instanceof UncancellableReadError) return false;
   if (e instanceof NetworkError) return true;
   return e instanceof HttpResponseError && e.status >= 500;
 }
@@ -390,6 +528,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
     headers: requestHeaders,
     requestTimeout,
     onResponseMeta,
+    maxResponseBytes,
     fetch: fetchImpl,
     // consumed by requestWithRetry, excluded from raw fetch options
     cached_endpoints,
@@ -404,6 +543,14 @@ async function _request(options: RequestOptions): Promise<unknown> {
   void ttl;
   void idempotent;
   void logger;
+
+  if (
+    maxResponseBytes !== undefined &&
+    (!Number.isSafeInteger(maxResponseBytes) || maxResponseBytes <= 0)
+  ) {
+    throw new CTSError('maxResponseBytes must be a positive integer');
+  }
+  const responseByteCap = maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
 
   const requestFetch = fetchImpl ?? fetch;
   const body = requestBody ? JSONInt.stringify(requestBody) : undefined;
@@ -437,102 +584,124 @@ async function _request(options: RequestOptions): Promise<unknown> {
     }
   }
 
-  let response: Response;
+  // Signals stay armed until the body is fully consumed: both the timeout and a caller abort
+  // must be able to stop a body that streams slowly or never ends, not just the initial fetch.
   try {
-    response = await requestFetch(endpoint, {
-      body,
-      headers,
-      // Anti-fingerprinting fetch options.
-      cache: 'no-store', // prevent cache tracking (eg ETag)
-      credentials: 'omit', // prevent cookie-based tracking
-      referrer: '', // prevent leaking the embedding page URL
-      referrerPolicy: 'no-referrer', // belt-and-braces for referrer across all contexts
-      ...fetchOptions, // allows override of above options
-      signal, // not overridable (includes caller signal)
-    });
-  } catch (err) {
-    const timedOut = !!timeoutController?.signal.aborted;
-    const callerAborted = !!callerSignal?.aborted;
-    if (timedOut) {
-      throw new NetworkError(`Request timed out after ${requestTimeout}ms`, { cause: err });
+    let response: Response;
+    try {
+      response = await requestFetch(endpoint, {
+        body,
+        headers,
+        // Anti-fingerprinting fetch options.
+        cache: 'no-store', // prevent cache tracking (eg ETag)
+        credentials: 'omit', // prevent cookie-based tracking
+        referrer: '', // prevent leaking the embedding page URL
+        referrerPolicy: 'no-referrer', // belt-and-braces for referrer across all contexts
+        ...fetchOptions, // allows override of above options
+        signal, // not overridable (includes caller signal)
+      });
+    } catch (err) {
+      const timedOut = !!timeoutController?.signal.aborted;
+      const callerAborted = !!callerSignal?.aborted;
+      if (timedOut) {
+        throw new NetworkError(`Request timed out after ${requestTimeout}ms`, { cause: err });
+      }
+      if (callerAborted) {
+        throw new CallerAbortError(errorMessage(err, 'Request aborted by caller'));
+      }
+      if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+        throw new NetworkError(err.message, { cause: err });
+      }
+      // A fetch() promise only rejects when the request fails,
+      // for example, because of a badly-formed request URL or a network error.
+      throw new NetworkError(errorMessage(err, 'Network request failed'), { cause: err });
     }
-    if (callerAborted) {
-      throw new CallerAbortError(errorMessage(err, 'Request aborted by caller'));
+
+    // Parse Retry-After once for reuse in both ResponseMeta and RateLimitError
+    const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
+
+    // Build and fire ResponseMeta callback before any throw or return
+    if (onResponseMeta && response.headers) {
+      const meta: ResponseMeta = {
+        endpoint,
+        status: response.status,
+        retryAfterMs,
+        rateLimit: response.headers.get('RateLimit') ?? undefined,
+        rateLimitPolicy: response.headers.get('RateLimit-Policy') ?? undefined,
+        headers: response.headers,
+      };
+      safeCallback(onResponseMeta, meta, requestLogger, {
+        op: 'request.onResponseMeta',
+        status: response.status,
+        endpoint,
+      });
     }
-    if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
-      throw new NetworkError(err.message, { cause: err });
+
+    if (!response.ok) {
+      let errorData: ApiError;
+      let errorDataCause: unknown;
+      try {
+        errorData = parseErrorBody(await readBodyText(response, responseByteCap, signal));
+      } catch (err) {
+        // A stalled error body is still a timeout / caller abort, not a genuine 4xx/5xx: surface
+        // it as such so retry classification matches the success path.
+        const aborted = abortError(err, timeoutController, requestTimeout, callerSignal);
+        if (aborted) throw aborted;
+        errorDataCause = err;
+        errorData = { error: 'bad response' };
+      }
+
+      if (response.status === 429) {
+        throw new RateLimitError('429 Too Many Requests', retryAfterMs);
+      }
+
+      if (
+        response.status === 400 &&
+        'code' in errorData &&
+        typeof errorData.code === 'number' &&
+        'detail' in errorData &&
+        typeof errorData.detail === 'string'
+      ) {
+        throw new MintOperationError(errorData.code, errorData.detail);
+      }
+
+      let httpErrorMessage = 'HTTP request failed';
+      if ('error' in errorData && typeof errorData.error === 'string') {
+        httpErrorMessage = errorData.error;
+      } else if ('detail' in errorData && typeof errorData.detail === 'string') {
+        httpErrorMessage = errorData.detail;
+      }
+
+      throw new HttpResponseError(httpErrorMessage, response.status, { cause: errorDataCause });
     }
-    // A fetch() promise only rejects when the request fails,
-    // for example, because of a badly-formed request URL or a network error.
-    throw new NetworkError(errorMessage(err, 'Network request failed'), { cause: err });
+
+    let responseText: string;
+    try {
+      responseText = await readBodyText(response, responseByteCap, signal);
+    } catch (err) {
+      // A body-read failure under an armed signal is an abort, not a bad response: classify it
+      // like the fetch-level catch so cached-endpoint retry still engages on a timeout.
+      const aborted = abortError(err, timeoutController, requestTimeout, callerSignal);
+      if (aborted) throw aborted;
+      requestLogger.error('Failed to read HTTP response', { err });
+      // Surface our own reason (eg the size cap), but keep a foreign transport error behind the
+      // stable "bad response" message rather than exposing it.
+      const message = err instanceof CTSError ? err.message : 'bad response';
+      throw new HttpResponseError(message, response.status, { cause: err });
+    }
+
+    try {
+      if (!responseText) {
+        throw new CTSError('Empty response body');
+      }
+      return JSONInt.parse(responseText);
+    } catch (err) {
+      requestLogger.error('Failed to parse HTTP response', { err });
+      throw new HttpResponseError('bad response', response.status, { cause: err });
+    }
   } finally {
     clearTimeout(timeoutId);
     cleanupAbortListeners?.();
-  }
-
-  // Parse Retry-After once for reuse in both ResponseMeta and RateLimitError
-  const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
-
-  // Build and fire ResponseMeta callback before any throw or return
-  if (onResponseMeta && response.headers) {
-    const meta: ResponseMeta = {
-      endpoint,
-      status: response.status,
-      retryAfterMs,
-      rateLimit: response.headers.get('RateLimit') ?? undefined,
-      rateLimitPolicy: response.headers.get('RateLimit-Policy') ?? undefined,
-      headers: response.headers,
-    };
-    safeCallback(onResponseMeta, meta, requestLogger, {
-      op: 'request.onResponseMeta',
-      status: response.status,
-      endpoint,
-    });
-  }
-
-  if (!response.ok) {
-    let errorData: ApiError;
-    let errorDataCause: unknown;
-    try {
-      errorData = parseErrorBody(await response.text());
-    } catch (err) {
-      errorDataCause = err;
-      errorData = { error: 'bad response' };
-    }
-
-    if (response.status === 429) {
-      throw new RateLimitError('429 Too Many Requests', retryAfterMs);
-    }
-
-    if (
-      response.status === 400 &&
-      'code' in errorData &&
-      typeof errorData.code === 'number' &&
-      'detail' in errorData &&
-      typeof errorData.detail === 'string'
-    ) {
-      throw new MintOperationError(errorData.code, errorData.detail);
-    }
-
-    let errorMessage = 'HTTP request failed';
-    if ('error' in errorData && typeof errorData.error === 'string') {
-      errorMessage = errorData.error;
-    } else if ('detail' in errorData && typeof errorData.detail === 'string') {
-      errorMessage = errorData.detail;
-    }
-
-    throw new HttpResponseError(errorMessage, response.status, { cause: errorDataCause });
-  }
-
-  try {
-    const responseText = await response.text();
-    if (!responseText) {
-      throw new CTSError('Empty response body');
-    }
-    return JSONInt.parse(responseText);
-  } catch (err) {
-    requestLogger.error('Failed to parse HTTP response', { err });
-    throw new HttpResponseError('bad response', response.status, { cause: err });
   }
 }
 

--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -36,7 +36,7 @@ export interface JSONIntApi {
    * Returns `unknown`, so validate or cast the result to an application-specific type.
    *
    * Unquoted JSON number tokens are parsed to BigInt when outside the safe integer range, otherwise
-   * to number.
+   * to number. Integer tokens longer than 100 characters are rejected as a syntax error.
    */
   parse(
     source: string,
@@ -51,7 +51,8 @@ export interface JSONIntApi {
    * BigInt aware JSON stringify.
    *
    * @remarks
-   * - BigInt is stringified as an unquoted JSON number token.
+   * - BigInt is stringified as an unquoted JSON number token; a BigInt whose decimal form exceeds 100
+   *   characters throws, symmetric with the parse cap, so output always round-trips.
    * - Parsing the result may yield `number` or `bigint` depending on the value and parse options.
    * - Returns `undefined` for top-level values that JSON cannot represent, matching `JSON.stringify`
    *   behavior.
@@ -76,6 +77,10 @@ type JSONIntValue = JSONIntPrimitive | JSONIntValue[] | { [key: string]: JSONInt
 type ReviverFn = (this: unknown, key: string, value: unknown) => unknown;
 type ReplacerFn = (this: unknown, key: string, value: unknown) => unknown;
 type ReplacerList = ReadonlyArray<string | number>;
+
+// The largest legitimate Cashu integer is a u64 (20 digits); reject absurdly
+// long tokens before conversion. Applies in all runtimes and fallback modes.
+const MAX_INT_TOKEN_LENGTH = 100;
 
 let safeBigIntLimits: { max: bigint; min: bigint } | undefined;
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -281,6 +286,10 @@ class Parser {
       return n;
     }
 
+    if (token.length > MAX_INT_TOKEN_LENGTH) {
+      throw this.syntaxError('Number token too long');
+    }
+
     if (!this.bigIntCtor) {
       switch (this.fallbackTo) {
         case 'number': {
@@ -466,9 +475,15 @@ function stringify(
         return Number.isFinite(val) ? String(val) : 'null';
       case 'boolean':
         return val ? 'true' : 'false';
-      case 'bigint':
-        // Intentionally emit raw JSON number tokens for BigInt.
-        return String(val);
+      case 'bigint': {
+        // Emit BigInt as a raw JSON number token, but refuse one longer than the parser accepts
+        // (see MAX_INT_TOKEN_LENGTH) so stringify output always round-trips back through parse.
+        const token = String(val);
+        if (token.length > MAX_INT_TOKEN_LENGTH) {
+          throw new CTSError(`integer token exceeds ${MAX_INT_TOKEN_LENGTH} characters`);
+        }
+        return token;
+      }
       case 'undefined':
         return undefined;
       case 'object': {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -1266,6 +1266,22 @@ describe('response body size cap', () => {
     } as unknown as Response;
   };
 
+  test('returns a within-cap body on the no-stream fallback', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      noStreamResponse({ text: async () => JSON.stringify({ keysets: [] }) }),
+    );
+    const result = await request({ endpoint, maxResponseBytes: 1000 });
+    expect(result).toEqual({ keysets: [] });
+  });
+
+  test('returns a no-stream fallback body under a requestTimeout that does not fire', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      noStreamResponse({ text: async () => JSON.stringify({ ok: true }) }),
+    );
+    const result = await request({ endpoint, maxResponseBytes: 1000, requestTimeout: 1000 });
+    expect(result).toEqual({ ok: true });
+  });
+
   test('rejects an over-cap body on the no-stream fallback (no Content-Length)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       noStreamResponse({ text: async () => 'y'.repeat(1008) }),
@@ -1273,6 +1289,23 @@ describe('response body size cap', () => {
     const thrown = await request({ endpoint, maxResponseBytes: 10 }).catch((e) => e);
     expect(thrown).toBeInstanceOf(HttpResponseError);
     expect((thrown as Error).message).toMatch(/exceeds 10 bytes/);
+  });
+
+  test('a foreign stream-read error surfaces as the stable "bad response"', async () => {
+    const reader = {
+      read: () => Promise.reject(new Error('stream broke')),
+      cancel: () => Promise.resolve(),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: { getReader: () => reader },
+      text: async () => '',
+    } as unknown as Response);
+    const thrown = await request({ endpoint }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect((thrown as Error).message).toBe('bad response');
   });
 
   test('timeout stops a hung no-stream fallback body', async () => {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -1121,6 +1121,203 @@ describe('idempotent single retry (non-cached endpoints)', () => {
   });
 });
 
+describe('response body size cap', () => {
+  const endpoint = mintUrl + '/v1/keys';
+
+  // A hand-rolled streamed Response: a plain reader so tests control chunk delivery and can
+  // simulate a body that stalls mid-stream (never delivering `done`). Avoids the ReadableStream
+  // global, which lint flags as unsupported on the declared Node floor.
+  const streamResponse = (
+    chunks: Uint8Array[],
+    opts: { hangAfter?: boolean; status?: number; contentLength?: number } = {},
+  ): Response => {
+    const { hangAfter = false, status = 200, contentLength } = opts;
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    if (contentLength !== undefined) headers.set('Content-Length', String(contentLength));
+    let i = 0;
+    let stalled: ((r: { done: boolean; value?: Uint8Array }) => void) | undefined;
+    const reader = {
+      read: () =>
+        new Promise<{ done: boolean; value?: Uint8Array }>((resolve) => {
+          if (i < chunks.length) return resolve({ done: false, value: chunks[i++] });
+          if (!hangAfter) return resolve({ done: true, value: undefined });
+          stalled = resolve; // stalled mid-stream; cancel() unblocks it, as a real stream does
+        }),
+      cancel: () => {
+        stalled?.({ done: true, value: undefined });
+        return Promise.resolve();
+      },
+    };
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers,
+      body: { getReader: () => reader },
+      text: async () => new TextDecoder().decode(concatChunks(chunks)),
+    } as unknown as Response;
+  };
+
+  const concatChunks = (chunks: Uint8Array[]): Uint8Array => {
+    const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) {
+      out.set(c, off);
+      off += c.byteLength;
+    }
+    return out;
+  };
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  afterEach(() => vi.restoreAllMocks());
+
+  test('rejects a success body over the cap via Content-Length pre-check', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      streamResponse([], { contentLength: 64 * 1024 * 1024 }),
+    );
+    const thrown = await request({ endpoint, maxResponseBytes: 1000 }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect((thrown as Error).message).toMatch(/exceeds 1000 bytes/);
+  });
+
+  test('rejects a streamed success body that exceeds the cap without Content-Length', async () => {
+    const chunk = enc('y'.repeat(600));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(streamResponse([chunk, chunk]));
+    const thrown = await request({ endpoint, maxResponseBytes: 1000 }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect((thrown as Error).message).toMatch(/exceeds 1000 bytes/);
+  });
+
+  test('accepts a streamed body within the cap', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      streamResponse([enc(JSON.stringify({ keysets: [] }))]),
+    );
+    const result = await request({ endpoint, maxResponseBytes: 1000 });
+    expect(result).toEqual({ keysets: [] });
+  });
+
+  test('rejects an oversized error body but still surfaces an HttpResponseError', async () => {
+    const chunk = enc('z'.repeat(600));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      streamResponse([chunk, chunk], { status: 500 }),
+    );
+    const thrown = await request({ endpoint, maxResponseBytes: 1000, idempotent: false }).catch(
+      (e) => e,
+    );
+    // The body read fails, but the status still drives a normal HttpResponseError.
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect((thrown as Error).message).toBe('bad response');
+    expect((thrown as InstanceType<typeof HttpResponseError>).status).toBe(500);
+  });
+
+  test('rejects a non-positive maxResponseBytes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(streamResponse([]));
+    await expect(request({ endpoint, maxResponseBytes: 0 })).rejects.toThrow(
+      'maxResponseBytes must be a positive integer',
+    );
+  });
+
+  test('timeout during a hung body read maps to NetworkError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      streamResponse([enc('{"keysets":')], { hangAfter: true }),
+    );
+    const thrown = await request({ endpoint, requestTimeout: 100, idempotent: false }).catch(
+      (e) => e,
+    );
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 100ms');
+  });
+
+  test('caller abort during a hung body read maps to CallerAbortError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      streamResponse([enc('{"keysets":')], { hangAfter: true }),
+    );
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 25);
+    const thrown = await request({ endpoint, signal: ac.signal }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).name).toBe('CallerAbortError');
+  });
+
+  // No `body` stream (eg React Native / custom transports): forces the response.text() fallback.
+  const noStreamResponse = (opts: {
+    text: () => Promise<string>;
+    status?: number;
+    contentLength?: number;
+  }): Response => {
+    const { status = 200, contentLength } = opts;
+    const headers = new Headers();
+    if (contentLength !== undefined) headers.set('Content-Length', String(contentLength));
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers,
+      body: null,
+      text: opts.text,
+    } as unknown as Response;
+  };
+
+  test('rejects an over-cap body on the no-stream fallback (no Content-Length)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      noStreamResponse({ text: async () => 'y'.repeat(1008) }),
+    );
+    const thrown = await request({ endpoint, maxResponseBytes: 10 }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect((thrown as Error).message).toMatch(/exceeds 10 bytes/);
+  });
+
+  test('timeout stops a hung no-stream fallback body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      noStreamResponse({ text: () => new Promise<string>(() => undefined) }),
+    );
+    const thrown = await request({ endpoint, requestTimeout: 100, idempotent: false }).catch(
+      (e) => e,
+    );
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 100ms');
+  }, 2000);
+
+  test('timeout during a hung error body maps to NetworkError, not a 5xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      noStreamResponse({ status: 500, text: () => new Promise<string>(() => undefined) }),
+    );
+    const thrown = await request({ endpoint, requestTimeout: 100, idempotent: false }).catch(
+      (e) => e,
+    );
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 100ms');
+  }, 2000);
+
+  test('caller abort during a hung error body maps to CallerAbortError, not a 4xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      noStreamResponse({ status: 404, text: () => new Promise<string>(() => undefined) }),
+    );
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 25);
+    const thrown = await request({ endpoint, signal: ac.signal }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).name).toBe('CallerAbortError');
+  }, 2000);
+
+  test('a timed-out uncancellable no-stream read is not retried on a cached endpoint', async () => {
+    // The read cannot be cancelled and may still be consuming the body; retrying would start a
+    // second one. A cancellable read would retry up to 10x here, so assert exactly one fetch.
+    let fetchCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      fetchCount++;
+      return noStreamResponse({ text: () => new Promise<string>(() => undefined) });
+    });
+    const thrown = await request({
+      endpoint,
+      requestTimeout: 5,
+      ttl: 60000,
+      cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
+    }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect(fetchCount).toBe(1);
+  }, 2000);
+});
+
 describe('parseRetryAfter', () => {
   test('returns undefined for null', () => {
     expect(parseRetryAfter(null)).toBeUndefined();

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -1137,6 +1137,10 @@ describe('response body size cap', () => {
     if (contentLength !== undefined) headers.set('Content-Length', String(contentLength));
     let i = 0;
     let stalled: ((r: { done: boolean; value?: Uint8Array }) => void) | undefined;
+    const cancel = () => {
+      stalled?.({ done: true, value: undefined });
+      return Promise.resolve();
+    };
     const reader = {
       read: () =>
         new Promise<{ done: boolean; value?: Uint8Array }>((resolve) => {
@@ -1144,16 +1148,13 @@ describe('response body size cap', () => {
           if (!hangAfter) return resolve({ done: true, value: undefined });
           stalled = resolve; // stalled mid-stream; cancel() unblocks it, as a real stream does
         }),
-      cancel: () => {
-        stalled?.({ done: true, value: undefined });
-        return Promise.resolve();
-      },
+      cancel,
     };
     return {
       ok: status >= 200 && status < 300,
       status,
       headers,
-      body: { getReader: () => reader },
+      body: { getReader: () => reader, cancel },
       text: async () => new TextDecoder().decode(concatChunks(chunks)),
     } as unknown as Response;
   };
@@ -1173,12 +1174,13 @@ describe('response body size cap', () => {
   afterEach(() => vi.restoreAllMocks());
 
   test('rejects a success body over the cap via Content-Length pre-check', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      streamResponse([], { contentLength: 64 * 1024 * 1024 }),
-    );
+    const response = streamResponse([], { contentLength: 64 * 1024 * 1024 });
+    const cancel = vi.spyOn(response.body!, 'cancel');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
     const thrown = await request({ endpoint, maxResponseBytes: 1000 }).catch((e) => e);
     expect(thrown).toBeInstanceOf(HttpResponseError);
     expect((thrown as Error).message).toMatch(/exceeds 1000 bytes/);
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   test('rejects a streamed success body that exceeds the cap without Content-Length', async () => {
@@ -1283,6 +1285,27 @@ describe('response body size cap', () => {
     expect(thrown).toBeInstanceOf(NetworkError);
     expect((thrown as Error).message).toContain('Request timed out after 100ms');
   }, 2000);
+
+  test('does not start a no-stream body read after the caller aborts', async () => {
+    let textCalls = 0;
+    const ac = new AbortController();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      noStreamResponse({
+        text: async () => {
+          textCalls++;
+          return '{}';
+        },
+      }),
+    );
+    const thrown = await request({
+      endpoint,
+      signal: ac.signal,
+      onResponseMeta: () => ac.abort(),
+    }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).name).toBe('CallerAbortError');
+    expect(textCalls).toBe(0);
+  });
 
   test('a timed-out uncancellable no-stream read is not retried on a non-cached endpoint', async () => {
     let fetchCount = 0;

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -20,6 +20,7 @@ import {
   detectBrowserLike,
   buildRequestHeaders,
   errorMessage,
+  readBodyText,
 } from '../../src/transport/request';
 import { MINTCACHE } from '../consts';
 
@@ -1196,6 +1197,12 @@ describe('response body size cap', () => {
     expect(result).toEqual({ keysets: [] });
   });
 
+  test('accepts a within-cap body split across many chunks', async () => {
+    const chunks = new Array<Uint8Array>(150_000).fill(enc('x'));
+    const text = await readBodyText(streamResponse(chunks), chunks.length);
+    expect(text).toHaveLength(chunks.length);
+  });
+
   test('rejects an oversized error body but still surfaces an HttpResponseError', async () => {
     const chunk = enc('z'.repeat(600));
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -1275,6 +1282,17 @@ describe('response body size cap', () => {
     );
     expect(thrown).toBeInstanceOf(NetworkError);
     expect((thrown as Error).message).toContain('Request timed out after 100ms');
+  }, 2000);
+
+  test('a timed-out uncancellable no-stream read is not retried on a non-cached endpoint', async () => {
+    let fetchCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      fetchCount++;
+      return noStreamResponse({ text: () => new Promise<string>(() => undefined) });
+    });
+    const thrown = await request({ endpoint, requestTimeout: 5 }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect(fetchCount).toBe(1);
   }, 2000);
 
   test('timeout during a hung error body maps to NetworkError, not a 5xx', async () => {

--- a/test/utils/JSONInt.test.ts
+++ b/test/utils/JSONInt.test.ts
@@ -58,6 +58,15 @@ describe('native BigInt support: stringify', () => {
     );
   });
 
+  test('rejects a BigInt whose decimal form exceeds the token cap (symmetric with parse)', () => {
+    const ok = BigInt('9'.repeat(100));
+    const out = JSONInt.stringify(ok)!;
+    expect(out).toBe('9'.repeat(100));
+    expect(JSONInt.parse(out)).toBe(ok); // round-trips at the boundary
+    // A value the parser would reject must not be emittable, so output always round-trips.
+    expect(() => JSONInt.stringify(BigInt('9'.repeat(101)))).toThrow('exceeds 100 characters');
+  });
+
   test('stringifies arrays with undefined as null', () => {
     const output = JSONInt.stringify([1, undefined, 3]);
     expect(output).toBe('[1,null,3]');
@@ -224,6 +233,12 @@ describe('parse errors', () => {
 
   test('rejects trailing input', () => {
     expect(() => JSONInt.parse('true false')).toThrow('Unexpected trailing input');
+  });
+
+  test('rejects oversized integer tokens', () => {
+    expect(JSONInt.parse('9'.repeat(100))).toBe(BigInt('9'.repeat(100)));
+    expect(() => JSONInt.parse('9'.repeat(101))).toThrow('Number token too long');
+    expect(() => JSONInt.parse(`{"amount":${'9'.repeat(101)}}`)).toThrow('Number token too long');
   });
 });
 

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -795,9 +795,9 @@ describe('NUT-18 payment payloads', () => {
         /malformed proof at index 0/,
       ],
       [
-        'a non-numeric proof amount',
+        'a quoted proof amount (plain JSON.stringify tell)',
         JSON.stringify({ ...valid(), proofs: [{ ...valid().proofs[0], amount: '2' }] }),
-        /malformed proof amount at index 0/,
+        /amounts must be JSON numbers/,
       ],
     ])('rejects %s', (_name, input, expected) => {
       expect(() => PaymentRequest.decodePayload(input)).toThrow(expected);


### PR DESCRIPTION
## Summary

Three small, independent tidy-ups to response reading and number parsing.

### `fix(transport): include the response body read in the request timeout`

The request timeout and caller abort signal only covered connecting and reading the response headers; the body read ran outside them, so `requestTimeout` did not cover the whole response.

- The body read now sits inside the timeout and the caller signal, and each read is raced against the abort signal, so a body that arrives slowly, never completes, or ignores the signal is stopped rather than read indefinitely.
- The read streams through a size sanity-cap (`maxResponseBytes` on `RequestOptions`, default 8 MiB, overridable per request or globally via `setGlobalRequestOptions`) with a `Content-Length` pre-check. Runtimes without a readable stream (eg React Native) fall back to `response.text()`, still raced against the signal and size-checked after decoding.
- A body-read failure under an armed signal, on both the success and the error path, is classified as timeout / caller-abort so NUT-19 cached-endpoint retry still engages.

### `fix(utils): cap integer token length in JSONInt`

A bigint number token can be arbitrarily long, but Cashu only ever needs a u64 (20 digits). Integer tokens over 100 characters (about 5x that) now fail before `BigInt` conversion, symmetric in both directions: parse rejects a longer token, stringify refuses to emit one, so output always round-trips. This bounds the one untrusted JSON path a consumer may not size themselves, `decodePayload`, which the transport cap does not cover.

### `fix(model): give an actionable error for quoted proof amounts`

`Amount.toJSON` serializes amounts as decimal strings, so a caller who reaches for plain `JSON.stringify` (with a bigint replacer) produces a body that `decodePayload` rejected with a generic "malformed proof amount". It now throws a named error pointing at `encodePayload` / `JSONInt.stringify`, and the `encodePayload` docs note that plain `JSON.stringify` is not wire format.

## Testing

`npm run prtasks` (lint, format, api:update, full unit suite across node + chromium + webkit + firefox) passes. New coverage: the response-read cap and timeout scope (Content-Length pre-check, streamed over-cap, within-cap success, oversized error body, option validation, timeout / caller-abort during a hung body read on both the streaming and no-stream fallback paths, and error-body aborts), the symmetric `JSONInt` stringify cap, the capped-token parse, and the quoted-amount `decodePayload` case.

## Notes

- No public API removed; `maxResponseBytes` is the only addition to the surface  (`etc/cashu-ts.api.md` updated).
- The amount value-object boundary (`Amount.from`) already length-gates decimal
  strings before `BigInt`, which covers CBOR / TLV / hand-built proof amounts;  the `JSONInt` cap complements it for the JSON number-token path.
- v4 backport is #887 (transport only; the `JSONInt` cap is v5-only, and v4 has  no `decodePayload`).
