### PR TITLE
fix(mintinfo): bound mint-advertised method and endpoint lists [backport v4-dev]

### DIFF
--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,6 +1,10 @@
 import { type Logger, NULL_LOGGER } from '../logger';
 import { nullIfUndefined } from '../utils/core';
-import { ABSOLUTE_MAX_BATCH_SIZE, ABSOLUTE_MAX_PER_MINT } from '../utils/limits';
+import {
+  ABSOLUTE_MAX_BATCH_SIZE,
+  ABSOLUTE_MAX_PER_MINT,
+  MAX_MINT_INFO_LIST,
+} from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
 
 import { Amount } from './Amount';
@@ -41,10 +45,10 @@ export class MintInfo {
     const log = logger ?? NULL_LOGGER;
     this._mintInfo = MintInfo.normalizeInfo(info, log);
 
-    const pe22 = this.toEndpoints(this._mintInfo?.nuts?.[22]?.protected_endpoints);
+    const pe22 = this.toEndpoints(this._mintInfo?.nuts?.[22]?.protected_endpoints, log);
     this._protected22 = this.buildIndex(pe22);
 
-    const pe21 = this.toEndpoints(this._mintInfo?.nuts?.[21]?.protected_endpoints);
+    const pe21 = this.toEndpoints(this._mintInfo?.nuts?.[21]?.protected_endpoints, log);
     this._protected21 = this.buildIndex(pe21);
   }
 
@@ -57,7 +61,7 @@ export class MintInfo {
           ? {
               '4': {
                 ...info.nuts['4'],
-                methods: MintInfo.normalizeSwapMethods(info.nuts['4'].methods),
+                methods: MintInfo.normalizeSwapMethods(info.nuts['4'].methods, logger),
               },
             }
           : {}),
@@ -65,7 +69,7 @@ export class MintInfo {
           ? {
               '5': {
                 ...info.nuts['5'],
-                methods: MintInfo.normalizeSwapMethods(info.nuts['5'].methods),
+                methods: MintInfo.normalizeSwapMethods(info.nuts['5'].methods, logger),
               },
             }
           : {}),
@@ -79,8 +83,9 @@ export class MintInfo {
   // Per NUT-04/05/25/XX, `min_amount` and `max_amount` are `<int|null>`. Mints that omit
   // them entirely (older Nutshell, etc.) leave the field as `undefined`; coerce to null
   // so the runtime value matches the `AmountLike | null` type.
-  private static normalizeSwapMethods(methods: SwapMethod[]): SwapMethod[] {
-    return methods.map((m) => {
+  private static normalizeSwapMethods(methods: SwapMethod[], logger: Logger): SwapMethod[] {
+    const bounded = MintInfo.capList(methods, 'nuts.4/5.methods', logger);
+    return bounded.map((m) => {
       const next = { ...m } as Record<string, unknown>;
       nullIfUndefined(next, 'min_amount', 'max_amount');
       return next as SwapMethod;
@@ -288,10 +293,24 @@ export class MintInfo {
 
   // ---------- private helpers ----------
 
-  private toEndpoints(maybe: unknown): Endpoint[] {
+  /**
+   * Bounds a mint-advertised list to `MAX_MINT_INFO_LIST` before any per-entry work, warning once
+   * when it truncates. Guards against memory amplification from a hostile `/v1/info`.
+   */
+  private static capList<T>(list: T[], label: string, logger: Logger): T[] {
+    if (list.length <= MAX_MINT_INFO_LIST) return list;
+    logger.warn(`MintInfo: ${label} exceeds internal cap and was truncated`, {
+      advertised: list.length,
+      cap: MAX_MINT_INFO_LIST,
+    });
+    return list.slice(0, MAX_MINT_INFO_LIST);
+  }
+
+  private toEndpoints(maybe: unknown, logger: Logger): Endpoint[] {
     if (!Array.isArray(maybe)) return [];
+    const bounded = MintInfo.capList(maybe, 'nuts.21/22.protected_endpoints', logger);
     const out: Endpoint[] = [];
-    for (const e of maybe) {
+    for (const e of bounded) {
       if (e && typeof e === 'object') {
         const rec = e as Record<string, unknown>;
         const mm = rec.method;

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -28,6 +28,14 @@ export const ABSOLUTE_MAX_BATCH_SIZE = 100;
 export const MAX_KEYSET_DENOMINATIONS = 256;
 
 /**
+ * Upper bound on entries we process from a mint-advertised list (NUT-04/05 `methods`, NUT-21/22
+ * `protected_endpoints`). Real mints advertise tens; the transport 8 MiB cap still admits ~100k
+ * small records, so an unbounded map/clone/sort over them is a memory-amplification vector. Lists
+ * longer than this are truncated with a warning rather than processed in full.
+ */
+export const MAX_MINT_INFO_LIST = 1_024;
+
+/**
  * Max u64 (2^64 - 1): the ceiling every Amount is held to. Enforced in the Amount constructor, so
  * arithmetic results are bounded too; muldiv helpers keep their wide intermediate in bigint and
  * only construct the divided-down result.

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { Amount } from '../../src/model/Amount';
 import { MintInfo } from '../../src/model/MintInfo';
+import { MAX_MINT_INFO_LIST } from '../../src/utils/limits';
 import { MINTINFORESP } from '../consts';
 
 describe('MintInfo protected endpoint matching', () => {
@@ -698,5 +699,70 @@ describe('MintInfo method/unit capability checks', () => {
   it('supportsAmountless returns false when NUT-5 info is absent', () => {
     const info = new MintInfo({ ...MINTINFORESP, nuts: {} });
     expect(info.supportsAmountless()).toBe(false);
+  });
+});
+
+describe('MintInfo list caps', () => {
+  function spyLogger() {
+    return { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn() };
+  }
+
+  it('truncates an oversized NUT-04 method list and warns', () => {
+    const logger = spyLogger();
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          4: {
+            disabled: false,
+            methods: Array.from({ length: MAX_MINT_INFO_LIST + 5 }, () => ({
+              method: 'bolt11',
+              unit: 'sat',
+            })),
+          },
+        },
+      },
+      logger,
+    );
+
+    expect(info.nuts[4]?.methods).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/methods/i),
+      expect.objectContaining({ advertised: MAX_MINT_INFO_LIST + 5 }),
+    );
+  });
+
+  it('truncates an oversized protected-endpoint list before indexing and warns', () => {
+    const logger = spyLogger();
+    const endpoints = Array.from({ length: MAX_MINT_INFO_LIST + 5 }, (_, i) => ({
+      method: 'POST',
+      path: `/v1/x${i}`,
+    }));
+    // The endpoint just past the cap must not be treated as protected.
+    const info = new MintInfo(
+      {
+        ...MINTINFORESP,
+        nuts: {
+          ...MINTINFORESP.nuts,
+          22: { bat_max_mint: 100, protected_endpoints: endpoints },
+        },
+      },
+      logger,
+    );
+
+    expect(info.requiresBlindAuthToken('POST', '/v1/x0')).toBe(true);
+    expect(info.requiresBlindAuthToken('POST', `/v1/x${MAX_MINT_INFO_LIST + 4}`)).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/endpoint/i),
+      expect.objectContaining({ advertised: MAX_MINT_INFO_LIST + 5 }),
+    );
+  });
+
+  it('leaves a normal-sized method list untouched', () => {
+    const logger = spyLogger();
+    const info = new MintInfo(MINTINFORESP, logger);
+    expect(info.nuts[4]?.methods?.length).toBeGreaterThan(0);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Description
Backport of #928 to `v4-dev`.