### PR TITLE
fix(transport): split request option precedence by option class

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -50,6 +50,8 @@ await wallet.loadMint();
 
 Use `setGlobalRequestOptions({ fetch })` when your whole app uses the same mint transport policy.
 
+Precedence depends on the option. Global values for fetch's own `RequestInit` (`cache`, `credentials`, `redirect` etc) are a process-wide transport policy and override the per-request value. Global values for library options (`requestTimeout`, `fetch`, `maxResponseBytes`, `idempotent`, NUT-19 policy) are defaults that a per-request value overrides. Global and per-request `headers` merge, with the per-request value winning per key. The exception is `redirect`, which is always `error` on a request carrying a NUT-21/22 auth header.
+
 Use `customRequest` when you need to replace the entire request pipeline instead of only the fetch-compatible transport.
 
 `requestFetch` only applies to Cashu mint HTTP requests. OIDC discovery and token requests use `oidc.fetch` because they target the identity provider and use OAuth/OIDC request and error semantics.

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -341,12 +341,41 @@ export function parseRetryAfter(header: string | null): number | undefined {
   return undefined;
 }
 
+/**
+ * The options that are library semantics rather than fetch transport config.
+ *
+ * @remarks
+ * Precedence differs by class: a global value for these is only a default and the per-call value
+ * wins, while `RequestInit` fields go the other way (global is an embedder override). Adding an
+ * option to {@link RequestOptions} outside `RequestInit` will not compile until it is listed below.
+ * @internal
+ */
+type PerCallOption = Exclude<keyof RequestOptions, keyof RequestInit>;
+
+const PER_CALL_OPTIONS = {
+  endpoint: true,
+  requestBody: true,
+  logger: true,
+  ttl: true,
+  cached_endpoints: true,
+  requestTimeout: true,
+  maxResponseBytes: true,
+  idempotent: true,
+  onResponseMeta: true,
+  fetch: true,
+} satisfies Record<PerCallOption, true>;
+
 let globalRequestOptions: Partial<RequestOptions> = {};
 let requestLogger = NULL_LOGGER;
 
 /**
- * An object containing any custom settings that you want to apply to the global fetch method.
+ * An object containing any custom settings that you want to apply to every mint request.
  *
+ * @remarks
+ * `RequestInit` fields (`cache`, `credentials`, `mode` etc) override the per-call value: they are
+ * process-wide transport policy. Library options (`requestTimeout`, `fetch`, `maxResponseBytes`,
+ * `idempotent`, NUT-19 policy) are defaults a per-call value overrides. `headers` merge, per-call
+ * wins per key; `redirect` is always `error` on requests carrying auth headers.
  * @param options See possible options here:
  *   https://developer.mozilla.org/en-US/docs/Web/API/fetch#options.
  */
@@ -367,6 +396,7 @@ const MAX_CACHED_RETRIES = 9; // 10 requests total
 const MAX_DELAY = 1000; // 1 sec
 const BASE_DELAY = 100; // 100 ms
 const DEFAULT_MAX_RESPONSE_BYTES = 8_388_608; // 8 MiB; >10x any realistic mint response
