### PR TITLE
fix(crypto): harden HTLC witness parsing edge cases

### DIFF
--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -192,6 +192,8 @@ export function getHTLCWitnessPreimage(witness: Proof['witness']): string | unde
     console.error('Failed to parse HTLC witness string:', e);
     return undefined;
   }
+  // A parsed primitive (eg "null", "1", "true") is not a witness; treat it as absent.
+  if (!parsed || typeof parsed !== 'object') return undefined;
   // Check preimage is a non-empty string
   const preimage = parsed.preimage;
   return typeof preimage === 'string' && preimage.length > 0 ? preimage : undefined;

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -260,6 +260,14 @@ describe('getHTLCWitnessPreimage', () => {
     expect(spy).toHaveBeenCalledWith('Failed to parse HTLC witness string:', expect.anything());
     spy.mockRestore();
   });
+
+  test('returns undefined for a parsed primitive witness (no throw)', () => {
+    // JSON.parse('null') yields null, which parses cleanly but is not a witness;
+    // reading .preimage off it must not throw at the verification boundary.
+    expect(getHTLCWitnessPreimage('null')).toBeUndefined();
+    expect(getHTLCWitnessPreimage('123')).toBeUndefined();
+    expect(getHTLCWitnessPreimage('"abcd"')).toBeUndefined();
+  });
 });
 
 describe('HTLC refund (sender) pathway', () => {


### PR DESCRIPTION
`getHTLCWitnessPreimage` parses an untrusted witness, but the try/catch only traps JSON syntax errors. A witness string that parses to a JSON primitive (eg `"null"`) got past the catch and then had a field read off it, so a malformed witness surfaced a raw error at the verification boundary instead of being treated as absent.

This adds the same non-object guard the P2PK witness parser (`parseWitnessData`) already carries, so both NUT-11 and NUT-14 witness parsing behave consistently: a parsed primitive is treated as no witness and returns `undefined`.

Regression tests cover `"null"`, a numeric primitive and a bare string. `npm run prtasks` green.