### PR TITLE
fix(wallet): reject duplicate proofs before selection

### DIFF
--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -137,7 +137,16 @@ export function selectProofsRGLI(
    */
   let totalAmount = 0n;
   let totalFeePPK = 0n;
-  const proofWithFees = normalizedProofs.map((p) => {
+  // A proof is bearer value redeemable once, so we can't have duplicates.
+  const seen = new Set<string>();
+  const proofWithFees = normalizedProofs.map((p, i) => {
+    failIf(
+      seen.has(p.secret),
+      `Duplicate proof at index ${i}: each proof may appear only once`,
+      _logger,
+      { index: i },
+    );
+    seen.add(p.secret);
     const ppkfee = feeForProof(p);
     const amountBig = p.amount.toBigInt();
     // Floor the proof's own fee: keeps exFee an integer sort key, and the economical
@@ -369,8 +378,18 @@ export function selectProofsRotating(
 
   // Bucket by staleness: version rank (base64 = 0, else first id byte + 1), with
   // inactive before active within a version. Lower keys are staler.
+  // Duplicates would both inflate the bucket totals and break the keep/send
+  // partition below, which identifies proofs by secret.
+  const seen = new Set<string>();
   const buckets = new Map<number, { proofs: Proof[]; gross: bigint; ppk: bigint }>();
-  for (const p of normalizedProofs) {
+  for (const [i, p] of normalizedProofs.entries()) {
+    failIf(
+      seen.has(p.secret),
+      `Duplicate proof at index ${i}: each proof may appear only once`,
+      _logger,
+      { index: i },
+    );
+    seen.add(p.secret);
     const ks = keyChain.getKeyset(p.id); // throws for unknown keyset ids
     failIf(
       !keyChain.isUnitKeyset(p.id),

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -321,6 +321,16 @@ describe('selectProofsRGLI, deterministic selection', () => {
 });
 
 describe('selectProofsRGLI, invariants', () => {
+  test('rejects duplicate bearer proofs instead of counting one proof twice', () => {
+    const proof: Proof = { id: 'A', amount: Amount.from(1), secret: 'same', C: 'C1' };
+    const kc = keychainStub({ A: 0 });
+
+    // The index names the offending array position so a caller can find the bad row.
+    expect(() => selectProofsRGLI([proof, { ...proof }], 2, kc, false, true)).toThrow(
+      /duplicate proof at index 1/i,
+    );
+  });
+
   test('a feasible close match never returns under the target (repeated unseeded runs)', () => {
     // Exact 5 exists ({1,4}); every run must net >= target with no RNG mocking.
     const proofs: Proof[] = [

--- a/test/wallet/selectProofsRotating.test.ts
+++ b/test/wallet/selectProofsRotating.test.ts
@@ -46,6 +46,13 @@ const secrets = (proofs: Proof[]) => proofs.map((p) => p.secret).sort();
 const total = (proofs: Proof[]) => proofs.reduce((a, p) => a + p.amount.toNumber(), 0);
 
 describe('selectProofsRotating', () => {
+  test('rejects duplicate bearer proofs instead of counting one proof twice', () => {
+    const p = P(V1A, 2);
+    const kc = keychainStub({ [V1A]: {} });
+
+    expect(() => selectProofsRotating([p, { ...p }], 4, kc)).toThrow(/duplicate proof at index 1/i);
+  });
+
   test('base64 outranks inactive hex keysets regardless of active status', () => {
     // Active base64 must be forced ahead of the inactive v1 bucket
     const b64 = P(B64, 2);

--- a/test/wallet/wallet-output-mutants.node.test.ts
+++ b/test/wallet/wallet-output-mutants.node.test.ts
@@ -25,8 +25,15 @@ const seed = hexToBytes(
   'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
 );
 
+// Each call gets its own secret: two proofs sharing one are the same bearer proof.
+let proofN = 0;
 function makeProof(amount: number): Proof {
-  return { id: keysetId, amount: Amount.from(amount), secret, C: proofC };
+  return {
+    id: keysetId,
+    amount: Amount.from(amount),
+    secret: `${secret.slice(0, -2)}${(++proofN).toString(16).padStart(2, '0')}`,
+    C: proofC,
+  };
 }
 
 interface SwapBody {

--- a/test/wallet/wallet-send-mutants.node.test.ts
+++ b/test/wallet/wallet-send-mutants.node.test.ts
@@ -24,8 +24,15 @@ const seed = hexToBytes(
   'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
 );
 
+// Each call gets its own secret: two proofs sharing one are the same bearer proof.
+let proofN = 0;
 function makeProof(amount: number): Proof {
-  return { id: keysetId, amount: Amount.from(amount), secret, C: proofC };
+  return {
+    id: keysetId,
+    amount: Amount.from(amount),
+    secret: `${secret.slice(0, -2)}${(++proofN).toString(16).padStart(2, '0')}`,
+    C: proofC,
+  };
 }
 
 interface SwapBody {
@@ -96,12 +103,13 @@ describe('send offline/swap routing', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    const result = await wallet.send(1, [makeProof(1)]);
+    const proof = makeProof(1);
+    const result = await wallet.send(1, [proof]);
     expect(swap.calls).toBe(0);
     expect(result.keep).toHaveLength(0);
     expect(result.send).toHaveLength(1);
     // Offline path returns the original proof secret unchanged
-    expect(result.send[0].secret).toBe(secret);
+    expect(result.send[0].secret).toBe(proof.secret);
   });
 
   test('deterministic policy forces a swap even for an exact match', async () => {
@@ -109,11 +117,12 @@ describe('send offline/swap routing', () => {
     const wallet = new Wallet(mint, { unit, bip39seed: seed });
     await wallet.loadMint();
 
-    const result = await wallet.send(1, [makeProof(1)]);
+    const proof = makeProof(1);
+    const result = await wallet.send(1, [proof]);
     expect(swap.calls).toBe(1);
     expect(result.send).toHaveLength(1);
     // Swap produced a fresh deterministic secret, not the input secret
-    expect(result.send[0].secret).not.toBe(secret);
+    expect(result.send[0].secret).not.toBe(proof.secret);
   });
 
   test('keysetId override forces a swap', async () => {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -250,7 +250,7 @@ describe('send', () => {
     {
       id: '00bd033559de27d0',
       amount: Amount.from(1),
-      secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+      secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a01',
       C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
     },
   ];
@@ -285,7 +285,7 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a02',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -388,7 +388,7 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a03',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ]);
@@ -430,7 +430,7 @@ describe('send', () => {
         {
           id: '00bd033559de27d0',
           amount: Amount.from(2),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a04',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
       ],
@@ -472,7 +472,7 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a05',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -523,13 +523,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a06',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a07',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -592,13 +592,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a08',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(2),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a09',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -657,7 +657,7 @@ describe('send', () => {
         {
           id: '00bd033559de27d0',
           amount: Amount.from(2),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0a',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
       ]),
@@ -711,13 +711,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0b',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0c',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -787,13 +787,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0d',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0e',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -847,13 +847,13 @@ describe('send', () => {
       {
         id: '00bd033559de27d0',
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a0f',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: '00bd033559de27d0',
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a10',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -886,13 +886,13 @@ describe('send', () => {
       {
         id: keysetId,
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a11',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: keysetId,
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a12',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -1015,13 +1015,13 @@ describe('send', () => {
       {
         id: keysetId,
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674aff',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: keysetId,
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a14',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -1045,13 +1045,13 @@ describe('send', () => {
         {
           id: '00bd033559de27d0',
           amount: Amount.from(1),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a15',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
         {
           id: '00bd033559de27d0',
           amount: Amount.from(8),
-          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+          secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a16',
           C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
         },
       ]),
@@ -1079,13 +1079,13 @@ describe('send', () => {
       {
         id: keysetId,
         amount: Amount.from(1),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a17',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
       {
         id: keysetId,
         amount: Amount.from(8),
-        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a18',
         C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       },
     ];
@@ -1151,7 +1151,7 @@ describe('deterministic', () => {
           {
             id: '00bd033559de27d0',
             amount: Amount.from(2),
-            secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+            secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a19',
             C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
           },
         ],


### PR DESCRIPTION
Hand-written backport of the selector half of #916.

Proof arrays were summed entry by entry with no check for repeats, so copies of one proof counted as separate spendable inputs. `sendOffline` is the path that matters: it hands proofs straight to a recipient with no mint round trip, so duplicates there short the recipient silently. On the online path the mint rejects duplicate inputs anyway, so there this only turns a confusing remote error into a clear local one.

This rejects input that was never valid rather than changing behaviour for legitimate callers — `selectProofsRotating` has been carrying a comment asserting "proof secrets are unique", and with duplicates present its keep/send partition drops both copies from `keep`. 

Worth being explicit about the blast radius, though: the check runs over the whole input array, so a wallet whose storage has accumulated a duplicate row will now see every send throw until it is cleaned up, including sends that would not have selected that row. That is the intended trade — such a wallet already has a wrong balance and is already either failing at the mint or shorting offline recipients.

Not carried over from #916: the `isPaymentRequestSatisfied` guard and its widened signature. v4 has no such method, and the signature change does not belong on the LTS line.

Test fixtures reused one secret literal across many proofs, encoding a wallet state that cannot exist; those now get distinct secrets, matching main. `npm run prtasks` green on the v4 lockfile.