### PR TITLE
fix(utils): cap JSON nesting depth in JSONInt.parse

### DIFF
--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -82,6 +82,10 @@ type ReplacerList = ReadonlyArray<string | number>;
 // long tokens before conversion. Applies in all runtimes and fallback modes.
 const MAX_INT_TOKEN_LENGTH = 100;
 
+// Legitimate Cashu payloads nest a handful of levels; the recursive descent
+// overflows the call stack near ~5k. Mirrors MAX_CBOR_DEPTH in cbor.ts.
+const MAX_PARSE_DEPTH = 64;
+
 let safeBigIntLimits: { max: bigint; min: bigint } | undefined;
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -114,7 +118,7 @@ class Parser {
   ) {}
 
   parse(): JSONIntValue {
-    const out = this.parseValue();
+    const out = this.parseValue(0);
     this.skipWhitespace();
     if (!this.isEnd()) {
       throw this.syntaxError('Unexpected trailing input');
@@ -122,11 +126,14 @@ class Parser {
     return out;
   }
 
-  private parseValue(): JSONIntValue {
+  private parseValue(depth: number): JSONIntValue {
+    if (depth > MAX_PARSE_DEPTH) {
+      throw this.syntaxError('JSON nesting exceeds the maximum depth');
+    }
     this.skipWhitespace();
     const ch = this.peek();
-    if (ch === '{') return this.parseObject();
-    if (ch === '[') return this.parseArray();
+    if (ch === '{') return this.parseObject(depth);
+    if (ch === '[') return this.parseArray(depth);
     if (ch === '"') return this.parseString();
     if (ch === '-' || this.isDigit(ch)) return this.parseNumber();
     if (ch === 't') return this.parseLiteral('true', true);
@@ -135,7 +142,7 @@ class Parser {
     throw this.syntaxError(`Unexpected token '${ch || 'EOF'}'`);
   }
 
-  private parseObject(): { [key: string]: JSONIntValue } {
+  private parseObject(depth: number): { [key: string]: JSONIntValue } {
     this.expect('{');
     this.skipWhitespace();
     const out: { [key: string]: JSONIntValue } = {};
@@ -155,7 +162,7 @@ class Parser {
       this.expect(':');
       // Define explicitly to avoid __proto__ prototype pollution.
       Object.defineProperty(out, key, {
-        value: this.parseValue(),
+        value: this.parseValue(depth + 1),
         writable: true,
         enumerable: true,
         configurable: true,
@@ -173,7 +180,7 @@ class Parser {
     throw this.syntaxError('Unterminated object');
   }
 
-  private parseArray(): JSONIntValue[] {
+  private parseArray(depth: number): JSONIntValue[] {
     this.expect('[');
     this.skipWhitespace();
     const out: JSONIntValue[] = [];
@@ -183,7 +190,7 @@ class Parser {
     }
 
     while (!this.isEnd()) {
-      out.push(this.parseValue());
+      out.push(this.parseValue(depth + 1));
       this.skipWhitespace();
       const ch = this.peek();
       if (ch === ']') {

--- a/test/utils/JSONInt.test.ts
+++ b/test/utils/JSONInt.test.ts
@@ -240,6 +240,18 @@ describe('parse errors', () => {
     expect(() => JSONInt.parse('9'.repeat(101))).toThrow('Number token too long');
     expect(() => JSONInt.parse(`{"amount":${'9'.repeat(101)}}`)).toThrow('Number token too long');
   });
+
+  test('accepts nesting up to the depth cap and rejects one level beyond', () => {
+    const nested = (depth: number) => '['.repeat(depth) + ']'.repeat(depth);
+    expect(JSONInt.parse(nested(65))).toBeDefined();
+    expect(() => JSONInt.parse(nested(66))).toThrow('nesting exceeds the maximum depth');
+  });
+
+  test('deeply nested input throws a parse error, not a stack overflow', () => {
+    const deep = '['.repeat(100_000) + ']'.repeat(100_000);
+    expect(() => JSONInt.parse(deep)).toThrow(SyntaxError);
+    expect(() => JSONInt.parse(deep)).not.toThrow(RangeError);
+  });
 });
 
 describe('reviver behavior', () => {


### PR DESCRIPTION
The recursive-descent parser in `JSONInt` had no depth bound: `parseValue` -> `parseObject`/`parseArray` recurse per nesting level, so pathologically nested input (reachable through v3 token decoding and proof-tag deserialization, which call `parse` without a try/catch) exhausted the call stack at around 5k levels instead of failing as a parse error.

Thread a depth counter through the value dispatch and reject past `MAX_PARSE_DEPTH = 64` with a normal `SyntaxError`, mirroring the existing `MAX_CBOR_DEPTH` pattern in the CBOR decoder (same cap, same entry-point check). Real Cashu payloads nest about 5 levels, so the cap is generous. The reviver walk is bounded for free since it only traverses what parse produced; `stringify` operates on the caller's own data and is unchanged.

Tests cover the exact boundary (65 container levels parse, 66 reject) and the pathological case (100k levels now throws `SyntaxError`, not `RangeError`). `npm run prtasks` green.