### PR TITLE
fix(auth): coerce the device-flow polling interval to a finite value

### DIFF
--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -270,7 +270,11 @@ export class OIDCAuth {
     }
   > {
     const start = await this.deviceStart();
-    const interval = Math.max(start.interval ?? 1, intervalSec);
+    // Coerce the provider's interval to a number and validate it is finite and positive.
+    const providerInterval = Number(start.interval);
+    const safeProviderInterval =
+      Number.isFinite(providerInterval) && providerInterval > 0 ? providerInterval : 1;
+    const interval = Math.max(safeProviderInterval, intervalSec);
     let aborted = false;
 
     const poll = async (): Promise<TokenResponse> => {

--- a/test/auth/OIDCAuth.node.test.ts
+++ b/test/auth/OIDCAuth.node.test.ts
@@ -327,6 +327,43 @@ describe('OIDCAuth: device flow', () => {
     }
   });
 
+  test('startDeviceAuth clamps a non-numeric provider interval instead of hot-looping', async () => {
+    server.use(
+      http.post(DEVICE_EP, () =>
+        HttpResponse.json({
+          device_code: 'dev-123',
+          user_code: 'UCODE-123',
+          verification_uri: `${ISSUER}/device`,
+          interval: 'not-a-number', // hostile provider: non-numeric interval
+          expires_in: 600,
+        }),
+      ),
+      http.post(TOKEN_EP, () =>
+        HttpResponse.json({ access_token: 'ok', token_type: 'Bearer', expires_in: 300 }),
+      ),
+    );
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client' });
+
+    // Capture the delay the loop would sleep for without actually waiting.
+    const delays: number[] = [];
+    const sleepSpy = vi
+      .spyOn(oidc as unknown as { sleep: (ms: number) => Promise<void> }, 'sleep')
+      .mockImplementation((ms: number) => {
+        delays.push(ms);
+        return Promise.resolve();
+      });
+
+    const start = await oidc.startDeviceAuth(5);
+    await start.poll();
+
+    expect(sleepSpy).toHaveBeenCalled();
+    // A malformed interval must not produce a NaN (immediate) sleep.
+    for (const ms of delays) {
+      expect(Number.isFinite(ms)).toBe(true);
+      expect(ms).toBeGreaterThanOrEqual(1000);
+    }
+  });
+
   test('startDeviceAuth: cancel() aborts polling', async () => {
     const oidc = new OIDCAuth(DISCOVERY, {
       clientId: 'cashu-client',


### PR DESCRIPTION
## Description

`startDeviceAuth` used the device authorization response's `interval` field directly: `Math.max(start.interval ?? 1, intervalSec)`. Because the response is only cast to its type, a provider returning a non-numeric `interval` (e.g. the string `"not-a-number"`) makes `Math.max` yield `NaN`, which flows through to `sleep(NaN)` and schedules an immediate timer. A provider that keeps returning `authorization_pending` then drives a tight polling loop from a single user action.

## Changes

- Coerce `start.interval` with `Number(...)` and fall back to 1 unless it is a finite positive number, before combining it with the caller's `intervalSec`.

## Reviewer Notes

- Only the network-sourced `start.interval` is sanitised; `intervalSec` is our own typed API parameter with a default, not a trust boundary.