### PR TITLE
fix(auth): detach the OIDC token listener when the provider is replaced [backport v4-dev]

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1315,6 +1315,7 @@ export class OIDCAuth {
     passwordGrant(username: string, password: string): Promise<TokenResponse>;
     // (undocumented)
     refresh(refresh_token: string): Promise<TokenResponse>;
+    removeTokenListener(fn: (t: TokenResponse) => void | Promise<void>): void;
     // (undocumented)
     setClient(id: string): void;
     // (undocumented)

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -85,6 +85,8 @@ export class AuthManager implements AuthProvider {
 
   // Open ID Connect (OIDC)
   private oidc?: OIDCAuth;
+  // The listener registered on the current `oidc`, kept so it can be detached on replacement.
+  private oidcListener?: (t: TokenResponse) => void;
   private tokens: StoredTokens = {};
 
   // Blind Auth Token (BAT) pool
@@ -128,8 +130,15 @@ export class AuthManager implements AuthProvider {
    * internal CAT/refresh state on new tokens.
    */
   attachOIDC(oidc: OIDCAuth): this {
+    // Detach the listener from any previously attached provider. Otherwise a delayed token from the
+    // old provider would still run updateFromOIDC, installing its credentials into this manager and
+    // handing its refresh token to whichever provider is now current.
+    if (this.oidc && this.oidcListener) {
+      this.oidc.removeTokenListener(this.oidcListener);
+    }
     this.oidc = oidc;
-    this.oidc.addTokenListener((t) => this.updateFromOIDC(t));
+    this.oidcListener = (t) => this.updateFromOIDC(t);
+    this.oidc.addTokenListener(this.oidcListener);
     return this;
   }
 

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -102,6 +102,13 @@ export class OIDCAuth {
     this.tokenListeners.push(fn);
   }
 
+  /**
+   * Remove a previously registered token listener (by reference).
+   */
+  removeTokenListener(fn: (t: TokenResponse) => void | Promise<void>): void {
+    this.tokenListeners = this.tokenListeners.filter((l) => l !== fn);
+  }
+
   // ---- Discovery ----
 
   async loadConfig(): Promise<OIDCConfig> {

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -205,6 +205,42 @@ describe('AuthManager: CAT lifecycle', () => {
     expect(am.getCAT()).toBeUndefined();
     expect(am['tokens'].refreshToken).toBeUndefined();
   });
+
+  test('attachOIDC detaches the previous provider so its late token cannot install state', () => {
+    function providerStub() {
+      const listeners: Array<(t: unknown) => void> = [];
+      return {
+        listeners,
+        addTokenListener: (fn: (t: unknown) => void) => listeners.push(fn),
+        removeTokenListener: (fn: (t: unknown) => void) => {
+          const i = listeners.indexOf(fn);
+          if (i >= 0) listeners.splice(i, 1);
+        },
+        refresh: vi.fn(),
+        // Simulate a delayed authorization/device-flow completion.
+        fire: (t: unknown) => listeners.forEach((l) => l(t)),
+      };
+    }
+
+    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn });
+    const first = providerStub();
+    const second = providerStub();
+
+    am.attachOIDC(first as any);
+    am.attachOIDC(second as any);
+
+    // The replaced provider must no longer hold a listener into this manager.
+    expect(first.listeners).toHaveLength(0);
+
+    // A delayed token from the detached provider must not install its credentials.
+    first.fire({ access_token: 'p1-cat', refresh_token: 'p1-refresh', expires_in: 300 });
+    expect(am.getCAT()).toBeUndefined();
+    expect(am['tokens'].refreshToken).toBeUndefined();
+
+    // The current provider still updates state.
+    second.fire({ access_token: 'p2-cat', refresh_token: 'p2-refresh', expires_in: 300 });
+    expect(am.getCAT()).toBe('p2-cat');
+  });
 });
 
 describe('AuthManager: constructor limits', () => {

--- a/test/auth/OIDCAuth.node.test.ts
+++ b/test/auth/OIDCAuth.node.test.ts
@@ -164,6 +164,26 @@ describe('OIDCAuth: PKCE + auth code', () => {
     );
   });
 
+  test('removeTokenListener stops a listener from firing', async () => {
+    server.use(http.post(TOKEN_EP, () => HttpResponse.json(accessOk)));
+
+    const kept = vi.fn();
+    const removed = vi.fn();
+    const oidc = new OIDCAuth(DISCOVERY, { clientId: 'cashu-client' });
+    oidc.addTokenListener(kept);
+    oidc.addTokenListener(removed);
+    oidc.removeTokenListener(removed);
+
+    await oidc.exchangeAuthCode({
+      code: 'auth_code_123',
+      redirectUri: 'http://localhost:3388/callback',
+      codeVerifier: 'verifier_123',
+    });
+
+    expect(kept).toHaveBeenCalledTimes(1);
+    expect(removed).not.toHaveBeenCalled();
+  });
+
   test('exchangeAuthCode throws if provider returns 400 (strict)', async () => {
     server.use(
       http.post(TOKEN_EP, () =>


### PR DESCRIPTION
# Description
Backport of #939 to `v4-dev`.