### PR TITLE
fix(wallet): name the offending index when rejecting duplicate proofs

### DIFF
--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -139,10 +139,13 @@ export function selectProofsRGLI(
   let totalFeePPK = 0n;
   // A proof is bearer value redeemable once, so we can't have duplicates.
   const seen = new Set<string>();
-  const proofWithFees = normalizedProofs.map((p) => {
-    failIf(seen.has(p.secret), 'Duplicate proofs: each proof may appear only once', _logger, {
-      id: p.id,
-    });
+  const proofWithFees = normalizedProofs.map((p, i) => {
+    failIf(
+      seen.has(p.secret),
+      `Duplicate proof at index ${i}: each proof may appear only once`,
+      _logger,
+      { index: i },
+    );
     seen.add(p.secret);
     const ppkfee = feeForProof(p);
     const amountBig = p.amount.toBigInt();
@@ -379,10 +382,13 @@ export function selectProofsRotating(
   // partition below, which identifies proofs by secret.
   const seen = new Set<string>();
   const buckets = new Map<number, { proofs: Proof[]; gross: bigint; ppk: bigint }>();
-  for (const p of normalizedProofs) {
-    failIf(seen.has(p.secret), 'Duplicate proofs: each proof may appear only once', _logger, {
-      id: p.id,
-    });
+  for (const [i, p] of normalizedProofs.entries()) {
+    failIf(
+      seen.has(p.secret),
+      `Duplicate proof at index ${i}: each proof may appear only once`,
+      _logger,
+      { index: i },
+    );
     seen.add(p.secret);
     const ks = keyChain.getKeyset(p.id); // throws for unknown keyset ids
     failIf(

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1574,15 +1574,16 @@ class Wallet {
    * @throws If two proofs share a secret.
    */
   private assertNoDuplicateProofs(proofs: Array<Pick<Proof, 'secret'>>): void {
-    const secrets = new Set(proofs.map((p) => p.secret));
-    this.failIf(
-      secrets.size !== proofs.length,
-      'Duplicate proofs: each proof may appear only once',
-      {
-        proofs: proofs.length,
-        unique: secrets.size,
-      },
-    );
+    const seen = new Set<string>();
+    for (const [i, p] of proofs.entries()) {
+      // Report the position, never the secret: it is the spending material.
+      this.failIf(
+        seen.has(p.secret),
+        `Duplicate proof at index ${i}: each proof may appear only once`,
+        { index: i },
+      );
+      seen.add(p.secret);
+    }
   }
 
   /**

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -325,7 +325,10 @@ describe('selectProofsRGLI, invariants', () => {
     const proof: Proof = { id: 'A', amount: Amount.from(1), secret: 'same', C: 'C1' };
     const kc = keychainStub({ A: 0 });
 
-    expect(() => selectProofsRGLI([proof, { ...proof }], 2, kc, false, true)).toThrow(/duplicate/i);
+    // The index names the offending array position so a caller can find the bad row.
+    expect(() => selectProofsRGLI([proof, { ...proof }], 2, kc, false, true)).toThrow(
+      /duplicate proof at index 1/i,
+    );
   });
 
   test('a feasible close match never returns under the target (repeated unseeded runs)', () => {

--- a/test/wallet/selectProofsRotating.test.ts
+++ b/test/wallet/selectProofsRotating.test.ts
@@ -50,7 +50,7 @@ describe('selectProofsRotating', () => {
     const p = P(V1A, 2);
     const kc = keychainStub({ [V1A]: {} });
 
-    expect(() => selectProofsRotating([p, { ...p }], 4, kc)).toThrow(/duplicate/i);
+    expect(() => selectProofsRotating([p, { ...p }], 4, kc)).toThrow(/duplicate proof at index 1/i);
   });
 
   test('base64 outranks inactive hex keysets regardless of active status', () => {

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -295,7 +295,9 @@ describe('wallet.isPaymentRequestSatisfied', () => {
     const pr = new PaymentRequest({ id: 'dup', amount: 100, unit: 'sat' });
     const [proof] = proofsTotalling([60]);
 
-    expect(() => wallet.isPaymentRequestSatisfied(pr, [proof, { ...proof }])).toThrow(/duplicate/i);
+    expect(() => wallet.isPaymentRequestSatisfied(pr, [proof, { ...proof }])).toThrow(
+      /duplicate proof at index 1/i,
+    );
   });
 
   test('rejects proofs from another unit on the same mint', async () => {


### PR DESCRIPTION
Follow-up to #916. The duplicate-proof error reported the keyset id, which every proof in a wallet typically shares, so it did not tell a caller *which* entry was the repeat. Report the array index instead, in both the message and the log context, and drop the keyset id: once the index names the exact row, the id adds nothing.

The secret stays out of the message and the log deliberately

Applied at all three call sites so the wording is identical wherever the check runs, and matching the v4 backport in #918 byte for byte. `npm run prtasks` green.