### PR TITLE
feat(wallet): claim manual counter ranges up front with CounterSource.reserveAt

### DIFF
--- a/docs-src/deterministic_counters.md
+++ b/docs-src/deterministic_counters.md
@@ -7,7 +7,7 @@ Deterministic outputs use per-keyset counters. The wallet reserves them atomical
 API at a glance:
 
 - `wallet.counters.peekNext(id)` – returns the current "next" for a keyset
-- `wallet.counters.advanceToAtLeast(id, n)` – bump forward if behind
+- `wallet.counters.advanceToAtLeast(id, n)` – bump forward if behind; no-op if already ahead (restore/sync)
 - `wallet.on.countersReserved(cb)` – subscribe to reservations (see [WalletEvents](./wallet_events/wallet_events.md) for subscription patterns)
 
 ** Optional:** - Depends on CounterSource:
@@ -99,7 +99,7 @@ The ephemeral source is memory-only — counters do not survive page reloads. Us
 ```ts
 function wireCounterPersistence(wallet: Wallet) {
   wallet.on.countersReserved(({ keysetId, next }) => {
-    saveNextToDb(keysetId, next);
+    saveNextToDb(keysetId, next); // your atomic save function
   });
 }
 
@@ -118,7 +118,9 @@ Because the source is shared, the global event on any wallet instance reflects t
 
 ### Custom CounterSource implementations
 
-`createEphemeralCounterSource` returns the built-in in-memory implementation. For durable storage you can implement `CounterSource` directly:
+`createEphemeralCounterSource` returns the built-in in-memory implementation, which survives restarts when paired with the `countersReserved` persistence above. For multi-wallet use inside a single app instance, it is usually enough.
+
+Implement `CounterSource` yourself when the cursor must live in your storage: when several tabs or processes reserve from one DB, or when a crash between reserving and saving must not risk reusing a counter. Each method is then one atomic transaction:
 
 ```ts
 import type { CounterSource, CounterRange } from '@cashu/cashu-ts';
