### PR TITLE
feat(wallet): size request batches from the mint's advertised cap

### DIFF
--- a/docs-src/usage/restore_proofs.md
+++ b/docs-src/usage/restore_proofs.md
@@ -30,7 +30,7 @@ for (const [keysetId, last] of Object.entries(lastCounters)) {
 const { proofs, lastCounterWithSignature } = await wallet.batchRestore({
   keysetId: '00bd033559de27d0', // defaults to the wallet's keyset
   gapLimit: 300, // consecutive empty counters that end the scan
-  batchSize: 500, // counters per request (mint caps are typically 1000)
+  batchSize: 500, // counters per request (defaults to the mint's advertised cap)
   counter: 0, // starting counter
   filterSpent: true, // drop spent proofs via NUT-07 before returning
 });
@@ -40,6 +40,7 @@ Semantics worth knowing:
 
 - **`gapLimit` is a floor, not an exact ceiling.** Batches are fetched through a small request pool, so a few batches are already in flight when the gap closes. Their results are still processed: proofs sitting shortly past the gap limit are recovered rather than dropped, and the scan may probe up to three extra batches of counters past the gap.
 - **`filterSpent` drops SPENT proofs and keeps PENDING ones** (a pending melt can fail and return them to spendable). Pass `filterSpent: false` for the raw output, e.g. for auditing. `lastCounterWithSignature` is never affected by filtering.
+- **`batchSize` defaults to what the mint will accept.** A mint advertising `max_request_length` (NUT-06) sets the default; without one it is 500. Setting it yourself is still allowed, but a value above the mint's cap gets the request rejected.
 - **`maxCounter` bounds the scan** (inclusive); nothing above it is probed. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall:
 
 ```typescript

--- a/docs-src/usage/restore_proofs.md
+++ b/docs-src/usage/restore_proofs.md
@@ -40,7 +40,7 @@ Semantics worth knowing:
 
 - **`gapLimit` is a floor, not an exact ceiling.** Batches are fetched through a small request pool, so a few batches are already in flight when the gap closes. Their results are still processed: proofs sitting shortly past the gap limit are recovered rather than dropped, and the scan may probe up to three extra batches of counters past the gap.
 - **`filterSpent` drops SPENT proofs and keeps PENDING ones** (a pending melt can fail and return them to spendable). Pass `filterSpent: false` for the raw output, e.g. for auditing. `lastCounterWithSignature` is never affected by filtering.
-- **`batchSize` defaults to what the mint will accept.** A mint advertising `max_request_length` (NUT-06) sets the default; without one it is 500. Setting it yourself is still allowed, but a value above the mint's cap gets the request rejected.
+- **`batchSize` defaults to what the mint will accept.** A mint advertising `max_array_length` (NUT-06) sets the default; without one it is 500. Setting it yourself is still allowed, but a value above the mint's cap gets the request rejected.
 - **`maxCounter` bounds the scan** (inclusive); nothing above it is probed. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall:
 
 ```typescript

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -529,6 +529,7 @@ export type GetInfoResponse = {
     description?: string;
     description_long?: string;
     icon_url?: string;
+    max_request_length?: number;
     contact: MintContactInfo[];
     nuts: {
         '4': {
@@ -1150,6 +1151,7 @@ export class MintInfo {
         supported: boolean;
         params?: Nut29Info;
     };
+    get maxRequestLength(): number;
     // (undocumented)
     get motd(): string | undefined;
     // (undocumented)

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -529,7 +529,7 @@ export type GetInfoResponse = {
     description?: string;
     description_long?: string;
     icon_url?: string;
-    max_request_length?: number;
+    max_array_length?: number;
     contact: MintContactInfo[];
     nuts: {
         '4': {
@@ -1151,7 +1151,7 @@ export class MintInfo {
         supported: boolean;
         params?: Nut29Info;
     };
-    get maxRequestLength(): number;
+    get maxArrayLength(): number;
     // (undocumented)
     get motd(): string | undefined;
     // (undocumented)

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -172,7 +172,7 @@ If you were already passing the proofs you received (the normal case — `proofs
 `Wallet.batchRestore(gapLimit?, batchSize?, counter?, keysetId?)` is now `batchRestore(config?: BatchRestoreConfig)`. Behavior changes ride along:
 
 - Batches are fetched through a bounded request pool (4 in flight), cutting restore wall-clock to roughly a quarter; the request count is nearly unchanged.
-- `batchSize` defaults to 500 (was 300), matching the request size `checkProofsStates` already uses against reference mint caps.
+- `batchSize` now defaults to the mint's advertised `max_request_length` (NUT-06), or 500 when it advertises none (was a fixed 300). `checkProofsStates` sizes its batches the same way.
 - Spent proofs are dropped by default via a NUT-07 state check before returning; pending proofs are kept. Pass `filterSpent: false` for the old raw output. `lastCounterWithSignature` always reflects all found signatures, so counter advancement is unaffected by filtering.
 - `gapLimit` is now a floor rather than an exact ceiling: batches already in flight when the gap closes are still processed, so proofs sitting shortly past the gap limit may still be recovered.
 - New `maxCounter` option: an inclusive scan ceiling, nothing above it is probed. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall.

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -172,7 +172,7 @@ If you were already passing the proofs you received (the normal case — `proofs
 `Wallet.batchRestore(gapLimit?, batchSize?, counter?, keysetId?)` is now `batchRestore(config?: BatchRestoreConfig)`. Behavior changes ride along:
 
 - Batches are fetched through a bounded request pool (4 in flight), cutting restore wall-clock to roughly a quarter; the request count is nearly unchanged.
-- `batchSize` now defaults to the mint's advertised `max_request_length` (NUT-06), or 500 when it advertises none (was a fixed 300). `checkProofsStates` sizes its batches the same way.
+- `batchSize` now defaults to the mint's advertised `max_array_length` (NUT-06), or 500 when it advertises none (was a fixed 300). `checkProofsStates` sizes its batches the same way.
 - Spent proofs are dropped by default via a NUT-07 state check before returning; pending proofs are kept. Pass `filterSpent: false` for the old raw output. `lastCounterWithSignature` always reflects all found signatures, so counter advancement is unaffected by filtering.
 - `gapLimit` is now a floor rather than an exact ceiling: batches already in flight when the gap closes are still processed, so proofs sitting shortly past the gap limit may still be recovered.
 - New `maxCounter` option: an inclusive scan ceiling, nothing above it is probed. Combine with `gapLimit: Infinity` to fetch a known counter range wall to wall.

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,10 +1,10 @@
 import { type Logger, NULL_LOGGER } from '../logger';
 import { nullIfUndefined } from '../utils/core';
 import {
+  ABSOLUTE_MAX_ARRAY_LENGTH,
   ABSOLUTE_MAX_BATCH_SIZE,
   ABSOLUTE_MAX_PER_MINT,
-  ABSOLUTE_MAX_REQUEST_LENGTH,
-  DEFAULT_MAX_REQUEST_LENGTH,
+  DEFAULT_MAX_ARRAY_LENGTH,
   MAX_METHOD_LENGTH,
   MAX_MINT_INFO_LIST,
 } from '../utils/limits';
@@ -56,12 +56,12 @@ export class MintInfo {
   // NUT-21, Clear-auth protected endpoints
   private readonly _protected21?: ProtectedIndex;
   // NUT-06, resolved request array cap
-  private readonly _maxRequestLength: number;
+  private readonly _maxArrayLength: number;
 
   constructor(info: GetInfoResponse, logger?: Logger) {
     const log = logger ?? NULL_LOGGER;
     this._mintInfo = MintInfo.normalizeInfo(info, log);
-    this._maxRequestLength = MintInfo.resolveMaxRequestLength(info.max_request_length, log);
+    this._maxArrayLength = MintInfo.resolveMaxArrayLength(info.max_array_length, log);
 
     const pe22 = this.toEndpoints(this._mintInfo?.nuts?.[22]?.protected_endpoints, log);
     this._protected22 = this.buildIndex(pe22);
@@ -115,27 +115,27 @@ export class MintInfo {
   }
 
   /**
-   * NUT-06: `max_request_length` bounds every array the wallet puts in a request, so it always
+   * NUT-06: `max_array_length` bounds every array the wallet puts in a request, so it always
    * resolves to a usable number. Missing or malformed falls back to the library default; an
-   * advertised value is clamped into `[1, ABSOLUTE_MAX_REQUEST_LENGTH]`. The response itself keeps
+   * advertised value is clamped into `[1, ABSOLUTE_MAX_ARRAY_LENGTH]`. The response itself keeps
    * whatever the mint sent, so `cache` never reports a limit the mint did not advertise.
    */
-  private static resolveMaxRequestLength(value: number | undefined, logger: Logger): number {
-    if (value == null) return DEFAULT_MAX_REQUEST_LENGTH;
+  private static resolveMaxArrayLength(value: number | undefined, logger: Logger): number {
+    if (value == null) return DEFAULT_MAX_ARRAY_LENGTH;
 
     let max: number;
     try {
-      max = normalizeSafeIntegerMetadata(value, 'max_request_length');
+      max = normalizeSafeIntegerMetadata(value, 'max_array_length');
     } catch {
-      logger.warn('MintInfo: max_request_length is malformed, defaulting to internal default', {
+      logger.warn('MintInfo: max_array_length is malformed, defaulting to internal default', {
         value,
       });
-      return DEFAULT_MAX_REQUEST_LENGTH;
+      return DEFAULT_MAX_ARRAY_LENGTH;
     }
 
-    if (max < 1 || max > ABSOLUTE_MAX_REQUEST_LENGTH) {
-      const clamped = Math.min(Math.max(max, 1), ABSOLUTE_MAX_REQUEST_LENGTH);
-      logger.warn('MintInfo: max_request_length is out of range and was clamped', {
+    if (max < 1 || max > ABSOLUTE_MAX_ARRAY_LENGTH) {
+      const clamped = Math.min(Math.max(max, 1), ABSOLUTE_MAX_ARRAY_LENGTH);
+      logger.warn('MintInfo: max_array_length is out of range and was clamped', {
         advertised: max,
         clampedTo: clamped,
       });
@@ -471,8 +471,8 @@ export class MintInfo {
    * NUT-06: max length the mint accepts for any array in a request (`inputs`, `outputs`, `Ys`).
    * Always a usable number: the library default when the mint advertises none.
    */
-  get maxRequestLength(): number {
-    return this._maxRequestLength;
+  get maxArrayLength(): number {
+    return this._maxArrayLength;
   }
 
   /**

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -3,6 +3,8 @@ import { nullIfUndefined } from '../utils/core';
 import {
   ABSOLUTE_MAX_BATCH_SIZE,
   ABSOLUTE_MAX_PER_MINT,
+  ABSOLUTE_MAX_REQUEST_LENGTH,
+  DEFAULT_MAX_REQUEST_LENGTH,
   MAX_METHOD_LENGTH,
   MAX_MINT_INFO_LIST,
 } from '../utils/limits';
@@ -53,10 +55,13 @@ export class MintInfo {
   private readonly _protected22?: ProtectedIndex;
   // NUT-21, Clear-auth protected endpoints
   private readonly _protected21?: ProtectedIndex;
+  // NUT-06, resolved request array cap
+  private readonly _maxRequestLength: number;
 
   constructor(info: GetInfoResponse, logger?: Logger) {
     const log = logger ?? NULL_LOGGER;
     this._mintInfo = MintInfo.normalizeInfo(info, log);
+    this._maxRequestLength = MintInfo.resolveMaxRequestLength(info.max_request_length, log);
 
     const pe22 = this.toEndpoints(this._mintInfo?.nuts?.[22]?.protected_endpoints, log);
     this._protected22 = this.buildIndex(pe22);
@@ -107,6 +112,36 @@ export class MintInfo {
       }
       return next as SwapMethod;
     });
+  }
+
+  /**
+   * NUT-06: `max_request_length` bounds every array the wallet puts in a request, so it always
+   * resolves to a usable number. Missing or malformed falls back to the library default; an
+   * advertised value is clamped into `[1, ABSOLUTE_MAX_REQUEST_LENGTH]`. The response itself keeps
+   * whatever the mint sent, so `cache` never reports a limit the mint did not advertise.
+   */
+  private static resolveMaxRequestLength(value: number | undefined, logger: Logger): number {
+    if (value == null) return DEFAULT_MAX_REQUEST_LENGTH;
+
+    let max: number;
+    try {
+      max = normalizeSafeIntegerMetadata(value, 'max_request_length');
+    } catch {
+      logger.warn('MintInfo: max_request_length is malformed, defaulting to internal default', {
+        value,
+      });
+      return DEFAULT_MAX_REQUEST_LENGTH;
+    }
+
+    if (max < 1 || max > ABSOLUTE_MAX_REQUEST_LENGTH) {
+      const clamped = Math.min(Math.max(max, 1), ABSOLUTE_MAX_REQUEST_LENGTH);
+      logger.warn('MintInfo: max_request_length is out of range and was clamped', {
+        advertised: max,
+        clampedTo: clamped,
+      });
+      return clamped;
+    }
+    return max;
   }
 
   private static normalizeNut19(
@@ -431,6 +466,13 @@ export class MintInfo {
   }
   get motd() {
     return this._mintInfo.motd;
+  }
+  /**
+   * NUT-06: max length the mint accepts for any array in a request (`inputs`, `outputs`, `Ys`).
+   * Always a usable number: the library default when the mint advertises none.
+   */
+  get maxRequestLength(): number {
+    return this._maxRequestLength;
   }
 
   /**

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -12,6 +12,10 @@ export type GetInfoResponse = {
   description?: string;
   description_long?: string;
   icon_url?: string;
+  /**
+   * Max length the mint accepts for any array in a request (`inputs`, `outputs`, `Ys`).
+   */
+  max_request_length?: number;
   contact: MintContactInfo[];
   nuts: {
     '4': {

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -15,7 +15,7 @@ export type GetInfoResponse = {
   /**
    * Max length the mint accepts for any array in a request (`inputs`, `outputs`, `Ys`).
    */
-  max_request_length?: number;
+  max_array_length?: number;
   contact: MintContactInfo[];
   nuts: {
     '4': {

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -21,6 +21,19 @@ export const MAX_SPLIT_OUTPUTS = 8_192;
 export const ABSOLUTE_MAX_BATCH_SIZE = 100;
 
 /**
+ * NUT-06: Fallback for `max_request_length` when a mint advertises none. Both reference mints cap
+ * request arrays at 1000 by default; half that leaves headroom for stricter operator configs.
+ */
+export const DEFAULT_MAX_REQUEST_LENGTH = 500;
+
+/**
+ * NUT-06: Hard ceiling for an advertised `max_request_length`. Bounds the work a mint can talk the
+ * wallet into doing per request (a restore batch is one derivation and one blinded message per
+ * entry). Values outside `[1, cap]` are clamped, the floor so batching loops still make progress.
+ */
+export const ABSOLUTE_MAX_REQUEST_LENGTH = 10_000;
+
+/**
  * NUT-02: Hard ceiling on the number of denominations a mint-supplied keyset may carry, checked
  * before any per-key work (id derivation hashes every pubkey). Real keysets carry ~64 keys (powers
  * of two to 2^63), so 256 is ample headroom. Oversized keysets fail id verification.

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -21,17 +21,17 @@ export const MAX_SPLIT_OUTPUTS = 8_192;
 export const ABSOLUTE_MAX_BATCH_SIZE = 100;
 
 /**
- * NUT-06: Fallback for `max_request_length` when a mint advertises none. Both reference mints cap
+ * NUT-06: Fallback for `max_array_length` when a mint advertises none. Both reference mints cap
  * request arrays at 1000 by default; half that leaves headroom for stricter operator configs.
  */
-export const DEFAULT_MAX_REQUEST_LENGTH = 500;
+export const DEFAULT_MAX_ARRAY_LENGTH = 500;
 
 /**
- * NUT-06: Hard ceiling for an advertised `max_request_length`. Bounds the work a mint can talk the
+ * NUT-06: Hard ceiling for an advertised `max_array_length`. Bounds the work a mint can talk the
  * wallet into doing per request (a restore batch is one derivation and one blinded message per
  * entry). Values outside `[1, cap]` are clamped, the floor so batching loops still make progress.
  */
-export const ABSOLUTE_MAX_REQUEST_LENGTH = 10_000;
+export const ABSOLUTE_MAX_ARRAY_LENGTH = 10_000;
 
 /**
  * NUT-02: Hard ceiling on the number of denominations a mint-supplied keyset may carry, checked

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -67,6 +67,7 @@ import {
   sumProofs,
   verifyProofsForReceive,
   ABSOLUTE_MAX_BATCH_SIZE,
+  DEFAULT_MAX_REQUEST_LENGTH,
 } from '../utils';
 
 import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
@@ -443,6 +444,14 @@ class Wallet {
       'Mint info not initialized; call loadMint or loadMintFromCache first',
     );
     return this._mintInfo;
+  }
+
+  /**
+   * NUT-06: the mint's advertised cap on the length of any array in a request, used to size the
+   * checkstate and restore batches. Falls back to the library default until mint info is loaded.
+   */
+  private get maxRequestLength(): number {
+    return this._mintInfo?.maxRequestLength ?? DEFAULT_MAX_REQUEST_LENGTH;
   }
 
   /**
@@ -1737,7 +1746,8 @@ class Wallet {
    *   gap rule (use with `maxCounter`). Default is `300`
    * @param [config.maxCounter] Inclusive scan ceiling; no counter above it is probed. Default is
    *   unbounded.
-   * @param [config.batchSize=500] Counters per restore request. Default is `500`
+   * @param [config.batchSize] Counters per restore request. Defaults to the mint's advertised
+   *   `max_request_length` (NUT-06), or `500` when it advertises none.
    * @param [config.counter=0] Starting counter. Default is `0`
    * @param [config.keysetId] Keyset to restore; defaults to the wallet's.
    * @param [config.filterSpent=true] Drop spent proofs (NUT-07) before returning. Default is `true`
@@ -1745,7 +1755,12 @@ class Wallet {
   async batchRestore(
     config?: BatchRestoreConfig,
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
-    const { gapLimit = 300, batchSize = 500, keysetId, filterSpent = true } = config ?? {};
+    const {
+      gapLimit = 300,
+      batchSize = this.maxRequestLength,
+      keysetId,
+      filterSpent = true,
+    } = config ?? {};
     let counter = config?.counter ?? 0;
     const bound = config?.maxCounter ?? Number.MAX_SAFE_INTEGER;
     const requiredEmptyBatches = Math.ceil(gapLimit / batchSize);
@@ -3400,13 +3415,10 @@ class Wallet {
         ? hashToCurveBls(enc.encode(p.secret)).toHex(true)
         : hashToCurve(enc.encode(p.secret)).toHex(true),
     );
-    // Nutshell (mint_max_request_length) and CDK (max_inputs) both cap requests at 1000 items
-    // by default; half that leaves headroom for stricter operator configs.
-    // TODO: Replace this with a value from the info endpoint of the mint eventually
-    const BATCH_SIZE = 500;
+    const batchSize = this.maxRequestLength;
     const slices: string[][] = [];
-    for (let i = 0; i < Ys.length; i += BATCH_SIZE) {
-      slices.push(Ys.slice(i, i + BATCH_SIZE));
+    for (let i = 0; i < Ys.length; i += batchSize) {
+      slices.push(Ys.slice(i, i + batchSize));
     }
     // Slices are independent, so run them through the bounded pool; results keep slice order.
     const batches = await runPool(slices, BATCH_POOL_SIZE, async (YsSlice) => {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -67,7 +67,7 @@ import {
   sumProofs,
   verifyProofsForReceive,
   ABSOLUTE_MAX_BATCH_SIZE,
-  DEFAULT_MAX_REQUEST_LENGTH,
+  DEFAULT_MAX_ARRAY_LENGTH,
 } from '../utils';
 
 import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
@@ -450,8 +450,8 @@ class Wallet {
    * NUT-06: the mint's advertised cap on the length of any array in a request, used to size the
    * checkstate and restore batches. Falls back to the library default until mint info is loaded.
    */
-  private get maxRequestLength(): number {
-    return this._mintInfo?.maxRequestLength ?? DEFAULT_MAX_REQUEST_LENGTH;
+  private get maxArrayLength(): number {
+    return this._mintInfo?.maxArrayLength ?? DEFAULT_MAX_ARRAY_LENGTH;
   }
 
   /**
@@ -1747,7 +1747,7 @@ class Wallet {
    * @param [config.maxCounter] Inclusive scan ceiling; no counter above it is probed. Default is
    *   unbounded.
    * @param [config.batchSize] Counters per restore request. Defaults to the mint's advertised
-   *   `max_request_length` (NUT-06), or `500` when it advertises none.
+   *   `max_array_length` (NUT-06), or `500` when it advertises none.
    * @param [config.counter=0] Starting counter. Default is `0`
    * @param [config.keysetId] Keyset to restore; defaults to the wallet's.
    * @param [config.filterSpent=true] Drop spent proofs (NUT-07) before returning. Default is `true`
@@ -1757,7 +1757,7 @@ class Wallet {
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
     const {
       gapLimit = 300,
-      batchSize = this.maxRequestLength,
+      batchSize = this.maxArrayLength,
       keysetId,
       filterSpent = true,
     } = config ?? {};
@@ -3415,7 +3415,7 @@ class Wallet {
         ? hashToCurveBls(enc.encode(p.secret)).toHex(true)
         : hashToCurve(enc.encode(p.secret)).toHex(true),
     );
-    const batchSize = this.maxRequestLength;
+    const batchSize = this.maxArrayLength;
     const slices: string[][] = [];
     for (let i = 0; i < Ys.length; i += batchSize) {
       slices.push(Ys.slice(i, i + batchSize));

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -27,8 +27,8 @@ export type BatchRestoreConfig = {
    */
   maxCounter?: number;
   /**
-   * Counters per restore request. Defaults to the mint's advertised `max_request_length` (NUT-06),
-   * or `500` when it advertises none.
+   * Counters per restore request. Defaults to the mint's advertised `max_array_length` (NUT-06), or
+   * `500` when it advertises none.
    */
   batchSize?: number;
   /**

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -27,7 +27,8 @@ export type BatchRestoreConfig = {
    */
   maxCounter?: number;
   /**
-   * Counters per restore request. Default is `500`
+   * Counters per restore request. Defaults to the mint's advertised `max_request_length` (NUT-06),
+   * or `500` when it advertises none.
    */
   batchSize?: number;
   /**

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { Amount } from '../../src/model/Amount';
 import { MintInfo } from '../../src/model/MintInfo';
 import {
-  ABSOLUTE_MAX_REQUEST_LENGTH,
-  DEFAULT_MAX_REQUEST_LENGTH,
+  ABSOLUTE_MAX_ARRAY_LENGTH,
+  DEFAULT_MAX_ARRAY_LENGTH,
   MAX_METHOD_LENGTH,
   MAX_MINT_INFO_LIST,
 } from '../../src/utils/limits';
@@ -935,7 +935,7 @@ describe('MintInfo list caps', () => {
   });
 });
 
-describe('MintInfo max_request_length (NUT-06)', () => {
+describe('MintInfo max_array_length (NUT-06)', () => {
   function mockLogger() {
     return {
       error: vi.fn(),
@@ -950,32 +950,32 @@ describe('MintInfo max_request_length (NUT-06)', () => {
   it('defaults to the library default when the mint advertises none', () => {
     const logger = mockLogger();
     const info = new MintInfo(MINTINFORESP, logger);
-    expect(info.maxRequestLength).toBe(DEFAULT_MAX_REQUEST_LENGTH);
+    expect(info.maxArrayLength).toBe(DEFAULT_MAX_ARRAY_LENGTH);
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('uses an advertised value inside the allowed range', () => {
-    const info = new MintInfo({ ...MINTINFORESP, max_request_length: 1000 });
-    expect(info.maxRequestLength).toBe(1000);
+    const info = new MintInfo({ ...MINTINFORESP, max_array_length: 1000 });
+    expect(info.maxArrayLength).toBe(1000);
   });
 
   it('clamps an advertised value above the internal cap', () => {
     const logger = mockLogger();
     const info = new MintInfo(
-      { ...MINTINFORESP, max_request_length: ABSOLUTE_MAX_REQUEST_LENGTH + 1 },
+      { ...MINTINFORESP, max_array_length: ABSOLUTE_MAX_ARRAY_LENGTH + 1 },
       logger,
     );
-    expect(info.maxRequestLength).toBe(ABSOLUTE_MAX_REQUEST_LENGTH);
+    expect(info.maxArrayLength).toBe(ABSOLUTE_MAX_ARRAY_LENGTH);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('clamped'),
-      expect.objectContaining({ clampedTo: ABSOLUTE_MAX_REQUEST_LENGTH }),
+      expect.objectContaining({ clampedTo: ABSOLUTE_MAX_ARRAY_LENGTH }),
     );
   });
 
   it('raises a zero to 1 so batching still makes progress', () => {
     const logger = mockLogger();
-    const info = new MintInfo({ ...MINTINFORESP, max_request_length: 0 }, logger);
-    expect(info.maxRequestLength).toBe(1);
+    const info = new MintInfo({ ...MINTINFORESP, max_array_length: 0 }, logger);
+    expect(info.maxArrayLength).toBe(1);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('clamped'),
       expect.objectContaining({ advertised: 0, clampedTo: 1 }),
@@ -986,8 +986,8 @@ describe('MintInfo max_request_length (NUT-06)', () => {
     'falls back to the default for a malformed value (%s)',
     (value) => {
       const logger = mockLogger();
-      const info = new MintInfo({ ...MINTINFORESP, max_request_length: value }, logger);
-      expect(info.maxRequestLength).toBe(DEFAULT_MAX_REQUEST_LENGTH);
+      const info = new MintInfo({ ...MINTINFORESP, max_array_length: value }, logger);
+      expect(info.maxArrayLength).toBe(DEFAULT_MAX_ARRAY_LENGTH);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('malformed'),
         expect.objectContaining({ value }),

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { Amount } from '../../src/model/Amount';
 import { MintInfo } from '../../src/model/MintInfo';
-import { MAX_METHOD_LENGTH, MAX_MINT_INFO_LIST } from '../../src/utils/limits';
+import {
+  ABSOLUTE_MAX_REQUEST_LENGTH,
+  DEFAULT_MAX_REQUEST_LENGTH,
+  MAX_METHOD_LENGTH,
+  MAX_MINT_INFO_LIST,
+} from '../../src/utils/limits';
 import { MINTINFORESP } from '../consts';
 
 describe('MintInfo protected endpoint matching', () => {
@@ -928,4 +933,65 @@ describe('MintInfo list caps', () => {
     expect(info.nuts[4]?.methods?.length).toBeGreaterThan(0);
     expect(logger.warn).not.toHaveBeenCalled();
   });
+});
+
+describe('MintInfo max_request_length (NUT-06)', () => {
+  function mockLogger() {
+    return {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+  }
+
+  it('defaults to the library default when the mint advertises none', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(MINTINFORESP, logger);
+    expect(info.maxRequestLength).toBe(DEFAULT_MAX_REQUEST_LENGTH);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('uses an advertised value inside the allowed range', () => {
+    const info = new MintInfo({ ...MINTINFORESP, max_request_length: 1000 });
+    expect(info.maxRequestLength).toBe(1000);
+  });
+
+  it('clamps an advertised value above the internal cap', () => {
+    const logger = mockLogger();
+    const info = new MintInfo(
+      { ...MINTINFORESP, max_request_length: ABSOLUTE_MAX_REQUEST_LENGTH + 1 },
+      logger,
+    );
+    expect(info.maxRequestLength).toBe(ABSOLUTE_MAX_REQUEST_LENGTH);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('clamped'),
+      expect.objectContaining({ clampedTo: ABSOLUTE_MAX_REQUEST_LENGTH }),
+    );
+  });
+
+  it('raises a zero to 1 so batching still makes progress', () => {
+    const logger = mockLogger();
+    const info = new MintInfo({ ...MINTINFORESP, max_request_length: 0 }, logger);
+    expect(info.maxRequestLength).toBe(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('clamped'),
+      expect.objectContaining({ advertised: 0, clampedTo: 1 }),
+    );
+  });
+
+  it.each([-1, 2.5, NaN, 'lots' as unknown as number])(
+    'falls back to the default for a malformed value (%s)',
+    (value) => {
+      const logger = mockLogger();
+      const info = new MintInfo({ ...MINTINFORESP, max_request_length: value }, logger);
+      expect(info.maxRequestLength).toBe(DEFAULT_MAX_REQUEST_LENGTH);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('malformed'),
+        expect.objectContaining({ value }),
+      );
+    },
+  );
 });

--- a/test/wallet/wallet-state.node.test.ts
+++ b/test/wallet/wallet-state.node.test.ts
@@ -93,11 +93,11 @@ describe('checkProofsStates batching', () => {
     });
   });
 
-  test("sizes batches from the mint's advertised max_request_length", async () => {
+  test("sizes batches from the mint's advertised max_array_length", async () => {
     const requestSizes: number[] = [];
     server.use(
       http.get(mintUrl + '/v1/info', () => {
-        return HttpResponse.json({ ...mintInfoResp, max_request_length: 100 });
+        return HttpResponse.json({ ...mintInfoResp, max_array_length: 100 });
       }),
       http.post(mintUrl + '/v1/checkstate', async ({ request }) => {
         const body = (await request.json()) as { Ys: string[] };

--- a/test/wallet/wallet-state.node.test.ts
+++ b/test/wallet/wallet-state.node.test.ts
@@ -3,7 +3,7 @@ import { test, describe, expect } from 'vitest';
 
 import { Wallet, CheckStateEnum, Amount, hashToCurve } from '../../src';
 
-import { mint, unit, mintUrl, useTestServer } from './_setup';
+import { mint, unit, mintUrl, mintInfoResp, useTestServer } from './_setup';
 
 const server = useTestServer();
 
@@ -91,6 +91,55 @@ describe('checkProofsStates batching', () => {
     many.forEach((p, i) => {
       expect(states[i].Y).toBe(hashToCurve(enc.encode(p.secret)).toHex(true));
     });
+  });
+
+  test("sizes batches from the mint's advertised max_request_length", async () => {
+    const requestSizes: number[] = [];
+    server.use(
+      http.get(mintUrl + '/v1/info', () => {
+        return HttpResponse.json({ ...mintInfoResp, max_request_length: 100 });
+      }),
+      http.post(mintUrl + '/v1/checkstate', async ({ request }) => {
+        const body = (await request.json()) as { Ys: string[] };
+        requestSizes.push(body.Ys.length);
+        return HttpResponse.json({
+          states: body.Ys.map((Y) => ({ Y, state: CheckStateEnum.UNSPENT, witness: null })),
+        });
+      }),
+    );
+    const many = Array.from({ length: 250 }, (_, i) => ({
+      id: '00bd033559de27d0',
+      secret: `probe-secret-${i}`,
+    }));
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await wallet.checkProofsStates(many);
+
+    expect(requestSizes.sort((a, b) => b - a)).toEqual([100, 100, 50]);
+  });
+
+  test('falls back to the library default before mint info is loaded', async () => {
+    const requestSizes: number[] = [];
+    server.use(
+      http.post(mintUrl + '/v1/checkstate', async ({ request }) => {
+        const body = (await request.json()) as { Ys: string[] };
+        requestSizes.push(body.Ys.length);
+        return HttpResponse.json({
+          states: body.Ys.map((Y) => ({ Y, state: CheckStateEnum.UNSPENT, witness: null })),
+        });
+      }),
+    );
+    const many = Array.from({ length: 600 }, (_, i) => ({
+      id: '00bd033559de27d0',
+      secret: `unloaded-secret-${i}`,
+    }));
+    // no loadMint(): checkProofsStates needs no keys, so the wallet has no mint info to size from
+    const wallet = new Wallet(mint, { unit });
+
+    await wallet.checkProofsStates(many);
+
+    expect(requestSizes.sort((a, b) => b - a)).toEqual([500, 100]);
   });
 });
 


### PR DESCRIPTION
# NUTS:

- cashubtc/nuts#425

## TL;DR

The wallet sizes its `/v1/checkstate` and `/v1/restore` batches from the mint's advertised [NUT-06](https://github.com/cashubtc/nuts/blob/main/06.md) `max_array_length` instead of a hardcoded 500.

## Changes

- `GetInfoResponse.max_array_length`, normalized in `MintInfo` and exposed as `maxArrayLength`. Missing or malformed falls back to 500; an advertised value is clamped to `[1, 10_000]` with a warning.
- `checkProofsStates` and `batchRestore`'s default `batchSize` both read it.

## Impact

Additive. A mint advertising nothing behaves exactly as before. Swap and melt inputs are not pre-checked against the figure: those arrays cannot be split, so the mint's own error is better than a wallet guess off possibly stale info.

