### PR TITLE
fix(crypto): bound the deterministic counter to the safe integer range

### DIFF
--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -199,16 +199,17 @@ function deriveHmacSecretAndBlindingFactor(
   keysetId: string,
   counter: number,
 ): DerivedSecretAndBlindingFactor {
-  // NUT-13 encodes the counter as u64, but setBigUint64 wraps, so an out-of-range value would
-  // alias onto a valid counter and re-derive its secret. Cap at MAX_SAFE_INTEGER rather than
-  // 2^64: past it `counter + 1 === counter`, so a batch would derive one counter twice.
+  // NUT-13 encodes the counter as u64, but cap at MAX_SAFE_INTEGER: past it
+  // `counter + 1 === counter`, so a batch would derive one counter twice.
   if (!Number.isSafeInteger(counter) || counter < 0) {
     throw new CTSError('Counter must be an integer in the range 0 <= counter <= 2^53 - 1');
   }
   const base = Bytes.concat(
     Bytes.fromString('Cashu_KDF_HMAC_SHA256'),
     Bytes.fromHex(keysetId),
-    Bytes.writeBigUint64BE(BigInt(counter)),
+    // numberToBytesBE throws rather than wrapping, so an out-of-range counter can never
+    // be silently encoded as a different one even if the guard above is ever moved.
+    numberToBytesBE(counter, 8),
   );
   return {
     secret: hmac(sha256, seed, Bytes.concat(base, Bytes.fromHex('00'))),

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -199,6 +199,12 @@ function deriveHmacSecretAndBlindingFactor(
   keysetId: string,
   counter: number,
 ): DerivedSecretAndBlindingFactor {
+  // NUT-13 encodes the counter as u64, but setBigUint64 wraps, so an out-of-range value would
+  // alias onto a valid counter and re-derive its secret. Cap at MAX_SAFE_INTEGER rather than
+  // 2^64: past it `counter + 1 === counter`, so a batch would derive one counter twice.
+  if (!Number.isSafeInteger(counter) || counter < 0) {
+    throw new CTSError('Counter must be an integer in the range 0 <= counter <= 2^53 - 1');
+  }
   const base = Bytes.concat(
     Bytes.fromString('Cashu_KDF_HMAC_SHA256'),
     Bytes.fromHex(keysetId),

--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -65,12 +65,6 @@ export class Bytes {
     return new Uint8Array(size);
   }
 
-  static writeBigUint64BE(value: bigint): Uint8Array {
-    const buffer = new ArrayBuffer(8);
-    new DataView(buffer).setBigUint64(0, value, false);
-    return new Uint8Array(buffer);
-  }
-
   static toBase64(bytes: Uint8Array): string {
     const bufferConstructor = getBufferConstructor();
     if (bufferConstructor) {

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -282,36 +282,6 @@ describe('Bytes utility class', () => {
     });
   });
 
-  describe('writeBigUint64BE', () => {
-    test('should write bigint as big-endian bytes', () => {
-      const value = 0x0123456789abcdefn;
-      const result = Bytes.writeBigUint64BE(value);
-      const expected = new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle zero value', () => {
-      const value = 0n;
-      const result = Bytes.writeBigUint64BE(value);
-      const expected = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle maximum uint64 value', () => {
-      const value = 0xffffffffffffffffn;
-      const result = Bytes.writeBigUint64BE(value);
-      const expected = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle small values', () => {
-      const value = 0x42n;
-      const result = Bytes.writeBigUint64BE(value);
-      const expected = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42]);
-      expect(result).toEqual(expected);
-    });
-  });
-
   describe('toBase64', () => {
     test('should convert Uint8Array to base64', () => {
       const bytes = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
@@ -587,29 +557,6 @@ describe('Bytes utility class', () => {
       expect(extractedPart1).toEqual(part1);
       expect(extractedPart2).toEqual(part2);
       expect(extractedPart3).toEqual(part3);
-    });
-
-    test('bigint serialization consistency', () => {
-      const testValues = [
-        0n,
-        1n,
-        255n,
-        256n,
-        65535n,
-        65536n,
-        0xdeadbeefcafebaben,
-        0xffffffffffffffffn,
-      ];
-
-      testValues.forEach((value) => {
-        const bytes = Bytes.writeBigUint64BE(value);
-        expect(bytes.length).toBe(8);
-
-        // verify we can read it back with DataView
-        const view = new DataView(bytes.buffer);
-        const result = view.getBigUint64(0, false); // false = big endian
-        expect(result).toBe(value);
-      });
     });
 
     test('comparison and equality consistency', () => {

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -59,6 +59,35 @@ describe('v3 (BLS) derivation', () => {
   });
 });
 
+describe('HMAC counter range', () => {
+  const seed = new TextEncoder().encode('nut13 counter range seed');
+  const v2KeysetId = '01abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567';
+
+  test('rejects counters that a uint64 encoding would alias onto a valid one', () => {
+    // setBigUint64 wraps, so 2^64 would serialize exactly like 0 and derive its secret.
+    expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 2 ** 64)).toThrow(/counter/i);
+    expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, -1)).toThrow(/counter/i);
+    expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 1.5)).toThrow(/counter/i);
+    expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, NaN)).toThrow(/counter/i);
+  });
+
+  test('rejects counters above MAX_SAFE_INTEGER, where +1 no longer yields a distinct value', () => {
+    // Number.MAX_SAFE_INTEGER + 2 === Number.MAX_SAFE_INTEGER + 3, so a batch would
+    // derive one counter twice and issue duplicate outputs.
+    expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 2 ** 53)).toThrow(/counter/i);
+    expect(() =>
+      deriveSecretAndBlindingFactor(seed, v2KeysetId, Number.MAX_SAFE_INTEGER + 2),
+    ).toThrow(/counter/i);
+  });
+
+  test('accepts the full safe range', () => {
+    expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 0)).not.toThrow();
+    expect(() =>
+      deriveSecretAndBlindingFactor(seed, v2KeysetId, Number.MAX_SAFE_INTEGER),
+    ).not.toThrow();
+  });
+});
+
 describe('derivation kind selection', () => {
   // Known BIP-32 seed (NUT-13 spec / NUT-09 fixtures).
   const seed = Bytes.fromHex(

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -36,6 +36,21 @@ describe('DefaultOutputDataCreator', () => {
     expect(outputs).toEqual(OutputData.createDeterministicData(3, seed, 7, keyset, [1, 2]));
   });
 
+  test('a batch whose counters run past the safe range is rejected, not silently aliased', () => {
+    const keyset: HasKeysetKeys = {
+      id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
+      keys: { '1': 'unused', '2': 'unused' },
+    };
+    const creator = new DefaultOutputDataCreator();
+    const seed = new Uint8Array([1]);
+
+    // The first output is fine; the second lands on 2^53, where counter + 1 stops
+    // producing a distinct value, so a batch would derive one counter twice.
+    expect(() =>
+      creator.createDeterministicData(3, seed, Number.MAX_SAFE_INTEGER, keyset, [1, 2]),
+    ).toThrow(/counter/i);
+  });
+
   test('delegates deterministic batch creation to subclassed single-output override', () => {
     const calls: Array<{ amount: string; counter: number; keysetId: string }> = [];
     const keyset: HasKeysetKeys = {


### PR DESCRIPTION
The HMAC branch of the NUT-13 derivation fed the counter straight into a uint64 encoding. `DataView.setBigUint64` applies modulo 2^64 rather than rejecting out-of-range input, so an out-of-range counter aliased onto a valid one and re-derived its secret: `2 ** 64` serialised exactly like `0`, and negatives became valid encodings too. The BIP-32 branch has had a range guard for this reason; the HMAC branch had none.

The cap is `MAX_SAFE_INTEGER`, not 2^64. Above it `counter + 1` no longer produces a distinct value, so a batch of outputs would derive one counter twice and issue duplicate blinded messages rather than independent coins. Rejecting the unsafe range closes both the wrap and the precision case with one bound.

Guarding the deriver covers every caller: batch creation adds `i` to the base counter and funnels through here (`OutputData.ts`), so the creator needs no separate check. Tests cover the wrap value, negatives, non-integers, the precision boundary, and a batch that crosses it, plus the full accepted range at both ends.

The second commit removes the underlying footgun. `Bytes.writeBigUint64BE` existed only to wrap `setBigUint64`, so it silently produced a different value than asked for. noble's `numberToBytesBE` throws on both overflow and negatives, is already imported in this file, and emits identical bytes across the valid u64 range. It had a single caller and was not part of the public API, so it goes with its tests rather than being reimplemented. The explicit guard stays as the contract check with an actionable message; the encoder is now the backstop that makes silent aliasing impossible even if that guard is ever moved.

`npm run prtasks` green.