### PR TITLE
fix(crypto): tighten NUT-10 secret and tag-integer parsing

### DIFF
--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -87,8 +87,8 @@ export function parseSecret(secret: string | Secret): Secret {
   if (typeof data.nonce !== 'string' || typeof data.data !== 'string') {
     throw new CTSError('Invalid NUT-10 secret nonce / data');
   }
-  if (data.tags) {
-    // Check data.tags is an array
+  if (data.tags != null) {
+    // Check data.tags is an array (a falsy non-array must be rejected here)
     if (!Array.isArray(data.tags)) {
       throw new CTSError('Invalid NUT-10 secret tags');
     }
@@ -107,8 +107,8 @@ export function parseSecret(secret: string | Secret): Secret {
     {
       nonce: data.nonce,
       data: data.data,
-      tags: data.tags,
-    } as SecretData,
+      tags: data.tags ?? undefined, // a tolerated null becomes undefined
+    },
   ];
 }
 
@@ -218,7 +218,7 @@ export function getTagScalar(secret: Secret | string, key: string): string | und
 }
 
 /**
- * Get the first scalar value of a tag parsed as base-10 integer, or undefined.
+ * Get the first scalar value of a tag parsed as a base-10 integer, or undefined.
  *
  * @param secret - The Proof secret.
  * @param key - Tag key to lookup.
@@ -227,6 +227,11 @@ export function getTagScalar(secret: Secret | string, key: string): string | und
 export function getTagInt(secret: Secret | string, key: string): number | undefined {
   const v = getTagScalar(secret, key);
   if (v === undefined) return undefined;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : undefined;
+  // Strict integer parse: reject the partial parses ("1700000000abc" -> 1700000000)
+  // and hex/exponent/float forms Number.parseInt would accept. The sign is kept so a
+  // caller's semantic check (assertPositiveInteger, getLocktime's `<= 0`) still fails
+  // closed on an out-of-range value instead of it being silently dropped to undefined.
+  if (!/^-?\d+$/.test(v)) return undefined;
+  const n = Number(v);
+  return Number.isSafeInteger(n) ? n : undefined;
 }

--- a/test/crypto/NUT10.test.ts
+++ b/test/crypto/NUT10.test.ts
@@ -106,6 +106,20 @@ describe('NUT10 module core functions', () => {
     expect(getTagInt(proof.secret, 'not_exists')).toBeFalsy();
     expect(getTagInt(proof.secret, 'sigflag')).toBeFalsy();
   });
+
+  test('getTagInt rejects non-integer tag values instead of partial-parsing', () => {
+    // Number.parseInt would accept these; a spending-condition integer must not
+    // be inferred from a partial or non-decimal value (eg a locktime).
+    for (const bad of ['1700000000abc', '2 of 3', '0x1f', '1e3', '12.5', '  9']) {
+      const secret = createSecret('P2PK', DATA, [['locktime', bad]]);
+      expect(getTagInt(secret, 'locktime')).toBeUndefined();
+    }
+  });
+
+  test('getTagInt rejects an integer beyond safe range', () => {
+    const secret = createSecret('P2PK', DATA, [['locktime', '99999999999999999999']]);
+    expect(getTagInt(secret, 'locktime')).toBeUndefined();
+  });
 });
 
 describe('NUT10 parseSecret round-trip and serialization', () => {
@@ -181,6 +195,24 @@ describe('NUT10 parseSecret shape validation', () => {
   test('rejects a non-string nonce or data', () => {
     expect(() => parseSecret(`["P2PK",{"nonce":123,"data":"${DATA}"}]`)).toThrow(/nonce \/ data/);
     expect(() => parseSecret(`["P2PK",{"nonce":"${NONCE}","data":123}]`)).toThrow(/nonce \/ data/);
+  });
+
+  test('rejects a falsy non-array tags value', () => {
+    // A truthiness check let 0/false/"" slip past array validation and surface a
+    // raw TypeError in downstream tag readers; they must be rejected here instead.
+    for (const bad of ['0', 'false', '""']) {
+      expect(() =>
+        parseSecret(`["P2PK",{"nonce":"${NONCE}","data":"${DATA}","tags":${bad}}]`),
+      ).toThrow(/^Invalid NUT-10 secret tags$/);
+    }
+  });
+
+  test('tolerates an absent or null tags value, normalising null to undefined', () => {
+    expect(parseSecret(`["P2PK",{"nonce":"${NONCE}","data":"${DATA}"}]`)[1].tags).toBeUndefined();
+    // A tolerated null must not surface as a runtime null (the field is typed string[][] | undefined).
+    expect(
+      parseSecret(`["P2PK",{"nonce":"${NONCE}","data":"${DATA}","tags":null}]`)[1].tags,
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Two input-hygiene fixes at the NUT-10 parse boundary.

**`parseSecret` tags check.** `tags` was validated behind an `if (data.tags)` truthiness check. A present but falsy non-array value (`0`, `false`, `""`) skipped the array validation and passed straight through, where a downstream tag reader (`.some()`/`for..of`) then choked on it. The check now gates on presence (`!= null`), so any defined non-array value is rejected here with a controlled `CTSError`. Per NUT-10, `tags` is optional and, when present, an array; `null`/absent are tolerated as "no tags" (matching `getTags`' `?? []`) and a tolerated `null` is normalised to `undefined` on output so the field is never a runtime `null`.

**`getTagInt` parsing.** It used `Number.parseInt`, which partial-parses (`"1700000000abc"` -> `1700000000`) and accepts hex/exponent/float forms. It now requires a strict base-10 integer within the safe-integer range, returning `undefined` otherwise, so a malformed tag reads as absent. The sign is deliberately retained: callers apply their own semantic checks (`assertPositiveInteger` for `n_sigs`, `getLocktime`'s `<= 0` guard) and those stay fail-closed on an out-of-range value rather than seeing it silently dropped.

Regression tests cover the falsy-non-array tags cases, the null/absent tolerance (asserting normalised output), and the strict-integer rejections. `npm run prtasks` green.