+const AUTH_HEADERS = ['blind-auth', 'clear-auth']; // NUT-21/22 tokens, lowercased for comparison
 
 class CallerAbortError extends NetworkError {
   constructor(message: string) {
@@ -571,6 +601,9 @@ async function _request(options: RequestOptions): Promise<unknown> {
   const requestFetch = fetchImpl ?? fetch;
   const body = requestBody ? JSONInt.stringify(requestBody) : undefined;
   const headers = buildRequestHeaders(body, requestHeaders);
+  const carriesAuth = Object.keys(headers).some((name) =>
+    AUTH_HEADERS.includes(name.toLowerCase()),
+  );
   const callerSignal = options.signal ?? undefined;
   if (callerSignal?.aborted) {
     throw new CallerAbortError('Request aborted by caller');
@@ -614,6 +647,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
         referrer: '', // prevent leaking the embedding page URL
         referrerPolicy: 'no-referrer', // belt-and-braces for referrer across all contexts
         ...fetchOptions, // allows override of above options
+        ...(carriesAuth ? { redirect: 'error' as const } : undefined), // not overridable on auth requests
         signal, // not overridable (includes caller signal)
       });
     } catch (err) {
@@ -753,12 +787,11 @@ export default async function request<T>(options: RequestOptions): Promise<T> {
   const perRequest = options.onResponseMeta;
   const globalMeta = globalRequestOptions.onResponseMeta;
   const merged: RequestOptions = { ...options, ...globalRequestOptions };
-
-  // Scoped transports should override the process-wide default.
-  if (options.fetch) merged.fetch = options.fetch;
-
-  // Default: per-request callback only
-  if (perRequest) merged.onResponseMeta = perRequest;
+  for (const key of Object.keys(PER_CALL_OPTIONS) as PerCallOption[]) {
+    if (options[key] !== undefined) (merged as Record<string, unknown>)[key] = options[key];
+  }
+  // Neither side owns the header bag: a global adds app-wide headers, per-call carries auth.
+  merged.headers = { ...globalRequestOptions.headers, ...options.headers };
 
   // Both set: wrap in safeCallback so a throw in one doesn't prevent the other from firing.
   if (perRequest && globalMeta && perRequest !== globalMeta) {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -179,6 +179,109 @@ describe('requests', { timeout: 7500 }, () => {
     }
   });
 
+  test('global RequestInit overrides the per-request value', async () => {
+    let init: Parameters<RequestFetch>[1];
+    const captureFetch = (async (
+      _input: Parameters<RequestFetch>[0],
+      requestInit?: Parameters<RequestFetch>[1],
+    ) => {
+      init = requestInit;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    setGlobalRequestOptions({ redirect: 'follow', cache: 'default' });
+
+    await request({ endpoint: `${mintUrl}/v1/info`, redirect: 'error', fetch: captureFetch });
+
+    expect(init?.redirect).toBe('follow');
+    expect(init?.cache).toBe('default');
+  });
+
+  test('redirect is error on requests carrying auth headers', async () => {
+    let init: Parameters<RequestFetch>[1];
+    const captureFetch = (async (
+      _input: Parameters<RequestFetch>[0],
+      requestInit?: Parameters<RequestFetch>[1],
+    ) => {
+      init = requestInit;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    setGlobalRequestOptions({ redirect: 'follow' });
+
+    await request({
+      endpoint: `${mintUrl}/v1/info`,
+      headers: { 'Blind-auth': 'authABC' },
+      redirect: 'follow',
+      fetch: captureFetch,
+    });
+
+    expect(init?.redirect).toBe('error');
+  });
+
+  test('per-request library options override the global default', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    server.use(
+      http.get(endpoint, async () => {
+        await delay(3000);
+        return HttpResponse.json({ keysets: [] });
+      }),
+    );
+
+    setGlobalRequestOptions({ requestTimeout: 2000 });
+
+    const thrown = await request({ endpoint, requestTimeout: 20, idempotent: false }).catch(
+      (e) => e,
+    );
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 20ms');
+  });
+
+  test('global library options apply when the request does not set them', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    server.use(
+      http.get(endpoint, async () => {
+        await delay(3000);
+        return HttpResponse.json({ keysets: [] });
+      }),
+    );
+
+    setGlobalRequestOptions({ requestTimeout: 20 });
+
+    const thrown = await request({ endpoint, idempotent: false }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 20ms');
+  });
+
+  test('global and per-request headers merge, per-request winning', async () => {
+    let headers: Headers;
+    server.use(
+      http.get(mintUrl + '/v1/keys', ({ request }) => {
+        headers = request.headers;
+        return HttpResponse.json({ keysets: [] });
+      }),
+    );
+
+    setGlobalRequestOptions({ headers: { 'x-app': 'global', 'x-both': 'global' } });
+
+    await request({
+      endpoint: mintUrl + '/v1/keys',
+      headers: { 'x-call': 'per-request', 'x-both': 'per-request' },
+    });
+
+    expect(headers!.get('x-app')).toBe('global');
+    expect(headers!.get('x-call')).toBe('per-request');
+    expect(headers!.get('x-both')).toBe('per-request');
+  });
+
   test('handles HttpResponseError on non-200 response', async () => {
     server.use(
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {


### PR DESCRIPTION
## TL;DR

`setGlobalRequestOptions` values no longer clobber per-call values for library options; precedence now depends on the option class.

## Why

The global options spread last, so a global value won for every key. That is correct for fetch's own `RequestInit` fields (a process-wide transport policy) but wrong for options that are library semantics, which is why `fetch` (#677) and `onResponseMeta` (#596) already needed hand-written exceptions. Surfaced by #963, where a global `requestTimeout` for React Native would clobber any per-call value.

## Changes

- `RequestInit` fields keep global-wins; library options (`requestTimeout`, `fetch`, `maxResponseBytes`, `idempotent`, NUT-19 policy) become defaults that a per-call value overrides. Both existing exceptions retire into this rule.
- A `satisfies` guard on the option-class list means a new `RequestOptions` member fails to compile until it declares its class.
- `headers` now merge (global adds app-wide headers, per-call wins per key) instead of one bag replacing the other.
- `redirect` is always `error` on requests carrying NUT-21/22 auth headers.
- Tests pin both precedence directions; `create_wallet.md` documents the rules.

## Impact

Behaviour changes only when a global and a per-call value are both set for the same library option: the per-call value now wins.