### PR TITLE
fix(token): return per-proof amounts, not proofs, from getTokenMetadata

### DIFF
--- a/docs-src/usage/get_token.md
+++ b/docs-src/usage/get_token.md
@@ -16,12 +16,15 @@ try {
   console.log(meta.mint); // "https://mint.example.com"
   console.log(meta.unit); // "sat"
   console.log(meta.amount.toNumber()); // e.g. 64  (amount is Amount, not number)
+  console.log(meta.proofAmounts.map((a) => a.toString())); // e.g. ['32', '16', '16'] per-proof amounts
 } catch (_) {
   console.log('Invalid token');
 }
 ```
 
-`getTokenMetadata` never needs keyset data — it is always safe to call without a wallet.
+`getTokenMetadata` never needs keyset data — it is always safe to call without a wallet. It returns
+per-proof `proofAmounts` (amounts only) for inspection, not the proofs themselves: claim the token
+with `wallet.decodeToken` below to obtain spendable `Proof[]`.
 
 ## Post-wallet: `wallet.decodeToken`
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2234,7 +2234,7 @@ export type TokenMetadata = {
     memo?: string;
     mint: string;
     amount: Amount;
-    incompleteProofs: Array<Omit<Proof, 'id'>>;
+    proofAmounts: Amount[];
 };
 
 // @public (undocumented)

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -477,3 +477,27 @@ new PaymentRequest({
 ```
 
 Decoding (`decodePaymentRequest`, `PaymentRequest.fromEncodedRequest`, `fromRawRequest`) is unaffected. A positional call fails to type-check.
+
+---
+
+## `TokenMetadata.incompleteProofs` is replaced by `proofAmounts`
+
+`getTokenMetadata()` returned `incompleteProofs: Array<Omit<Proof, 'id'>>` — proofs with only the keyset id removed. Handing back partial proofs from a pre-wallet inspection helper was a recurring source of confusion, and the field carried far more than inspection needs. It is now `proofAmounts: Amount[]` — the per-proof amounts only, enough to inspect the proof set (e.g. reject a pathological all-1-sat token). Decode the token with a loaded wallet when you need the proofs themselves.
+
+### Migration
+
+To inspect amounts, read `proofAmounts`. To obtain actual proofs, decode the token with a loaded wallet.
+
+```ts
+// Before
+const { incompleteProofs } = getTokenMetadata(token);
+const amounts = incompleteProofs.map((p) => p.amount);
+
+// After
+const { proofAmounts } = getTokenMetadata(token);
+
+// Need the proofs themselves? Decode with a wallet (resolves keyset ids):
+const wallet = new Wallet(meta.mint, { unit: meta.unit });
+await wallet.loadMint();
+const { proofs } = wallet.decodeToken(token);
+```

