### PR TITLE
fix(wallet): check bolt11 quote amounts against the invoice

### DIFF
--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -368,6 +368,22 @@ Generic mint quote responses (custom payment methods) are now base-validated lik
 
 ---
 
+## Bolt11 mint quotes are checked against the requested amount
+
+`createMintQuoteBolt11` and `createLockedMintQuote` now throw when the mint's response does not carry the amount that was asked for. For `sat` quotes the BOLT11 invoice's HRP amount must also equal the quoted amount; amountless or unreadable invoices fail the same check. The `checkMintQuoteBolt11` and `checkMintQuoteBatchBolt11` lookups apply the invoice check against each returned quote's own amount. Other units are not directly comparable to an invoice, so only the quoted amount is verified there.
+
+Apps talking to conforming mints need no change. Tests that stub bolt11 mint quote responses must give the invoice an HRP that matches the quoted amount, e.g. `request: 'lnbc10u1pfake'` for a 1,000 sat quote; the raw `createMintQuote('bolt11', …)` escape hatch remains unvalidated.
+
+---
+
+## Bolt11 melt quotes must not charge more than the invoice
+
+For `sat` quotes, `createMeltQuoteBolt11` now throws when the quote's `amount` exceeds the invoice's encoded amount (a sub-sat invoice may round up to the next sat). Amountless invoices are bounded by the caller's `amountMsat` when given, and `createMultiPathMeltQuote` is bounded by the requested partial amount. `checkMeltQuoteBolt11` applies the same bound against the quote's own `request`, and rejects a response whose `request` is not readable as a BOLT11 invoice. Undercharging is not rejected, and other units are not directly comparable to the invoice, so they are unchecked; the raw `createMeltQuote`/`checkMeltQuote` escape hatches also remain unvalidated.
+
+Test stubs follow the same HRP rule as mint quotes above.
+
+---
+
 ## Melt quote responses require `request` and carry `method`
 
 `request` (the method-specific payment routing instructions) moved from the bolt11/onchain response types into `MeltQuoteBaseResponse`, and the base type gains an optional `fee_reserve`. Melt quote responses from any method — including custom ones — that lack a `request` string now throw `Invalid response from mint`.

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -935,5 +935,54 @@ function removePrefix(token: string): string {
  * @internal
  */
 export function invoiceHasAmountInHRP(invoice: string): boolean {
-  return /^ln[a-z]{2,}[1-9][0-9]*(?:[mun]|0p)?1/i.test(invoice);
+  try {
+    return bolt11AmountMsat(invoice) !== null;
+  } catch {
+    return false; // malformed invoice or amount: no readable amount in the HRP
+  }
+}
+
+/**
+ * Msat per HRP amount unit for each BOLT11 multiplier ('p' is handled separately).
+ */
+const MULTIPLIER_MSAT: Record<string, bigint> = {
+  m: 100_000_000n, // milli-bitcoin
+  u: 100_000n, // micro-bitcoin
+  n: 100n, // nano-bitcoin
+};
+
+const MSAT_PER_BTC = 100_000_000_000n;
+
+/**
+ * Reads the amount a BOLT11 invoice asks for from its human readable part, in millisats.
+ *
+ * @remarks
+ * HRP only: no checksum or signature validation, that is the payer's job. Returns null for an
+ * amountless invoice.
+ * @throws If the string is not shaped like a BOLT11 invoice or the amount is malformed.
+ * @internal
+ */
+export function bolt11AmountMsat(pr: string): bigint | null {
+  if (typeof pr !== 'string') throw new CTSError('BOLT11 invoice must be a string');
+  const lower = pr.toLowerCase();
+  // The bech32 charset excludes '1', so the last '1' is the HRP separator.
+  const sep = lower.lastIndexOf('1');
+  if (!lower.startsWith('ln') || sep < 3 || sep === lower.length - 1) {
+    throw new CTSError('Invalid BOLT11 invoice');
+  }
+  const match = /^ln[a-z]+?(\d*)([munp]?)$/.exec(lower.slice(0, sep));
+  if (!match) throw new CTSError('Invalid BOLT11 invoice');
+
+  const [, digits, multiplier] = match;
+  if (digits === '') return null; // amountless invoice
+  // BOLT11 forbids leading zeros, which also rules out a zero amount.
+  if (digits.startsWith('0')) throw new CTSError('Invalid BOLT11 amount');
+  const n = BigInt(digits);
+  if (multiplier === '') return n * MSAT_PER_BTC;
+  if (multiplier === 'p') {
+    // Pico-bitcoin is 0.1 msat per unit; BOLT11 requires a multiple of 10.
+    if (n % 10n !== 0n) throw new CTSError('Invalid BOLT11 amount');
+    return n / 10n;
+  }
+  return n * MULTIPLIER_MSAT[multiplier];
 }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -59,6 +59,7 @@ import type { Token } from '../model/types/token';
 import { BATCH_POOL_SIZE, runPool } from '../transport';
 import type { RequestFetch, RequestFn } from '../transport';
 import {
+  bolt11AmountMsat,
   getDecodedToken,
   invoiceHasAmountInHRP,
   normalizeMintUrl,
@@ -1918,6 +1919,33 @@ class Wallet {
   }
 
   /**
+   * Asserts a bolt11 mint quote matches the amount the caller asked for.
+   *
+   * @remarks
+   * For sat quotes the invoice HRP amount is compared too; other units are not directly comparable
+   * to the invoice, so only the quoted amount is checked.
+   */
+  private assertBolt11MintQuoteAmount(res: MintQuoteBolt11Response, expected: Amount): void {
+    this.failIf(!res.amount.equals(expected), 'Mint quote amount does not match', {
+      expected: expected.toString(),
+      quoted: res.amount.toString(),
+    });
+    if (this._unit !== 'sat') return;
+    let msat: bigint | null = null;
+    try {
+      msat = bolt11AmountMsat(res.request);
+    } catch {
+      // fall through: an unreadable invoice fails the comparison below
+    }
+    // A sat quote's invoice must ask for exactly the requested amount (in whole sats).
+    const matches = msat !== null && expected.multiplyBy(1000).equals(msat);
+    this.failIf(!matches, 'Mint quote invoice amount does not match the quote', {
+      expected: expected.toString(),
+      invoiceMsat: msat,
+    });
+  }
+
+  /**
    * Requests a mint quote from the mint. Response returns a Lightning payment request for the
    * requested given amount and unit.
    *
@@ -1948,6 +1976,7 @@ class Wallet {
       description: description,
     };
     const res = await this.mint.createMintQuoteBolt11(mintQuotePayload);
+    this.assertBolt11MintQuoteAmount(res, mintAmount);
     return { ...res, unit: res.unit || this._unit };
   }
 
@@ -1979,6 +2008,7 @@ class Wallet {
       pubkey: normPubkey,
     };
     const res = await this.mint.createMintQuoteBolt11(mintQuotePayload);
+    this.assertBolt11MintQuoteAmount(res, mintAmount);
     this.failIf(typeof res.pubkey !== 'string', 'Mint returned unlocked mint quote');
     const resPubkey = res.pubkey!;
     this.failIf(
@@ -2096,7 +2126,10 @@ class Wallet {
     quote: string | MintQuoteBolt11Response,
   ): Promise<MintQuoteBolt11Response> {
     const quoteId = typeof quote === 'string' ? quote : quote.quote;
-    return this.mint.checkMintQuoteBolt11(quoteId);
+    const res = await this.mint.checkMintQuoteBolt11(quoteId);
+    // No caller-side expectation here, so check the invoice against the quote's own amount.
+    this.assertBolt11MintQuoteAmount(res, res.amount);
+    return res;
   }
 
   /**
@@ -2161,7 +2194,9 @@ class Wallet {
     quotes: Array<string | MintQuoteBolt11Response>,
   ): Promise<MintQuoteBolt11Response[]> {
     const quoteIds = quotes.map((quote) => (typeof quote === 'string' ? quote : quote.quote));
-    return this.mint.checkMintQuoteBatchBolt11(quoteIds);
+    const res = await this.mint.checkMintQuoteBatchBolt11(quoteIds);
+    for (const quote of res) this.assertBolt11MintQuoteAmount(quote, quote.amount);
+    return res;
   }
 
   /**
@@ -2765,6 +2800,27 @@ class Wallet {
   }
 
   /**
+   * Asserts a bolt11 melt quote does not charge more than the invoice asks for.
+   *
+   * @remarks
+   * Sat quotes only; other units are not directly comparable to the invoice. One-sided by design: a
+   * quote may round a sub-sat invoice up to the next sat, and undercharging is the mint's loss.
+   * Pass `null` when there is no millisat expectation to compare against.
+   */
+  private assertBolt11MeltQuoteAmount(
+    res: MeltQuoteBolt11Response,
+    expectedMsat: AmountLike | null,
+  ): void {
+    if (this._unit !== 'sat' || expectedMsat === null) return;
+    const msat = Amount.from(expectedMsat);
+    const maxSat = msat.ceilPercent(1, 1000); // ceil(msat / 1000)
+    this.failIf(res.amount.greaterThan(maxSat), 'Melt quote amount exceeds the invoice amount', {
+      quoted: res.amount.toString(),
+      invoiceMsat: msat.toString(),
+    });
+  }
+
+  /**
    * Requests a melt quote from the mint. Response returns amount and fees for a given unit in order
    * to pay a Lightning invoice.
    *
@@ -2806,6 +2862,16 @@ class Wallet {
         : {}),
     };
     const meltQuote = await this.mint.createMeltQuoteBolt11(meltQuotePayload);
+    let expectedMsat: AmountLike | null = null;
+    try {
+      expectedMsat = bolt11AmountMsat(invoice);
+    } catch {
+      // Unreadable caller invoice: the mint validates it; nothing to compare against.
+    }
+    if (expectedMsat === null && normalizedAmountMsat !== undefined) {
+      expectedMsat = normalizedAmountMsat;
+    }
+    this.assertBolt11MeltQuoteAmount(meltQuote, expectedMsat);
     return {
       ...meltQuote,
       unit: meltQuote.unit || this._unit,
@@ -2896,6 +2962,8 @@ class Wallet {
       options: { mpp: { amount: normalizedMillisatPartialAmount } },
     };
     const meltQuote = await this.mint.createMeltQuoteBolt11(meltQuotePayload);
+    // A partial quote is bounded by the caller's own millisat share, not the invoice total.
+    this.assertBolt11MeltQuoteAmount(meltQuote, normalizedMillisatPartialAmount);
     return { ...meltQuote, request: invoice, unit: this._unit };
   }
 
@@ -2938,7 +3006,18 @@ class Wallet {
     quote: string | MeltQuoteBolt11Response,
   ): Promise<MeltQuoteBolt11Response> {
     const quoteId = typeof quote === 'string' ? quote : quote.quote;
-    return this.mint.checkMeltQuoteBolt11(quoteId);
+    const res = await this.mint.checkMeltQuoteBolt11(quoteId);
+    // No caller-side expectation here, so check the quote against its own invoice.
+    if (this._unit === 'sat') {
+      let expectedMsat: bigint | null = null;
+      try {
+        expectedMsat = bolt11AmountMsat(res.request);
+      } catch {
+        this.fail('Melt quote request is not a valid bolt11 invoice', { quote: res.quote });
+      }
+      this.assertBolt11MeltQuoteAmount(res, expectedMsat);
+    }
+    return res;
   }
 
   /**

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -67,7 +67,7 @@ describe('requests', { timeout: 7500 }, () => {
           state: 'UNPAID',
           unit: 'sat',
           expiry: 9999999999,
-          request: 'bolt11invoice...',
+          request: 'lnbc20u1pfake',
         });
       }),
     );
@@ -93,7 +93,7 @@ describe('requests', { timeout: 7500 }, () => {
           state: 'UNPAID',
           unit: 'sat',
           expiry: 9999999999,
-          request: 'bolt11invoice...',
+          request: 'lnbc20u1pfake',
         });
       }),
     );
@@ -128,7 +128,7 @@ describe('requests', { timeout: 7500 }, () => {
           state: 'UNPAID',
           unit: 'sat',
           expiry: 9999999999,
-          request: 'bolt11invoice...',
+          request: 'lnbc20u1pfake',
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );

--- a/test/utils/bolt11.test.ts
+++ b/test/utils/bolt11.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { bolt11AmountMsat } from '../../src/utils';
+
+// The 2,000 sat fixture invoice from test/wallet/_setup (not imported: _setup pulls in msw/node,
+// which does not load in the browser projects).
+const invoice =
+  'lnbc20u1p3u27nppp5pm074ffk6m42lvae8c6847z7xuvhyknwgkk7pzdce47grf2ksqwsdpv2phhwetjv4jzqcneypqyc6t8dp6xu6twva2xjuzzda6qcqzpgxqyz5vqsp5sw6n7cztudpl5m5jv3z6dtqpt2zhd3q6dwgftey9qxv09w82rgjq9qyyssqhtfl8wv7scwp5flqvmgjjh20nf6utvv5daw5h43h69yqfwjch7wnra3cn94qkscgewa33wvfh7guz76rzsfg9pwlk8mqd27wavf2udsq3yeuju';
+
+describe('bolt11AmountMsat', () => {
+  it('reads the fixture invoice amount (20u = 2,000 sat)', () => {
+    expect(bolt11AmountMsat(invoice)).toBe(2_000_000n);
+  });
+
+  it.each([
+    ['lnbc20u1pfake', 2_000_000n], // micro-bitcoin
+    ['lnbc1m1pfake', 100_000_000n], // milli-bitcoin, amount digit before the separator
+    ['lnbc1500n1pfake', 150_000n], // nano-bitcoin
+    ['lnbc2500p1pfake', 250n], // pico-bitcoin
+    ['lnbc21pfake', 200_000_000_000n], // whole bitcoin, no multiplier
+    ['lntbs10u1pfake', 1_000_000n], // signet prefix
+    ['lnbcrt500n1pfake', 50_000n], // regtest prefix
+    ['LNBC20U1PFAKE', 2_000_000n], // uppercase form
+  ])('parses %s', (pr, msat) => {
+    expect(bolt11AmountMsat(pr)).toBe(msat);
+  });
+
+  it('returns null for an amountless invoice', () => {
+    expect(bolt11AmountMsat('lnbc1pfake')).toBeNull();
+  });
+
+  it.each([
+    ['lnbc2501p1pfake'], // pico amount not a multiple of 10 (sub-msat)
+    ['lnbc0500u1pfake'], // leading zero
+    ['lnbc01pfake'], // zero amount
+    ['lnbc20u'], // no separator
+    ['notaninvoice'],
+    [''],
+  ])('throws on %s', (pr) => {
+    expect(() => bolt11AmountMsat(pr)).toThrow();
+  });
+
+  it('throws on non-string input', () => {
+    expect(() => bolt11AmountMsat(null as unknown as string)).toThrow();
+  });
+});

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -490,7 +490,7 @@ describe('test info', () => {
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
         HttpResponse.json({
           quote: 'sat-quote',
-          request: 'lnbc...',
+          request: 'lnbc10u1pfake', // HRP encodes the quoted 1,000 sat
           unit: 'sat',
           amount: 1000,
           state: MintQuoteState.UNPAID,
@@ -594,7 +594,7 @@ describe('test fees', () => {
           quote: 'test_melt_quote_id',
           amount: Amount.from(2000),
           unit: 'sat',
-          request: '',
+          request: 'lnbc20u1pfake', // HRP encodes the quoted 2,000 sat
           fee_reserve: Amount.from(20),
           payment_preimage: null,
           state: 'UNPAID',

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -170,7 +170,7 @@ describe('Legacy (pre-v1) keyset output gating', () => {
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
         HttpResponse.json({
           quote: 'bolt11-quote-1',
-          request: 'lnbc1000...',
+          request: 'lnbc10u1pfake', // HRP encodes the quoted 1,000 sat
           unit: 'sat',
           amount: 1000,
           state: 'UNPAID',

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -1200,3 +1200,143 @@ describe('async melt preference body', () => {
     expect(res.quote.quote).toBe('q-auth-12');
   });
 });
+
+describe('bolt11 melt quote amount validation', () => {
+  const meltQuoteJson = (amount: number, request: string) => ({
+    quote: 'melt-amt',
+    amount,
+    fee_reserve: 2,
+    unit: 'sat',
+    request,
+    state: 'UNPAID',
+    expiry: 1673972705,
+    payment_preimage: null,
+  });
+
+  test('createMeltQuoteBolt11 rejects a quote charging more than the invoice', async () => {
+    server.use(
+      http.post(
+        mintUrl + '/v1/melt/quote/bolt11',
+        () => HttpResponse.json(meltQuoteJson(2001, invoice)), // fixture invoice asks for 2,000 sat
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMeltQuoteBolt11(invoice)).rejects.toThrow(/exceeds the invoice/i);
+  });
+
+  test('createMeltQuoteBolt11 accepts a quote matching the invoice', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/melt/quote/bolt11', () =>
+        HttpResponse.json(meltQuoteJson(2000, invoice)),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const quote = await wallet.createMeltQuoteBolt11(invoice);
+    expect(quote.amount.toBigInt()).toBe(2000n);
+  });
+
+  test('createMeltQuoteBolt11 allows rounding a sub-sat invoice up to the next sat', async () => {
+    const subSat = 'lnbc15000p1pfake'; // 1,500 msat
+    server.use(
+      http.post(mintUrl + '/v1/melt/quote/bolt11', () =>
+        HttpResponse.json(meltQuoteJson(2, subSat)),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMeltQuoteBolt11(subSat)).resolves.toBeDefined();
+  });
+
+  test('createMeltQuoteBolt11 rejects rounding beyond the next sat', async () => {
+    const subSat = 'lnbc15000p1pfake'; // 1,500 msat
+    server.use(
+      http.post(mintUrl + '/v1/melt/quote/bolt11', () =>
+        HttpResponse.json(meltQuoteJson(3, subSat)),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMeltQuoteBolt11(subSat)).rejects.toThrow(/exceeds the invoice/i);
+  });
+
+  test('createMeltQuoteBolt11 bounds an amountless invoice by the caller millisat amount', async () => {
+    const amountless = 'lnbc1pfake';
+    server.use(
+      http.post(
+        mintUrl + '/v1/melt/quote/bolt11',
+        () => HttpResponse.json(meltQuoteJson(6, amountless)), // caller authorized 5,000 msat = 5 sat
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMeltQuoteBolt11(amountless, 5000)).rejects.toThrow(
+      /exceeds the invoice/i,
+    );
+  });
+
+  test('createMultiPathMeltQuote rejects a quote charging more than the partial amount', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/info', () =>
+        HttpResponse.json({
+          ...mintInfoResp,
+          nuts: { ...mintInfoResp.nuts, 15: { methods: [{ method: 'bolt11', unit: 'sat' }] } },
+        }),
+      ),
+      http.post(
+        mintUrl + '/v1/melt/quote/bolt11',
+        () => HttpResponse.json(meltQuoteJson(2, invoice)), // partial of 1,000 msat allows at most 1 sat
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMultiPathMeltQuote(invoice, 1000)).rejects.toThrow(
+      /exceeds the invoice/i,
+    );
+  });
+
+  test('checkMeltQuoteBolt11 rejects when the quote charges more than its invoice', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/melt/quote/bolt11/melt-check-over', () =>
+        HttpResponse.json({ ...meltQuoteJson(2001, invoice), quote: 'melt-check-over' }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.checkMeltQuoteBolt11('melt-check-over')).rejects.toThrow(
+      /exceeds the invoice/i,
+    );
+  });
+
+  test('checkMeltQuoteBolt11 rejects an unreadable invoice in the response', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/melt/quote/bolt11/melt-check-junk', () =>
+        HttpResponse.json({ ...meltQuoteJson(1, 'not-an-invoice'), quote: 'melt-check-junk' }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.checkMeltQuoteBolt11('melt-check-junk')).rejects.toThrow(/bolt11 invoice/i);
+  });
+
+  test('checkMeltQuoteBolt11 accepts an amountless invoice in the response', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/melt/quote/bolt11/melt-check-amountless', () =>
+        HttpResponse.json({ ...meltQuoteJson(5, 'lnbc1pfake'), quote: 'melt-check-amountless' }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.checkMeltQuoteBolt11('melt-check-amountless')).resolves.toBeDefined();
+  });
+});

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -25,7 +25,7 @@ import { verifyMintQuoteSignatureLegacy } from '../../src/crypto/NUT20';
 import request from '../../src/transport';
 import { Bytes, sumProofs } from '../../src/utils';
 
-import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
+import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp, invoice } from './_setup';
 
 const server = useTestServer();
 const mintInfoRespWithNut12 = {
@@ -1148,7 +1148,7 @@ describe('generic mint/melt methods', () => {
         http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
           HttpResponse.json({
             quote: 'bolt11-quote-1',
-            request: 'lnbc1000...',
+            request: 'lnbc10u1pfake', // HRP encodes the quoted 1,000 sat
             unit: 'sat',
             amount: 1000,
             state: MintQuoteState.UNPAID,
@@ -1166,12 +1166,122 @@ describe('generic mint/melt methods', () => {
       expect(quote.amount.toBigInt()).toBe(1000n);
     });
 
+    test('rejects a mint quote whose invoice encodes a different sat amount', async () => {
+      server.use(
+        http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+          HttpResponse.json({
+            quote: 'bolt11-amount-mismatch',
+            request: invoice, // 2,000 sat fixture invoice
+            unit: 'sat',
+            amount: 1,
+            state: MintQuoteState.UNPAID,
+            expiry: 3600,
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+
+      await expect(wallet.createMintQuoteBolt11(1)).rejects.toThrow(/invoice amount/i);
+    });
+
+    test('rejects a mint quote whose amount differs from the request', async () => {
+      server.use(
+        http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+          HttpResponse.json({
+            quote: 'bolt11-echo-mismatch',
+            request: invoice, // internally consistent: 2,000 sat invoice and amount
+            unit: 'sat',
+            amount: 2000,
+            state: MintQuoteState.UNPAID,
+            expiry: 3600,
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+
+      await expect(wallet.createMintQuoteBolt11(1)).rejects.toThrow(/amount/i);
+    });
+
+    test('accepts a mint quote whose invoice matches the requested sat amount', async () => {
+      server.use(
+        http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
+          HttpResponse.json({
+            quote: 'bolt11-amount-match',
+            request: invoice, // 2,000 sat fixture invoice
+            unit: 'sat',
+            amount: 2000,
+            state: MintQuoteState.UNPAID,
+            expiry: 3600,
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+
+      const quote = await wallet.createMintQuoteBolt11(2000);
+      expect(quote.quote).toBe('bolt11-amount-match');
+    });
+
+    test('checkMintQuoteBolt11 rejects when the invoice does not match the quote amount', async () => {
+      server.use(
+        http.get(mintUrl + '/v1/mint/quote/bolt11/bolt11-check-mismatch', () =>
+          HttpResponse.json({
+            quote: 'bolt11-check-mismatch',
+            request: invoice, // 2,000 sat fixture invoice
+            unit: 'sat',
+            amount: 1,
+            state: MintQuoteState.UNPAID,
+            expiry: 3600,
+          }),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+
+      await expect(wallet.checkMintQuoteBolt11('bolt11-check-mismatch')).rejects.toThrow(
+        /invoice amount/i,
+      );
+    });
+
+    test('checkMintQuoteBatchBolt11 rejects a quote whose invoice does not match its amount', async () => {
+      server.use(
+        http.post(mintUrl + '/v1/mint/quote/bolt11/check', () =>
+          HttpResponse.json([
+            {
+              quote: 'bolt11-batch-ok',
+              request: invoice, // 2,000 sat fixture invoice
+              unit: 'sat',
+              amount: 2000,
+              state: MintQuoteState.UNPAID,
+              expiry: 3600,
+            },
+            {
+              quote: 'bolt11-batch-bad',
+              request: invoice, // 2,000 sat fixture invoice
+              unit: 'sat',
+              amount: 1,
+              state: MintQuoteState.UNPAID,
+              expiry: 3600,
+            },
+          ]),
+        ),
+      );
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+
+      await expect(
+        wallet.checkMintQuoteBatchBolt11(['bolt11-batch-ok', 'bolt11-batch-bad']),
+      ).rejects.toThrow(/invoice amount/i);
+    });
+
     test('checkMintQuoteBolt11 does not merge caller fields over mint response', async () => {
       server.use(
         http.get(mintUrl + '/v1/mint/quote/bolt11/bolt11-quote-merge', () =>
           HttpResponse.json({
             quote: 'bolt11-quote-merge',
-            request: 'lnbc-remote',
+            request: 'lnbc10u1premote', // HRP encodes the quoted 1,000 sat
             unit: 'sat',
             amount: 1000,
             state: MintQuoteState.PAID,
@@ -1191,7 +1301,7 @@ describe('generic mint/melt methods', () => {
         expiry: null,
       });
 
-      expect(quote.request).toBe('lnbc-remote');
+      expect(quote.request).toBe('lnbc10u1premote');
       expect(quote.unit).toBe('sat');
     });
 
@@ -1257,7 +1367,7 @@ describe('generic mint/melt methods', () => {
           return HttpResponse.json([
             {
               quote: 'bolt11-batch-1',
-              request: 'lnbc1000...',
+              request: 'lnbc10u1pfake', // HRP encodes the quoted 1,000 sat
               unit: 'sat',
               amount: 1000,
               state: MintQuoteState.PAID,
@@ -1265,7 +1375,7 @@ describe('generic mint/melt methods', () => {
             },
             {
               quote: 'bolt11-batch-2',
-              request: 'lnbc2000...',
+              request: 'lnbc20u1pfake', // HRP encodes the quoted 2,000 sat
               unit: 'sat',
               amount: 2000,
               state: MintQuoteState.UNPAID,
@@ -1837,7 +1947,7 @@ describe('generic mint/melt methods', () => {
             state: MeltQuoteState.PAID,
             expiry: 3600,
             fee_reserve: 50,
-            request: 'lnbc-remote',
+            request: 'lnbc50u1premote', // HRP encodes the quoted 5,000 sat
           }),
         ),
       );
@@ -1855,7 +1965,7 @@ describe('generic mint/melt methods', () => {
         payment_preimage: null,
       });
 
-      expect(quote.request).toBe('lnbc-remote');
+      expect(quote.request).toBe('lnbc50u1premote');
       expect(quote.unit).toBe('sat');
     });
 

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -219,7 +219,7 @@ describe('createMintQuoteBolt11 mutants', () => {
         body = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json({
           quote: 'q-desc',
-          request: 'lnbc...',
+          request: 'lnbc10u1pfake', // HRP encodes the quoted 1,000 sat
           unit: '', // empty → wallet must substitute its own unit
           amount: 1000,
           state: MintQuoteState.UNPAID,
@@ -249,7 +249,7 @@ describe('createMintQuoteBolt11 mutants', () => {
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
         HttpResponse.json({
           quote: 'q-nodesc',
-          request: 'lnbc...',
+          request: 'lnbc10u1pfake',
           unit: 'sat',
           amount: 1000,
           state: MintQuoteState.UNPAID,
@@ -954,7 +954,7 @@ describe('createLockedMintQuote mutants', () => {
         body = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json({
           quote: 'locked-q',
-          request: 'lnbc...',
+          request: 'lnbc1u1pfake', // HRP encodes the quoted 100 sat
           unit: '', // empty → wallet substitutes its own unit
           amount: 100,
           state: MintQuoteState.UNPAID,
@@ -981,7 +981,7 @@ describe('createLockedMintQuote mutants', () => {
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
         HttpResponse.json({
           quote: 'locked-but-unlocked',
-          request: 'lnbc...',
+          request: 'lnbc1u1pfake', // HRP encodes the quoted 100 sat
           unit: 'sat',
           amount: 100,
           state: MintQuoteState.UNPAID,
@@ -1004,7 +1004,7 @@ describe('createLockedMintQuote mutants', () => {
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
         HttpResponse.json({
           quote: 'locked-elsewhere',
-          request: 'lnbc...',
+          request: 'lnbc1u1pfake', // HRP encodes the quoted 100 sat
           unit: 'sat',
           amount: 100,
           state: MintQuoteState.UNPAID,
@@ -1027,7 +1027,7 @@ describe('createLockedMintQuote mutants', () => {
       http.post(mintUrl + '/v1/mint/quote/bolt11', () =>
         HttpResponse.json({
           quote: 'locked-upper',
-          request: 'lnbc...',
+          request: 'lnbc1u1pfake', // HRP encodes the quoted 100 sat
           unit: 'sat',
           amount: 100,
           state: MintQuoteState.UNPAID,
@@ -1069,7 +1069,7 @@ describe('checkMintQuoteBolt11 mutants', () => {
         seen.push(params.quoteId as string);
         return HttpResponse.json({
           quote: params.quoteId,
-          request: 'lnbc...',
+          request: 'lnbc10n1pfake', // HRP encodes the quoted 1 sat
           unit: 'sat',
           amount: 1,
           state: MintQuoteState.UNPAID,
@@ -1293,7 +1293,7 @@ describe('createMultiPathMeltQuote mutants', () => {
     await wallet.loadMint();
     // `some` must match the sat entry among the two methods. An `every` mutant would reject
     // because the usd entry does not match.
-    const quote = await wallet.createMultiPathMeltQuote(invoice, 1000);
+    const quote = await wallet.createMultiPathMeltQuote(invoice, 5000);
     expect(quote.quote).toBe('mpp-quote');
   });
 });


### PR DESCRIPTION
## Description

A mint's bolt11 quote responses were taken at face value: the quoted amount and the invoice could disagree with what the caller asked for. The wallet now cross-checks them. Mint quotes must echo the requested amount, and for `sat` quotes the invoice must ask for exactly that amount. Melt quotes are bounded the other way: a `sat` quote may round a sub-sat invoice up to the next sat, but never charge beyond it.

---

## Changes

- New internal `bolt11AmountMsat()` reads the HRP amount in millisats (`null` for amountless, throws on malformed). `invoiceHasAmountInHRP` is now a wrapper over it, so the HRP grammar lives in one place.
- Mint side (`createMintQuoteBolt11`, `createLockedMintQuote`, `checkMintQuoteBolt11`, `checkMintQuoteBatchBolt11`): the quoted amount must match, and for `sat` quotes the invoice HRP must match it exactly; amountless or unreadable invoices are rejected.
- Melt side (`createMeltQuoteBolt11`, `createMultiPathMeltQuote`, `checkMeltQuoteBolt11`): the quoted amount must not exceed the invoice, the caller's `amountMsat` for amountless invoices, or the MPP partial amount. Undercharging passes.
- Non-sat units check the quoted amount only (no invoice comparison without a rate); the raw `createMintQuote` / `createMeltQuote` / `checkMeltQuote` escape hatches stay unvalidated.
- Migration guide entries. Test stubs need invoice HRPs matching their quoted amounts (eg `lnbc10u1...` for a 1,000 sat quote); fixtures updated across the suite.

## Reviewer Notes

- The parser reads the HRP only: no checksum or signature validation, paying remains the LN stack's job.
- The melt bound is one-sided by design; sub-sat invoices legitimately round up to the next sat, and undercharging is the mint's loss, not the caller's.
- Labelled for v4 backport: the throw only fires on a non-conforming mint response, outside normal operation.