### PR TITLE
fix(wallet): allow minting paid expired quotes (v4 backport)

### DIFF
--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2166,7 +2166,7 @@ class Wallet {
   /**
    * @internal
    */
-  validateMintQuote(quote: Partial<MintQuoteBaseResponse> & { expiry?: number | null }): void {
+  validateMintQuote(quote: Partial<MintQuoteBaseResponse>): void {
     this.failIf(
       'unit' in quote && typeof quote.unit === 'string' && quote.unit !== this.unit,
       `Quote unit '${quote.unit}' does not match wallet unit '${this.unit}'`,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2171,13 +2171,6 @@ class Wallet {
       'unit' in quote && typeof quote.unit === 'string' && quote.unit !== this.unit,
       `Quote unit '${quote.unit}' does not match wallet unit '${this.unit}'`,
     );
-    this.failIf(
-      'expiry' in quote &&
-        typeof quote.expiry === 'number' &&
-        quote.expiry > 0 && // some mints (e.g. CDK) emit 0 for "no expiry"; spec says null
-        quote.expiry < Math.floor(Date.now() / 1000),
-      `Mint quote has expired`,
-    );
   }
 
   /**

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -417,13 +417,14 @@ describe('validateMintQuote mutants', () => {
   test('expiry does not prevent minting a paid bolt11 quote', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
-    const quote = {
+    const quote: MintQuoteBolt11Response = {
       quote: 'expired-paid-quote',
+      request: 'lnbc...',
       amount: Amount.from(42),
       unit,
       state: MintQuoteState.PAID,
       expiry: 1,
-    } as unknown as MintQuoteBolt11Response;
+    };
 
     await expect(wallet.prepareMint('bolt11', 42, quote)).resolves.toBeDefined();
   });

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -414,17 +414,18 @@ describe('validateMintQuote mutants', () => {
     ).not.toThrow();
   });
 
-  test('expiry handling: past throws, zero and future are treated as valid', async () => {
+  test('expiry does not prevent minting a paid bolt11 quote', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
-    const nowSec = Math.floor(Date.now() / 1000);
+    const quote = {
+      quote: 'expired-paid-quote',
+      amount: Amount.from(42),
+      unit,
+      state: MintQuoteState.PAID,
+      expiry: 1,
+    } as unknown as MintQuoteBolt11Response;
 
-    expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec - 100 })).toThrow(
-      'Mint quote has expired',
-    );
-    // 0 means "no expiry" (CDK quirk); a future expiry is still valid.
-    expect(() => wallet.validateMintQuote({ quote: 'q', expiry: 0 })).not.toThrow();
-    expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec + 3600 })).not.toThrow();
+    await expect(wallet.prepareMint('bolt11', 42, quote)).resolves.toBeDefined();
   });
 });
 
@@ -1061,29 +1062,6 @@ describe('checkMintQuoteBolt11 mutants', () => {
     await wallet.checkMintQuoteBolt11('str-id');
     await wallet.checkMintQuoteBolt11({ quote: 'obj-id' } as MintQuoteBolt11Response);
     expect(seen).toEqual(['str-id', 'obj-id']);
-  });
-});
-
-describe('validateMintQuote expiry boundary mutants', () => {
-  test('an expiry equal to the current second is not expired', () => {
-    const wallet = new Wallet(mint, { unit });
-    const FIXED_MS = 1_700_000_000_000;
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(FIXED_MS);
-    try {
-      const nowSec = Math.floor(FIXED_MS / 1000);
-      // Spec: expired means strictly in the past. Equal-to-now must pass (a `<=` mutant throws).
-      expect(() => wallet.validateMintQuote({ quote: 'q', expiry: nowSec })).not.toThrow();
-    } finally {
-      nowSpy.mockRestore();
-    }
-  });
-
-  test('a non-number expiry is ignored even if it looks past', () => {
-    const wallet = new Wallet(mint, { unit });
-    // A stringified past expiry must be ignored (a `typeof === 'number'` -> true mutant throws).
-    expect(() =>
-      wallet.validateMintQuote({ quote: 'q', expiry: '100' as unknown as number }),
-    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
# NUT

- https://github.com/cashubtc/nuts/pull/427
 
## What changed

- Remove the wall-clock expiry rejection from `Wallet.validateMintQuote` on v4.
- Add a regression proving a legacy BOLT11 quote with `state: "PAID"` can still be prepared after its invoice expiry.
- Remove boundary tests that defended the incorrect expiry guard.

Backport of #969 for the v4 release line.

## Why

NUT-23 defines `expiry` as the deadline for paying the BOLT11 request, not a deadline for issuing ecash after payment. The previous client-side guard prevented wallets from claiming already-paid quotes after the invoice expiry.

v4 retains its existing BOLT11 behavior of deferring final quote-balance validation to the mint; this backport only removes the incorrect time-based rejection.

## Impact

Wallets on v4 can mint an already-paid BOLT11 quote after the payment request expires.

## Validation

- `npx vitest run --project node` — 2,080 tests passed
- Focused wallet and mint suites — 215 tests passed
- `npm run check-lint` — passed
- `npm run check-format` — passed
- `npm run api:update` — passed

`npm run check-types` is currently blocked by three unrelated existing test mocks that do not implement the newly typed `fetch.preconnect` property. Browser tests remain unavailable on this development host because Playwright system libraries are missing.