### PR TITLE
fix(wallet): harden P2PK spending-condition locktime and tag validation

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -341,9 +341,14 @@ export function buildP2PKTags(lock: LockConditions): string[][] {
   const pubkeys = lock.pubkeys ?? [];
   const refund = lock.refundKeys ?? [];
 
-  const ts = lock.locktime ?? NaN;
-  if (Number.isSafeInteger(ts) && ts >= 0) {
-    tags.push(['locktime', String(ts)]);
+  // Reject a present-but-invalid locktime, don't drop it: refund keys without a locktime
+  // is a structural violation the verifier rejects outright ("refund keys require a
+  // locktime"), so a silent drop makes the whole proof unspendable, main keys included.
+  if (lock.locktime !== undefined) {
+    if (!Number.isSafeInteger(lock.locktime) || lock.locktime < 0) {
+      throw new CTSError(`locktime must be a non-negative integer, got ${lock.locktime}`);
+    }
+    tags.push(['locktime', String(lock.locktime)]);
   }
 
   if (pubkeys.length > 0) {
@@ -367,7 +372,12 @@ export function buildP2PKTags(lock: LockConditions): string[][] {
   if (lock.additionalTags?.length) {
     const extraTags = lock.additionalTags.map(([k, ...vals]) => {
       assertValidTagKey(k); // Validate key
-      return [k, ...vals.map(String)]; // all to strings
+      const stringVals = vals.map(String); // all to strings
+      // NUT-10 tag values must be non-empty strings (parseSecret rejects empties on read).
+      if (stringVals.some((v) => v.length === 0)) {
+        throw new CTSError(`tag "${k}" values must be non-empty strings`);
+      }
+      return [k, ...stringVals];
     });
     tags.push(...extraTags);
   }

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -10,9 +10,11 @@ import {
 import { CTSError } from '../model/Errors';
 import { OutputData } from '../model/OutputData';
 
-function toUnixSeconds(input: Date | number): number {
-  if (input instanceof Date) return Math.floor(input.getTime() / 1000);
-  return input < 1e12 ? Math.floor(input) : Math.floor(input / 1000); // > 1e12 = ms
+function assertUnixSeconds(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new CTSError(`locktime must be a non-negative finite Unix time, got ${seconds}`);
+  }
+  return Math.floor(seconds);
 }
 
 export class P2PKBuilder {
@@ -40,7 +42,15 @@ export class P2PKBuilder {
   }
 
   lockUntil(when: Date | number) {
-    this.locktime = toUnixSeconds(when);
+    let seconds: number;
+    if (when instanceof Date) {
+      seconds = when.getTime() / 1000;
+    } else {
+      // A value that looks like epoch milliseconds (>= 1e12) is read as ms so
+      // lockUntil(Date.now()) works; smaller values are treated as Unix seconds.
+      seconds = when < 1e12 ? when : when / 1000;
+    }
+    this.locktime = assertUnixSeconds(seconds);
     return this;
   }
 
@@ -63,7 +73,13 @@ export class P2PKBuilder {
   addTag(key: string, values?: string[] | string) {
     assertValidTagKey(key); //  Validate key
     const vals = values === undefined ? [] : Array.isArray(values) ? values : [values];
-    this.extraTags.push([key, ...vals.map(String)]); // all to strings
+    const stringVals = vals.map(String); // all to strings
+    // NUT-10 tag values must be non-empty strings; reject at the setter so an empty
+    // value fails here rather than producing a secret parseSecret later rejects.
+    if (stringVals.some((v) => v.length === 0)) {
+      throw new CTSError(`tag "${key}" values must be non-empty strings`);
+    }
+    this.extraTags.push([key, ...stringVals]);
     return this;
   }
 
@@ -148,7 +164,9 @@ export class P2PKBuilder {
     } else {
       b.addLockPubkey([p2pk.data, ...(p2pk.pubkeys ?? [])]);
     }
-    if (p2pk.locktime !== undefined) b.lockUntil(p2pk.locktime);
+    // p2pk.locktime is already canonical Unix seconds; assign directly so lockUntil's
+    // ms heuristic can't re-interpret a >= 1e12 second value and expire the lock.
+    if (p2pk.locktime !== undefined) b.locktime = assertUnixSeconds(p2pk.locktime);
     if (p2pk.refundKeys?.length) b.addRefundPubkey(p2pk.refundKeys);
     if (p2pk.requiredSignatures !== undefined) b.requireLockSignatures(p2pk.requiredSignatures);
     if (p2pk.requiredRefundSignatures !== undefined)

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -297,14 +297,29 @@ describe('OutputData.createSingleP2PKData tag construction', () => {
     ]);
   });
 
-  test('omits the locktime tag for a negative locktime', () => {
-    const out = OutputData.createSingleP2PKData(
-      { kind: 'P2PK', data: pub(0), locktime: -1 },
-      1,
-      KEYSET_ID,
-    );
-    // -1 fails the `>= 0` guard; a mutated `||`/forced-true guard would emit the tag anyway.
-    expect(readSecret(out).tags.find(([t]) => t === 'locktime')).toBeUndefined();
+  test('throws for a present but invalid locktime instead of silently dropping it', () => {
+    // Refund keys with a dropped locktime is a structural violation the verifier rejects
+    // outright (unspendable, main keys included), so a present-but-invalid value
+    // (negative / non-finite) must be rejected here, not omitted.
+    for (const bad of [-1, NaN, Infinity]) {
+      expect(() =>
+        OutputData.createSingleP2PKData(
+          { kind: 'P2PK', data: pub(0), locktime: bad },
+          1,
+          KEYSET_ID,
+        ),
+      ).toThrow(/locktime/i);
+    }
+  });
+
+  test('throws for an empty additionalTags value on the direct build path', () => {
+    expect(() =>
+      OutputData.createSingleP2PKData(
+        { kind: 'P2PK', data: pub(0), additionalTags: [['memo', '']] },
+        1,
+        KEYSET_ID,
+      ),
+    ).toThrow(/non-empty/i);
   });
 
   test('emits an exact sigflag tag for SIG_ALL', () => {
@@ -331,8 +346,9 @@ describe('OutputData.createSingleP2PKData tag construction', () => {
         1,
         KEYSET_ID,
       );
-    const base = [...new TextDecoder().decode(build(0).secret)].length;
-    const target = MAX_SECRET_LENGTH - base;
+    // Measure with a single 'A' (an empty tag value is rejected), then add the rest.
+    const base = [...new TextDecoder().decode(build(1).secret)].length;
+    const target = MAX_SECRET_LENGTH - base + 1;
 
     const atLimit = build(target);
     // Exactly MAX_SECRET_LENGTH must be accepted (kills `>` -> `>=`).

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -134,11 +134,40 @@ describe('P2PKBuilder.toOptions()', () => {
     expect(opts.locktime).toBe(999_999_999_999);
   });
 
+  it('rejects a non-finite, negative or invalid-Date locktime at the setter', () => {
+    // A silently-dropped locktime with refund keys present yields an unspendable proof
+    // (refund path needs a locktime), so an unusable value must fail here.
+    const base = () =>
+      new P2PKBuilder().addLockPubkey(comp('a', '02')).addRefundPubkey(comp('b', '02'));
+    for (const bad of [NaN, Infinity, -Infinity, -1]) {
+      expect(() => base().lockUntil(bad)).toThrow(/locktime/i);
+    }
+    expect(() => base().lockUntil(new Date(NaN))).toThrow(/locktime/i);
+  });
+
+  it('fromOptions preserves a canonical seconds locktime >= 1e12 (no ms heuristic on replay)', () => {
+    // A locktime already in seconds must round-trip exactly; lockUntil's ms heuristic
+    // must not re-interpret it (dividing by 1000 would expire the lock).
+    const src: P2PKOptions = {
+      kind: 'P2PK',
+      data: comp('a', '02'),
+      locktime: 1_000_000_000_000, // 1e12 seconds: a valid far-future lock
+      refundKeys: [comp('b', '02')],
+    };
+    expect(P2PKBuilder.fromOptions(src).toOptions().locktime).toBe(1_000_000_000_000);
+  });
+
   it('returns a defensive copy of additionalTags, isolated from later mutations', () => {
     const b = new P2PKBuilder().addLockPubkey(comp('a', '02')).addTag('foo', ['bar']);
     const opts = b.toOptions();
     b.addTag('baz', ['qux']); // must not leak into the already-returned options
     expect(opts.additionalTags).toEqual([['foo', 'bar']]);
+  });
+
+  it('rejects an empty tag value (parseSecret refuses empty tag strings)', () => {
+    const b = () => new P2PKBuilder().addLockPubkey(comp('a', '02'));
+    expect(() => b().addTag('memo', '')).toThrow(/non-empty/i);
+    expect(() => b().addTag('memo', ['ok', ''])).toThrow(/non-empty/i);
   });
 
   it('requireLockSignatures throws on non-integer and values less than 1', () => {


### PR DESCRIPTION
`P2PKBuilder` (and the shared write path beneath it) accepted inputs that produced NUT-10/11 secrets the library later refuses to parse or verify. This tightens both.

**Builder (`P2PKBuilder`)**
- `lockUntil` validates the resolved Unix time via `assertUnixSeconds`, rejecting `NaN`/`Infinity`/negative values and invalid `Date`s at the setter, instead of letting a bad value flow through and be silently dropped downstream.
- `addTag` rejects empty tag values, matching `parseSecret`'s read-side rule (NUT-10 tag values must be non-empty strings) and the file's existing "validate at the setter" convention.
- `fromOptions` assigns the canonical seconds `locktime` directly rather than replaying it through `lockUntil`'s millisecond heuristic. A locktime already in seconds and `>= 1e12` was otherwise divided by 1000 and expired; the heuristic only belongs at the ergonomic `lockUntil` entry, not when re-reading an already-normalised options object.

**Write chokepoint (`buildP2PKTags`)**
Both the builder and a direct `OutputData.createSingleP2PKData(options)` call flow through `buildP2PKTags`, so the same rules are enforced there:
- A present-but-invalid `locktime` now throws instead of being silently dropped. A dropped locktime alongside refund keys is a structural violation the verifier rejects outright (`refund keys require a locktime`), leaving a secret that is unspendable via any path, so it must fail at construction.
- Empty `additionalTags` values are rejected, matching the read side.

Regression tests cover the builder setters, the `fromOptions` round-trip of a `>= 1e12` second locktime, and the direct-build-path rejections. A prior test that pinned the silent-locktime-drop is updated to expect the throw, and the `MAX_SECRET_LENGTH` boundary test is rebased off a single-character pad (it had used an empty tag value as a measuring stick). `npm run prtasks` green.