### PR TITLE
feat(utils): findCashuPayload to locate tokens and payment requests in text

### DIFF
--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -22,14 +22,22 @@ normalizeMintUrl('ftp://mint.example.com'); // throws CTSError
 
 Finds the first token or payment request out of a block of text which could be a chat message, a wallet URL with the token in its fragment, a `bitcoin:` URI carrying a request in a query parameter.
 
-A match is found by prefix and then decoded to verify they are correct, so anything that is not really a payload gets skipped and the scan carries on, because we are looking for a correct payload and not the wrapper. What it finds comes back exactly as it appeared, ready for `getDecodedToken` or `decodePaymentRequest`, or `null` if nothing decodes.
+A match is found by prefix and then decoded to verify they are correct, so anything that is not really a payload gets skipped and the scan carries on, because we are looking for a correct payload and not the wrapper. What it finds comes back as it appeared, apart from bech32m requests, which are lowercased to their canonical form, and you get `null` if nothing decodes.
 
 ```ts
-import { findCashuPayload, getDecodedToken, decodePaymentRequest } from '@cashu/cashu-ts';
+import {
+  findCashuPayload,
+  getTokenMetadata,
+  getDecodedToken,
+  decodePaymentRequest,
+} from '@cashu/cashu-ts';
 
 const found = findCashuPayload(pastedText);
 
 if (found?.kind === 'token') {
+  const meta = getTokenMetadata(found.payload); // mint, unit and amount, no keysets needed
+  // getDecodedToken resolves short keyset IDs against the keysets you pass it, so it throws for a
+  // mint you have not loaded, which is the common case for a stranger's paste.
   const token = getDecodedToken(found.payload, myKeyChain.getAllKeysetIds());
 } else if (found?.kind === 'paymentRequest') {
   const pr = decodePaymentRequest(found.payload);

--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -20,12 +20,9 @@ normalizeMintUrl('ftp://mint.example.com'); // throws CTSError
 
 ## `findCashuPayload`
 
-Finds the first cashu token or payment request inside arbitrary text: a chat message, a clipboard
-blob, a `bitcoin:` URI parameter, a wallet URL fragment. Candidates are matched by prefix and then
-decoded to validate, so a prefix that does not decode is skipped and the search continues. The
-payload is returned exactly as it appeared, ready to hand to `getDecodedToken` or
-`decodePaymentRequest`. Scanning for the payload itself covers the wrapper forms, so there is no
-table of known wallet URL prefixes to maintain.
+Finds the first token or payment request out of a block of text which could be a chat message, a wallet URL with the token in its fragment, a `bitcoin:` URI carrying a request in a query parameter.
+
+A match is found by prefix and then decoded to verify they are correct, so anything that is not really a payload gets skipped and the scan carries on, because we are looking for a correct payload and not the wrapper. What it finds comes back exactly as it appeared, ready for `getDecodedToken` or `decodePaymentRequest`, or `null` if nothing decodes.
 
 ```ts
 import { findCashuPayload, getDecodedToken, decodePaymentRequest } from '@cashu/cashu-ts';
@@ -38,5 +35,3 @@ if (found?.kind === 'token') {
   const pr = decodePaymentRequest(found.payload);
 }
 ```
-
-Returns `null` when the text carries no payload that decodes.

--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -17,3 +17,26 @@ import { normalizeMintUrl } from '@cashu/cashu-ts';
 normalizeMintUrl('https://Mint.Example.COM/'); // 'https://mint.example.com'
 normalizeMintUrl('ftp://mint.example.com'); // throws CTSError
 ```
+
+## `findCashuPayload`
+
+Finds the first cashu token or payment request inside arbitrary text: a chat message, a clipboard
+blob, a `bitcoin:` URI parameter, a wallet URL fragment. Candidates are matched by prefix and then
+decoded to validate, so a prefix that does not decode is skipped and the search continues. The
+payload is returned exactly as it appeared, ready to hand to `getDecodedToken` or
+`decodePaymentRequest`. Scanning for the payload itself covers the wrapper forms, so there is no
+table of known wallet URL prefixes to maintain.
+
+```ts
+import { findCashuPayload, getDecodedToken, decodePaymentRequest } from '@cashu/cashu-ts';
+
+const found = findCashuPayload(pastedText);
+
+if (found?.kind === 'token') {
+  const token = getDecodedToken(found.payload, myKeyChain.getAllKeysetIds());
+} else if (found?.kind === 'paymentRequest') {
+  const pr = decodePaymentRequest(found.payload);
+}
+```
+
+Returns `null` when the text carries no payload that decodes.

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -39,7 +39,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |
 | [Amounts](./amounts.md)                             | Work with the `Amount` and `AmountWithUnit` value objects.                      |
 | [Fees](./fees.md)                                   | Pick the right fee helper: input fees, sender-pays-fees, send-max, NUT-18.      |
-| [Helpers](./helpers.md)                             | Standalone public utility functions — mint URL normalization, token detection.  |
+| [Helpers](./helpers.md)                             | Standalone helpers: normalize mint URLs, find tokens and payment requests.      |
 
 ## Related docs
 

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -39,7 +39,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |
 | [Amounts](./amounts.md)                             | Work with the `Amount` and `AmountWithUnit` value objects.                      |
 | [Fees](./fees.md)                                   | Pick the right fee helper: input fees, sender-pays-fees, send-max, NUT-18.      |
