### PR TITLE
fix(p2bk): share one ephemeral key across a blinded SIG_ALL batch

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1510,7 +1510,7 @@ export class OutputData implements OutputDataLike {
     // (undocumented)
     static createSingleDeterministicData(amount: AmountLike, seed: Uint8Array, counter: number, keysetId: string): OutputData;
     // (undocumented)
-    static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData;
+    static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string, eBytes?: Uint8Array): OutputData;
     // (undocumented)
     static createSingleRandomData(amount: AmountLike, keysetId: string): OutputData;
     static deserialize(serialized: SerializedOutputData): OutputData;

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -10,6 +10,7 @@ import {
   constructUnblindedSignatureBls,
   createSecretAndBlindingFactorDeriver,
   constructUnblindedSignature,
+  createRandomSecretKey,
   deriveP2BKBlindedPubkeys,
   deriveSecretAndBlindingFactor,
   isBlsKeyset,
@@ -237,10 +238,23 @@ export class OutputData implements OutputDataLike {
     customSplit?: AmountLike[],
   ): OutputData[] {
     const amounts = splitAmount(amount, keyset.keys, customSplit);
-    return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id));
+    // NUT-28: a SIG_ALL batch shares one ephemeral key so every secret carries the
+    // identical data/tags that NUT-11 requires; SIG_INPUTS keeps per-output keys.
+    const eBytes =
+      p2pk.blindKeys && p2pk.sigFlag === 'SIG_ALL' ? createRandomSecretKey() : undefined;
+    return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id, eBytes));
   }
 
