### PR TITLE
feat(wallet): claim manual counter ranges with optional CounterSource.reserveAt (v4)

### DIFF
--- a/docs-src/deterministic_counters.md
+++ b/docs-src/deterministic_counters.md
@@ -118,7 +118,9 @@ Because the source is shared, the global event on any wallet instance reflects t
 
 ### Custom CounterSource implementations
 
-`createEphemeralCounterSource` returns the built-in in-memory implementation. For durable storage you can implement `CounterSource` directly:
+`createEphemeralCounterSource` returns the built-in in-memory implementation, which survives restarts when paired with the `countersReserved` persistence above. For multi-wallet use inside a single app instance, it is usually enough.
+
+Implement `CounterSource` yourself when the cursor must live in your storage: when several tabs or processes reserve from one DB, or when a crash between reserving and saving must not risk reusing a counter. Each method is then one atomic transaction:
 
 ```ts
 import type { CounterSource, CounterRange } from '@cashu/cashu-ts';
@@ -127,9 +129,14 @@ class IndexedDbCounterSource implements CounterSource {
   async reserve(keysetId: string, n: number): Promise<CounterRange> {
     // atomic read-and-increment in your DB
   }
+  async reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange> {
+    // one transaction: throw if start < next, else SET next = start + count
+  }
   async advanceToAtLeast(keysetId: string, minNext: number): Promise<void> {
     // conditional update: SET next = max(next, minNext)
   }
   // Optional: snapshot(), setNext()
 }
 ```
+
+`reserveAt` claims a caller-chosen range instead of taking the next free one, and throws when `start` is already below the cursor. It is optional in v4 (required in v5) but recommended: when present, manual deterministic counters go through it, so a counter that another operation has already been given is reported rather than quietly reused. Without it the wallet falls back to `advanceToAtLeast` and logs a warning when the range was already issued. Do the check and the update in one transaction: splitting them leaves a window for a concurrent `reserve` to hand out counters inside the range.

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -286,6 +286,7 @@ export interface CounterRange {
 export interface CounterSource {
     advanceToAtLeast(keysetId: string, minNext: number): Promise<void>;
     reserve(keysetId: string, n: number): Promise<CounterRange>;
+    reserveAt?(keysetId: string, start: number, count: number): Promise<CounterRange>;
     setNext?(keysetId: string, next: number): Promise<void>;
     snapshot?(): Promise<Record<string, number>>;
 }

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -19,6 +19,17 @@ export interface CounterSource {
    */
   reserve(keysetId: string, n: number): Promise<CounterRange>;
   /**
+   * Reserve a caller-chosen range `[start, start+count)` for a keyset.
+   *
+   * Optional in v4, will be required in v5.
+   *
+   * @remarks
+   * Used for manual deterministic counters when present; without it the wallet falls back to
+   * `advanceToAtLeast`. MUST be atomic with `reserve()` and throw if `start` is below the cursor
+   * (range already issued). Counters below `start` are burned, matching `advanceToAtLeast`.
+   */
+  reserveAt?(keysetId: string, start: number, count: number): Promise<CounterRange>;
+  /**
    * Monotonic bump, ensure the next counter is at least minNext.
    */
   advanceToAtLeast(keysetId: string, minNext: number): Promise<void>;
@@ -86,6 +97,22 @@ export class EphemeralCounterSource implements CounterSource {
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
       this.next.set(keysetId, cur + n);
       return { start: cur, count: n };
+    });
+  }
+
+  async reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange> {
+    if (start < 0 || count < 0) {
+      throw new CTSError('reserveAt called with a negative start or count');
+    }
+    return this.withLock(keysetId, () => {
+      const cur = this.next.get(keysetId) ?? 0;
+      if (start < cur) {
+        throw new CTSError(
+          `Counter ${start} for keyset ${keysetId} was already issued (next is ${cur})`,
+        );
+      }
+      this.next.set(keysetId, start + count);
+      return { start, count };
     });
   }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -551,14 +551,41 @@ class Wallet {
       }
     }
 