-| [Helpers](./helpers.md)                             | Standalone public utility functions — currently mint URL normalization.         |
+| [Helpers](./helpers.md)                             | Standalone public utility functions — mint URL normalization, token detection.  |
 
 ## Related docs
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -262,6 +262,9 @@ export function buildMintBackupPayload(mints: string[], timestamp: number): stri
 export type CancellerLike = SubscriptionCanceller | Promise<SubscriptionCanceller>;
 
 // @public
+export type CashuPayloadKind = 'token' | 'paymentRequest';
+
+// @public
 export const CheckStateEnum: {
     readonly UNSPENT: "UNSPENT";
     readonly PENDING: "PENDING";
@@ -491,6 +494,12 @@ export type DLEQ = {
 
 // @public (undocumented)
 export type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N ? Acc[number] : Enumerate<N, [...Acc, Acc['length']]>;
+
+// @public
+export function findCashuPayload(text: string): {
+    kind: CashuPayloadKind;
+    payload: string;
+} | null;
 
 // @public
 export function findSigningKey(pubkey: string, privkeys: string | string[]): string;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -33,7 +33,7 @@ import { encodeBase64ToJson, encodeBase64toUint8, encodeUint8toBase64Url } from 
 import { Bytes } from './Bytes';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
-import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_SPLIT_OUTPUTS } from './limits';
+import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_PAYLOAD_LENGTH, MAX_SPLIT_OUTPUTS } from './limits';
 
 /**
  * Splits the amount into denominations of the provided keyset.
@@ -390,23 +390,32 @@ export function getTokenMetadata(token: string): TokenMetadata {
 export type CashuPayloadKind = 'token' | 'paymentRequest';
 
 /**
- * One scanner per payload prefix: a literal prefix plus a single character class, so matching
- * cannot backtrack catastrophically. The base64 class spans both alphabets so it never truncates a
- * real payload, the decoder decides validity. `creqb1` (NUT-26) is matched case-insensitively
- * because QR alphanumeric mode emits the uppercase form.
+ * One scanner per payload prefix: a literal prefix plus a single character-class quantifier, so
+ * matching cannot backtrack catastrophically, bounded by {@link MAX_PAYLOAD_LENGTH} so a hostile run
+ * cannot produce one huge match for the decoders to chew on. Tokens and `creqA` use the base64url
+ * class only, `+` and `/` are excluded deliberately, since `/` lets a token in a URL path swallow
+ * the following segment and the decoders accept the trailing junk rather than reject it. `creqb1`
+ * (NUT-26) uses the bech32 class and is matched case-insensitively because QR alphanumeric mode
+ * emits the uppercase form.
  */
 const PAYLOAD_SCANNERS: ReadonlyArray<{ regExp: RegExp; kind: CashuPayloadKind }> = [
-  { regExp: /cashu[AB][A-Za-z0-9=_-]+/g, kind: 'token' },
-  { regExp: /creqA[A-Za-z0-9=_-]+/g, kind: 'paymentRequest' },
-  { regExp: /creqb1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+/gi, kind: 'paymentRequest' },
+  { regExp: new RegExp(`cashu[AB][A-Za-z0-9=_-]{1,${MAX_PAYLOAD_LENGTH}}`, 'g'), kind: 'token' },
+  {
+    regExp: new RegExp(`creqA[A-Za-z0-9=_-]{1,${MAX_PAYLOAD_LENGTH}}`, 'g'),
+    kind: 'paymentRequest',
+  },
+  {
+    regExp: new RegExp(`creqb1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{1,${MAX_PAYLOAD_LENGTH}}`, 'gi'),
+    kind: 'paymentRequest',
+  },
 ];
 
 /**
- * Finds the first cashu token (v3 or v4) or payment request (`creqA` NUT-18, `creqB` NUT-26)
- * embedded in arbitrary text: chat messages, clipboard blobs, `bitcoin:` URI parameters, wallet URL
- * fragments. Candidates are matched by prefix and then decoded to validate, so a prefix that does
- * not decode is skipped. The match is returned verbatim, ready for {@link getDecodedToken} or
- * `PaymentRequest.fromEncodedRequest`.
+ * Finds the first cashu token (v3 or v4) or payment request (`creqA` NUT-18, `creqb1` / `CREQB1`
+ * NUT-26) embedded in arbitrary text: chat messages, clipboard blobs, `bitcoin:` URI parameters,
+ * wallet URL fragments. Candidates are matched by prefix and then decoded to validate, so a prefix
+ * that does not decode is skipped. The match is returned verbatim, ready for {@link getDecodedToken}
+ * or `PaymentRequest.fromEncodedRequest`.
  *
  * @example
  *

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -33,7 +33,7 @@ import { encodeBase64ToJson, encodeBase64toUint8, encodeUint8toBase64Url } from 
 import { Bytes } from './Bytes';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
-import { MAX_SPLIT_OUTPUTS } from './limits';
+import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_SPLIT_OUTPUTS } from './limits';
 
 /**
  * Splits the amount into denominations of the provided keyset.
@@ -382,6 +382,68 @@ export function getTokenMetadata(token: string): TokenMetadata {
     ...(tokenObj.memo && { memo: tokenObj.memo }),
     proofAmounts: tokenObj.proofs.map((p) => p.amount),
   };
+}
+
+/**
+ * What {@link findCashuPayload} located: a cashu token, or a NUT-18 / NUT-26 payment request.
+ */
+export type CashuPayloadKind = 'token' | 'paymentRequest';
+
+/**
+ * One scanner per payload prefix: a literal prefix plus a single character class, so matching
+ * cannot backtrack catastrophically. The base64 class spans both alphabets so it never truncates a
+ * real payload, the decoder decides validity. `creqb1` (NUT-26) is matched case-insensitively
+ * because QR alphanumeric mode emits the uppercase form.
+ */
+const PAYLOAD_SCANNERS: ReadonlyArray<{ regExp: RegExp; kind: CashuPayloadKind }> = [
+  { regExp: /cashu[AB][A-Za-z0-9=_-]+/g, kind: 'token' },
+  { regExp: /creqA[A-Za-z0-9=_-]+/g, kind: 'paymentRequest' },
+  { regExp: /creqb1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+/gi, kind: 'paymentRequest' },
+];
+
+/**
+ * Finds the first cashu token (v3 or v4) or payment request (`creqA` NUT-18, `creqB` NUT-26)
+ * embedded in arbitrary text: chat messages, clipboard blobs, `bitcoin:` URI parameters, wallet URL
+ * fragments. Candidates are matched by prefix and then decoded to validate, so a prefix that does
+ * not decode is skipped. The match is returned verbatim, ready for {@link getDecodedToken} or
+ * `PaymentRequest.fromEncodedRequest`.
+ *
+ * @example
+ *
+ *     findCashuPayload('paying you back cashuBo2Ft… thanks!');
+ *     // { kind: 'token', payload: 'cashuBo2Ft…' }
+ *
+ * @returns The first valid payload by position, or `null` if the text carries none.
+ */
+export function findCashuPayload(text: string): { kind: CashuPayloadKind; payload: string } | null {
+  let searchFrom = 0;
+  for (let attempts = 0; attempts < MAX_PAYLOAD_DECODE_ATTEMPTS; attempts++) {
+    let earliestMatch: { index: number; text: string; kind: CashuPayloadKind } | null = null;
+    for (const scanner of PAYLOAD_SCANNERS) {
+      // Global regexes resume from lastIndex, so point each one at the current search position.
+      scanner.regExp.lastIndex = searchFrom;
+      const match = scanner.regExp.exec(text);
+      if (match && (earliestMatch === null || match.index < earliestMatch.index)) {
+        earliestMatch = { index: match.index, text: match[0], kind: scanner.kind };
+      }
+    }
+    if (earliestMatch === null) {
+      return null;
+    }
+    try {
+      if (earliestMatch.kind === 'token') {
+        handleTokens(removePrefix(earliestMatch.text));
+      } else {
+        PaymentRequest.fromEncodedRequest(earliestMatch.text);
+      }
+      return { kind: earliestMatch.kind, payload: earliestMatch.text };
+    } catch {
+      // Resume one character into the failed match because another valid
+      // payload may begin inside the same regex match.
+      searchFrom = earliestMatch.index + 1;
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -390,13 +390,13 @@ export function getTokenMetadata(token: string): TokenMetadata {
 export type CashuPayloadKind = 'token' | 'paymentRequest';
 
 /**
- * One scanner per payload prefix: a literal prefix plus a single character-class quantifier, so
- * matching cannot backtrack catastrophically, bounded by {@link MAX_PAYLOAD_LENGTH} so a hostile run
- * cannot produce one huge match for the decoders to chew on. Tokens and `creqA` use the base64url
- * class only, `+` and `/` are excluded deliberately, since `/` lets a token in a URL path swallow
- * the following segment and the decoders accept the trailing junk rather than reject it. `creqb1`
- * (NUT-26) uses the bech32 class and is matched case-insensitively because QR alphanumeric mode
- * emits the uppercase form.
+ * One scanner per payload prefix: a literal prefix plus a single character class, so matching
+ * cannot backtrack catastrophically, capped by {@link MAX_PAYLOAD_LENGTH}. Tokens and `creqA` use
+ * base64url, the alphabet NUT-00 mandates for these payloads. The two characters that separate it
+ * from standard base64 are delimiters in the places people paste tokens, `/` in URL paths and `+`
+ * as a space in query strings, so stopping at them keeps an embedded payload findable instead of
+ * swallowing its surroundings. `creqb1` (NUT-26) uses bech32m, matched case-insensitively because
+ * QR alphanumeric mode uppercases it.
  */
 const PAYLOAD_SCANNERS: ReadonlyArray<{ regExp: RegExp; kind: CashuPayloadKind }> = [
   { regExp: new RegExp(`cashu[AB][A-Za-z0-9=_-]{1,${MAX_PAYLOAD_LENGTH}}`, 'g'), kind: 'token' },
@@ -411,20 +411,26 @@ const PAYLOAD_SCANNERS: ReadonlyArray<{ regExp: RegExp; kind: CashuPayloadKind }
 ];
 
 /**
- * Finds the first cashu token (v3 or v4) or payment request (`creqA` NUT-18, `creqb1` / `CREQB1`
- * NUT-26) embedded in arbitrary text: chat messages, clipboard blobs, `bitcoin:` URI parameters,
- * wallet URL fragments. Candidates are matched by prefix and then decoded to validate, so a prefix
- * that does not decode is skipped. The match is returned verbatim, ready for {@link getDecodedToken}
- * or `PaymentRequest.fromEncodedRequest`.
+ * Finds the first token or payment request out of a block of text, wherever it sits. Covers v3 and
+ * v4 tokens and both request encodings (`creqA` per NUT-18, `creqb1` / `CREQB1` per NUT-26).
+ * Matches are found by prefix and then decoded to check them, so a prefix that is not really a
+ * payload gets skipped. What it finds comes back as it appeared, except for bech32m requests, which
+ * are lowercased to their canonical form. Feed it to {@link getDecodedToken} or
+ * `PaymentRequest.fromEncodedRequest`.
  *
  * @example
  *
  *     findCashuPayload('paying you back cashuBo2Ft… thanks!');
  *     // { kind: 'token', payload: 'cashuBo2Ft…' }
  *
- * @returns The first valid payload by position, or `null` if the text carries none.
+ * @returns The first valid payload by position or `null` if the text carries none, a valid payload
+ *   sits beyond `MAX_PAYLOAD_DECODE_ATTEMPTS` failed candidates, or the only candidate is a
+ *   multi-entry v3 token (unsupported).
  */
 export function findCashuPayload(text: string): { kind: CashuPayloadKind; payload: string } | null {
+  if (typeof text !== 'string') {
+    throw new CTSError('text must be a string');
+  }
   let searchFrom = 0;
   for (let attempts = 0; attempts < MAX_PAYLOAD_DECODE_ATTEMPTS; attempts++) {
     let earliestMatch: { index: number; text: string; kind: CashuPayloadKind } | null = null;
@@ -433,7 +439,12 @@ export function findCashuPayload(text: string): { kind: CashuPayloadKind; payloa
       scanner.regExp.lastIndex = searchFrom;
       const match = scanner.regExp.exec(text);
       if (match && (earliestMatch === null || match.index < earliestMatch.index)) {
-        earliestMatch = { index: match.index, text: match[0], kind: scanner.kind };
+        earliestMatch = {
+          index: match.index,
+          // A case-insensitive scanner emits canonical lowercase (bech32m case carries no data).
+          text: scanner.regExp.flags.includes('i') ? match[0].toLowerCase() : match[0],
+          kind: scanner.kind,
+        };
       }
     }
     if (earliestMatch === null) {

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -70,3 +70,10 @@ export const MAX_MINT_INFO_LIST = 1_024;
  * only construct the divided-down result.
  */
 export const U64_MAX = 2n ** 64n - 1n;
+
+/**
+ * Maximum number of candidate payloads `findCashuPayload` will attempt to decode in one scan.
+ * Prevents pathological input from causing excessive parsing work. Real pastes carry one payload
+ * and a few near-misses, so 16 clears them; scans that exhaust the budget return null.
+ */
+export const MAX_PAYLOAD_DECODE_ATTEMPTS = 16;

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -77,3 +77,13 @@ export const U64_MAX = 2n ** 64n - 1n;
  * and a few near-misses, so 16 clears them; scans that exhaust the budget return null.
  */
 export const MAX_PAYLOAD_DECODE_ATTEMPTS = 16;
+
+/**
+ * Upper bound on the encoded payload a single `findCashuPayload` candidate may span. The scan
+ * quantifiers are bounded by it, so a hostile paste of millions of charset characters yields a
+ * capped candidate instead of one huge match handed to the base64/CBOR decoders, the attempt cap
+ * alone bounds how many candidates are tried, not the cost of each. 256 KiB is ~90x the largest
+ * token in the test tree and holds roughly a thousand proofs, so it clears any real payload; a
+ * longer run is truncated, fails to decode, and the scan moves on.
+ */
+export const MAX_PAYLOAD_LENGTH = 262_144;

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -79,11 +79,11 @@ export const U64_MAX = 2n ** 64n - 1n;
 export const MAX_PAYLOAD_DECODE_ATTEMPTS = 16;
 
 /**
- * Upper bound on the encoded payload a single `findCashuPayload` candidate may span. The scan
- * quantifiers are bounded by it, so a hostile paste of millions of charset characters yields a
- * capped candidate instead of one huge match handed to the base64/CBOR decoders, the attempt cap
- * alone bounds how many candidates are tried, not the cost of each. 256 KiB is ~90x the largest
- * token in the test tree and holds roughly a thousand proofs, so it clears any real payload; a
- * longer run is truncated, fails to decode, and the scan moves on.
+ * How much text a single `findCashuPayload` candidate may cover. The scan quantifiers are bounded
+ * by it, so a hostile paste of millions of charset characters yields a capped candidate rather than
+ * one huge match for the base64/CBOR decoders. {@link MAX_PAYLOAD_DECODE_ATTEMPTS} bounds how many
+ * candidates are tried; this bounds what each one costs. 1 MiB holds several thousand proofs, well
+ * past the largest token a wallet would hand a user, and it cannot go much higher: V8 matches a
+ * bounded quantifier recursively, so a match of a few million characters overflows the stack.
  */
-export const MAX_PAYLOAD_LENGTH = 262_144;
+export const MAX_PAYLOAD_LENGTH = 1_048_576;

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -15,6 +15,7 @@ import { CTSError } from '../../src/model/Errors';
 import * as utils from '../../src/utils';
 import {
   bigIntStringify,
+  findCashuPayload,
   getKeysetAmounts,
   hasValidDleq,
   hexToNumber,
@@ -26,6 +27,7 @@ import {
   sortProofsById,
   normalizeMintUrl,
 } from '../../src/utils';
+import { MAX_PAYLOAD_DECODE_ATTEMPTS } from '../../src/utils/limits';
 import {
   NUT02_V1_VECTOR1_KEYS,
   NUT02_V1_VECTOR2_KEYS,
@@ -368,6 +370,113 @@ describe('test getTokenMetadata', () => {
         Amount.from(1),
       ],
     });
+  });
+});
+
+describe('findCashuPayload', () => {
+  // Payload fixtures reused from the decode tests above and from paymentRequests.test.ts.
+  const V3_TOKEN =
+    'cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
+  const V4_TOKEN =
+    'cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=';
+  const CREQ_A =
+    'creqApGF0gaNhdGVub3N0cmFheKlucHJvZmlsZTFxeTI4d3VtbjhnaGo3dW45ZDNzaGp0bnl2OWtoMnVld2Q5aHN6OW1od2RlbjV0ZTB3ZmprY2N0ZTljdXJ4dmVuOWVlaHFjdHJ2NWhzenJ0aHdkZW41dGUwZGVoaHh0bnZkYWtxcWd5bWRleDNndmZzZnVqcDN4eW43ZTdxcnM4eXlxOWQ4enN1MnpxdWp4dXhjYXBmcXZ6YzhncnFka3RzYWeBgmFuYjE3YWloNDg0MGY1MWVhdWNzYXRhbYFwaHR0cHM6Ly9taW50LmNvbQ==';
+  const CREQ_B_UPPER =
+    'CREQB1QYQQSC3HVYUNQVFHXCPQQZQQQQQQQQQQQQ9QXQQPQQZSQ9MGW368QUE69UHNSVENXVH8XURPVDJN5VENXVUQWQREQYQQZQQZQQSGM6QFA3C8DTZ2FVZHVFQEACMWM0E50PE3K5TFMVPJJMN0VJ7M2TGRQQZSZMSZXYMSXQQHQ9EPGAMNWVAZ7TMJV4KXZ7FWV3SK6ATN9E5K7QCQRGQHY9MHWDEN5TE0WFJKCCTE9CURXVEN9EEHQCTRV5HSXQQSQ9EQ6AMNWVAZ7TMWDAEJUMR0DSRYDPGF';
+  const CREQ_B_LOWER = CREQ_B_UPPER.toLowerCase();
+  // Never decodes; burns one attempt.
+  const DECOY = 'cashuAzz';
+
+  test('finds a bare token', () => {
+    expect(findCashuPayload(V4_TOKEN)).toStrictEqual({ kind: 'token', payload: V4_TOKEN });
+  });
+
+  test('finds a token in prose, excluding trailing punctuation', () => {
+    const found = findCashuPayload(`here you go: ${V4_TOKEN}. thanks!`);
+    expect(found).toStrictEqual({ kind: 'token', payload: V4_TOKEN });
+  });
+
+  test('finds a token in a URL fragment', () => {
+    const found = findCashuPayload(`https://wallet.example/#token=${V4_TOKEN}`);
+    expect(found?.payload).toBe(V4_TOKEN);
+  });
+
+  test('finds a token in a query parameter', () => {
+    const found = findCashuPayload(`https://wallet.example/?token=${V4_TOKEN}&x=1`);
+    expect(found?.payload).toBe(V4_TOKEN);
+  });
+
+  test('finds a token behind a URI scheme', () => {
+    // The wrapper's own "cashu" is followed by ':', not [AB], so it cannot false-anchor.
+    const found = findCashuPayload(`web+cashu://${V4_TOKEN}`);
+    expect(found?.payload).toBe(V4_TOKEN);
+  });
+
+  test('finds a v3 token in prose', () => {
+    const found = findCashuPayload(`old wallet backup ${V3_TOKEN} from 2023`);
+    expect(found).toStrictEqual({ kind: 'token', payload: V3_TOKEN });
+  });
+
+  test('finds a creqA payment request in a bitcoin: URI parameter', () => {
+    const found = findCashuPayload(`bitcoin:bc1qexample?amount=0.001&cashu=${CREQ_A}`);
+    expect(found).toStrictEqual({ kind: 'paymentRequest', payload: CREQ_A });
+  });
+
+  test('finds a lowercase creqb1 payment request', () => {
+    expect(findCashuPayload(`pay me: ${CREQ_B_LOWER}`)).toStrictEqual({
+      kind: 'paymentRequest',
+      payload: CREQ_B_LOWER,
+    });
+  });
+
+  test('finds an uppercase CREQB1 payment request and returns it verbatim', () => {
+    // QR alphanumeric mode emits the uppercase form; it must come back un-normalized.
+    const found = findCashuPayload(`scanned: ${CREQ_B_UPPER}`);
+    expect(found).toStrictEqual({ kind: 'paymentRequest', payload: CREQ_B_UPPER });
+    expect(found?.payload).not.toBe(CREQ_B_LOWER);
+  });
+
+  test('re-enters the scan to find a payload swallowed by a failed candidate', () => {
+    // One unbroken charset run: the greedy cashuA candidate eats it all and fails, so the scan
+    // must resume inside that span rather than past it.
+    const found = findCashuPayload(`cashuAzzzz${V4_TOKEN}`);
+    expect(found).toStrictEqual({ kind: 'token', payload: V4_TOKEN });
+  });
+
+  test('returns the first valid payload by position', () => {
+    expect(findCashuPayload(`${V4_TOKEN} or ${CREQ_A}`)?.payload).toBe(V4_TOKEN);
+    expect(findCashuPayload(`${CREQ_A} or ${V4_TOKEN}`)?.payload).toBe(CREQ_A);
+  });
+
+  test('gives up once the decode attempt cap is exhausted', () => {
+    const decoys = Array(MAX_PAYLOAD_DECODE_ATTEMPTS).fill(DECOY).join(' ');
+    expect(findCashuPayload(`${decoys} ${V4_TOKEN}`)).toBeNull();
+  });
+
+  test('finds a payload on the last attempt within the cap', () => {
+    const decoys = Array(MAX_PAYLOAD_DECODE_ATTEMPTS - 1)
+      .fill(DECOY)
+      .join(' ');
+    expect(findCashuPayload(`${decoys} ${V4_TOKEN}`)?.payload).toBe(V4_TOKEN);
+  });
+
+  test('returns null when there is no payload', () => {
+    expect(findCashuPayload('')).toBeNull();
+    expect(findCashuPayload('just a normal sentence about cashu wallets')).toBeNull();
+  });
+
+  test('does not match an uppercased token prefix', () => {
+    expect(findCashuPayload(`CASHUB${V4_TOKEN.slice('cashuB'.length)}`)).toBeNull();
+  });
+
+  test('finds a token in a URL path without swallowing the next segment', () => {
+    // Regression: with `/` in the charset the match ran on into `/more`, and the decoders accept
+    // the trailing junk instead of rejecting it, so the payload came back corrupted rather than
+    // null. Adding `+` or `/` back must fail here.
+    const found = findCashuPayload(`https://wallet.example/${V4_TOKEN}/more`);
+    expect(found).toStrictEqual({ kind: 'token', payload: V4_TOKEN });
+    expect(findCashuPayload(`https://wallet.example/${V3_TOKEN}/more`)?.payload).toBe(V3_TOKEN);
+    expect(findCashuPayload(`https://wallet.example/${CREQ_A}/more`)?.payload).toBe(CREQ_A);
   });
 });
 

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -27,7 +27,7 @@ import {
   sortProofsById,
   normalizeMintUrl,
 } from '../../src/utils';
-import { MAX_PAYLOAD_DECODE_ATTEMPTS } from '../../src/utils/limits';
+import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_PAYLOAD_LENGTH } from '../../src/utils/limits';
 import {
   NUT02_V1_VECTOR1_KEYS,
   NUT02_V1_VECTOR2_KEYS,
@@ -467,6 +467,17 @@ describe('findCashuPayload', () => {
 
   test('does not match an uppercased token prefix', () => {
     expect(findCashuPayload(`CASHUB${V4_TOKEN.slice('cashuB'.length)}`)).toBeNull();
+  });
+
+  test('bounds a single candidate at MAX_PAYLOAD_LENGTH', () => {
+    // The attempt cap bounds how many candidates are decoded, not the cost of each: without a
+    // bounded quantifier a hostile run hands one enormous match to the base64/CBOR decoders.
+    const hostile = `cashuB${'A'.repeat(MAX_PAYLOAD_LENGTH * 2)}`;
+    const started = Date.now();
+    expect(findCashuPayload(hostile)).toBeNull();
+    expect(Date.now() - started).toBeLessThan(5_000);
+    // A payload sitting after the oversized run is still reachable.
+    expect(findCashuPayload(`${hostile} ${V4_TOKEN}`)?.payload).toBe(V4_TOKEN);
   });
 
   test('finds a token in a URL path without swallowing the next segment', () => {

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -500,6 +500,14 @@ describe('findCashuPayload', () => {
     expect(findCashuPayload(under)).toStrictEqual({ kind: 'token', payload: under });
   });
 
+  test('rejects a candidate carrying a junk suffix', () => {
+    // the decoders reject the trailing bytes rather than
+    // decode the valid prefix and hand back the junk attached.
+    expect(findCashuPayload(`${V4_TOKEN}abc`)).toBeNull();
+    expect(findCashuPayload(`${V3_TOKEN}abc`)).toBeNull();
+    expect(findCashuPayload(`${CREQ_A}abc`)).toBeNull();
+  });
+
   test('finds a token in a URL path without swallowing the next segment', () => {
     // Regression: with `/` in the charset the match ran on into `/more`, and the decoders accept
     // the trailing junk instead of rejecting it, so the payload came back corrupted rather than

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -27,6 +27,7 @@ import {
   sortProofsById,
   normalizeMintUrl,
 } from '../../src/utils';
+import { encodeJsonToBase64 } from '../../src/utils/base64';
 import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_PAYLOAD_LENGTH } from '../../src/utils/limits';
 import {
   NUT02_V1_VECTOR1_KEYS,
@@ -38,6 +39,11 @@ import {
   NUT02_V3_VECTOR2_KEYS,
   PUBKEYS,
 } from '../consts';
+
+const V3_TOKEN =
+  'cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
+const V4_TOKEN =
+  'cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=';
 
 const keys: Keys = {};
 for (let i = 1; i <= 2048; i *= 2) {
@@ -213,9 +219,7 @@ describe('test decode token', () => {
     };
     const uriPrefixes = ['web+cashu://', 'cashu://', 'cashu:'];
     uriPrefixes.forEach((prefix) => {
-      const token =
-        prefix +
-        'cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
+      const token = prefix + V3_TOKEN;
 
       const result = utils.getDecodedToken(token, ['009a1f293253e41e']);
       expect(result).toStrictEqual(obj);
@@ -255,8 +259,7 @@ describe('test decode token', () => {
       ],
     };
 
-    const token =
-      'cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=';
+    const token = V4_TOKEN;
 
     const result = utils.getDecodedToken(token, ['009a1f293253e41e']);
     expect(result).toStrictEqual(v3Token);
@@ -374,11 +377,7 @@ describe('test getTokenMetadata', () => {
 });
 
 describe('findCashuPayload', () => {
-  // Payload fixtures reused from the decode tests above and from paymentRequests.test.ts.
-  const V3_TOKEN =
-    'cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzMzOCIsInByb29mcyI6W3siaWQiOiJJMnlOK2lSWWZrelQiLCJhbW91bnQiOjEsInNlY3JldCI6Ijk3emZtbWFHZjVrOE1nMGdhanBuYm1wZXJ2VHRFZUU4d3dLcmk3cldwVXM9IiwiQyI6IjAyMTk1MDgxZTYyMmY5OGJmYzE5YTA1ZWJlMjM0MWQ5NTVjMGQxMjU4OGM1OTQ4Yzg1OGQwN2FkZWMwMDdiYzFlNCJ9XX1dfQ';
-  const V4_TOKEN =
-    'cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=';
+  // Payment request fixtures copied from paymentRequests.test.ts.
   const CREQ_A =
     'creqApGF0gaNhdGVub3N0cmFheKlucHJvZmlsZTFxeTI4d3VtbjhnaGo3dW45ZDNzaGp0bnl2OWtoMnVld2Q5aHN6OW1od2RlbjV0ZTB3ZmprY2N0ZTljdXJ4dmVuOWVlaHFjdHJ2NWhzenJ0aHdkZW41dGUwZGVoaHh0bnZkYWtxcWd5bWRleDNndmZzZnVqcDN4eW43ZTdxcnM4eXlxOWQ4enN1MnpxdWp4dXhjYXBmcXZ6YzhncnFka3RzYWeBgmFuYjE3YWloNDg0MGY1MWVhdWNzYXRhbYFwaHR0cHM6Ly9taW50LmNvbQ==';
   const CREQ_B_UPPER =
@@ -429,11 +428,16 @@ describe('findCashuPayload', () => {
     });
   });
 
-  test('finds an uppercase CREQB1 payment request and returns it verbatim', () => {
-    // QR alphanumeric mode emits the uppercase form; it must come back un-normalized.
+  test('canonicalises an uppercase CREQB1 payment request to lowercase', () => {
+    // QR alphanumeric mode uppercases; bech32m carries no case, and mixed case is spec-invalid,
+    // so a case-insensitive match is emitted lowercase rather than as it was found.
     const found = findCashuPayload(`scanned: ${CREQ_B_UPPER}`);
-    expect(found).toStrictEqual({ kind: 'paymentRequest', payload: CREQ_B_UPPER });
-    expect(found?.payload).not.toBe(CREQ_B_LOWER);
+    expect(found).toStrictEqual({ kind: 'paymentRequest', payload: CREQ_B_LOWER });
+  });
+
+  test('canonicalises a mixed-case creqb1 payment request to lowercase', () => {
+    const mixed = `Creqb1${CREQ_B_LOWER.slice('creqb1'.length)}`;
+    expect(findCashuPayload(`from a phone: ${mixed}`)?.payload).toBe(CREQ_B_LOWER);
   });
 
   test('re-enters the scan to find a payload swallowed by a failed candidate', () => {
@@ -460,6 +464,11 @@ describe('findCashuPayload', () => {
     expect(findCashuPayload(`${decoys} ${V4_TOKEN}`)?.payload).toBe(V4_TOKEN);
   });
 
+  test('rejects a non-string argument', () => {
+    // Plain-JS callers reach this; exec would otherwise coerce and scan "null".
+    expect(() => findCashuPayload(null as unknown as string)).toThrow(CTSError);
+  });
+
   test('returns null when there is no payload', () => {
     expect(findCashuPayload('')).toBeNull();
     expect(findCashuPayload('just a normal sentence about cashu wallets')).toBeNull();
@@ -470,14 +479,25 @@ describe('findCashuPayload', () => {
   });
 
   test('bounds a single candidate at MAX_PAYLOAD_LENGTH', () => {
-    // The attempt cap bounds how many candidates are decoded, not the cost of each: without a
-    // bounded quantifier a hostile run hands one enormous match to the base64/CBOR decoders.
-    const hostile = `cashuB${'A'.repeat(MAX_PAYLOAD_LENGTH * 2)}`;
-    const started = Date.now();
-    expect(findCashuPayload(hostile)).toBeNull();
-    expect(Date.now() - started).toBeLessThan(5_000);
-    // A payload sitting after the oversized run is still reachable.
-    expect(findCashuPayload(`${hostile} ${V4_TOKEN}`)?.payload).toBe(V4_TOKEN);
+    const paddedToken = (memoLength: number) =>
+      `cashuA${encodeJsonToBase64({
+        token: [
+          {
+            mint: 'http://localhost:3338',
+            proofs: [{ id: 'I2yN+iRYfkzT', amount: 1, secret: 'x', C: '02' }],
+          },
+        ],
+        unit: 'sat',
+        memo: 'm'.repeat(memoLength),
+      })}`;
+
+    const over = paddedToken(MAX_PAYLOAD_LENGTH);
+    expect(over.length).toBeGreaterThan(MAX_PAYLOAD_LENGTH);
+    expect(findCashuPayload(over)).toBeNull();
+
+    const under = paddedToken(MAX_PAYLOAD_LENGTH / 2);
+    expect(under.length).toBeLessThan(MAX_PAYLOAD_LENGTH);
+    expect(findCashuPayload(under)).toStrictEqual({ kind: 'token', payload: under });
   });
 
   test('finds a token in a URL path without swallowing the next segment', () => {
@@ -599,8 +619,7 @@ describe('test keyset derivation', () => {
 
 describe('test v4 encoding', () => {
   test('standard token', async () => {
-    const encodedV4 =
-      'cashuBpGF0gaJhaUgArSaMTR9YJmFwgaNhYQFhc3hAOWE2ZGJiODQ3YmQyMzJiYTc2ZGIwZGYxOTcyMTZiMjlkM2I4Y2MxNDU1M2NkMjc4MjdmYzFjYzk0MmZlZGI0ZWFjWCEDhhhUP_trhpXfStS6vN6So0qWvc2X3O4NfM-Y1HISZ5JhZGlUaGFuayB5b3VhbXVodHRwOi8vbG9jYWxob3N0OjMzMzhhdWNzYXQ=';
+    const encodedV4 = V4_TOKEN;
     const v3Token = {
       memo: 'Thank you',
       mint: 'http://localhost:3338',


### PR DESCRIPTION
## TL;DR

Adds `findCashuPayload(text)`, which locates the first cashu token or payment request inside arbitrary text and returns the encoded payload verbatim. Wallets can drop their hand-rolled URL-prefix tables and regexes.

Fixes #849

## Why

Wallets receive payloads buried in whatever the user pasted: chat messages, clipboard blobs, `bitcoin:` URI parameters, wallet-site URLs. `getDecodedToken` already handles the clean cases (it strips `cashu:`, `cashu://`, `web+cashu://`), but nothing in the library locates a payload inside text that contains other content. Every wallet ends up maintaining its own curated table of known wallet URL prefixes plus a regex, and those tables rot as the ecosystem churns. Scanning for the payload itself subsumes every wrapper form, so there is no per-wallet knowledge to maintain.

## Changes

Two-stage, exactly as specced in #849:

1. **Candidate scan**: one scanner per prefix (`cashuA`/`cashuB`, `creqA`, `creqb1`), each a literal prefix plus a single character-class quantifier. No alternation, no nested quantifiers, so no catastrophic backtracking. `creqb1` (NUT-26) is matched case-insensitively because QR alphanumeric mode emits the uppercase form.
2. **Decode to validate**: `handleTokens` for tokens, `PaymentRequest.fromEncodedRequest` for requests. A regex alone false-positives; the decoder is the authority. First candidate that decodes, by position, wins.

Notes for review:

- **The charset is base64url only (`[A-Za-z0-9=_-]`), not base64.** This is the one place the implementation departs from the issue text, which says "base64/base64url charset". Including `+` and `/` is actively wrong: a token in a URL path (`example.com/cashuB…/more`) has the trailing segment swallowed into the candidate, and base64 decoding ignores what follows the padding while CBOR ignores trailing bytes, so the candidate **decodes successfully** and the payload comes back as `cashuB…/more`. The decoders validate the prefix, not the boundary. The cashu specs are base64url throughout (NUT-00 tokens, NUT-18 `creqA`), so nothing spec-compliant is lost. Regression test pins all three payload types. Happy to revisit if you want the wider charset back.
- **Re-entry on failed decode resumes at `matchIndex + 1`**, not match end, so a payload swallowed inside a failed greedy span is still found, the `cashuB`-inside-`cashuA` example is a test case.
- **Decode-attempt cap**: `MAX_PAYLOAD_DECODE_ATTEMPTS = 16` in `utils/limits.ts`, following the house pattern there. Bounds the adversarial prefix-stuffed case to linear total work. The number is a suggestion and is a one-integer change if needed.
- **Token validation uses the module-private `handleTokens` via `removePrefix`**: keyset-free, and avoids `getDecodedToken`'s 5.0 `keysetIds` requirement, which the finder has no business needing.
- `CashuPayloadKind` is exported as a named alias for `'token' | 'paymentRequest'` so consumers can type against it. Structurally identical to the inline signature in the issue.
- Non-goals honored: no wallet URL table, no multi-match variant, no clipboard/DOM integration, and the returned payload is never normalized (uppercase `CREQB1…` comes back uppercase — test case).

Docs: new section on the Helpers page; the usage-index Helpers row previously named mint URL normalization as the page's only content, so it is broadened.

## Impact

Purely additive, one new function and one new exported type, no existing behavior touched. The API report diff is those two entries and nothing else.