-  static createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData {
+  /**
+   * @param eBytes Optional fixed P2BK ephemeral key; batch callers pass one shared key for SIG_ALL.
+   *   Omit for a fresh random key.
+   */
+  static createSingleP2PKData(
+    p2pk: P2PKOptions,
+    amount: AmountLike,
+    keysetId: string,
+    eBytes?: Uint8Array,
+  ): OutputData {
     const amountValue = Amount.from(amount);
     const normalized = normalizeP2PKOptions(p2pk);
     const isHTLC = normalized.kind === 'HTLC';
@@ -261,7 +275,7 @@ export class OutputData implements OutputDataLike {
       const lockKeys = isHTLC ? pubkeys : [data, ...pubkeys];
       const ordered = [...lockKeys, ...refundKeys];
       // For HTLC the hashlock occupies slot 0, so key slots start at 1 (NUT-28)
-      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered, undefined, !isHTLC);
+      const { blinded, Ehex: _E } = deriveP2BKBlindedPubkeys(ordered, eBytes, !isHTLC);
       if (isHTLC) {
         // hashlock is in data, all locking keys into pubkeys
         pubkeys = blinded.slice(0, lockKeys.length);

--- a/src/model/OutputDataCreator.ts
+++ b/src/model/OutputDataCreator.ts
@@ -56,6 +56,11 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputDataLike[] {
+    if (this.createSingleP2PKData === DefaultOutputDataCreator.prototype.createSingleP2PKData) {
+      // Preserve subclasses that customize only the single-output hook. The default
+      // hook can use the batch path, which shares one P2BK ephemeral key for SIG_ALL.
+      return OutputData.createP2PKData(p2pk, amount, keyset, customSplit);
+    }
     const amounts = splitAmount(amount, keyset.keys, customSplit);
     return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id));
   }

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { getPubKeyFromPrivKey } from '../../src/crypto';
+import { getPubKeyFromPrivKey, type P2PKOptions } from '../../src/crypto';
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import { OutputData, isOutputDataFactory } from '../../src/model/OutputData';
 import type { OutputDataFactory, OutputDataLike } from '../../src/model/OutputData';
@@ -34,6 +34,45 @@ describe('DefaultOutputDataCreator', () => {
     expect(batchSpy).toHaveBeenCalledWith(3, seed, 7, keyset, [1, 2]);
     batchSpy.mockRestore();
     expect(outputs).toEqual(OutputData.createDeterministicData(3, seed, 7, keyset, [1, 2]));
+  });
+
+  test('default P2PK batch shares one ephemeral key for a blinded SIG_ALL split', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const keyset: HasKeysetKeys = {
+      id: '009a1f293253e41e',
+      keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
+    };
+
+    const outputs = new DefaultOutputDataCreator().createP2PKData(
+      { kind: 'P2PK', data: pubkey, blindKeys: true, sigFlag: 'SIG_ALL' },
+      7,
+      keyset,
+    );
+
+    expect(outputs).toHaveLength(3);
+    expect(new Set(outputs.map((o) => o.ephemeralE)).size).toBe(1);
+  });
+
+  test('a subclassed single-output P2PK hook is still called once per split amount', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const keyset: HasKeysetKeys = {
+      id: '009a1f293253e41e',
+      keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
+    };
+    const seen: AmountLike[] = [];
+    class CustomCreator extends DefaultOutputDataCreator {
+      createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputData {
+        seen.push(amount);
+        return OutputData.createSingleP2PKData(p2pk, amount, keysetId);
+      }
+    }
+
+    const outputs = new CustomCreator().createP2PKData({ kind: 'P2PK', data: pubkey }, 7, keyset);
+
+    expect(outputs).toHaveLength(3);
+    expect(seen).toHaveLength(3);
   });
 
   test('a batch whose counters run past the safe range is rejected, not silently aliased', () => {
@@ -173,6 +212,61 @@ describe('OutputData helpers', () => {
     expect(pubkeysTag?.slice(1)).toHaveLength(1);
     expect(pubkeysTag?.[1]).not.toBe(pubkey);
     expect(output.ephemeralE).toBeDefined();
+  });
+
+  test('a blinded SIG_ALL batch shares one ephemeral key across all outputs', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const keyset: HasKeysetKeys = {
+      id: '009a1f293253e41e',
+      keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
+    };
+
+    // 7 splits into three outputs. NUT-11 requires SIG_ALL proofs to carry identical
+    // data/tags, so the batch must reuse one ephemeral key per NUT-28.
+    const outputs = OutputData.createP2PKData(
+      { kind: 'P2PK', data: pubkey, blindKeys: true, sigFlag: 'SIG_ALL' },
+      7,
+      keyset,
+    );
+
+    expect(outputs).toHaveLength(3);
+    const secrets = outputs.map(
+      (o) =>
+        (
+          JSON.parse(new TextDecoder().decode(o.secret)) as [
+            string,
+            { data: string; tags: string[][] },
+          ]
+        )[1],
+    );
+    for (let i = 1; i < outputs.length; i++) {
+      expect(secrets[i].data).toBe(secrets[0].data);
+      expect(secrets[i].tags).toEqual(secrets[0].tags);
+      expect(outputs[i].ephemeralE).toBe(outputs[0].ephemeralE);
+    }
+  });
+
+  test('a blinded SIG_INPUTS batch blinds each output with its own ephemeral key', () => {
+    const privkey = Bytes.fromHex('01'.repeat(32));
+    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const keyset: HasKeysetKeys = {
+      id: '009a1f293253e41e',
+      keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
+    };
+
+    const outputs = OutputData.createP2PKData(
+      { kind: 'P2PK', data: pubkey, blindKeys: true },
+      7,
+      keyset,
+    );
+
+    expect(outputs).toHaveLength(3);
+    const data = outputs.map(
+      (o) => (JSON.parse(new TextDecoder().decode(o.secret)) as [string, { data: string }])[1].data,
+    );
+    expect(new Set(data).size).toBe(outputs.length);
+    expect(new Set(outputs.map((o) => o.ephemeralE)).size).toBe(outputs.length);
   });
 });
 


### PR DESCRIPTION
## Description

NUT-28 requires a SIG_ALL batch to reuse one ephemeral keypair: NUT-11's equality rule means every proof in the batch must carry identical `data` and `tags`, which only holds if all outputs are blinded with the same `e`. `createP2PKData` was generating a fresh key per split output, so the minted proofs could never be spent together.

## Changes

- `OutputData.createP2PKData` generates one ephemeral key (via the existing `createRandomSecretKey`) when `blindKeys` is set with `sigFlag: 'SIG_ALL'`, and threads it through a new optional `eBytes` param on `createSingleP2PKData`. SIG_INPUTS batches keep per-output keys.
- `DefaultOutputDataCreator.createP2PKData` delegates to the batch path unless the single-output hook is overridden, mirroring the deterministic path's existing pattern.
- Tests cover the shared-key SIG_ALL batch, per-key SIG_INPUTS batch, creator delegation, and subclassed hooks.

## Reviewer Notes

- `createSingleP2PKData` gains an optional trailing param (additive, API report updated).
- Subclasses that override only `createSingleP2PKData` keep the per-output loop; per the `OutputDataCreator` docs, compatibility outside the default implementation is the integrator's responsibility.