-    // If any deterministic OutputType has a manual counter (> 0), advance
-    // the counter source so future "auto" allocations do not reuse counters.
+    // If any deterministic OutputType has a manual counter (> 0), claim the range so
+    // "auto" allocations do not reuse counters. Prefer reserveAt (claims up front and
+    // detects a range that was already handed out); fall back to the historic bump for
+    // sources that do not implement it, with a best-effort peek to report reuse.
     if (manual.length > 0) {
-      // Get the max counter manually allocated
+      const minManualStart = Math.min(...manual.map((ot) => ot.counter));
       const maxManualEnd = Math.max(...manual.map((ot) => ot.counter + ot.denominations!.length));
 
-      // Bump cursor to at least the end of the manually allocated range
-      await this._counterSource.advanceToAtLeast(keysetId, maxManualEnd);
+      if (this._counterSource.reserveAt) {
+        try {
+          await this._counterSource.reserveAt(
+            keysetId,
+            minManualStart,
+            maxManualEnd - minManualStart,
+          );
+        } catch {
+          this._logger.warn('Manual deterministic counter range was already issued', {
+            keysetId,
+            minManualStart,
+            maxManualEnd,
+          });
+          await this._counterSource.advanceToAtLeast(keysetId, maxManualEnd);
+        }
+      } else {
+        // reserve(n=0) is the documented read-only peek of the cursor.
+        const { start: next } = await this._counterSource.reserve(keysetId, 0);
+        if (next > minManualStart) {
+          this._logger.warn('Manual deterministic counter range was already issued', {
+            keysetId,
+            minManualStart,
+            maxManualEnd,
+          });
+        }
+        await this._counterSource.advanceToAtLeast(keysetId, maxManualEnd);
+      }
       this._logger.debug('Counter source advanced to respect manual deterministic counters', {
         keysetId,
         maxManualEnd,

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -19,6 +19,55 @@ describe('EphemeralCounterSource', () => {
     expect(snap).toEqual({ a: 5, b: 2 });
   });
 
+  it('reserveAt claims a caller-chosen range and moves the cursor past it', async () => {
+    const src = new EphemeralCounterSource();
+    const range = await src.reserveAt('ks', 5, 3);
+
+    expect(range).toEqual({ start: 5, count: 3 });
+    // The gap below the claim is burned: the cursor is monotonic.
+    expect((await src.reserve('ks', 0)).start).toBe(8);
+  });
+
+  it('reserveAt rejects a range whose start was already issued', async () => {
+    const src = new EphemeralCounterSource();
+    await src.reserve('ks', 2); // hands out 0,1
+
+    await expect(src.reserveAt('ks', 1, 2)).rejects.toThrow(/already/i);
+    // The failed claim must not move the cursor.
+    expect((await src.reserve('ks', 0)).start).toBe(2);
+  });
+
+  it('reserveAt rejects a negative start or count', async () => {
+    const src = new EphemeralCounterSource();
+
+    await expect(src.reserveAt('ks', -1, 1)).rejects.toThrow(/negative/i);
+    await expect(src.reserveAt('ks', 0, -1)).rejects.toThrow(/negative/i);
+    // Rejected calls must not move the cursor.
+    expect((await src.reserve('ks', 0)).start).toBe(0);
+  });
+
+  it('reserveAt accepts a range starting exactly at the cursor', async () => {
+    const src = new EphemeralCounterSource();
+    await src.reserve('ks', 2);
+
+    await expect(src.reserveAt('ks', 2, 1)).resolves.toEqual({ start: 2, count: 1 });
+  });
+
+  it('a claim and a concurrent auto reservation never overlap', async () => {
+    const src = new EphemeralCounterSource();
+    // Interleaved: whichever lands first, the two ranges must be disjoint.
+    const [claimed, auto] = await Promise.all([src.reserveAt('ks', 0, 2), src.reserve('ks', 2)]);
+
+    const used = new Set<number>();
+    for (const r of [claimed, auto]) {
+      for (let i = r.start; i < r.start + r.count; i++) {
+        expect(used.has(i)).toBe(false);
+        used.add(i);
+      }
+    }
+    expect(used.size).toBe(4);
+  });
+
   it('reserve(n=0) returns {start:0,count:0} and does not mutate state', async () => {
     const src = new EphemeralCounterSource();
     const r = await src.reserve('k', 0);

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -1,12 +1,14 @@
 import { hexToBytes } from '@noble/curves/utils.js';
 import { HttpResponse, http } from 'msw';
-import { test, describe, expect } from 'vitest';
+import { test, describe, expect, vi } from 'vitest';
 
 import {
   Wallet,
   Amount,
   CTSError,
   OutputData,
+  createEphemeralCounterSource,
+  type CounterSource,
   type Proof,
   type ProofLike,
   type OutputConfig,
@@ -1061,6 +1063,138 @@ describe('send', () => {
     expect(res.inputs.length).toBeGreaterThan(0);
     expect(res.inputs.every((p) => p.amount instanceof Amount)).toBe(true);
   });
+  test('warns when a manual counter range was already handed out', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 0 }],
+        }),
+      ),
+    );
+
+    const keysetId = '00bd033559de27d0';
+    const seed = hexToBytes(
+      'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
+    );
+    const proof = (n: number, amount: number): Proof => ({
+      id: keysetId,
+      amount: Amount.from(amount),
+      secret: `1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674b${n
+        .toString(16)
+        .padStart(2, '0')}`,
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+    });
+
+    // Two wallets on one shared source: the documented multi-wallet pattern.
+    const counterSource = createEphemeralCounterSource();
+    const warn = vi.fn();
+    const spyLogger = { error: vi.fn(), warn, info: vi.fn(), debug: vi.fn(), trace: vi.fn() };
+    const autoWallet = new Wallet(mint, { unit, bip39seed: seed, counterSource });
+    const manualWallet = new Wallet(mint, {
+      unit,
+      bip39seed: seed,
+      counterSource,
+      logger: spyLogger,
+    });
+    await Promise.all([autoWallet.loadMint(), manualWallet.loadMint()]);
+
+    // The auto operation takes the low counters first.
+    await autoWallet.prepareSwapToSend(
+      2,
+      [proof(1, 4)],
+      {},
+      {
+        send: { type: 'deterministic', counter: 0 },
+        keep: { type: 'deterministic', counter: 0 },
+      },
+    );
+    expect(await autoWallet.counters.peekNext(keysetId)).toBeGreaterThan(1);
+
+    // Counter 1 was handed out above. The operation still completes (v4 behaviour is
+    // unchanged), but the collision is reported instead of passing silently.
+    const res = await manualWallet.prepareSwapToSend(
+      2,
+      [proof(2, 4)],
+      {},
+      {
+        send: { type: 'deterministic', counter: 1 },
+        keep: { type: 'deterministic', counter: 0 },
+      },
+    );
+    expect(res.sendOutputs?.length ?? 0).toBeGreaterThan(0);
+    expect(warn).toHaveBeenCalledWith(
+      'Manual deterministic counter range was already issued',
+      expect.objectContaining({ keysetId }),
+    );
+  });
+
+  test('warns for a reused manual counter range on a source without reserveAt', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ id: '00bd033559de27d0', unit: 'sat', active: true, input_fee_ppk: 0 }],
+        }),
+      ),
+    );
+
+    const keysetId = '00bd033559de27d0';
+    const seed = hexToBytes(
+      'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
+    );
+    const proof = (n: number, amount: number): Proof => ({
+      id: keysetId,
+      amount: Amount.from(amount),
+      secret: `1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674c${n
+        .toString(16)
+        .padStart(2, '0')}`,
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+    });
+
+    // A pre-reserveAt CounterSource: only the two original required methods.
+    const inner = createEphemeralCounterSource();
+    const legacySource: CounterSource = {
+      reserve: (id, n) => inner.reserve(id, n),
+      advanceToAtLeast: (id, n) => inner.advanceToAtLeast(id, n),
+    };
+    const warn = vi.fn();
+    const wallet = new Wallet(mint, {
+      unit,
+      bip39seed: seed,
+      counterSource: legacySource,
+      logger: { error: vi.fn(), warn, info: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+    });
+    await wallet.loadMint();
+
+    // A fresh manual range draws no warning.
+    await wallet.prepareSwapToSend(
+      2,
+      [proof(1, 4)],
+      {},
+      {
+        send: { type: 'deterministic', counter: 5 },
+        keep: { type: 'deterministic', counter: 0 },
+      },
+    );
+    expect(warn).not.toHaveBeenCalled();
+    const next = await wallet.counters.peekNext(keysetId);
+    expect(next).toBeGreaterThan(5); // cursor still bumped past the manual range
+
+    // Asking for the same range again is reported.
+    await wallet.prepareSwapToSend(
+      2,
+      [proof(2, 4)],
+      {},
+      {
+        send: { type: 'deterministic', counter: 5 },
+        keep: { type: 'deterministic', counter: 0 },
+      },
+    );
+    expect(warn).toHaveBeenCalledWith(
+      'Manual deterministic counter range was already issued',
+      expect.objectContaining({ keysetId }),
+    );
+  });
+
   test('manual counters advances cursor, then auto allocation must not reuse counters', async () => {
     server.use(
       http.get(mintUrl + '/v1/keysets', () => {


### PR DESCRIPTION
## Description

v4 companion to #923. Manual deterministic counters are applied by bumping the shared cursor after the outputs are assigned; with wallets sharing one `CounterSource`, an auto allocation on the same keyset can take counters inside the manual range first, and the later bump does not notice. v5 adds a required `reserveAt` that claims the range up front. v4 takes it as an optional method so no existing implementation breaks, and follows the v4 warn-not-throw convention: a range that was already handed out is reported in the log while behaviour is otherwise unchanged.

---

## Changes

- Optional `reserveAt?(keysetId, start, count)` on `CounterSource`, implemented by `EphemeralCounterSource`: claim `[start, start + count)` atomically, throw if `start` is below the cursor.
- The wallet prefers `reserveAt` for manual ranges; on a range that was already handed out it warns and falls back to the historic bump. Sources without `reserveAt` keep the old path, with a peek-based warning.
- Docs: custom `CounterSource` section updated; `reserveAt` is optional in v4 and required in v5.

---

## Reviewer Notes

- Non-breaking: the new interface member is optional; no v4 consumer or custom implementation needs changes.
- With the built-in source, warn-and-proceed keeps v4 behaviour identical apart from the log line.