### PR TITLE
feat(token): add getTokenMetadata proofAmounts and deprecate incompleteProofs

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2012,6 +2012,7 @@ export type TokenMetadata = {
     mint: string;
     amount: Amount;
     incompleteProofs: Array<Omit<Proof, 'id'>>;
+    proofAmounts: Amount[];
 };
 
 // @public (undocumented)

--- a/src/model/types/token.ts
+++ b/src/model/types/token.ts
@@ -81,6 +81,13 @@ export type TokenMetadata = {
   amount: Amount;
   /**
    * The incomplete proofs of the token.
+   *
+   * @deprecated Removed in v5. Use {@link TokenMetadata.proofAmounts} to inspect amounts, or decode
+   *   the token with a loaded wallet to obtain proofs.
    */
   incompleteProofs: Array<Omit<Proof, 'id'>>;
+  /**
+   * The per-proof amounts of the token, in order.
+   */
+  proofAmounts: Amount[];
 };

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -374,6 +374,7 @@ export function getTokenMetadata(token: string): TokenMetadata {
       void id;
       return rest;
     }),
+    proofAmounts: tokenObj.proofs.map((p) => p.amount),
   };
 }
 

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -352,6 +352,13 @@ describe('test getTokenMetadata', () => {
           secret: 'f64259355a1f2d5d892c64f5beafae861da163998acb27f778761ac7e226dcf3',
         },
       ],
+      proofAmounts: [
+        Amount.from(4),
+        Amount.from(2),
+        Amount.from(2),
+        Amount.from(1),
+        Amount.from(1),
+      ],
     });
   });
   test('testing v4 Token', async () => {
@@ -413,6 +420,13 @@ describe('test getTokenMetadata', () => {
           },
           secret: 'f64259355a1f2d5d892c64f5beafae861da163998acb27f778761ac7e226dcf3',
         },
+      ],
+      proofAmounts: [
+        Amount.from(4),
+        Amount.from(2),
+        Amount.from(2),
+        Amount.from(1),
+        Amount.from(1),
       ],
     });
   });


### PR DESCRIPTION
## Description

v4 companion to #941 (which removes `incompleteProofs` on v5). Handing back partial proofs from `getTokenMetadata()`, the pre-wallet inspection helper, was a recurring source of confusion, and the field carried more than inspection needs. This LTS change is additive and non-breaking: it adds `proofAmounts` and marks `incompleteProofs` deprecated rather than removing it.

## Changes

- `TokenMetadata`: new `proofAmounts: Amount[]`; `incompleteProofs` kept and `@deprecated` (removed in v5).
- `getTokenMetadata` populates both fields.
- Tests updated.

## Reviewer Notes

- Non-breaking: existing `incompleteProofs` consumers are unaffected; the deprecation surfaces in editors/tsc via the JSDoc tag.
- To obtain actual proofs, decode with a loaded wallet.