### PR TITLE
fix(hooks): run both pre-push checks and fail on either

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,7 +7,7 @@ if ! command -v npm >/dev/null 2>&1; then
 	exit 1
 fi
 
-if ! npm run check-lint && npm run check-format; then
+if ! npm run check-lint || ! npm run check-format; then
 	echo "Pre-push checks failed. Push aborted." >&2
 	exit 1
 fi


### PR DESCRIPTION
## Description

The pre-push hook was badly written: format has effectively never been gated on push, and a double failure sails through. `|| !` gives the intended behaviour: run both, abort on either.

This is a hand-written backport of the same fix on `main`, where it rides along with unrelated tooling changes that do not apply to this line.

## Changes

- One operator in `.husky/pre-push`.

## Reviewer Notes

- No runtime or API impact; hooks only. CI already ran lint and format as separate required workflows, so nothing unformatted reached `main` through this gap, it just meant contributors found out from CI rather than locally.
