### PR TITLE
fix(mint): derive a missing bolt11 quote state from the accounting fields

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1173,6 +1173,9 @@ export type MintQuoteBaseResponse = {
     request: string;
     unit: string;
     pubkey?: string;
+    amount_paid?: Amount;
+    amount_issued?: Amount;
+    updated_at?: number | null;
 };
 
 // @public

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -19,6 +19,7 @@ import {
   type MeltQuoteBolt11Response,
   type MeltQuoteBolt12Response,
   MeltQuoteState,
+  MintQuoteState,
   type MintResponse,
   type GetInfoResponse,
   type MeltRequest,
@@ -1236,9 +1237,8 @@ class Mint {
     response: TRes,
     normalize?: (raw: Record<string, unknown>) => TRes,
   ): TRes {
-    // MintQuoteBaseResponse has no Amount fields to normalize at the base level.
-    // Stack first-class normalization for known methods.
     const data: Record<string, unknown> = { ...response };
+    this.normalizeMintBaseFields(data);
     if (method === 'bolt11') {
       this.normalizeMintQuoteBolt11Fields(data);
     } else if (method === 'bolt12') {
@@ -1250,7 +1250,39 @@ class Mint {
   }
 
   /**
+   * Mutates `data` in place, normalizing protocol-mandatory mint quote base fields.
+   *
+   * The NUT-04 accounting fields are optional on this line, so a mint that predates them is left
+   * untouched rather than given fabricated zeros. v5 requires them and derives them from the legacy
+   * `state` instead.
+   */
+  private normalizeMintBaseFields(data: Record<string, unknown>): void {
+    if (data.amount_paid != null && data.amount_issued != null) {
+      data.amount_paid = Amount.from(data.amount_paid as AmountLike);
+      data.amount_issued = Amount.from(data.amount_issued as AmountLike);
+    }
+    data.updated_at = normalizeSafeIntegerMetadata(
+      data.updated_at as number | undefined,
+      'mintQuote.updated_at',
+      null,
+    );
+  }
+
+  /**
+   * Derives the deprecated single-use `state` from the NUT-04 accounting fields.
+   */
+  private deriveMintQuoteState(paid: Amount, issued: Amount): MintQuoteState {
+    if (paid.isZero() && issued.isZero()) {
+      return MintQuoteState.UNPAID;
+    }
+    return paid.greaterThan(issued) ? MintQuoteState.PAID : MintQuoteState.ISSUED;
+  }
+
+  /**
    * Mutates `data` in place, normalizing bolt11 mint-quote fields.
+   *
+   * NUT-23 deprecates `state` and lets mints omit it. Where it is missing, derive it from the
+   * accounting fields so consumers reading `state` keep working against a modern mint.
    */
   private normalizeMintQuoteBolt11Fields(data: Record<string, unknown>): void {
     data.amount = Amount.from(data.amount as AmountLike);
@@ -1259,6 +1291,15 @@ class Mint {
       'mintQuoteBolt11.expiry',
       null,
     );
+    if (
+      typeof data.state !== 'string' ||
+      !Object.values(MintQuoteState).includes(data.state as MintQuoteState)
+    ) {
+      // Accounting is optional on this line, so only derive where the mint reported it.
+      if (data.amount_paid instanceof Amount && data.amount_issued instanceof Amount) {
+        data.state = this.deriveMintQuoteState(data.amount_paid, data.amount_issued);
+      }
+    }
   }
 
   /**

--- a/src/model/types/NUT04.ts
+++ b/src/model/types/NUT04.ts
@@ -1,3 +1,5 @@
+import { type Amount } from '../Amount';
+
 import { type SerializedBlindedMessage, type SerializedBlindedSignature } from './blinded';
 
 export const MintQuoteState = {
@@ -43,6 +45,21 @@ export type MintQuoteBaseResponse = {
    * Optional. Public key the quote is locked to (NUT-20)
    */
   pubkey?: string;
+  /**
+   * Total amount paid to the mint for this quote, in `unit`. Absent on mints that predate the
+   * NUT-04 accounting fields; required from v5. Method-specific types may narrow it to required.
+   */
+  amount_paid?: Amount;
+  /**
+   * Total amount of ecash issued for this quote, in `unit`. The mintable amount is `amount_paid -
+   * amount_issued`, which supersedes the deprecated bolt11 `state`.
+   */
+  amount_issued?: Amount;
+  /**
+   * Unix timestamp of the last quote update, `null` when the mint does not report one. Optional so
+   * that callers constructing quote objects are unaffected; responses from `Mint` always carry it.
+   */
+  updated_at?: number | null;
 };
 
 /**

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -7,6 +7,7 @@ import {
   Mint,
   MintInfo,
   MeltQuoteState,
+  MintQuoteState,
   WSConnection,
   injectWebSocketImpl,
   RateLimitError,
@@ -368,6 +369,76 @@ describe('Mint normalization', () => {
 
     expect(response.amount.toBigInt()).toBe(21n);
     expect(response.expiry).toBeNull();
+  });
+
+  it.each([
+    ['UNPAID', 0, 0, MintQuoteState.UNPAID],
+    ['PAID', 21, 0, MintQuoteState.PAID],
+    ['ISSUED', 21, 21, MintQuoteState.ISSUED],
+  ])(
+    'derives a missing bolt11 state as %s from the accounting fields',
+    async (_label, paid, issued, expected) => {
+      // NUT-23 deprecates `state` and lets a mint omit it. Without this, consumers reading
+      // `state` would silently see undefined against a modern mint.
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          request: 'lnbc1...',
+          unit: 'sat',
+          amount: 21,
+          amount_paid: paid,
+          amount_issued: issued,
+          updated_at: 1234567800,
+          expiry: null,
+        }),
+      });
+
+      const response = await mint.checkMintQuoteBolt11('q1');
+
+      expect(response.state).toBe(expected);
+      expect(response.amount_paid?.toBigInt()).toBe(BigInt(paid));
+      expect(response.amount_issued?.toBigInt()).toBe(BigInt(issued));
+      expect(response.updated_at).toBe(1234567800);
+    },
+  );
+
+  it('keeps a mint-reported bolt11 state rather than deriving over it', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({
+        quote: 'q1',
+        request: 'lnbc1...',
+        unit: 'sat',
+        amount: 21,
+        state: MintQuoteState.ISSUED,
+        amount_paid: 21,
+        amount_issued: 0, // would derive PAID; the mint's own value wins
+        expiry: null,
+      }),
+    });
+
+    const response = await mint.checkMintQuoteBolt11('q1');
+
+    expect(response.state).toBe(MintQuoteState.ISSUED);
+  });
+
+  it('leaves accounting absent for a mint that predates it, without fabricating zeros', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({
+        quote: 'q1',
+        request: 'lnbc1...',
+        unit: 'sat',
+        amount: 21,
+        state: MintQuoteState.PAID,
+        expiry: null,
+      }),
+    });
+
+    const response = await mint.checkMintQuoteBolt11('q1');
+
+    expect(response.state).toBe(MintQuoteState.PAID);
+    expect(response.amount_paid).toBeUndefined();
+    expect(response.amount_issued).toBeUndefined();
+    expect(response.updated_at).toBeNull();
   });
 
   it('createMintQuoteBolt12 coerces omitted amount to null and normalizes paid and issued amounts', async () => {


### PR DESCRIPTION
## TL;DR

Makes v4 survive a mint that stops sending the deprecated bolt11 `state`, by deriving it from the NUT-04 accounting fields. Non-breaking: the three accounting fields are added as optional.

## Why

[NUT-23](https://github.com/cashubtc/nuts/blob/main/23.md) marks the mint quote `state` deprecated and optional, so a mint may legitimately stop sending it. This line has no base-level accounting normalization at all: `normalizeMintQuoteBolt11Fields` touches only `amount` and `expiry`, and the accounting fields are declared on bolt12 and onchain only.

So against a mint that drops `state`, v4 does not throw. It returns `state: undefined` while the type promises a required `MintQuoteState`, and every consumer doing `if (quote.state === MintQuoteState.PAID)` silently never fires, leaving a user unable to mint with no error to explain it. v5 already backfills in both directions; v4 backfilled in neither.

## Changes

- `amount_paid`, `amount_issued` and `updated_at` added to `MintQuoteBaseResponse` as **optional**, so nothing that constructs a quote object needs to change. The bolt12 and onchain types already declare the first two as required, and the intersection keeps them required there.
- Accounting is normalized when the mint reports it. A mint that predates it is left untouched rather than given fabricated zeros, which is the one place this deliberately differs from v5.
- For bolt11, `state` is derived from the accounting fields when absent or unrecognised. A state the mint did send always wins.
- Tests cover all three derived states, the mint-sent state winning, and a legacy mint keeping absent accounting.

## Impact

None for existing callers: the API report diff is three added optional fields, with no removals or signature changes. Behaviourally additive, since it only fills a field that would otherwise be `undefined`.

Deliberately shaped to match v5 (same `normalizeMintBaseFields` / `deriveMintQuoteState` names and control flow) so later backports land on the same lines. The remaining gap is that v5 requires the accounting fields and derives them from the legacy `state`, which would be breaking here.
