### PR TITLE
fix(crypto): validate the blind point in the BLS signer

### DIFF
--- a/src/crypto/curve_bls.ts
+++ b/src/crypto/curve_bls.ts
@@ -188,6 +188,11 @@ export function createBlindSignatureBls(
   privateKey: Uint8Array,
   id: string,
 ): BlindSignature {
+  // B_ is caller-supplied and may not have come through pointFromHexG1, so validate it here too:
+  // signing a point outside the prime-order subgroup would leak the mint scalar mod the point's
+  // small order via C_ = a * B_.
+  if (B_.is0()) throw new CTSError('G1 point at infinity');
+  if (!B_.isTorsionFree()) throw new CTSError('G1 point not in prime-order subgroup');
   const a = Fr.fromBytes(privateKey);
   if (a === 0n) {
     throw new CTSError('Mint scalar must be non-zero');

--- a/test/crypto/bls.test.ts
+++ b/test/crypto/bls.test.ts
@@ -190,6 +190,23 @@ describe('BLS deterministic round-trip (Nutshell test_deterministic_bls_steps)',
     );
   });
 
+  test('createBlindSignatureBls rejects a B_ point outside the prime-order subgroup', () => {
+    // Order-3 point on y^2 = x^3 + 4 (x=0, y=2): on-curve but not torsion-free. fromAffine skips the
+    // subgroup check that fromHex/fromBytes enforce, standing in for a mint that builds B_ directly.
+    // Signing it would leak a mod 3 through C_ = a * B_.
+    const order3 = bls12_381.G1.Point.fromAffine({ x: 0n, y: 2n });
+    expect(order3.isTorsionFree()).toBe(false);
+    expect(() => createBlindSignatureBls(order3, hexToBytes('0'.repeat(63) + '2'), 'test')).toThrow(
+      CTSError,
+    );
+  });
+
+  test('createBlindSignatureBls rejects the G1 identity as B_', () => {
+    expect(() =>
+      createBlindSignatureBls(bls12_381.G1.Point.ZERO, hexToBytes('0'.repeat(63) + '2'), 'test'),
+    ).toThrow(CTSError);
+  });
+
   test('getG2PubKeyFromPrivKey rejects an all-zero private key', () => {
     // a=0 -> BLS_G2_GENERATOR.multiply(0n) would throw noble's 'invalid scalar'; pin our wording.
     expect(() => getG2PubKeyFromPrivKey(new Uint8Array(32))).toThrow(


### PR DESCRIPTION
## Description

`createBlindSignatureBls` is the exported mint-side signing primitive. It multiplied the caller-supplied `G1Point` by the mint scalar without checking `is0()` or `isTorsionFree()`. `pointFromHexG1` already rejects such points, but nothing forced a mint caller to decode `B_` through it. A caller that builds `B_` another way could pass a small-order point (e.g. the order-3 point x=0, y=2); `C_ = a * B_` then reveals `a` mod the point's order.

## Changes

- `createBlindSignatureBls` rejects `B_` at infinity or outside the prime-order subgroup before the scalar multiply, reusing the checks `pointFromHexG1` applies.

## Reviewer Notes

- v5-only: the BLS module (v3 keysets) does not exist on v4-dev, so no backport.
- The signer is the only function in the module where a caller point meets a secret scalar; verify/batchVerify are boolean pairing checks (already `is0()`-guarded, no secret), and unblind multiplies by the caller's own scalar. No other function needs the check.
- Largely defence-in-depth: the repo's Noble rejects non-subgroup points in `fromHex`/`fromBytes`, so the test builds the point via `fromAffine` to stand in for a mint that constructs `B_` directly.