### PR TITLE
fix(crypto): bound pow2height in createNewMintKeys at runtime [backport v4-dev]

### DIFF
--- a/src/crypto/NUT01.ts
+++ b/src/crypto/NUT01.ts
@@ -70,6 +70,11 @@ export function createNewMintKeys(
     versionByte?: number;
   },
 ): KeysetPair {
+  // The IntRange type is erased at runtime; a plain-JS or JSON-derived caller can pass any number
+  // (including Infinity), and each iteration does an EC multiply. Bound it before the loop.
+  if (!Number.isInteger(pow2height) || pow2height < 0 || pow2height > 64) {
+    throw new CTSError('createNewMintKeys: pow2height must be an integer in [0, 64]');
+  }
   const { expiry, input_fee_ppk, unit = 'sat', versionByte = 1 } = options || {};
   let counter = 0n;
   const pubKeys: RawMintKeys = {};

--- a/test/crypto/NUT01.test.ts
+++ b/test/crypto/NUT01.test.ts
@@ -40,6 +40,15 @@ describe('new mint keys', () => {
     expect(serializedRandom).not.toEqual(PUBKEYS);
     expect(serializedRandom).toHaveProperty('288230376151711744');
   });
+
+  test('rejects an out-of-range or non-integer pow2height before generating keys', () => {
+    // Type is erased at runtime; a JS/JSON caller can pass anything.
+    for (const bad of [65, 1e6, Infinity, -1, 1.5, NaN]) {
+      expect(() => createNewMintKeys(bad as Parameters<typeof createNewMintKeys>[0])).toThrow(
+        /pow2height/i,
+      );
+    }
+  });
 });
 describe('serialize mint keys', () => {
   test('derive', () => {


### PR DESCRIPTION
# Description
Backport of #938 to `v4-dev`.