### PR TITLE
fix(crypto): require a 64-byte seed and slim the seed error context

### DIFF
--- a/src/crypto/NUT27.ts
+++ b/src/crypto/NUT27.ts
@@ -18,6 +18,11 @@ export const MINT_BACKUP_D_TAG = 'mint-list';
 const BACKUP_DOMAIN_SEPARATOR = utf8ToBytes('cashu-mint-backup');
 
 /**
+ * Length of a BIP-39 seed, the only input NUT-27 derivation accepts.
+ */
+const BIP39_SEED_BYTES = 64;
+
+/**
  * Plaintext shape that gets NIP-44-encrypted into the event `content`.
  */
 export interface MintBackupPayload {
@@ -37,8 +42,12 @@ export interface MintBackupPayload {
  * @returns `{ privkey, pubkey }` as lowercase hex strings.
  */
 export function deriveMintBackupKeys(seed: Uint8Array): { privkey: string; pubkey: string } {
-  if (!(seed instanceof Uint8Array) || seed.length === 0) {
-    throw new CTSError('seed must be a non-empty Uint8Array');
+  // Derivation is defined over the 64-byte BIP-39 seed. Types are erased for JS callers,
+  // so check the length here rather than trusting the signature.
+  if (!(seed instanceof Uint8Array) || seed.length !== BIP39_SEED_BYTES) {
+    throw new CTSError(
+      'seed must be a 64-byte BIP-39 seed (Uint8Array), e.g. mnemonicToSeedSync()',
+    );
   }
   const privkey = sha256(Bytes.concat(seed, BACKUP_DOMAIN_SEPARATOR));
   const pubkey = schnorr.getPublicKey(privkey); // 32-byte x-only

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -255,12 +255,11 @@ class Wallet {
     this._unit = options?.unit ?? this._unit;
     this._boundKeysetId = options?.keysetId ?? this._boundKeysetId;
     if (options?.bip39seed) {
+      // failIf forwards this context to the logger, so pass the type, never the seed.
       this.failIf(
         !(options.bip39seed instanceof Uint8Array),
         'bip39seed must be a valid Uint8Array',
-        {
-          bip39seed: options.bip39seed,
-        },
+        { received: typeof options.bip39seed },
       );
       this._seed = options.bip39seed;
     }

--- a/test/crypto/NUT27.test.ts
+++ b/test/crypto/NUT27.test.ts
@@ -42,11 +42,16 @@ describe('NUT-27 deriveMintBackupKeys', () => {
   });
 
   test('rejects an empty or non-Uint8Array seed with an actionable message', () => {
-    expect(() => deriveMintBackupKeys(new Uint8Array(0))).toThrow(
-      'seed must be a non-empty Uint8Array',
-    );
+    expect(() => deriveMintBackupKeys(new Uint8Array(0))).toThrow(/64-byte/);
     // @ts-expect-error testing runtime guard
-    expect(() => deriveMintBackupKeys('not bytes')).toThrow('seed must be a non-empty Uint8Array');
+    expect(() => deriveMintBackupKeys('not bytes')).toThrow(/64-byte/);
+  });
+
+  test('rejects seeds that are not the documented 64-byte length', () => {
+    expect(() => deriveMintBackupKeys(new Uint8Array([1]))).toThrow(/64-byte/);
+    expect(() => deriveMintBackupKeys(new Uint8Array(32))).toThrow(/64-byte/);
+    expect(() => deriveMintBackupKeys(new Uint8Array(65))).toThrow(/64-byte/);
+    expect(() => deriveMintBackupKeys(new Uint8Array(64))).not.toThrow();
   });
 });
 

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -62,6 +62,19 @@ describe('constructor mutants', () => {
     );
   });
 
+  test('never logs the rejected seed value', () => {
+    // failIf logs its context before throwing, so the value must not appear there.
+    const mnemonic = 'abandon abandon abandon abandon about';
+    const error = vi.fn();
+    const logger = { error, warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn() };
+
+    expect(() => new Wallet(mint, { unit, logger, bip39seed: mnemonic as never })).toThrow();
+
+    const logged = JSON.stringify(error.mock.calls);
+    expect(logged).not.toContain(mnemonic);
+    expect(logged).not.toContain('abandon');
+  });
+
   test('secretsPolicy overrides the default rather than being ANDed with it', () => {
     // `options.secretsPolicy ?? this._secretsPolicy`: an explicit 'random' must win even
     // when a seed is present (a `&&` mutant would collapse to the 'auto' default).


### PR DESCRIPTION
Two places where the seed input was looser than the contract.

**`deriveMintBackupKeys` accepted any non-empty seed.** NUT-27 derivation is defined over the 64-byte BIP-39 seed, but only emptiness was rejected. TypeScript types are erased for JavaScript callers, so the length is now checked at runtime like the other public-boundary guards in this file.

**The Wallet constructor kept the rejected value in its error context.** `failIf` forwards that context to the configured logger, so the guard now passes the received type rather than the value. Construction still throws exactly as before; only what reaches the log changes.

Tests cover the accepted length at both edges and the rejected cases, plus an assertion that the constructor's log calls do not contain the supplied value.

Note for the backport: only the constructor half applies to v4-dev, which has no NUT-27 backup helper. The bot's PR will need the `NUT27.ts` hunks dropped.

`npm run prtasks` green.