### PR TITLE
fix(types): make nut08Change expressible and NUT-10 tags optional

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -787,6 +787,7 @@ export type MeltProofsConfig = {
     keysetId?: string;
     privkey?: string | string[];
     onCountersReserved?: OnCountersReserved;
+    nut08Change?: boolean;
 };
 
 // @public
@@ -1263,7 +1264,7 @@ export function normalizeProofAmounts(raw: ProofLike[]): Proof[];
 export type NUT10Option = {
     kind: string;
     data: string;
-    tags: string[][];
+    tags?: string[][];
 };
 
 // @public (undocumented)
@@ -1596,10 +1597,8 @@ export type PostRestoreResponse = {
     signatures: SerializedBlindedSignature[];
 };
 
-// @public (undocumented)
-export type PrepareMeltConfig = MeltProofsConfig & {
-    nut08Change?: boolean;
-};
+// @public @deprecated (undocumented)
+export type PrepareMeltConfig = MeltProofsConfig;
 
 // @public
 export type PrivKey = Uint8Array | string;
@@ -1650,7 +1649,7 @@ export type RawMintKeys = {
 export type RawNUT10Option = {
     k: string;
     d: string;
-    t: string[][];
+    t?: string[][];
 };
 
 // @public (undocumented)
@@ -2160,7 +2159,7 @@ export class Wallet {
         amount: AmountLike;
         quote: TQuote;
     }>, config?: MintProofsConfig, outputType?: OutputType): Promise<BatchMintPreview<TQuote>>;
-    prepareMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(method: string, meltQuote: TQuote, proofsToSend: ProofLike[], config?: PrepareMeltConfig, outputType?: OutputType): Promise<MeltPreview<TQuote>>;
+    prepareMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'>>(method: string, meltQuote: TQuote, proofsToSend: ProofLike[], config?: MeltProofsConfig, outputType?: OutputType): Promise<MeltPreview<TQuote>>;
     prepareMint<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>>(method: string, amount: AmountLike, quote: TQuote, config?: MintProofsConfig, outputType?: OutputType): Promise<MintPreview<TQuote>>;
     prepareSwapToReceive(token: Token | string | ProofLike[], config?: ReceiveConfig, outputType?: OutputType): Promise<SwapPreview>;
     prepareSwapToSend(amount: AmountLike, proofs: ProofLike[], config?: SendConfig, outputConfig?: OutputConfig): Promise<SwapPreview>;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -80,7 +80,6 @@ import {
   type ReceiveConfig,
   type MintProofsConfig,
   type MeltProofsConfig,
-  type PrepareMeltConfig,
   type CompleteMeltOptions,
   type SwapTransaction,
   type MeltProofsResponse,
@@ -3069,7 +3068,7 @@ class Wallet {
     method: string,
     meltQuote: TQuote,
     proofsToSend: ProofLike[],
-    config?: PrepareMeltConfig,
+    config?: MeltProofsConfig,
     outputType?: OutputType,
   ): Promise<MeltPreview<TQuote>> {
     this.validateMeltQuote(meltQuote);

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -152,11 +152,18 @@ export type MeltProofsConfig = {
   keysetId?: string;
   privkey?: string | string[];
   onCountersReserved?: OnCountersReserved;
-};
-
-export type PrepareMeltConfig = MeltProofsConfig & {
+  /**
+   * Request NUT-08 blank outputs so the mint can return unspent fee reserve. Defaults to true. Set
+   * false to forfeit the change, which also permits melting on an inactive keyset.
+   */
   nut08Change?: boolean;
 };
+
+/**
+ * @deprecated Use {@link MeltProofsConfig}, which now carries `nut08Change`. This alias is retained
+ *   for compatibility and is removed in v5.
+ */
+export type PrepareMeltConfig = MeltProofsConfig;
 
 export type CompleteMeltOptions = {
   preferAsync?: boolean;

--- a/src/wallet/types/payment-requests.ts
+++ b/src/wallet/types/payment-requests.ts
@@ -9,7 +9,7 @@ export type RawTransport = {
 export type RawNUT10Option = {
   k: string; // kind
   d: string; // data
-  t: string[][]; // tags
+  t?: string[][]; // tags (optional per NUT-18)
 };
 
 export type RawPaymentRequest = {
@@ -55,7 +55,8 @@ export type NUT10Option = {
    */
   data: string;
   /**
-   * Tags associated with the spending condition for additional data.
+   * Optional tags associated with the spending condition for additional data. Absent and empty are
+   * equivalent: neither is encoded.
    */
-  tags: string[][];
+  tags?: string[][];
 };


### PR DESCRIPTION
## Description

Two public type corrections carried back from the v5 line (#955), shaped so that nothing is removed from this stable major. The point is partly the fixes themselves and partly keeping the two lines' type shapes aligned so future backports apply cleanly.

## Changes

- **`nut08Change` moves onto `MeltProofsConfig`.** `meltProofs`, `meltProofsBolt11`, `meltProofsBolt12` and `meltProofsOnchain` all take `MeltProofsConfig` and forward it wholesale to `prepareMelt`, which took the wider `PrepareMeltConfig`. So the option already worked at runtime through every helper but could not be expressed in TypeScript. `PrepareMeltConfig` remains, as a deprecated alias of `MeltProofsConfig`, so no import breaks.
- **`NUT10Option.tags` and `RawNUT10Option.t` are optional.** NUT-10 marks `tags` optional and NUT-18 describes `t` as "optional NUT-10 payment tags". The implementation already agreed: `utils/tlv.ts` declares its internal `Nut10SpendingCondition.tags` optional and deliberately returns `undefined` when absent, and every read site guards with `?? []` or a length check. Decoding a spec-valid request that omits tags therefore produced an object that violated its own declared type.

## Reviewer Notes

- Nothing is removed from the public surface. The API report diff is additive apart from the two fields becoming optional and `PrepareMeltConfig` collapsing to an alias.
- The one compatibility wrinkle: TypeScript consumers who *read* `nut10.tags` now see `string[][] | undefined` and need a guard. That is the truth they were already exposed to at runtime, and `PaymentRequestTransport.tags` on this line is already optional, so it also removes an internal inconsistency.
- In v5 `PrepareMeltConfig` is removed outright rather than aliased, which the v5 migration guide now records.
- Verified on this branch: `src/` type checks clean, node suite passes 62 files and 2077 tests, lint and format clean, `api:update` run and committed.
