### PR TITLE
fix(wallet): slim the seed error context [backport v4-dev]

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -232,12 +232,11 @@ class Wallet {
     this._unit = options?.unit ?? this._unit;
     this._boundKeysetId = options?.keysetId ?? this._boundKeysetId;
     if (options?.bip39seed) {
+      // failIf forwards this context to the logger, so pass the type, never the seed.
       this.failIf(
         !(options.bip39seed instanceof Uint8Array),
         'bip39seed must be a valid Uint8Array',
-        {
-          bip39seed: options.bip39seed,
-        },
+        { received: typeof options.bip39seed },
       );
       this._seed = options.bip39seed;
     }

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -60,6 +60,19 @@ describe('constructor mutants', () => {
     );
   });
 
+  test('never logs the rejected seed value', () => {
+    // failIf logs its context before throwing, so the value must not appear there.
+    const mnemonic = 'abandon abandon abandon abandon about';
+    const error = vi.fn();
+    const logger = { error, warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn() };
+
+    expect(() => new Wallet(mint, { unit, logger, bip39seed: mnemonic as never })).toThrow();
+
+    const logged = JSON.stringify(error.mock.calls);
+    expect(logged).not.toContain(mnemonic);
+    expect(logged).not.toContain('abandon');
+  });
+
   test('secretsPolicy overrides the default rather than being ANDed with it', () => {
     // `options.secretsPolicy ?? this._secretsPolicy`: an explicit 'random' must win even
     // when a seed is present (a `&&` mutant would collapse to the 'auto' default).


### PR DESCRIPTION
Backport of the constructor half of #920.

The `bip39seed` guard put the received value in its error context, which `failIf` forwards to the configured logger. It now passes the received type instead. Construction still throws exactly as before; only what reaches the log changes.

The NUT-27 seed-length check is not carried over. v4 has no backup helper, so the cherry-pick brought `src/crypto/NUT27.ts` and its tests across as new files, unexported and unreachable on this line. Adding a v5 module is not a backport, so both are dropped and only the constructor change remains.