--- a/src/model/types/token.ts
+++ b/src/model/types/token.ts
@@ -80,7 +80,7 @@ export type TokenMetadata = {
    */
   amount: Amount;
   /**
-   * The incomplete proofs of the token.
+   * The per-proof amounts of the token, in order.
    */
-  incompleteProofs: Array<Omit<Proof, 'id'>>;
+  proofAmounts: Amount[];
 };

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -380,11 +380,7 @@ export function getTokenMetadata(token: string): TokenMetadata {
     mint: tokenObj.mint,
     amount: sumProofs(tokenObj.proofs),
     ...(tokenObj.memo && { memo: tokenObj.memo }),
-    incompleteProofs: tokenObj.proofs.map((p) => {
-      const { id, ...rest } = p;
-      void id;
-      return rest;
-    }),
+    proofAmounts: tokenObj.proofs.map((p) => p.amount),
   };
 }
 

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -343,57 +343,12 @@ describe('test getTokenMetadata', () => {
       unit: 'sat',
       mint: 'https://testnut.cashu.space',
       amount: Amount.from(10),
-      incompleteProofs: [
-        {
-          C: '027f390f7160a0171e0113a4311564447b2942833ae9dff0beb49cb314677ba6a4',
-          amount: Amount.from(4),
-          dleq: {
-            e: 'b5e5011baeb4c13d5c448745ae3b4dc4bf517b51e4eb03e9f74204e2c693cebe',
-            r: '7b7e868012f0d462406be790f713d8a42762c4a9efbbe2134df1cf9fc581df98',
-            s: '32475fe73ba9839dda273fb37e4deae3987aa086e68150a8b8187618cf146b0b',
-          },
-          secret: '4e585c19592a0a10007b451822e22f8129ec2753da0be3f22dec26a92b1302db',
-        },
-        {
-          C: '03957a7e9ab75f2152ba9eb5f1b6f3cd12dbb2b3100d4fabc3fd457f95b11dcbce',
-          amount: Amount.from(2),
-          dleq: {
-            e: 'bff2e8aee32ac15b21b38e991394f23e84c56845b1f74710d6741c67117c7d11',
-            r: '46d74791d56760b39317555f1283e2f4ad1cfa4a36a67c04e6cde510f22ed1ee',
-            s: '81cb23d0799341bc94f1f87235bc63f6b3a27c8b6f13a9dcf5f97a18485215c0',
-          },
-          secret: '16a0cc2214adcf80b19f60e972b7ad1d9efa7a1eed84de111df6b0d982f217fb',
-        },
-        {
-          C: '026f79804899c4c830475fab2bb030734f569d784cf7a02adf744e1fa695ab3d2d',
-          amount: Amount.from(2),
-          dleq: {
-            e: '3d7e00ffae6a115875b47fa4d5d41338f2105e53c354c96fe9449d1d9285d009',
-            r: 'b1347b584b48517761475c3a58fca47f80c368fcbbe06abdfdc8258235b41e21',
-            s: 'efe730298fae0764403efbfc004d5e7d8cabb6d62570061aabacc0c1e1796dae',
-          },
-          secret: 'a53274b9476067a7ae0c7d1fba7c3f53a7b4b3610f03af736c6e1fc5361ec6ac',
-        },
-        {
-          C: '03d01a81d573403e2803496358b2abefc2f4592e51d3f41f907e2d6c4792a6518f',
-          amount: Amount.from(1),
-          dleq: {
-            e: '5b0a219b83f0a5935dbd48187d7de38b06f22093e29394e919aeb9d4e6579103',
-            r: '16fa016d727fd7ac4cc390c18f33611d9418eba8fe557e168f671de99ae34b99',
-            s: '77f917378c5b0ed4c99d52fdab25f7cb201cb33ef3fb764083c6552cdaece39e',
-          },
-          secret: 'ab52ba6a75b6659859927a337083241c4adc79e76d4fdb2fb3a07cb2564b6462',
-        },
-        {
-          C: '0342d3499d47354e8c270f3d95b37d88cd2cbbc238a13d3ff02ad0f340d59e4fdd',
-          amount: Amount.from(1),
-          dleq: {
-            e: 'cfd3ef7d297dd21a4d9a76d63947fd47eb61cae331f8b8765df3b6e46d4d30a1',
-            r: 'b2cdebe02d50fcb9a82cd2956123a4ff868f20696fea7c3df596b2100d2968a0',
-            s: '9a63f7d05a8d9ef18d3d52b814e22716aff4e2f696f28727e31e86721015f1be',
-          },
-          secret: 'f64259355a1f2d5d892c64f5beafae861da163998acb27f778761ac7e226dcf3',
-        },
+      proofAmounts: [
+        Amount.from(4),
+        Amount.from(2),
+        Amount.from(2),
+        Amount.from(1),
+        Amount.from(1),
       ],
     });
   });
