### PR TITLE
fix(auth): drop a CAT refresh that completes after the session changes

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -78,6 +78,9 @@ export class AuthManager implements AuthProvider {
   private info?: MintInfo;
   private lockChain?: Promise<void>;
   private inflightRefresh?: Promise<void>;
+  // Bumped whenever the caller sets or clears the CAT. An in-flight refresh that started under an
+  // older generation must not write its result back (eg a refresh landing after logout).
+  private tokenGeneration = 0;
   private static readonly MIN_VALID_SECS = 30;
 
   // Open ID Connect (OIDC)
@@ -156,6 +159,8 @@ export class AuthManager implements AuthProvider {
   }
 
   setCAT(cat: string | undefined): void {
+    // Invalidate any in-flight refresh: the caller is taking control of the token state.
+    this.tokenGeneration++;
     this.tokens.accessToken = cat;
     if (!cat) {
       this.tokens.refreshToken = undefined;
@@ -178,10 +183,12 @@ export class AuthManager implements AuthProvider {
 
     // One refresh at a time
     if (!this.inflightRefresh) {
+      const startedGeneration = this.tokenGeneration;
       this.inflightRefresh = (async () => {
         try {
           const tok = await this.oidc!.refresh(this.tokens.refreshToken!);
-          this.updateFromOIDC(tok);
+          // Drop the result if the session was set or cleared while the refresh was in flight.
+          if (this.tokenGeneration === startedGeneration) this.updateFromOIDC(tok);
         } catch (err) {
           this.logger.warn('AuthManager: CAT refresh failed', { err });
         } finally {

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -177,6 +177,36 @@ describe('AuthManager: CAT lifecycle', () => {
     const cat = await am.ensureCAT(30);
     expect(cat).toBe('old-cat');
   });
+
+  test('setCAT(undefined) is not undone by an in-flight refresh', async () => {
+    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn });
+    am['tokens'] = { accessToken: 'old-cat', refreshToken: 'rrr', expiresAt: Date.now() - 1 };
+
+    let resolveRefresh!: (value: {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    }) => void;
+    const refresh = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    am['oidc'] = { refresh } as any;
+
+    // Launch the refresh, then clear the session while it is still in flight.
+    const pending = am.ensureCAT(30);
+    am.setCAT(undefined);
+
+    // The provider now answers the refresh that started before logout.
+    resolveRefresh({ access_token: 'new-cat', refresh_token: 'new-r', expires_in: 300 });
+
+    // The cleared session must stay cleared, not be resurrected by the late response.
+    expect(await pending).toBeUndefined();
+    expect(am.getCAT()).toBeUndefined();
+    expect(am['tokens'].refreshToken).toBeUndefined();
+  });
 });
 
 describe('AuthManager: constructor limits', () => {


### PR DESCRIPTION
## Description

`ensureCAT` launches at most one refresh at a time but never bound the in-flight refresh to the token state that started it. If a refresh was already awaiting the OIDC provider when the caller cleared the session via `setCAT(undefined)`, the late response still ran `updateFromOIDC` and repopulated the access/refresh tokens after logout, so the next protected request could authenticate the cleared session. Reachable in apps that keep the `AuthManager` across logout or account switch.

## Changes

- `AuthManager` tracks a `tokenGeneration` counter, bumped by `setCAT` (set or clear).
- `ensureCAT` captures the generation when it starts a refresh and applies `updateFromOIDC` only if the generation still matches; a refresh that finishes after a set/clear is discarded.

## Reviewer Notes

- Bumping on every `setCAT` (not just the clear path) means an explicit new token also wins over a racing refresh, which is the caller's intent.
- A post-clear `ensureCAT` that awaits the stale in-flight promise gets `undefined`: the refresh no longer writes back, and `refreshToken` was cleared, so there is nothing to retry.