### PR TITLE
fix(wallet): allow minting paid expired quotes

### DIFF
--- a/src/model/types/NUT04.ts
+++ b/src/model/types/NUT04.ts
@@ -68,7 +68,8 @@ export type MintQuoteBaseResponse = {
    */
   updated_at: number | null;
   /**
-   * Timestamp of when the quote expires. `null` when the mint does not set an expiry.
+   * Timestamp until which the payment request can be paid. `null` when the mint does not set an
+   * expiry.
    */
   expiry: number | null;
   /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2281,7 +2281,7 @@ class Wallet {
   /**
    * @internal
    */
-  validateMintQuote(quote: Partial<MintQuoteBaseResponse> & { expiry?: number | null }): void {
+  validateMintQuote(quote: Partial<MintQuoteBaseResponse>): void {
     this.failIf(
       'unit' in quote && typeof quote.unit === 'string' && quote.unit !== this.unit,
       `Quote unit '${quote.unit}' does not match wallet unit '${this.unit}'`,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2286,13 +2286,6 @@ class Wallet {
       'unit' in quote && typeof quote.unit === 'string' && quote.unit !== this.unit,
       `Quote unit '${quote.unit}' does not match wallet unit '${this.unit}'`,
     );
-    this.failIf(
-      'expiry' in quote &&
-        typeof quote.expiry === 'number' &&
-        quote.expiry > 0 && // some mints (e.g. CDK) emit 0 for "no expiry"; spec says null
-        quote.expiry < Math.floor(Date.now() / 1000),
-      `Mint quote has expired`,
-    );
   }
 
   /**

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -434,12 +434,18 @@ describe('validateMintQuote mutants', () => {
   test('expiry does not prevent minting an available quote balance', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
-    const quote = {
+    const quote: MintQuoteBolt11Response = {
       quote: 'expired-paid-quote',
+      request: 'lnbc...',
+      amount: Amount.from(42),
+      unit: 'sat',
+      method: 'bolt11',
+      state: MintQuoteState.PAID,
       expiry: 1,
-      amount_paid: 42,
-      amount_issued: 0,
-    } as unknown as MintQuoteBolt11Response;
+      amount_paid: Amount.from(42),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+    };
 
     await expect(wallet.prepareMint('bolt11', 42, quote)).resolves.toBeDefined();
     await expect(wallet.prepareMint('bolt11', 43, quote)).rejects.toThrow(

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -431,17 +431,20 @@ describe('validateMintQuote mutants', () => {
     ).not.toThrow();
   });
 
-  test('expiry handling: past throws, zero and future are treated as valid', async () => {
+  test('expiry does not prevent minting an available quote balance', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
-    const nowSec = Math.floor(Date.now() / 1000);
+    const quote = {
+      quote: 'expired-paid-quote',
+      expiry: 1,
+      amount_paid: 42,
+      amount_issued: 0,
+    } as unknown as MintQuoteBolt11Response;
 
-    expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec - 100 })).toThrow(
-      'Mint quote has expired',
+    await expect(wallet.prepareMint('bolt11', 42, quote)).resolves.toBeDefined();
+    await expect(wallet.prepareMint('bolt11', 43, quote)).rejects.toThrow(
+      'has only 42 available to mint; requested 43',
     );
-    // 0 means "no expiry" (CDK quirk); a future expiry is still valid.
-    expect(() => wallet.validateMintQuote({ quote: 'q', expiry: 0 })).not.toThrow();
-    expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec + 3600 })).not.toThrow();
   });
 });
 
@@ -1107,29 +1110,6 @@ describe('checkMintQuoteBolt11 mutants', () => {
     await wallet.checkMintQuoteBolt11('str-id');
     await wallet.checkMintQuoteBolt11({ quote: 'obj-id' } as MintQuoteBolt11Response);
     expect(seen).toEqual(['str-id', 'obj-id']);
-  });
-});
-
-describe('validateMintQuote expiry boundary mutants', () => {
-  test('an expiry equal to the current second is not expired', () => {
-    const wallet = new Wallet(mint, { unit });
-    const FIXED_MS = 1_700_000_000_000;
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(FIXED_MS);
-    try {
-      const nowSec = Math.floor(FIXED_MS / 1000);
-      // Spec: expired means strictly in the past. Equal-to-now must pass (a `<=` mutant throws).
-      expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec })).not.toThrow();
-    } finally {
-      nowSpy.mockRestore();
-    }
-  });
-
-  test('a non-number expiry is ignored even if it looks past', () => {
-    const wallet = new Wallet(mint, { unit });
-    // A stringified past expiry must be ignored (a `typeof === 'number'` -> true mutant throws).
-    expect(() =>
-      wallet.validateMintQuote({ quote: 'q', expiry: '100' as unknown as number }),
-    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
# NUT

- https://github.com/cashubtc/nuts/pull/427

## What changed

- Stop rejecting mint quotes solely because their payment-request expiry is in the past.
- Keep enforcing the quote's available balance (`amount_paid - amount_issued`).
- Clarify the `expiry` field documentation.
- Replace the old expiry rejection tests with a regression covering an expired quote with mintable balance.

## Why

NUT-23 defines `expiry` as the deadline for paying the BOLT11 request, not a deadline for issuing ecash after payment. NUT-04 defines the currently mintable amount as `amount_paid - amount_issued`.

The previous wall-clock guard in `Wallet.validateMintQuote` rejected already-paid quotes after their invoice expiry, even when the quote still had mintable balance.

Legacy `state: "PAID"` responses remain supported: quote normalization derives `amount_paid` from `amount` and sets `amount_issued` to zero.

## Impact

Wallets can mint remaining paid balance after the payment request has expired. Requests exceeding the remaining balance are still rejected locally.

## Validation

- `npx vitest run --project node` — 2,389 tests passed
- Focused wallet and mint suites — 238 tests passed
- `npm run check-lint` — passed
- `npm run check-format` — passed
- `npm run api:update` — passed

`npm run check-types` is currently blocked by unrelated existing test mocks that do not implement the newly typed `fetch.preconnect` property. Browser tests could not start on the development host because Playwright system libraries are missing.