### PR TITLE
fix(logger): escape control characters in log messages

### DIFF
--- a/src/logger/ConsoleLogger.ts
+++ b/src/logger/ConsoleLogger.ts
@@ -8,6 +8,21 @@ const LEVEL_ORDER: Record<LogLevel, number> = {
   trace: 4,
 };
 
+const CONTROL_ESCAPES: Record<string, string> = { '\n': '\\n', '\r': '\\r', '\t': '\\t' };
+// eslint-disable-next-line no-control-regex -- matching control chars is the point
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+
+/**
+ * Escapes C0/C1 control characters so one message renders as one log line and cannot carry terminal
+ * escape sequences.
+ */
+function escapeControlChars(message: string): string {
+  return String(message).replace(
+    CONTROL_CHARS,
+    (ch) => CONTROL_ESCAPES[ch] ?? '\\x' + ch.charCodeAt(0).toString(16).padStart(2, '0'),
+  );
+}
+
 /**
  * Outputs messages to the console based on the specified log level.
  *
@@ -46,7 +61,7 @@ export class ConsoleLogger implements Logger {
     }
   }
   private header(level: LogLevel, message: string): string {
-    return `[${level.toUpperCase()}] ${message}`;
+    return `[${level.toUpperCase()}] ${escapeControlChars(message)}`;
   }
   private flattenContext(ctx?: Record<string, unknown>): Record<string, unknown> | undefined {
     if (!ctx) return undefined;

--- a/test/logger/logger.test.ts
+++ b/test/logger/logger.test.ts
@@ -79,6 +79,17 @@ describe('ConsoleLogger', () => {
     });
   });
 
+  test('escapes control characters in the message', () => {
+    const infoSpy = vi.spyOn(console, 'info');
+    const logger = new ConsoleLogger('info');
+
+    logger.info('alice logged out\n[INFO] admin role granted\r\x1b[31malert\x00');
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[INFO] alice logged out\\n[INFO] admin role granted\\r\\x1b[31malert\\x00',
+    );
+  });
+
   test('generic log method works correctly', () => {
     const infoSpy = vi.spyOn(console, 'info');
     const debugSpy = vi.spyOn(console, 'debug');


### PR DESCRIPTION
ConsoleLogger passed the message argument to `console.*` verbatim, so embedded control characters (newlines, ANSI escape sequences) were emitted raw into the log stream. Some in-tree call sites interpolate remote-derived text (eg error messages) into the message position.

Escape control characters at the `header()` chokepoint, which every message passes through: C0 controls, DEL, and the C1 range (some terminals honour 8-bit CSI) render as visible escapes — `\n`, `\r`, `\t` by name, anything else as `\xNN` — so one log call renders as one line and escape sequences arrive defanged but readable. Context objects are unchanged: they already render through the console's own inspection, which quotes control characters in strings.

Behaviour note: a message containing an intentional tab or newline now shows the escape literally; no in-tree call site does that. `npm run prtasks` green.