### PR TITLE
fix(auth): stop following redirects on token-bearing requests

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -421,6 +421,8 @@ export class AuthManager implements AuthProvider {
       endpoint: joinUrls(this.mintUrl, '/v1/auth/blind/mint'),
       method: 'POST',
       headers,
+      // A CAT must never be replayed to a redirect target: fail rather than follow.
+      ...(cat ? { redirect: 'error' as const } : {}),
       requestBody: payload,
     });
     if (!Array.isArray(res?.signatures) || res.signatures.length !== outputs.length) {

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -1177,6 +1177,8 @@ class Mint {
       endpoint: joinUrls(this._mintUrl, path),
       method,
       headers,
+      // A CAT/BAT must never be replayed to a redirect target: fail rather than follow.
+      ...(bat || cat ? { redirect: 'error' as const } : {}),
       ...(nut19?.supported && nut19.params ? nut19.params : {}),
       onResponseMeta: this._captureResponseMetadata,
     });

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -257,6 +257,28 @@ describe('AuthManager: BAT pool minting/topUp/ensure', () => {
     } as any;
   }
 
+  test('topUp refuses redirects when a CAT accompanies the BAT mint', async () => {
+    const am = new AuthManager(mintUrl, {
+      request: reqSpy as RequestFn,
+      desiredPoolSize: 5,
+      maxPerMint: 99,
+    });
+    am['info'] = fakeInfo({ batMax: 2, needCATForMint: true });
+    am.setCAT('cat-token');
+    seedKeychain(am);
+
+    stubOutputs(2);
+    reqSpy.mockResolvedValueOnce({ signatures: [fakeSig, fakeSig] });
+    await am.ensure(5);
+
+    expect(reqSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: expect.stringContaining('/v1/auth/blind/mint'),
+        redirect: 'error',
+      }),
+    );
+  });
+
   test('ensure() mints up to desired target but not beyond bat_max_mint', async () => {
     const am = new AuthManager(mintUrl, {
       request: reqSpy as RequestFn,

--- a/test/wallet/wallet-auth.node.test.ts
+++ b/test/wallet/wallet-auth.node.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
-import { Wallet, Mint, type AuthProvider } from '../../src';
+import { Wallet, Mint, type AuthProvider, type RequestFn } from '../../src';
 
 import { mint, mintUrl, useTestServer } from './_setup';
 
@@ -68,5 +68,52 @@ describe('Clear Authentication', () => {
 
     // The refreshed token must appear in the Clear-auth header
     expect(receivedClearAuth).toBe(freshToken);
+  });
+});
+
+describe('Auth header redirect handling', () => {
+  const protectedSwapInfo = {
+    name: 'Testnut mint',
+    pubkey: '02abc',
+    version: 'Nutshell/x',
+    contact: [],
+    time: 0,
+    nuts: {
+      21: {
+        openid_discovery: 'https://auth.example.com/.well-known/openid-configuration',
+        client_id: 'cashu-client',
+        protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
+      },
+      22: {
+        bat_max_mint: 100,
+        protected_endpoints: [{ method: 'POST', path: '/v1/swap' }],
+      },
+    },
+  };
+
+  function mockAuthProvider(): AuthProvider {
+    return {
+      getBlindAuthToken: vi.fn().mockResolvedValue('bat-token'),
+      getCAT: vi.fn().mockReturnValue('cat-token'),
+      setCAT: vi.fn(),
+      ensureCAT: vi.fn().mockResolvedValue('cat-token'),
+    };
+  }
+
+  test('protected requests refuse redirects; unprotected requests are unchanged', async () => {
+    server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(protectedSwapInfo)));
+
+    const authedSpy = vi.fn((args: { endpoint: string }) =>
+      Promise.resolve(args.endpoint.includes('/v1/info') ? protectedSwapInfo : { signatures: [] }),
+    );
+    const authedMint = new Mint(mintUrl, { authProvider: mockAuthProvider() });
+    await authedMint.swap({ inputs: [], outputs: [] }, authedSpy as unknown as RequestFn);
+    const authedArgs = authedSpy.mock.calls.find((c) => c[0].endpoint.includes('/v1/swap'))![0];
+    expect(authedArgs).toMatchObject({ redirect: 'error' });
+
+    const plainSpy = vi.fn().mockResolvedValue({ signatures: [] });
+    const plainMint = new Mint(mintUrl);
+    await plainMint.swap({ inputs: [], outputs: [] }, plainSpy);
+    expect(plainSpy.mock.calls[0][0]).not.toHaveProperty('redirect');
   });
 });


### PR DESCRIPTION
## Description

Requests that carry a `Clear-auth` (CAT) or `Blind-auth` (BAT) header were sent through the ordinary pipeline with the default `redirect: 'follow'`. A trusted endpoint that emits a redirect (an open redirect on the mint frontend, a compromised redirect rule) causes the runtime to replay the same POST, tokens intact, at the redirect target. Token-bearing requests now set `redirect: 'error'`, so a 3xx fails the request instead of forwarding the token.

---

## Changes

- `Mint.requestWithAuth`: sets `redirect: 'error'` only when a BAT or CAT is actually attached; unauthenticated requests are untouched.
- `AuthManager.topUp`: same on the `/v1/auth/blind/mint` call, only when a CAT accompanies it.

## Reviewer Notes

- Reject-all over strip-and-follow or origin-check: auth endpoints have no legitimate reason to redirect, and rejecting also covers same-origin downgrade tricks. `redirect: 'error'` is inert on any non-3xx response, so normal auth requests are unchanged.
- Behaviour change: a mint that legitimately 3xx-redirects a token-bearing endpoint (eg trailing-slash normalisation on a reverse proxy) will now throw. This is engine-uniform (not an FF/WebKit quirk) and the right trade for a token-bearing request.
- Tests assert the option is passed on protected requests and absent on unprotected ones; the default transport honours `redirect`, custom transports (mobile/OHTTP/Tor) must implement it themselves, as with the other anti-fingerprinting options.