@@ -127,9 +129,14 @@ class IndexedDbCounterSource implements CounterSource {
   async reserve(keysetId: string, n: number): Promise<CounterRange> {
     // atomic read-and-increment in your DB
   }
+  async reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange> {
+    // one transaction: throw if start < next, else SET next = start + count
+  }
   async advanceToAtLeast(keysetId: string, minNext: number): Promise<void> {
     // conditional update: SET next = max(next, minNext)
   }
   // Optional: snapshot(), setNext()
 }
 ```
+
+`reserveAt` claims a caller-chosen range instead of taking the next free one, and throws when `start` is already below the cursor. Manual deterministic counters go through it, so a counter that another operation has already been given is reported rather than quietly reused. Do the check and the update in one transaction: splitting them leaves a window for a concurrent `reserve` to hand out counters inside the range.

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -331,6 +331,7 @@ export interface CounterRange {
 export interface CounterSource {
     advanceToAtLeast(keysetId: string, minNext: number): Promise<void>;
     reserve(keysetId: string, n: number): Promise<CounterRange>;
+    reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange>;
     setNext?(keysetId: string, next: number): Promise<void>;
     snapshot?(): Promise<Record<string, number>>;
 }

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -88,6 +88,43 @@ If you call `signMintQuote`/`verifyMintQuoteSignature` only to mint against a mi
 
 ---
 
+## `CounterSource` gains a required `reserveAt` method
+
+Only affects you if you implement `CounterSource` yourself; `createEphemeralCounterSource` and
+`Wallet` are updated. `reserve` and `advanceToAtLeast` are unchanged.
+
+Manual deterministic counters used to be honoured by bumping the cursor _after_ the outputs were
+assigned. A concurrent auto allocation on the same keyset could take counters inside the manual
+range first, after which the bump found the cursor already past and did nothing, leaving both
+operations deriving from the same counter. Wallets sharing one `CounterSource` are the documented
+multi-wallet pattern, so this was reachable without doing anything unusual.
+
+`reserveAt` claims the range up front instead, and throws when the range was already handed out.
+
+### Migration
+
+```ts
+class MyCounterSource implements CounterSource {
+  async reserve(keysetId: string, n: number): Promise<CounterRange> {
+    /* unchanged */
+  }
+
+  // New: claim [start, start + count) in one transaction.
+  async reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange> {
+    // throw if start < next, else SET next = start + count
+  }
+
+  async advanceToAtLeast(keysetId: string, minNext: number): Promise<void> {
+    /* unchanged */
+  }
+}
+```
+
+The check and the update must be one atomic step. Reading the cursor and then bumping it in two
+calls reintroduces the window this closes.
+
+---
+
 ## `checkProofsStates` now requires `id` on every proof
 
 `Wallet.checkProofsStates` previously accepted `Array<Pick<Proof, 'secret'>>` — only `secret` was required. v5 requires both `id` and `secret`: `Array<Pick<Proof, 'secret' | 'id'>>`.

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -19,7 +19,22 @@ export interface CounterSource {
    */
   reserve(keysetId: string, n: number): Promise<CounterRange>;
   /**
+   * Reserve a caller-chosen range `[start, start+count)` for a keyset.
+   *
+   * @remarks
+   * Use for manual deterministic counters, where the caller picks the range rather than taking the
+   * next free one. MUST be atomic with `reserve()`: checking the cursor and bumping it in two calls
+   * leaves a window for a concurrent reservation to take counters inside the range. Counters below
+   * `start` are burned, matching `advanceToAtLeast`.
+   * @throws If `start` is below the cursor, i.e. the range was already handed out.
+   */
+  reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange>;
+  /**
    * Monotonic bump, ensure the next counter is at least minNext.
+   *
+   * @remarks
+   * Unconditional: a cursor already past `minNext` is left alone. To take a specific range and find
+   * out whether it was already issued, use `reserveAt()`.
    */
   advanceToAtLeast(keysetId: string, minNext: number): Promise<void>;
   /**
@@ -86,6 +101,22 @@ export class EphemeralCounterSource implements CounterSource {
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
       this.next.set(keysetId, cur + n);
       return { start: cur, count: n };
+    });
+  }
+
+  async reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange> {
+    if (start < 0 || count < 0) {
+      throw new CTSError('reserveAt called with a negative start or count');
+    }
+    return this.withLock(keysetId, () => {
+      const cur = this.next.get(keysetId) ?? 0;
+      if (start < cur) {
+        throw new CTSError(
+          `Counter ${start} for keyset ${keysetId} was already issued (next is ${cur})`,
+        );
+      }
+      this.next.set(keysetId, start + count);
+      return { start, count };
     });
   }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -575,16 +575,17 @@ class Wallet {
       }
     }
 
-    // If any deterministic OutputType has a manual counter (> 0), advance
-    // the counter source so future "auto" allocations do not reuse counters.
+    // Claim the manual range up front. Bumping the cursor afterwards would leave a window
+    // for a concurrent auto reservation to hand out counters inside the range, and the bump
+    // would then silently do nothing because the cursor had already moved past it.
     if (manual.length > 0) {
-      // Get the max counter manually allocated
+      const minManualStart = Math.min(...manual.map((ot) => ot.counter));
       const maxManualEnd = Math.max(...manual.map((ot) => ot.counter + ot.denominations!.length));
 
-      // Bump cursor to at least the end of the manually allocated range
-      await this._counterSource.advanceToAtLeast(keysetId, maxManualEnd);
-      this._logger.debug('Counter source advanced to respect manual deterministic counters', {
+      await this._counterSource.reserveAt(keysetId, minManualStart, maxManualEnd - minManualStart);
+      this._logger.debug('Counter source claimed manual deterministic range', {
         keysetId,
+        minManualStart,
         maxManualEnd,
       });
     }

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -7,6 +7,46 @@ import {
 } from '../../src/wallet';
 
 describe('EphemeralCounterSource', () => {
+  it('reserveAt claims a caller-chosen range and moves the cursor past it', async () => {
+    const src = new EphemeralCounterSource();
+    const range = await src.reserveAt('ks', 5, 3);
+
+    expect(range).toEqual({ start: 5, count: 3 });
+    // The gap below the claim is burned: the cursor is monotonic.
+    expect((await src.reserve('ks', 0)).start).toBe(8);
+  });
+
+  it('reserveAt rejects a range whose start was already issued', async () => {
+    const src = new EphemeralCounterSource();
+    await src.reserve('ks', 2); // hands out 0,1
+
+    await expect(src.reserveAt('ks', 1, 2)).rejects.toThrow(/already/i);
+    // The failed claim must not move the cursor.
+    expect((await src.reserve('ks', 0)).start).toBe(2);
+  });
+
+  it('reserveAt accepts a range starting exactly at the cursor', async () => {
+    const src = new EphemeralCounterSource();
+    await src.reserve('ks', 2);
+
+    await expect(src.reserveAt('ks', 2, 1)).resolves.toEqual({ start: 2, count: 1 });
+  });
+
+  it('a claim and a concurrent auto reservation never overlap', async () => {
+    const src = new EphemeralCounterSource();
+    // Interleaved: whichever lands first, the two ranges must be disjoint.
+    const [claimed, auto] = await Promise.all([src.reserveAt('ks', 0, 2), src.reserve('ks', 2)]);
+
+    const used = new Set<number>();
+    for (const r of [claimed, auto]) {
+      for (let i = r.start; i < r.start + r.count; i++) {
+        expect(used.has(i)).toBe(false);
+        used.add(i);
+      }
+    }
+    expect(used.size).toBe(4);
+  });
+
   it('constructor seeds initial next values', async () => {
     const src = new EphemeralCounterSource({ a: 5, b: 2 });
     const snap = await src.snapshot();

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -25,6 +25,15 @@ describe('EphemeralCounterSource', () => {
     expect((await src.reserve('ks', 0)).start).toBe(2);
   });
 
+  it('reserveAt rejects a negative start or count', async () => {
+    const src = new EphemeralCounterSource();
+
+    await expect(src.reserveAt('ks', -1, 1)).rejects.toThrow(/negative/i);
+    await expect(src.reserveAt('ks', 0, -1)).rejects.toThrow(/negative/i);
+    // Rejected calls must not move the cursor.
+    expect((await src.reserve('ks', 0)).start).toBe(0);
+  });
+
   it('reserveAt accepts a range starting exactly at the cursor', async () => {
     const src = new EphemeralCounterSource();
     await src.reserve('ks', 2);

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -7,6 +7,7 @@ import {
   Amount,
   CTSError,
   OutputData,
+  createEphemeralCounterSource,
   type Proof,
   type ProofLike,
   type OutputConfig,
@@ -1126,6 +1127,63 @@ describe('send', () => {
     expect(res.inputs.length).toBeGreaterThan(0);
     expect(res.inputs.every((p) => p.amount instanceof Amount)).toBe(true);
   });
+  test('a manual counter already handed out is rejected, not silently reused', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 0 }],
+        }),
+      ),
+    );
+
+    const keysetId = '00bd033559de27d0';
+    const seed = hexToBytes(
+      'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
+    );
+    const proof = (n: number, amount: number): Proof => ({
+      id: keysetId,
+      amount: Amount.from(amount),
+      secret: `1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674b${n
+        .toString(16)
+        .padStart(2, '0')}`,
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+    });
+
+    // Two wallets on one shared source: the documented multi-wallet pattern.
+    const counterSource = createEphemeralCounterSource();
+    const opts = { unit, bip39seed: seed, counterSource };
+    const autoWallet = new Wallet(mint, opts);
+    const manualWallet = new Wallet(mint, opts);
+    await Promise.all([autoWallet.loadMint(), manualWallet.loadMint()]);
+
+    // The auto operation takes the low counters first.
+    await autoWallet.prepareSwapToSend(
+      2,
+      [proof(1, 4)],
+      {},
+      {
+        send: { type: 'deterministic', counter: 0 },
+        keep: { type: 'deterministic', counter: 0 },
+      },
+    );
+    const next = await autoWallet.counters.peekNext(keysetId);
+    expect(next).toBeGreaterThan(1);
+
+    // Counter 1 is now spent. Bumping the cursor afterwards would silently succeed and
+    // derive a duplicate; claiming the range surfaces it instead.
+    await expect(
+      manualWallet.prepareSwapToSend(
+        2,
+        [proof(2, 4)],
+        {},
+        {
+          send: { type: 'deterministic', counter: 1 },
+          keep: { type: 'deterministic', counter: 0 },
+        },
+      ),
+    ).rejects.toThrow(/already issued/i);
+  });
+
   test('manual counters advances cursor, then auto allocation must not reuse counters', async () => {
     server.use(
       http.get(mintUrl + '/v1/keysets', () => {


### PR DESCRIPTION
## Description

Manual deterministic counters (`counter: N` in an OutputConfig) used to be applied by bumping the shared cursor after the outputs were assigned. With wallets sharing one `CounterSource` (the documented multi-wallet pattern), an auto allocation on the same keyset could take counters inside the manual range first, and the later bump would not notice: both operations then derive from the same counter. This PR claims the manual range up front instead, so a range that was already handed out is reported to the caller.

---

## Changes

- New required `reserveAt(keysetId, start, count)` on `CounterSource`: claim `[start, start + count)` atomically, throw if `start` is below the cursor. `reserve` and `advanceToAtLeast` are unchanged.
- `EphemeralCounterSource` implements it under the same per-keyset lock as `reserve`.
- `Wallet` claims the manual range via `reserveAt` instead of calling `advanceToAtLeast` afterwards.
- Migration guide entry (only affects custom `CounterSource` implementations) plus deterministic counters doc updates, including when to implement `CounterSource` yourself versus persisting via `countersReserved`.

## Reviewer Notes

- The check and the cursor update in `reserveAt` must be a single atomic step; the TSDoc and docs spell this out for implementers.
- `WalletCounters` deliberately does not expose `reserveAt`: it stays a persist/inspect/bump view. Consumers who claim ranges externally hold the source object and call it directly.
- v5 only: adds a required method to a public interface, so no v4 backport.