### PR TITLE
fix(auth): drop a CAT refresh that completes after the session changes [backport v4-dev]

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -78,6 +78,9 @@ export class AuthManager implements AuthProvider {
   private info?: MintInfo;
   private lockChain?: Promise<void>;
   private inflightRefresh?: Promise<void>;
+  // Bumped whenever the caller sets or clears the CAT. An in-flight refresh that started under an
+  // older generation must not write its result back (eg a refresh landing after logout).
+  private tokenGeneration = 0;
   private static readonly MIN_VALID_SECS = 30;
 
   // Open ID Connect (OIDC)
@@ -156,6 +159,8 @@ export class AuthManager implements AuthProvider {
   }
 
   setCAT(cat: string | undefined): void {
+    // Invalidate any in-flight refresh: the caller is taking control of the token state.
+    this.tokenGeneration++;
     this.tokens.accessToken = cat;
     if (!cat) {
       this.tokens.refreshToken = undefined;
@@ -178,10 +183,12 @@ export class AuthManager implements AuthProvider {
 
     // One refresh at a time
     if (!this.inflightRefresh) {
+      const startedGeneration = this.tokenGeneration;
       this.inflightRefresh = (async () => {
         try {
           const tok = await this.oidc!.refresh(this.tokens.refreshToken!);
-          this.updateFromOIDC(tok);
+          // Drop the result if the session was set or cleared while the refresh was in flight.
+          if (this.tokenGeneration === startedGeneration) this.updateFromOIDC(tok);
         } catch (err) {
           this.logger.warn('AuthManager: CAT refresh failed', { err });
         } finally {

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -175,6 +175,36 @@ describe('AuthManager: CAT lifecycle', () => {
     const cat = await am.ensureCAT(30);
     expect(cat).toBe('old-cat');
   });
+
+  test('setCAT(undefined) is not undone by an in-flight refresh', async () => {
+    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn });
+    am['tokens'] = { accessToken: 'old-cat', refreshToken: 'rrr', expiresAt: Date.now() - 1 };
+
+    let resolveRefresh!: (value: {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    }) => void;
+    const refresh = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    am['oidc'] = { refresh } as any;
+
+    // Launch the refresh, then clear the session while it is still in flight.
+    const pending = am.ensureCAT(30);
+    am.setCAT(undefined);
+
+    // The provider now answers the refresh that started before logout.
+    resolveRefresh({ access_token: 'new-cat', refresh_token: 'new-r', expires_in: 300 });
+
+    // The cleared session must stay cleared, not be resurrected by the late response.
+    expect(await pending).toBeUndefined();
+    expect(am.getCAT()).toBeUndefined();
+    expect(am['tokens'].refreshToken).toBeUndefined();
+  });
 });
 
 describe('AuthManager: constructor limits', () => {


### PR DESCRIPTION
# Description
Backport of #927 to `v4-dev`.