### PR TITLE
fix(utils): align base64 fallback chunk size to a 3-byte boundary

### DIFF
--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -76,11 +76,14 @@ export class Bytes {
     if (bufferConstructor) {
       return bufferConstructor.from(bytes).toString('base64');
     }
-    // preventing stack overflow by chunking
-    if (bytes.length > 32768) {
+    // Chunk to avoid a String.fromCharCode arg-spread stack overflow. Chunk
+    // size must be a multiple of 3, else each chunk emits mid-string '='
+    // padding and the concatenated result is not valid base64.
+    const chunkSize = 32766;
+    if (bytes.length > chunkSize) {
       let result = '';
-      for (let i = 0; i < bytes.length; i += 32768) {
-        const chunk = bytes.slice(i, i + 32768);
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        const chunk = bytes.slice(i, i + chunkSize);
         result += btoa(String.fromCharCode(...chunk));
       }
       return result;

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -349,6 +349,28 @@ describe('Bytes utility class', () => {
       expect(typeof result).toBe('string');
       expect(result.length % 4).toBe(0);
     });
+
+    test('large arrays produce valid base64 on the btoa fallback path (no Buffer)', () => {
+      // Force the chunked btoa path that browsers use; harmless where Buffer
+      // is already absent.
+      const g = globalThis as typeof globalThis & { Buffer?: unknown };
+      const originalBuffer = g.Buffer;
+      try {
+        g.Buffer = undefined;
+        const size = 40000;
+        const bytes = new Uint8Array(size);
+        for (let i = 0; i < size; i++) {
+          bytes[i] = i % 256;
+        }
+        const result = Bytes.toBase64(bytes);
+        // '=' is only valid as trailing padding
+        expect(result.replace(/=+$/, '')).not.toContain('=');
+        // strict atob round-trip must reproduce the input
+        expect(Bytes.fromBase64(result)).toEqual(bytes);
+      } finally {
+        g.Buffer = originalBuffer;
+      }
+    });
   });
 
   describe('fromBase64', () => {


### PR DESCRIPTION
The no-Buffer fallback in `Bytes.toBase64` (the path browsers take) chunks input through `btoa` to avoid a `String.fromCharCode` arg-spread stack overflow. The chunk size was 32768, which is not a multiple of 3, so every chunk's output ended in `=` padding and the concatenated result contained mid-string padding for inputs over 32 KiB. That is not valid base64: strict decoders (`atob`, our own `fromBase64` on the same path) throw on it, and lenient decoders (Node `Buffer`) strip the stray `=` and decode to different bytes than were encoded.

Chunk by 32766 (a multiple of 3) instead: every non-final chunk encodes to a clean 4-char block and only the final chunk may pad, which is valid. The spread arg count stays within the previously safe bound.

The new test forces the fallback path by stubbing `Buffer` (a no-op in the browser projects, where it is already absent) and asserts both no mid-string `=` and a strict round-trip back to the input bytes; the existing large-array test only checked `length % 4`, which the invalid output happened to satisfy. `npm run prtasks` green.