### PR TITLE
fix: guard CBOR and keyset map lookups against prototype-chain keys [backport v4-dev]

### DIFF
--- a/src/utils/cbor.ts
+++ b/src/utils/cbor.ts
@@ -479,7 +479,14 @@ function decodeMap(
       throw new CTSError('Invalid key type');
     }
     const valueResult = decodeItem(view, keyResult.offset, depth + 1);
-    map[String(keyResult.value)] = valueResult.value;
+    // Define explicitly so a "__proto__" key becomes an own data property instead of
+    // hitting the prototype setter and reparenting the decoded map (see JSONInt.parseObject).
+    Object.defineProperty(map, String(keyResult.value), {
+      value: valueResult.value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
     currentOffset = valueResult.offset;
   }
   return { value: map, offset: currentOffset };

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -22,7 +22,10 @@ import { Keyset } from './Keyset';
 export class KeyChain {
   private mint: Mint;
   private unit: string;
-  private keysets: { [id: string]: Keyset } = {};
+  // Object.create(null): a mint-supplied id of '__proto__'/'constructor'/etc must resolve to
+  // an own entry or nothing, never an inherited Object.prototype member (which is truthy and
+  // would slip past the not-found guard in getKeyset).
+  private keysets: { [id: string]: Keyset } = Object.create(null) as { [id: string]: Keyset };
   private pendingKeyFetches: Map<string, Promise<Keyset>> = new Map();
 
   private assertInitialized(): void {
@@ -163,8 +166,8 @@ export class KeyChain {
    * @param allKeys Keys data from mint.getKeys() API.
    */
   private buildKeychain(allKeysets: MintKeyset[], allKeys: MintKeys[]): void {
-    // Clear existing keysets to avoid stale data
-    this.keysets = {};
+    // Clear existing keysets to avoid stale data (null-proto, see the field declaration)
+    this.keysets = Object.create(null) as { [id: string]: Keyset };
 
     const keysMap = new Map<string, MintKeys>(allKeys.map((k) => [k.id, k]));
 

--- a/test/utils/cbor.test.ts
+++ b/test/utils/cbor.test.ts
@@ -89,6 +89,22 @@ describe('cbor decoder', () => {
     expect(v).toBe(0x10);
   });
 
+  test('decodeMap does not let a __proto__ key reparent or pollute the result', () => {
+    // CBOR for {"__proto__": {"polluted": true}}. Assigning this key with `map[k] = v`
+    // would hit the prototype setter and reparent the decoded object.
+    const buf = new Uint8Array([
+      0xa1, 0x69, 0x5f, 0x5f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x5f, 0x5f, 0xa1, 0x68, 0x70, 0x6f,
+      0x6c, 0x6c, 0x75, 0x74, 0x65, 0x64, 0xf5,
+    ]);
+    const result = decodeCBOR(buf) as Record<string, unknown>;
+    // Prototype untouched, no inherited "polluted" leaks in (globally or on the result).
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(result.polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    // The entry is preserved as an own data key, not applied as a prototype.
+    expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(true);
+  });
+
   test('deeply nested input fails with a CTSError, not a stack overflow', () => {
     // 0x81 = "array of length 1"; nesting it far past the depth cap must throw a CTSError
     // rather than a RangeError that a decode-on-paste consumer would not catch.

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -122,6 +122,16 @@ describe('KeyChain initialization', () => {
     expect(active.expiry).toBe(1754296607);
   });
 
+  test('getKeyset rejects prototype-chain ids instead of returning inherited values', async () => {
+    const keyChain = new KeyChain(mint, unit);
+    await keyChain.init();
+    // A bare object map resolves these to Object.prototype members (truthy), bypassing
+    // the not-found guard; the lookup must return nothing for a non-own id.
+    for (const id of ['__proto__', 'constructor', 'toString', 'hasOwnProperty']) {
+      expect(() => keyChain.getKeyset(id)).toThrow(/not found/i);
+    }
+  });
+
   test('should initialize with mintUrl and load keys and keysets', async () => {
     const keyChain = new KeyChain('http://localhost:3338', unit);
     await keyChain.init();


### PR DESCRIPTION
# Description
Backport of #895 to `v4-dev`.