### PR TITLE
perf(wallet): look up keyset unit by map instead of scanning ids [backport v4-dev]

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -663,6 +663,7 @@ export class KeyChain {
     getKeyset(id?: string): Keyset;
     getKeysets(): Keyset[];
     init(forceRefresh?: boolean): Promise<void>;
+    isUnitKeyset(id?: string): boolean;
     loadFromCache(cache: KeyChainCache): void;
     static mintToCacheDTO(mintUrl: string, allKeysets: MintKeyset[], allKeys: MintKeys[]): KeyChainCache;
 }

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -298,6 +298,19 @@ export class KeyChain {
   }
 
   /**
+   * True if `id` is a keyset belonging to this KeyChain's unit.
+   *
+   * @remarks
+   * O(1) and non-throwing, unlike `getKeyset(id)` (cross-unit) and `getKeysets()` (allocates,
+   * throws when the unit has none). Use it to keep foreign-unit proofs out of amount arithmetic.
+   */
+  isUnitKeyset(id?: string): boolean {
+    if (!id) return false;
+    const keyset = this.keysets[id];
+    return keyset !== undefined && keyset.unit === this.unit;
+  }
+
+  /**
    * Returns all the keys in this KeyChain across all units.
    *
    * @returns Array of MintKeys objects.

--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -49,10 +49,13 @@ export function selectProofsRGLI(
     exFee: bigint;
     ppkfee: bigint;
   }
-  // Looks up fee for a proof
+  // Looks up fee for a proof. Foreign-unit proofs are bearer value in another
+  // asset, so they must never be selectable against a target in this unit.
+  // Unit check follows the lookup, so an unknown id still reports as such.
   const feeForProof = (proof: Proof): bigint => {
+    let fee: number;
     try {
-      return BigInt(keyChain.getKeyset(proof.id).fee);
+      fee = keyChain.getKeyset(proof.id).fee;
     } catch (e) {
       const message = `Could not get fee. No keyset found for keyset id: ${proof.id}`;
       _logger.error(message, {
@@ -61,6 +64,13 @@ export function selectProofsRGLI(
       });
       throw new CTSError(message, { cause: e });
     }
+    failIf(
+      !keyChain.isUnitKeyset(proof.id),
+      `Proof has unrecognised keyset. '${proof.id}' is not a keyset for this wallet unit`,
+      _logger,
+      { id: proof.id },
+    );
+    return BigInt(fee);
   };
   // Calculate net amount after fees (single ceil over the whole set)
   const sumExFees = (amount: bigint, feePPK: bigint): bigint => {
@@ -362,6 +372,12 @@ export function selectProofsRotating(
   const buckets = new Map<number, { proofs: Proof[]; gross: bigint; ppk: bigint }>();
   for (const p of normalizedProofs) {
     const ks = keyChain.getKeyset(p.id); // throws for unknown keyset ids
+    failIf(
+      !keyChain.isUnitKeyset(p.id),
+      `Proof has unrecognised keyset. '${p.id}' is not a keyset for this wallet unit`,
+      _logger,
+      { id: p.id },
+    );
     const rank = ks.hasHexId ? parseInt(p.id.slice(0, 2), 16) + 1 : 0;
     const key = rank * 2 + (ks.isActive ? 1 : 0);
     const bucket = buckets.get(key) ?? { proofs: [], gross: 0n, ppk: 0n };

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1014,16 +1014,7 @@ class Wallet {
     }
 
     // Validate all proof keyset IDs use this wallet's unit
-    const knownIds = this._keyChain.getKeysets().map((k) => k.id);
-    const badProof = proofs.find((p) => !p.id || !knownIds.includes(p.id));
-    this.failIf(
-      !!badProof,
-      `Proof has unrecognised keyset. '${badProof?.id}' is not a ${this._unit} keyset from this mint`,
-      {
-        id: badProof?.id,
-        knownIds,
-      },
-    );
+    this.assertProofsInWalletUnit(proofs);
 
     // Check total amount
     const totalAmount = this.parseAmount(sumProofs(proofs), 'prepareSwapToReceive', true);
@@ -1491,6 +1482,22 @@ class Wallet {
   getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount {
     const sumPPK = Amount.sum(proofs.map((proof) => this.getProofFeePPK(proof))).toBigInt();
     return Amount.from((sumPPK + 999n) / 1000n);
+  }
+
+  /**
+   * Asserts every proof belongs to a keyset of the wallet's unit.
+   *
+   * @remarks
+   * Amounts are unit-less numbers, so a foreign-unit proof would otherwise count toward a total.
+   * @throws If any proof's keyset is unknown or belongs to another unit of this mint.
+   */
+  private assertProofsInWalletUnit(proofs: Array<Pick<Proof, 'id'>>): void {
+    const badProof = proofs.find((p) => !this._keyChain.isUnitKeyset(p.id));
+    this.failIf(
+      !!badProof,
+      `Proof has unrecognised keyset. '${badProof?.id}' is not a ${this._unit} keyset from this mint`,
+      { id: badProof?.id },
+    );
   }
 
   /**

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -372,6 +372,13 @@ describe('KeyChain getters', () => {
     const satKeysets = multiChain.getKeysets();
     expect(satKeysets.every((k) => k.unit === 'sat')).toBe(true);
     expect(satKeysets.find((k) => k.id === usdKeysetId)).toBeUndefined();
+
+    // isUnitKeyset — wallet unit only, and never throws on a missing/unknown id
+    expect(multiChain.isUnitKeyset('00bd033559de27d0')).toBe(true);
+    expect(multiChain.isUnitKeyset(usdKeysetId)).toBe(false);
+    expect(multiChain.isUnitKeyset('notakeyset')).toBe(false);
+    expect(multiChain.isUnitKeyset('')).toBe(false);
+    expect(multiChain.isUnitKeyset(undefined)).toBe(false);
   });
 
   test('should throw getters if not initialized', () => {

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -10,11 +10,12 @@ import { selectProofsRGLI } from '../../src/wallet/SelectProofs';
 // These tests cover the edge case branches.
 // -----------------------------------------------------------------
 
-// Minimal keychain stub
+// Minimal keychain stub. Every listed id counts as this wallet's unit.
 function keychainStub(fees: Record<string, number>) {
   return {
     getKeyset: (id: string) => ({ fee: fees[id] ?? 0 }),
     getKeysets: () => Object.keys(fees).map((id) => ({ id, fee: fees[id] })),
+    isUnitKeyset: (id: string) => id in fees,
   } as any;
 }
 
@@ -159,6 +160,7 @@ describe('selectProofsRGLI, focused unit tests', () => {
     const kc = {
       getKeyset: () => ({ fee: 0 }),
       getKeysets: () => [{ id: 'Z', fee: 0 }],
+      isUnitKeyset: () => true,
     } as any;
 
     expect(() => selectProofsRGLI(proofs as any, 7, kc, false, true)).toThrow(/took too long/i);

--- a/test/wallet/selectProofsRotating.test.ts
+++ b/test/wallet/selectProofsRotating.test.ts
@@ -30,6 +30,7 @@ function keychainStub(keysets: Record<string, { fee?: number; active?: boolean }
       return entry(id);
     },
     getKeysets: () => Object.keys(keysets).map(entry),
+    isUnitKeyset: (id: string) => !!keysets[id],
   } as any;
 }
 

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -120,6 +120,39 @@ describe('sendOffline witness normalization', () => {
     expect(send[0].witness).toBeUndefined();
   });
 
+  test('refuses to select proofs from another unit on the same mint', async () => {
+    const usdKeysetId = '009a1f293253e41f';
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [
+            { id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 0 },
+            { id: usdKeysetId, unit: 'usd', active: true, input_fee_ppk: 0 },
+          ],
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const usdProof: Proof = {
+      id: usdKeysetId,
+      amount: Amount.from(1),
+      secret: 's-usd',
+      C: 'C-usd',
+    };
+    const satProof: Proof = {
+      id: '00bd033559de27d0',
+      amount: Amount.from(1),
+      secret: 's-sat',
+      C: 'C-sat',
+    };
+
+    // Alone, and mixed into an otherwise valid sat pool.
+    expect(() => wallet.sendOffline(1, [usdProof])).toThrow(/unrecognised keyset/);
+    expect(() => wallet.sendOffline(2, [satProof, usdProof])).toThrow(/unrecognised keyset/);
+  });
+
   test('preserves witness on NUT-10 unknown secret kind', async () => {
     const wallet = new Wallet(mint, { unit, requireSigDleq: true });
     await wallet.loadMint();


### PR DESCRIPTION
# Description
Backport of #909 to `v4-dev`.