### PR TITLE
fix(utils): align base64 fallback chunk size to a 3-byte boundary [backport v4-dev]

### DIFF
--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -76,11 +76,14 @@ export class Bytes {
     if (bufferConstructor) {
       return bufferConstructor.from(bytes).toString('base64');
     }
-    // preventing stack overflow by chunking
-    if (bytes.length > 32768) {
+    // Chunk to avoid a String.fromCharCode arg-spread stack overflow. Chunk
+    // size must be a multiple of 3, else each chunk emits mid-string '='
+    // padding and the concatenated result is not valid base64.
+    const chunkSize = 32766;
+    if (bytes.length > chunkSize) {
       let result = '';
-      for (let i = 0; i < bytes.length; i += 32768) {
-        const chunk = bytes.slice(i, i + 32768);
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        const chunk = bytes.slice(i, i + chunkSize);
         result += btoa(String.fromCharCode(...chunk));
       }
       return result;

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -349,6 +349,28 @@ describe('Bytes utility class', () => {
       expect(typeof result).toBe('string');
       expect(result.length % 4).toBe(0);
     });
+
+    test('large arrays produce valid base64 on the btoa fallback path (no Buffer)', () => {
+      // Force the chunked btoa path that browsers use; harmless where Buffer
+      // is already absent.
+      const g = globalThis as typeof globalThis & { Buffer?: unknown };
+      const originalBuffer = g.Buffer;
+      try {
+        g.Buffer = undefined;
+        const size = 40000;
+        const bytes = new Uint8Array(size);
+        for (let i = 0; i < size; i++) {
+          bytes[i] = i % 256;
+        }
+        const result = Bytes.toBase64(bytes);
+        // '=' is only valid as trailing padding
+        expect(result.replace(/=+$/, '')).not.toContain('=');
+        // strict atob round-trip must reproduce the input
+        expect(Bytes.fromBase64(result)).toEqual(bytes);
+      } finally {
+        g.Buffer = originalBuffer;
+      }
+    });
   });
 
   describe('fromBase64', () => {


### PR DESCRIPTION
# Description
Backport of #905 to `v4-dev`.