### PR TITLE
fix(crypto): count unique signers by x-only pubkey identity

### DIFF
--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -127,9 +127,7 @@ export const schnorrVerifyDigest = (
 ): boolean => {
   try {
     const digestBytes = typeof digest === 'string' ? hexToBytes(digest) : digest;
-    // Use X-only pubkey: strip 02/03 prefix if pubkey is 66 hex chars (33 bytes)
-    const pubkeyX = pubkey.length === 66 ? pubkey.slice(2) : pubkey;
-    return schnorr.verify(hexToBytes(signature), digestBytes, hexToBytes(pubkeyX));
+    return schnorr.verify(hexToBytes(signature), digestBytes, hexToBytes(toXOnlyPubkey(pubkey)));
   } catch (e) {
     if (throws) {
       throw e;
@@ -137,6 +135,19 @@ export const schnorrVerifyDigest = (
   }
   return false; // default fail
 };
+
+/**
+ * X-only identity of a P2PK pubkey: lowercased hex with any 02/03 parity prefix stripped.
+ *
+ * @remarks
+ * Verification and signer dedupe must share this so they agree on key identity. Non-string and
+ * non-02/03 prefixed 33-byte inputs pass through unchanged and fail verification downstream.
+ */
+function toXOnlyPubkey(pubkey: string): string {
+  if (typeof pubkey !== 'string') return pubkey;
+  const hex = pubkey.toLowerCase();
+  return hex.length === 66 && (hex.startsWith('02') || hex.startsWith('03')) ? hex.slice(2) : hex;
+}
 
 /**
  * Find the private key that can sign for a given compressed public key.
@@ -163,15 +174,22 @@ export function findSigningKey(pubkey: string, privkeys: string | string[]): str
  * @param message - The message to verify.
  * @param pubkeys - The Cashu P2PK public key(s) (hex-encoded, X-only or with 02/03 prefix) to
  *   check.
- * @returns Array of public keys who validly signed, duplicates removed.
+ * @returns Array of public keys who validly signed, duplicates removed. The same key in different
+ *   encodings (X-only, 02/03 prefix, letter case) counts once; the first occurrence is returned.
  */
 export function getValidSigners(
   signatures: string[],
   message: string,
   pubkeys: string[],
 ): string[] {
-  const uniquePubs = Array.from(new Set(pubkeys));
-  return uniquePubs.filter((pubkey) =>
+  // Dedupe by x-only identity: BIP-340 ignores the parity prefix, so 02|X, 03|X
+  // and X all verify against the same signature and must count as one signer.
+  const uniquePubs = new Map<string, string>();
+  for (const pubkey of pubkeys) {
+    const xOnly = toXOnlyPubkey(pubkey);
+    if (!uniquePubs.has(xOnly)) uniquePubs.set(xOnly, pubkey);
+  }
+  return Array.from(uniquePubs.values()).filter((pubkey) =>
     signatures.some((sig) => schnorrVerifyMessage(sig, message, pubkey)),
   );
 }

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -273,4 +273,9 @@ describe('getValidSigners / meetsSignerThreshold', () => {
   test('one signature cannot meet a 2-of-2 threshold across 02/03 encodings', () => {
     expect(meetsSignerThreshold([signature], message, [compressed, '03' + xOnly], 2)).toBe(false);
   });
+
+  test('non-string pubkey entries fail closed without throwing', () => {
+    const pubkeys = [42 as unknown as string, compressed];
+    expect(getValidSigners([signature], message, pubkeys)).toEqual([compressed]);
+  });
 });

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -17,10 +17,13 @@ import {
   constructUnblindedSignature,
   createRandomRawBlindedMessage,
   getKeysetIdInt,
+  getValidSigners,
   hash_e,
   isBlsKeyset,
+  meetsSignerThreshold,
   pointFromBytes,
   schnorrSignDigest,
+  schnorrSignMessage,
   schnorrVerifyDigest,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
@@ -243,5 +246,31 @@ describe('schnorrVerifyDigest', () => {
   test('swallows malformed input by default and throws when asked', () => {
     expect(schnorrVerifyDigest('not-hex', digest, pubkey)).toBe(false);
     expect(() => schnorrVerifyDigest('not-hex', digest, pubkey, true)).toThrow();
+  });
+
+  test('rejects a 33-byte pubkey with a non-02/03 prefix', () => {
+    expect(schnorrVerifyDigest(signature, digest, 'ff' + pubkey.slice(2))).toBe(false);
+  });
+});
+
+describe('getValidSigners / meetsSignerThreshold', () => {
+  const privkey = '0000000000000000000000000000000000000000000000000000000000000001';
+  const compressed = bytesToHex(secp256k1.getPublicKey(hexToBytes(privkey), true)); // 02-prefixed
+  const xOnly = compressed.slice(2);
+  const message = 'authorize-spend';
+  const signature = schnorrSignMessage(message, privkey);
+
+  test('one key listed under multiple encodings counts as a single signer', () => {
+    const signers = getValidSigners([signature], message, [
+      xOnly,
+      compressed,
+      '03' + xOnly,
+      compressed.toUpperCase(),
+    ]);
+    expect(signers).toEqual([xOnly]);
+  });
+
+  test('one signature cannot meet a 2-of-2 threshold across 02/03 encodings', () => {
+    expect(meetsSignerThreshold([signature], message, [compressed, '03' + xOnly], 2)).toBe(false);
   });
 });


### PR DESCRIPTION
The exported signer helpers disagreed on what makes a pubkey unique: `getValidSigners` deduped candidates by exact string, while `schnorrVerifyMessage`/`schnorrVerifyDigest` verify against the x-only key (BIP-340 ignores the parity prefix). One key written in different encodings (X-only, 02/03 prefix, letter case) was therefore counted as several signers. The NUT-11 P2PK path in this repo is unaffected because keys arrive pre-normalized via `normalizeSecpPubkey`; this tightens the helpers for direct callers.

- A single normalization helper (lowercase, strip a 02/03 prefix) now defines key identity for both dedupe and verification, so the two can never diverge again.
- `getValidSigners` dedupes by the x-only form, keeping the first occurrence.
- `schnorrVerifyDigest` only strips a recognized 02/03 prefix; previously any 66-char input had its first byte dropped, so e.g. an `ff`-prefixed key verified as its x-coordinate. Such inputs now fail verification.

No public API signature changes. New unit tests cover multi-encoding dedupe, signer-threshold counting, and the non-02/03 prefix reject. `npm run prtasks` green.