@@ -405,57 +360,12 @@ describe('test getTokenMetadata', () => {
       unit: 'sat',
       mint: 'https://testnut.cashu.space',
       amount: Amount.from(10),
-      incompleteProofs: [
-        {
-          C: '027f390f7160a0171e0113a4311564447b2942833ae9dff0beb49cb314677ba6a4',
-          amount: Amount.from(4),
-          dleq: {
-            e: 'b5e5011baeb4c13d5c448745ae3b4dc4bf517b51e4eb03e9f74204e2c693cebe',
-            r: '7b7e868012f0d462406be790f713d8a42762c4a9efbbe2134df1cf9fc581df98',
-            s: '32475fe73ba9839dda273fb37e4deae3987aa086e68150a8b8187618cf146b0b',
-          },
-          secret: '4e585c19592a0a10007b451822e22f8129ec2753da0be3f22dec26a92b1302db',
-        },
-        {
-          C: '03957a7e9ab75f2152ba9eb5f1b6f3cd12dbb2b3100d4fabc3fd457f95b11dcbce',
-          amount: Amount.from(2),
-          dleq: {
-            e: 'bff2e8aee32ac15b21b38e991394f23e84c56845b1f74710d6741c67117c7d11',
-            r: '46d74791d56760b39317555f1283e2f4ad1cfa4a36a67c04e6cde510f22ed1ee',
-            s: '81cb23d0799341bc94f1f87235bc63f6b3a27c8b6f13a9dcf5f97a18485215c0',
-          },
-          secret: '16a0cc2214adcf80b19f60e972b7ad1d9efa7a1eed84de111df6b0d982f217fb',
-        },
-        {
-          C: '026f79804899c4c830475fab2bb030734f569d784cf7a02adf744e1fa695ab3d2d',
-          amount: Amount.from(2),
-          dleq: {
-            e: '3d7e00ffae6a115875b47fa4d5d41338f2105e53c354c96fe9449d1d9285d009',
-            r: 'b1347b584b48517761475c3a58fca47f80c368fcbbe06abdfdc8258235b41e21',
-            s: 'efe730298fae0764403efbfc004d5e7d8cabb6d62570061aabacc0c1e1796dae',
-          },
-          secret: 'a53274b9476067a7ae0c7d1fba7c3f53a7b4b3610f03af736c6e1fc5361ec6ac',
-        },
-        {
-          C: '03d01a81d573403e2803496358b2abefc2f4592e51d3f41f907e2d6c4792a6518f',
-          amount: Amount.from(1),
-          dleq: {
-            e: '5b0a219b83f0a5935dbd48187d7de38b06f22093e29394e919aeb9d4e6579103',
-            r: '16fa016d727fd7ac4cc390c18f33611d9418eba8fe557e168f671de99ae34b99',
-            s: '77f917378c5b0ed4c99d52fdab25f7cb201cb33ef3fb764083c6552cdaece39e',
-          },
-          secret: 'ab52ba6a75b6659859927a337083241c4adc79e76d4fdb2fb3a07cb2564b6462',
-        },
-        {
-          C: '0342d3499d47354e8c270f3d95b37d88cd2cbbc238a13d3ff02ad0f340d59e4fdd',
-          amount: Amount.from(1),
-          dleq: {
-            e: 'cfd3ef7d297dd21a4d9a76d63947fd47eb61cae331f8b8765df3b6e46d4d30a1',
-            r: 'b2cdebe02d50fcb9a82cd2956123a4ff868f20696fea7c3df596b2100d2968a0',
-            s: '9a63f7d05a8d9ef18d3d52b814e22716aff4e2f696f28727e31e86721015f1be',
-          },
-          secret: 'f64259355a1f2d5d892c64f5beafae861da163998acb27f778761ac7e226dcf3',
-        },
+      proofAmounts: [
+        Amount.from(4),
+        Amount.from(2),
+        Amount.from(2),
+        Amount.from(1),
+        Amount.from(1),
       ],
     });
   });


### PR DESCRIPTION
## Description

`TokenMetadata.incompleteProofs` was typed `Array<Omit<Proof, 'id'>>` — proofs with only the keyset id removed. Handing back partial proofs from `getTokenMetadata()`, the pre-wallet inspection helper, was a recurring source of confusion, and the field carried far more than inspection needs. Replace it with `proofAmounts: Amount[]` — the per-proof amounts only, which is enough to inspect a token's shape (e.g. reject a pathological all-1-sat set).

## Changes

- `TokenMetadata`: `incompleteProofs` removed, `proofAmounts: Amount[]` added.
- `getTokenMetadata` maps proofs to their amounts.
- Migration guide entry, get_token doc, tests updated.

## Reviewer Notes

- Breaking change to a public type; v5-only (rc), no backport of the breaking change. A v4 signal could be a separate LTS PR keeping `incompleteProofs`, adding `proofAmounts`, and `@deprecated`-tagging the old field.
- To obtain actual proofs, decode with a loaded wallet (`wallet.decodeToken`), as the docs now state.