### PR TITLE
fix(utils): cap JSON nesting depth in JSONInt.parse [backport v4-dev]

### DIFF
--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -77,6 +77,10 @@ type ReviverFn = (this: unknown, key: string, value: unknown) => unknown;
 type ReplacerFn = (this: unknown, key: string, value: unknown) => unknown;
 type ReplacerList = ReadonlyArray<string | number>;
 
+// Legitimate Cashu payloads nest a handful of levels; the recursive descent
+// overflows the call stack near ~5k. Mirrors MAX_CBOR_DEPTH in cbor.ts.
+const MAX_PARSE_DEPTH = 64;
+
 let safeBigIntLimits: { max: bigint; min: bigint } | undefined;
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -109,7 +113,7 @@ class Parser {
   ) {}
 
   parse(): JSONIntValue {
-    const out = this.parseValue();
+    const out = this.parseValue(0);
     this.skipWhitespace();
     if (!this.isEnd()) {
       throw this.syntaxError('Unexpected trailing input');
@@ -117,11 +121,14 @@ class Parser {
     return out;
   }
 
-  private parseValue(): JSONIntValue {
+  private parseValue(depth: number): JSONIntValue {
+    if (depth > MAX_PARSE_DEPTH) {
+      throw this.syntaxError('JSON nesting exceeds the maximum depth');
+    }
     this.skipWhitespace();
     const ch = this.peek();
-    if (ch === '{') return this.parseObject();
-    if (ch === '[') return this.parseArray();
+    if (ch === '{') return this.parseObject(depth);
+    if (ch === '[') return this.parseArray(depth);
     if (ch === '"') return this.parseString();
     if (ch === '-' || this.isDigit(ch)) return this.parseNumber();
     if (ch === 't') return this.parseLiteral('true', true);
@@ -130,7 +137,7 @@ class Parser {
     throw this.syntaxError(`Unexpected token '${ch || 'EOF'}'`);
   }
 
-  private parseObject(): { [key: string]: JSONIntValue } {
+  private parseObject(depth: number): { [key: string]: JSONIntValue } {
     this.expect('{');
     this.skipWhitespace();
     const out: { [key: string]: JSONIntValue } = {};
@@ -150,7 +157,7 @@ class Parser {
       this.expect(':');
       // Define explicitly to avoid __proto__ prototype pollution.
       Object.defineProperty(out, key, {
-        value: this.parseValue(),
+        value: this.parseValue(depth + 1),
         writable: true,
         enumerable: true,
         configurable: true,
@@ -168,7 +175,7 @@ class Parser {
     throw this.syntaxError('Unterminated object');
   }
 
-  private parseArray(): JSONIntValue[] {
+  private parseArray(depth: number): JSONIntValue[] {
     this.expect('[');
     this.skipWhitespace();
     const out: JSONIntValue[] = [];
@@ -178,7 +185,7 @@ class Parser {
     }
 
     while (!this.isEnd()) {
-      out.push(this.parseValue());
+      out.push(this.parseValue(depth + 1));
       this.skipWhitespace();
       const ch = this.peek();
       if (ch === ']') {

--- a/test/utils/JSONInt.test.ts
+++ b/test/utils/JSONInt.test.ts
@@ -225,6 +225,18 @@ describe('parse errors', () => {
   test('rejects trailing input', () => {
     expect(() => JSONInt.parse('true false')).toThrow('Unexpected trailing input');
   });
+
+  test('accepts nesting up to the depth cap and rejects one level beyond', () => {
+    const nested = (depth: number) => '['.repeat(depth) + ']'.repeat(depth);
+    expect(JSONInt.parse(nested(65))).toBeDefined();
+    expect(() => JSONInt.parse(nested(66))).toThrow('nesting exceeds the maximum depth');
+  });
+
+  test('deeply nested input throws a parse error, not a stack overflow', () => {
+    const deep = '['.repeat(100_000) + ']'.repeat(100_000);
+    expect(() => JSONInt.parse(deep)).toThrow(SyntaxError);
+    expect(() => JSONInt.parse(deep)).not.toThrow(RangeError);
+  });
 });
 
 describe('reviver behavior', () => {


### PR DESCRIPTION
# Description
Backport of #907 to `v4-dev`.