### PR TITLE
fix(auth): validate OIDC provider URLs use an http(s) scheme [backport v4-dev]

### DIFF
--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -40,6 +40,24 @@ export type OIDCAuthOptions = {
   onTokens?: (t: TokenResponse) => void | Promise<void>;
 };
 
+/**
+ * Assert a provider-supplied URL uses an http(s) scheme.
+ *
+ * @remarks
+ * Guards against a `javascript:`/`data:` endpoint that the client would navigate to or open.
+ */
+function assertHttpUrl(url: string, label: string): void {
+  let protocol: string;
+  try {
+    protocol = new URL(url).protocol;
+  } catch {
+    throw new CTSError(`OIDCAuth: ${label} is not a valid URL`);
+  }
+  if (protocol !== 'https:' && protocol !== 'http:') {
+    throw new CTSError(`OIDCAuth: ${label} must be an http(s) URL`);
+  }
+}
+
 export class OIDCAuth {
   private readonly discoveryUrl: string;
   private readonly logger: Logger;
@@ -158,6 +176,7 @@ export class OIDCAuth {
     if (!cfg.authorization_endpoint) {
       throw new CTSError('OIDCAuth: discovery lacks authorization_endpoint');
     }
+    assertHttpUrl(cfg.authorization_endpoint, 'authorization_endpoint');
     return `${cfg.authorization_endpoint}?${params.toString()}`;
   }
 
@@ -186,7 +205,13 @@ export class OIDCAuth {
     if (!ep) throw new CTSError('OIDCAuth: provider lacks device_authorization_endpoint');
 
     const form = this.toForm({ client_id: this.clientId, scope: this.scope });
-    return this.postFormStrict<DeviceStartResponse>(ep, form);
+    const res = await this.postFormStrict<DeviceStartResponse>(ep, form);
+    // The client displays/opens these; a javascript: scheme would run on open.
+    assertHttpUrl(res.verification_uri, 'verification_uri');
+    if (res.verification_uri_complete !== undefined) {
+      assertHttpUrl(res.verification_uri_complete, 'verification_uri_complete');
+    }
+    return res;
   }
 
   async devicePoll(device_code: string, intervalSec = 5): Promise<TokenResponse> {

--- a/test/auth/OIDCAuth.node.test.ts
+++ b/test/auth/OIDCAuth.node.test.ts
@@ -105,6 +105,32 @@ describe('OIDCAuth: PKCE + auth code', () => {
     expect(sp.get('state')).toBe('abc123');
   });
 
+  test('buildAuthCodeUrl rejects a non-http(s) authorization_endpoint', async () => {
+    server.use(
+      http.get(DISCOVERY, () =>
+        HttpResponse.json({ ...goodDiscovery, authorization_endpoint: 'javascript:alert(1)' }),
+      ),
+    );
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client' });
+    const { challenge } = oidc.generatePKCE();
+    await expect(
+      oidc.buildAuthCodeUrl({ redirectUri: 'http://localhost/cb', codeChallenge: challenge }),
+    ).rejects.toThrow(/authorization_endpoint/i);
+  });
+
+  test('buildAuthCodeUrl rejects an unparseable authorization_endpoint', async () => {
+    server.use(
+      http.get(DISCOVERY, () =>
+        HttpResponse.json({ ...goodDiscovery, authorization_endpoint: 'not a url' }),
+      ),
+    );
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client' });
+    const { challenge } = oidc.generatePKCE();
+    await expect(
+      oidc.buildAuthCodeUrl({ redirectUri: 'http://localhost/cb', codeChallenge: challenge }),
+    ).rejects.toThrow(/not a valid URL/i);
+  });
+
   test('exchangeAuthCode posts correct form and fires callbacks', async () => {
     const bodies: string[] = [];
     server.use(
@@ -187,6 +213,39 @@ describe('OIDCAuth: device flow', () => {
     const start = await oidc.deviceStart();
     expect(start.device_code).toBe('dev-123');
     expect(start.user_code).toBe('UCODE-123');
+  });
+
+  test('deviceStart rejects a non-http(s) verification_uri', async () => {
+    server.use(
+      http.post(DEVICE_EP, () =>
+        HttpResponse.json({
+          device_code: 'dev-123',
+          user_code: 'UCODE-123',
+          verification_uri: 'javascript:alert(1)',
+          interval: 2,
+          expires_in: 600,
+        }),
+      ),
+    );
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client' });
+    await expect(oidc.deviceStart()).rejects.toThrow(/verification_uri/i);
+  });
+
+  test('deviceStart rejects a non-http(s) verification_uri_complete', async () => {
+    server.use(
+      http.post(DEVICE_EP, () =>
+        HttpResponse.json({
+          device_code: 'dev-123',
+          user_code: 'UCODE-123',
+          verification_uri: `${ISSUER}/device`,
+          verification_uri_complete: 'javascript:alert(1)',
+          interval: 2,
+          expires_in: 600,
+        }),
+      ),
+    );
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client' });
+    await expect(oidc.deviceStart()).rejects.toThrow(/verification_uri_complete/i);
   });
 
   test('devicePoll loops until access_token (authorization_pending → success)', async () => {


### PR DESCRIPTION
# Description
Backport of #896 to `v4-dev`.