### PR TITLE
fix(wallet): reject extraPayload keys reserved by the melt request

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3196,13 +3196,22 @@ class Wallet {
     // Prepare proofs for mint
     inputs = this._prepareInputsForMint(inputs);
 
-    // Construct melt payload
+    // Construct melt payload. Extension fields must not clobber the prepared request.
+    const extra = completeOptions.extraPayload;
+    if (extra) {
+      // Object.keys mirrors what the spread below copies (own enumerable keys).
+      const owned = ['quote', 'inputs', 'outputs', 'prefer_async'];
+      const reserved = Object.keys(extra).filter((k) => owned.includes(k));
+      this.failIf(reserved.length > 0, 'extraPayload cannot override reserved melt fields', {
+        reserved,
+      });
+    }
     const meltPayload: MeltRequest = {
       quote,
       inputs,
       outputs,
       ...(completeOptions.preferAsync ? { prefer_async: true } : {}),
-      ...completeOptions.extraPayload,
+      ...extra,
     };
 
     // Execute melt and validate result

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -199,5 +199,9 @@ export type PrepareMeltConfig = MeltProofsConfig & {
 
 export type CompleteMeltOptions = {
   preferAsync?: boolean;
+  /**
+   * Method-specific fields merged into the melt request. Keys that collide with the prepared
+   * request (`quote`, `inputs`, `outputs`, `prefer_async`) are rejected.
+   */
   extraPayload?: Record<string, unknown>;
 };

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -909,6 +909,80 @@ describe('async melt preference body', () => {
     });
   });
 
+  test('completeMelt rejects extraPayload keys that collide with the prepared request', async () => {
+    const meltQuote = {
+      quote: 'q-reserved',
+      amount: Amount.from(1),
+      unit: 'sat',
+      request: invoice,
+      state: 'UNPAID',
+      fee_reserve: Amount.from(0),
+    } as unknown as MeltQuoteBolt11Response;
+    const proofs: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(1),
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      },
+    ];
+
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const meltTxn = await wallet.prepareMelt('bolt11', meltQuote, proofs);
+
+    for (const key of ['quote', 'inputs', 'outputs', 'prefer_async']) {
+      await expect(
+        wallet.completeMelt(meltTxn, undefined, { extraPayload: { [key]: 'clobber' } }),
+      ).rejects.toThrow(/reserved melt fields/);
+    }
+  });
+
+  test('completeMelt forwards non-reserved extraPayload fields', async () => {
+    const meltQuote = {
+      quote: 'q-extra-ok',
+      amount: Amount.from(1),
+      unit: 'sat',
+      request: invoice,
+      state: 'UNPAID',
+      fee_reserve: Amount.from(0),
+    } as unknown as MeltQuoteBolt11Response;
+    const proofs: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(1),
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      },
+    ];
+
+    server.use(
+      http.post(mintUrl + '/v1/melt/bolt11', async ({ request }) => {
+        const body = (await request.json()) as { quote: string; fee_index?: number };
+        expect(body.quote).toBe(meltQuote.quote);
+        expect(body.fee_index).toBe(2);
+        return HttpResponse.json({
+          quote: meltQuote.quote,
+          amount: meltQuote.amount,
+          unit: meltQuote.unit,
+          request: meltQuote.request,
+          state: 'UNPAID',
+          expiry: 1234567890,
+          fee_reserve: meltQuote.fee_reserve,
+          payment_preimage: null,
+          change: [],
+        });
+      }),
+    );
+
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const meltTxn = await wallet.prepareMelt('bolt11', meltQuote, proofs);
+    const res = await wallet.completeMelt(meltTxn, undefined, { extraPayload: { fee_index: 2 } });
+
+    expect(res.quote.quote).toBe(meltQuote.quote);
+  });
+
   test('bolt11: does not send prefer_async when preferAsync is not set', async () => {
     const meltQuote = {
       quote: 'q-async-1b',


### PR DESCRIPTION
`CompleteMeltOptions.extraPayload` exists so callers can add method-specific fields to a melt request, but `completeMelt` spread it *after* the prepared `quote`, `inputs`, `outputs` and `prefer_async`. A colliding key therefore silently replaced data taken from the `MeltPreview`, breaking the boundary between the prepared transaction and the request actually sent.

Reject those four keys before the payload is built, using the wallet's usual `failIf` so the caller gets a `CTSError` naming the offending keys and no request is made. Rejecting is preferable to letting the prepared fields win silently: a caller supplying `quote` here either has a bug or is forwarding untrusted input, and both deserve to surface.

The key check uses `Object.keys`, which is exactly what the spread below copies, so the guard cannot drift from the thing it protects. Method-specific fields are unaffected — the in-tree onchain path passes `fee_index` and is covered by a test asserting it still reaches the mint. `npm run prtasks` green.