### PR TITLE
fix(wallet): reject duplicate proofs before totalling or selecting

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2371,7 +2371,7 @@ export class Wallet {
         pending: T[];
         spent: T[];
     }>;
-    isPaymentRequestSatisfied(pr: PaymentRequest_2, proofs: Array<Pick<Proof, 'id' | 'amount'>>, expectedAmount?: AmountLike): boolean;
+    isPaymentRequestSatisfied(pr: PaymentRequest_2, proofs: Array<Pick<Proof, 'id' | 'amount' | 'secret'>>, expectedAmount?: AmountLike): boolean;
     get keyChain(): KeyChain;
     get keysetId(): string;
     loadMint(forceRefresh?: boolean): Promise<void>;

--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -137,7 +137,13 @@ export function selectProofsRGLI(
    */
   let totalAmount = 0n;
   let totalFeePPK = 0n;
+  // A proof is bearer value redeemable once, so we can't have duplicates.
+  const seen = new Set<string>();
   const proofWithFees = normalizedProofs.map((p) => {
+    failIf(seen.has(p.secret), 'Duplicate proofs: each proof may appear only once', _logger, {
+      id: p.id,
+    });
+    seen.add(p.secret);
     const ppkfee = feeForProof(p);
     const amountBig = p.amount.toBigInt();
     // Floor the proof's own fee: keeps exFee an integer sort key, and the economical
@@ -369,8 +375,15 @@ export function selectProofsRotating(
 
   // Bucket by staleness: version rank (base64 = 0, else first id byte + 1), with
   // inactive before active within a version. Lower keys are staler.
+  // Duplicates would both inflate the bucket totals and break the keep/send
+  // partition below, which identifies proofs by secret.
+  const seen = new Set<string>();
   const buckets = new Map<number, { proofs: Proof[]; gross: bigint; ppk: bigint }>();
   for (const p of normalizedProofs) {
+    failIf(seen.has(p.secret), 'Duplicate proofs: each proof may appear only once', _logger, {
+      id: p.id,
+    });
+    seen.add(p.secret);
     const ks = keyChain.getKeyset(p.id); // throws for unknown keyset ids
     failIf(
       !keyChain.isUnitKeyset(p.id),

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1523,7 +1523,7 @@ class Wallet {
    */
   isPaymentRequestSatisfied(
     pr: PaymentRequest,
-    proofs: Array<Pick<Proof, 'id' | 'amount'>>,
+    proofs: Array<Pick<Proof, 'id' | 'amount' | 'secret'>>,
     expectedAmount?: AmountLike,
   ): boolean {
     const expected =
@@ -1535,6 +1535,7 @@ class Wallet {
       throw new CTSError(`request unit '${pr.unit}' does not match wallet unit '${this._unit}'`);
     }
     this.assertProofsInWalletUnit(proofs);
+    this.assertNoDuplicateProofs(proofs);
     // mf applies only when this mint is outside the request's mint list (NUT-18).
     let mf = Amount.zero();
     if (pr.supportedMethods?.length && !pr.includesMint(this.mint.mintUrl)) {
@@ -1561,6 +1562,26 @@ class Wallet {
       !!badProof,
       `Proof has unrecognised keyset. '${badProof?.id}' is not a ${this._unit} keyset from this mint`,
       { id: badProof?.id },
+    );
+  }
+
+  /**
+   * Asserts no proof appears twice.
+   *
+   * @remarks
+   * A proof is bearer value redeemable once: the mint keys spent state on `Y =
+   * hash_to_curve(secret)` (NUT-07), so copies sharing a secret are one proof, not two.
+   * @throws If two proofs share a secret.
+   */
+  private assertNoDuplicateProofs(proofs: Array<Pick<Proof, 'secret'>>): void {
+    const secrets = new Set(proofs.map((p) => p.secret));
+    this.failIf(
+      secrets.size !== proofs.length,
+      'Duplicate proofs: each proof may appear only once',
+      {
+        proofs: proofs.length,
+        unique: secrets.size,
+      },
     );
   }
 

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -321,6 +321,13 @@ describe('selectProofsRGLI, deterministic selection', () => {
 });
 
 describe('selectProofsRGLI, invariants', () => {
+  test('rejects duplicate bearer proofs instead of counting one proof twice', () => {
+    const proof: Proof = { id: 'A', amount: Amount.from(1), secret: 'same', C: 'C1' };
+    const kc = keychainStub({ A: 0 });
+
+    expect(() => selectProofsRGLI([proof, { ...proof }], 2, kc, false, true)).toThrow(/duplicate/i);
+  });
+
   test('a feasible close match never returns under the target (repeated unseeded runs)', () => {
     // Exact 5 exists ({1,4}); every run must net >= target with no RNG mocking.
     const proofs: Proof[] = [

--- a/test/wallet/selectProofsRotating.test.ts
+++ b/test/wallet/selectProofsRotating.test.ts
@@ -46,6 +46,13 @@ const secrets = (proofs: Proof[]) => proofs.map((p) => p.secret).sort();
 const total = (proofs: Proof[]) => proofs.reduce((a, p) => a + p.amount.toNumber(), 0);
 
 describe('selectProofsRotating', () => {
+  test('rejects duplicate bearer proofs instead of counting one proof twice', () => {
+    const p = P(V1A, 2);
+    const kc = keychainStub({ [V1A]: {} });
+
+    expect(() => selectProofsRotating([p, { ...p }], 4, kc)).toThrow(/duplicate/i);
+  });
+
   test('base64 outranks inactive hex keysets regardless of active status', () => {
     // Active base64 must be forced ahead of the inactive v1 bucket
     const b64 = P(B64, 2);

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -288,6 +288,16 @@ describe('wallet.isPaymentRequestSatisfied', () => {
     expect(wallet.isPaymentRequestSatisfied(amountless, proofsTotalling([10]), 10)).toBe(true);
   });
 
+  test('does not count repeated copies of one proof as distinct value', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const pr = new PaymentRequest({ id: 'dup', amount: 100, unit: 'sat' });
+    const [proof] = proofsTotalling([60]);
+
+    expect(() => wallet.isPaymentRequestSatisfied(pr, [proof, { ...proof }])).toThrow(/duplicate/i);
+  });
+
   test('rejects proofs from another unit on the same mint', async () => {
     const usdKeysetId = '009a1f293253e41f';
     server.use(

--- a/test/wallet/wallet-output-mutants.node.test.ts
+++ b/test/wallet/wallet-output-mutants.node.test.ts
@@ -25,8 +25,15 @@ const seed = hexToBytes(
   'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
 );
 
+// Each call gets its own secret: two proofs sharing one are the same bearer proof.
+let proofN = 0;
 function makeProof(amount: number): Proof {
-  return { id: keysetId, amount: Amount.from(amount), secret, C: proofC };
+  return {
+    id: keysetId,
+    amount: Amount.from(amount),
+    secret: `${secret.slice(0, -2)}${(++proofN).toString(16).padStart(2, '0')}`,
+    C: proofC,
+  };
 }
 
 interface SwapBody {

--- a/test/wallet/wallet-send-mutants.node.test.ts
+++ b/test/wallet/wallet-send-mutants.node.test.ts
@@ -24,8 +24,15 @@ const seed = hexToBytes(
   'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
 );
 
+// Each call gets its own secret: two proofs sharing one are the same bearer proof.
+let proofN = 0;
 function makeProof(amount: number): Proof {
-  return { id: keysetId, amount: Amount.from(amount), secret, C: proofC };
+  return {
+    id: keysetId,
+    amount: Amount.from(amount),
+    secret: `${secret.slice(0, -2)}${(++proofN).toString(16).padStart(2, '0')}`,
+    C: proofC,
+  };
 }
 
 interface SwapBody {
@@ -96,12 +103,13 @@ describe('send offline/swap routing', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    const result = await wallet.send(1, [makeProof(1)]);
+    const proof = makeProof(1);
+    const result = await wallet.send(1, [proof]);
     expect(swap.calls).toBe(0);
     expect(result.keep).toHaveLength(0);
     expect(result.send).toHaveLength(1);
     // Offline path returns the original proof secret unchanged
-    expect(result.send[0].secret).toBe(secret);
+    expect(result.send[0].secret).toBe(proof.secret);
   });
 
   test('deterministic policy forces a swap even for an exact match', async () => {
@@ -109,11 +117,12 @@ describe('send offline/swap routing', () => {
     const wallet = new Wallet(mint, { unit, bip39seed: seed });
     await wallet.loadMint();
 
-    const result = await wallet.send(1, [makeProof(1)]);
+    const proof = makeProof(1);
+    const result = await wallet.send(1, [proof]);
     expect(swap.calls).toBe(1);
     expect(result.send).toHaveLength(1);
     // Swap produced a fresh deterministic secret, not the input secret
-    expect(result.send[0].secret).not.toBe(secret);
+    expect(result.send[0].secret).not.toBe(proof.secret);
   });
 
   test('keysetId override forces a swap', async () => {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -315,7 +315,7 @@ describe('send', () => {
     {
       id: '00bd033559de27d0',
       amount: Amount.from(1),
-      secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+      secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a01',
       C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
     },
   ];
@@ -350,7 +350,7 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a02',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -453,7 +453,7 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a03',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ]);
@@ -495,7 +495,7 @@ describe('send', () => {
         {
           id: '00bd033559de27d0',
           amount: Amount.from(2),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a04',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
       ],
@@ -537,7 +537,7 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a05',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -588,13 +588,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a06',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a07',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -657,13 +657,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a08',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a09',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -722,7 +722,7 @@ describe('send', () => {
         {
           id: '00bd033559de27d0',
           amount: Amount.from(2),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0a',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
       ]),
@@ -776,13 +776,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0b',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0c',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -852,13 +852,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0d',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0e',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -912,13 +912,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0f',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a10',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -951,13 +951,13 @@ describe('send', () => {
       {
         id: keysetId,
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a11',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: keysetId,
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a12',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -1080,13 +1080,13 @@ describe('send', () => {
       {
         id: keysetId,
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674aff',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: keysetId,
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a14',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -1110,13 +1110,13 @@ describe('send', () => {
         {
           id: '00bd033559de27d0',
           amount: Amount.from(1),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a15',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
         {
           id: '00bd033559de27d0',
           amount: Amount.from(8),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a16',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
       ]),
@@ -1144,13 +1144,13 @@ describe('send', () => {
       {
         id: keysetId,
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a17',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: keysetId,
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a18',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -1216,7 +1216,7 @@ describe('deterministic', () => {
           {
             id: '00bd033559de27d0',
             amount: Amount.from(2),
-            secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+            secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a19',
             C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
           },
         ],


### PR DESCRIPTION
Proof arrays were summed entry by entry with no check for repeats, so copies of one proof counted as separate inputs. Repeating a single valid proof could therefore make a payment request look settled, or let offline selection return two copies of one proof as if they were two spendable inputs.

A proof is bearer value redeemable once: Comparing secrets is equivalent to comparing Y and costs nothing, so no curve work is needed. The check now runs in `isPaymentRequestSatisfied` and in both selectors, and throws rather than silently deduping: a repeated entry means a caller bug or hostile input, and dropping entries quietly would turn it into a short payment that still reports success.

`isPaymentRequestSatisfied` takes `Pick<Proof, 'id' | 'amount' | 'secret'>` instead of `'id' | 'amount'`. Proof identity cannot be established without the secret: id and amount alone cannot distinguish one proof passed twice from two genuine proofs of equal value from one keyset. Callers passing real proofs, including the documented payee flow in `docs-src/usage/payment_requests.md`, are unaffected.

`selectProofsRotating` already relied on this invariant: its keep/send partition identifies proofs by secret and is commented "proof secrets are unique". With duplicates present that partition drops both copies from `keep`, so this closes a latent bug as well as adding the guard.

Test fixtures reused one secret literal across many proofs, which encodes a wallet state that cannot exist; those now get distinct secrets, and two assertions that compared against the shared constant now compare against the actual input proof.

Main only, no backport label: the signature change is fine during RC but not on the LTS line, and v4 has no `isPaymentRequestSatisfied`. The selector half would need reworking to go back separately.
