### PR TITLE
fix(wallet): harden P2PK spending-condition locktime and tag validation [backport v4-dev]

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -275,7 +275,107 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
     ...(p2pk.additionalTags?.length ? { additionalTags: p2pk.additionalTags } : {}),
     ...(p2pk.blindKeys ? { blindKeys: true } : {}),
     ...(p2pk.sigFlag !== undefined ? { sigFlag: p2pk.sigFlag } : {}),
+<<<<<<< HEAD
     ...(p2pk.hashlock ? { hashlock: p2pk.hashlock } : {}),
+=======
+  };
+}
+
+// ------------------------------
+// Lock Tag Serialization
+// ------------------------------
+
+/**
+ * Asserts P2PK Tag key is valid.
+ *
+ * @param key Tag Key.
+ * @throws If not a string, or is a reserved string.
+ * @internal
+ */
+export function assertValidTagKey(key: string) {
+  if (!key || typeof key !== 'string') throw new CTSError('tag key must be a non empty string');
+  if (P2PK_KNOWN_TAG_KEYS.has(key)) {
+    throw new CTSError(`additionalTags must not use reserved key "${key}"`);
+  }
+}
+
+/**
+ * Serializes NUT-11 lock fields into secret tags.
+ *
+ * @remarks
+ * Expects {@link normalizeP2PKOptions}-canonical input (deduped keys, redundant thresholds dropped).
+ * Thresholds are only emitted alongside their key tag.
+ * @throws If an additional tag uses a reserved or invalid key.
+ * @internal
+ */
+export function buildP2PKTags(lock: LockConditions): string[][] {
+  const tags: string[][] = [];
+  const pubkeys = lock.pubkeys ?? [];
+  const refund = lock.refundKeys ?? [];
+
+  // Reject a present-but-invalid locktime, don't drop it: refund keys without a locktime
+  // is a structural violation the verifier rejects outright ("refund keys require a
+  // locktime"), so a silent drop makes the whole proof unspendable, main keys included.
+  if (lock.locktime !== undefined) {
+    if (!Number.isSafeInteger(lock.locktime) || lock.locktime < 0) {
+      throw new CTSError(`locktime must be a non-negative integer, got ${lock.locktime}`);
+    }
+    tags.push(['locktime', String(lock.locktime)]);
+  }
+
+  if (pubkeys.length > 0) {
+    tags.push(['pubkeys', ...pubkeys]);
+    if ((lock.requiredSignatures ?? 1) > 1) {
+      tags.push(['n_sigs', String(lock.requiredSignatures)]);
+    }
+  }
+
+  if (refund.length > 0) {
+    tags.push(['refund', ...refund]);
+    if ((lock.requiredRefundSignatures ?? 1) > 1) {
+      tags.push(['n_sigs_refund', String(lock.requiredRefundSignatures)]);
+    }
+  }
+
+  if (lock.sigFlag == 'SIG_ALL') {
+    tags.push(['sigflag', 'SIG_ALL']);
+  }
+
+  if (lock.additionalTags?.length) {
+    const extraTags = lock.additionalTags.map(([k, ...vals]) => {
+      assertValidTagKey(k); // Validate key
+      const stringVals = vals.map(String); // all to strings
+      // NUT-10 tag values must be non-empty strings (parseSecret rejects empties on read).
+      if (stringVals.some((v) => v.length === 0)) {
+        throw new CTSError(`tag "${k}" values must be non-empty strings`);
+      }
+      return [k, ...stringVals];
+    });
+    tags.push(...extraTags);
+  }
+
+  return tags;
+}
+
+/**
+ * Converts a {@link P2PKOptions} into the NUT-18 payment request `nut10` option.
+ *
+ * @remarks
+ * Validates and canonicalises the lock (deduped keys, redundant thresholds dropped). `blindKeys`
+ * throws: P2BK blinding is applied per output at send time, so a static request cannot carry it.
+ */
+export function p2pkOptionsToPRNut10(p2pk: P2PKOptions): NUT10Option {
+  const normalized = normalizeP2PKOptions(p2pk);
+  if (normalized.blindKeys) {
+    throw new CTSError(
+      'blindKeys is not expressible in a payment request; the payer applies P2BK blinding per output',
+    );
+  }
+  return {
+    kind: normalized.kind,
+    data: normalized.data,
+    tags: buildP2PKTags(normalized),
+>>>>>>> 6985fa1 (fix(wallet): harden P2PK spending-condition locktime and tag validation (#894))
   };
 }
 

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -2,9 +2,11 @@ import { dedupeP2PKPubkeys, type P2PKOptions, type P2PKTag, type SigFlag } from 
 import { CTSError } from '../model/Errors';
 import { assertValidTagKey, OutputData } from '../model/OutputData';
 
-function toUnixSeconds(input: Date | number): number {
-  if (input instanceof Date) return Math.floor(input.getTime() / 1000);
-  return input < 1e12 ? Math.floor(input) : Math.floor(input / 1000); // > 1e12 = ms
+function assertUnixSeconds(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new CTSError(`locktime must be a non-negative finite Unix time, got ${seconds}`);
+  }
+  return Math.floor(seconds);
 }
 
 export class P2PKBuilder {
@@ -32,7 +34,15 @@ export class P2PKBuilder {
   }
 
   lockUntil(when: Date | number) {
-    this.locktime = toUnixSeconds(when);
+    let seconds: number;
+    if (when instanceof Date) {
+      seconds = when.getTime() / 1000;
+    } else {
+      // A value that looks like epoch milliseconds (>= 1e12) is read as ms so
+      // lockUntil(Date.now()) works; smaller values are treated as Unix seconds.
+      seconds = when < 1e12 ? when : when / 1000;
+    }
+    this.locktime = assertUnixSeconds(seconds);
     return this;
   }
 
@@ -55,7 +65,13 @@ export class P2PKBuilder {
   addTag(key: string, values?: string[] | string) {
     assertValidTagKey(key); //  Validate key
     const vals = values === undefined ? [] : Array.isArray(values) ? values : [values];
-    this.extraTags.push([key, ...vals.map(String)]); // all to strings
+    const stringVals = vals.map(String); // all to strings
+    // NUT-10 tag values must be non-empty strings; reject at the setter so an empty
+    // value fails here rather than producing a secret parseSecret later rejects.
+    if (stringVals.some((v) => v.length === 0)) {
+      throw new CTSError(`tag "${key}" values must be non-empty strings`);
+    }
+    this.extraTags.push([key, ...stringVals]);
     return this;
   }
 
@@ -123,6 +139,7 @@ export class P2PKBuilder {
 
   static fromOptions(opts: P2PKOptions): P2PKBuilder {
     const b = new P2PKBuilder();
+<<<<<<< HEAD
     const locks = Array.isArray(opts.pubkey) ? opts.pubkey : [opts.pubkey];
     b.addLockPubkey(locks);
     if (opts.locktime !== undefined) b.lockUntil(opts.locktime);
@@ -134,6 +151,24 @@ export class P2PKBuilder {
     if (opts.blindKeys) b.blindKeys();
     if (opts.sigFlag == 'SIG_ALL') b.sigAll();
     if (opts.hashlock) b.addHashlock(opts.hashlock);
+=======
+    if (p2pk.kind === 'HTLC') {
+      b.addHashlock(p2pk.data);
+      if (p2pk.pubkeys?.length) b.addLockPubkey(p2pk.pubkeys);
+    } else {
+      b.addLockPubkey([p2pk.data, ...(p2pk.pubkeys ?? [])]);
+    }
+    // p2pk.locktime is already canonical Unix seconds; assign directly so lockUntil's
+    // ms heuristic can't re-interpret a >= 1e12 second value and expire the lock.
+    if (p2pk.locktime !== undefined) b.locktime = assertUnixSeconds(p2pk.locktime);
+    if (p2pk.refundKeys?.length) b.addRefundPubkey(p2pk.refundKeys);
+    if (p2pk.requiredSignatures !== undefined) b.requireLockSignatures(p2pk.requiredSignatures);
+    if (p2pk.requiredRefundSignatures !== undefined)
+      b.requireRefundSignatures(p2pk.requiredRefundSignatures);
+    if (p2pk.additionalTags?.length) b.addTags(p2pk.additionalTags);
+    if (p2pk.blindKeys) b.blindKeys();
+    if (p2pk.sigFlag == 'SIG_ALL') b.sigAll();
+>>>>>>> 6985fa1 (fix(wallet): harden P2PK spending-condition locktime and tag validation (#894))
     return b;
   }
 }

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -141,6 +141,186 @@ describe('OutputData.assertValidTagKey and reserved tags', () => {
   });
 });
 
+<<<<<<< HEAD
+=======
+describe('OutputData.createSingleP2PKData tag construction', () => {
+  const KEYSET_ID = '009a1f293253e41e';
+  const pub = (i: number): string => bytesToHex(getPubKeyFromPrivKey(secpPriv(i)));
+
+  test('does not blind keys when blindKeys is unset', () => {
+    const data = pub(0);
+    const out = OutputData.createSingleP2PKData({ kind: 'P2PK', data }, 1, KEYSET_ID);
+    expect(out.ephemeralE).toBeUndefined();
+    // data key stays in the clear (kills `if (blindKeys)` -> true).
+    expect(readSecret(out).data).toBe(data);
+  });
+
+  test('P2PK blinding: data key blinded, pubkeys/refund sliced by role', () => {
+    const data = pub(0);
+    const extraPub = pub(1);
+    const refundKey = pub(2);
+    const out = OutputData.createSingleP2PKData(
+      {
+        kind: 'P2PK',
+        data,
+        pubkeys: [extraPub],
+        refundKeys: [refundKey],
+        locktime: 1700000000,
+        blindKeys: true,
+      },
+      1,
+      KEYSET_ID,
+    );
+    const { data: secretData, tags } = readSecret(out);
+    const pubkeysTag = tags.find(([t]) => t === 'pubkeys');
+    const refundTag = tags.find(([t]) => t === 'refund');
+
+    expect(out.ephemeralE).toBeDefined();
+    // First locking key sits in data, blinded (kills `if (isHTLC)` -> true and the else-block wipe).
+    expect(secretData).not.toBe(data);
+    expect(secretData).toMatch(/^0[23][0-9a-f]{64}$/);
+    // Exactly one extra locking key in pubkeys (kills slice(1, lockKeys.length) -> blinded).
+    expect(pubkeysTag?.slice(1)).toHaveLength(1);
+    expect(pubkeysTag?.[1]).not.toBe(extraPub);
+    // Exactly one refund key (kills slice(lockKeys.length) -> blinded).
+    expect(refundTag?.slice(1)).toHaveLength(1);
+    expect(refundTag?.[1]).not.toBe(refundKey);
+  });
+
+  test('HTLC blinding: hashlock stays clear, all lock keys blinded into pubkeys', () => {
+    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+    const lock1 = pub(1);
+    const lock2 = pub(2);
+    const refundKey = pub(3);
+    const out = OutputData.createSingleP2PKData(
+      {
+        kind: 'HTLC',
+        data: hashlock,
+        pubkeys: [lock1, lock2],
+        refundKeys: [refundKey],
+        locktime: 1700000000,
+        blindKeys: true,
+      },
+      1,
+      KEYSET_ID,
+    );
+    const { kind, data: secretData, tags } = readSecret(out);
+    const pubkeysTag = tags.find(([t]) => t === 'pubkeys');
+    const refundTag = tags.find(([t]) => t === 'refund');
+
+    expect(kind).toBe('HTLC');
+    expect(secretData).toBe(hashlock);
+    // Both lock keys land in pubkeys, blinded (kills slice(0, lockKeys.length) -> blinded, which
+    // would also fold the refund key into pubkeys).
+    expect(pubkeysTag?.slice(1)).toHaveLength(2);
+    expect(pubkeysTag?.[1]).not.toBe(lock1);
+    expect(pubkeysTag?.[2]).not.toBe(lock2);
+    expect(refundTag?.slice(1)).toHaveLength(1);
+  });
+
+  test('HTLC blinding starts lock keys at slot 1 (NUT-28: hashlock occupies slot 0)', () => {
+    const hashlock = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+    const lockPriv = secpPriv(1);
+    const lock1 = pub(1);
+    const out = OutputData.createSingleP2PKData(
+      { kind: 'HTLC', data: hashlock, pubkeys: [lock1], blindKeys: true },
+      1,
+      KEYSET_ID,
+    );
+    const blinded = readSecret(out).tags.find(([t]) => t === 'pubkeys')![1];
+    // Independent receiver-side NUT-28 math: r1 = sha256(DST || Zx || 0x01), P' = P + r1·G
+    const p = secp256k1.Point.Fn.fromBytes(lockPriv);
+    const Zx = secp256k1.Point.fromHex(out.ephemeralE!).multiply(p).toBytes(true).slice(1);
+    const r1 = Bytes.toBigInt(sha256(Bytes.concat(P2BK_DST, Zx, Uint8Array.of(1))));
+    const expected = pointFromHex(lock1).add(secp256k1.Point.BASE.multiply(r1)).toHex(true);
+    expect(blinded).toBe(expected);
+  });
+
+  test('emits a locktime tag for locktime 0 (boundary)', () => {
+    const out = OutputData.createSingleP2PKData(
+      { kind: 'P2PK', data: pub(0), locktime: 0 },
+      1,
+      KEYSET_ID,
+    );
+    const locktimeTag = readSecret(out).tags.find(([t]) => t === 'locktime');
+    // locktime 0 is valid (kills `ts >= 0` -> `ts > 0`).
+    expect(locktimeTag).toEqual(['locktime', '0']);
+  });
+
+  test('emits a locktime tag for a positive locktime', () => {
+    const out = OutputData.createSingleP2PKData(
+      { kind: 'P2PK', data: pub(0), locktime: 1700000000 },
+      1,
+      KEYSET_ID,
+    );
+    expect(readSecret(out).tags.find(([t]) => t === 'locktime')).toEqual([
+      'locktime',
+      '1700000000',
+    ]);
+  });
+
+  test('throws for a present but invalid locktime instead of silently dropping it', () => {
+    // Refund keys with a dropped locktime is a structural violation the verifier rejects
+    // outright (unspendable, main keys included), so a present-but-invalid value
+    // (negative / non-finite) must be rejected here, not omitted.
+    for (const bad of [-1, NaN, Infinity]) {
+      expect(() =>
+        OutputData.createSingleP2PKData(
+          { kind: 'P2PK', data: pub(0), locktime: bad },
+          1,
+          KEYSET_ID,
+        ),
+      ).toThrow(/locktime/i);
+    }
+  });
+
+  test('throws for an empty additionalTags value on the direct build path', () => {
+    expect(() =>
+      OutputData.createSingleP2PKData(
+        { kind: 'P2PK', data: pub(0), additionalTags: [['memo', '']] },
+        1,
+        KEYSET_ID,
+      ),
+    ).toThrow(/non-empty/i);
+  });
+
+  test('emits an exact sigflag tag for SIG_ALL', () => {
+    const out = OutputData.createSingleP2PKData(
+      { kind: 'P2PK', data: pub(0), sigFlag: 'SIG_ALL' },
+      1,
+      KEYSET_ID,
+    );
+    // Exact contents guard against dropped/blanked strings and the emptied push array.
+    expect(readSecret(out).tags.find(([t]) => t === 'sigflag')).toEqual(['sigflag', 'SIG_ALL']);
+  });
+
+  test('omits the sigflag tag when not SIG_ALL', () => {
+    const out = OutputData.createSingleP2PKData({ kind: 'P2PK', data: pub(0) }, 1, KEYSET_ID);
+    expect(readSecret(out).tags.find(([t]) => t === 'sigflag')).toBeUndefined();
+  });
+
+  test('accepts a secret of exactly MAX_SECRET_LENGTH code points', () => {
+    // Pad an additional tag value so the JSON secret hits the limit exactly. Each ASCII 'A' adds
+    // one code point with no JSON escaping, so length is linear in the pad size.
+    const build = (pad: number): OutputData =>
+      OutputData.createSingleP2PKData(
+        { kind: 'P2PK', data: pub(0), additionalTags: [['x', 'A'.repeat(pad)]] },
+        1,
+        KEYSET_ID,
+      );
+    // Measure with a single 'A' (an empty tag value is rejected), then add the rest.
+    const base = [...new TextDecoder().decode(build(1).secret)].length;
+    const target = MAX_SECRET_LENGTH - base + 1;
+
+    const atLimit = build(target);
+    // Exactly MAX_SECRET_LENGTH must be accepted (kills `>` -> `>=`).
+    expect([...new TextDecoder().decode(atLimit.secret)].length).toBe(MAX_SECRET_LENGTH);
+    // One over must be rejected.
+    expect(() => build(target + 1)).toThrowError(/Secret too long/);
+  });
+});
+
+>>>>>>> 6985fa1 (fix(wallet): harden P2PK spending-condition locktime and tag validation (#894))
 describe('OutputData.deserialize', () => {
   test('wraps a malformed serialized payload with the underlying cause', () => {
     const serialized = OutputData.serialize(

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -120,11 +120,40 @@ describe('P2PKBuilder.toOptions()', () => {
     expect(opts.locktime).toBe(999_999_999_999);
   });
 
+  it('rejects a non-finite, negative or invalid-Date locktime at the setter', () => {
+    // A silently-dropped locktime with refund keys present yields an unspendable proof
+    // (refund path needs a locktime), so an unusable value must fail here.
+    const base = () =>
+      new P2PKBuilder().addLockPubkey(comp('a', '02')).addRefundPubkey(comp('b', '02'));
+    for (const bad of [NaN, Infinity, -Infinity, -1]) {
+      expect(() => base().lockUntil(bad)).toThrow(/locktime/i);
+    }
+    expect(() => base().lockUntil(new Date(NaN))).toThrow(/locktime/i);
+  });
+
+  it('fromOptions preserves a canonical seconds locktime >= 1e12 (no ms heuristic on replay)', () => {
+    // A locktime already in seconds must round-trip exactly; lockUntil's ms heuristic
+    // must not re-interpret it (dividing by 1000 would expire the lock).
+    const src: P2PKOptions = {
+      kind: 'P2PK',
+      data: comp('a', '02'),
+      locktime: 1_000_000_000_000, // 1e12 seconds: a valid far-future lock
+      refundKeys: [comp('b', '02')],
+    };
+    expect(P2PKBuilder.fromOptions(src).toOptions().locktime).toBe(1_000_000_000_000);
+  });
+
   it('returns a defensive copy of additionalTags, isolated from later mutations', () => {
     const b = new P2PKBuilder().addLockPubkey(comp('a', '02')).addTag('foo', ['bar']);
     const opts = b.toOptions();
     b.addTag('baz', ['qux']); // must not leak into the already-returned options
     expect(opts.additionalTags).toEqual([['foo', 'bar']]);
+  });
+
+  it('rejects an empty tag value (parseSecret refuses empty tag strings)', () => {
+    const b = () => new P2PKBuilder().addLockPubkey(comp('a', '02'));
+    expect(() => b().addTag('memo', '')).toThrow(/non-empty/i);
+    expect(() => b().addTag('memo', ['ok', ''])).toThrow(/non-empty/i);
   });
 
   it('requireLockSignatures throws on non-integer and values less than 1', () => {


### PR DESCRIPTION
# Description
Backport of #894 to `v4-dev`.