### PR TITLE
fix(transport): split request option precedence by option class [backport v4-dev]

### DIFF
--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -244,12 +244,38 @@ export function parseRetryAfter(header: string | null): number | undefined {
   return undefined;
 }
 
+/**
+ * The options that are library semantics rather than fetch transport config.
+ *
+ * @remarks
+ * Precedence differs by class: a global value for these is only a default and the per-call value
+ * wins, while `RequestInit` fields go the other way (global is an embedder override). Adding an
+ * option to {@link RequestOptions} outside `RequestInit` will not compile until it is listed below.
+ * @internal
+ */
+type PerCallOption = Exclude<keyof RequestOptions, keyof RequestInit>;
+
+const PER_CALL_OPTIONS = {
+  endpoint: true,
+  requestBody: true,
+  logger: true,
+  ttl: true,
+  cached_endpoints: true,
+  requestTimeout: true,
+  onResponseMeta: true,
+} satisfies Record<PerCallOption, true>;
+
 let globalRequestOptions: Partial<RequestOptions> = {};
 let requestLogger = NULL_LOGGER;
 
 /**
- * An object containing any custom settings that you want to apply to the global fetch method.
+ * An object containing any custom settings that you want to apply to every mint request.
  *
+ * @remarks
+ * `RequestInit` fields (`cache`, `credentials`, `mode` etc) override the per-call value: they are
+ * process-wide transport policy. Library options (`requestTimeout`, NUT-19 policy) are defaults a
+ * per-call value overrides. `headers` merge, per-call wins per key; `redirect` is always `error` on
+ * requests carrying auth headers.
  * @param options See possible options here:
  *   https://developer.mozilla.org/en-US/docs/Web/API/fetch#options.
  */
@@ -269,6 +295,7 @@ export function setRequestLogger(logger: Logger): void {
 const MAX_CACHED_RETRIES = 9; // 10 requests total
 const MAX_DELAY = 1000; // 1 sec
 const BASE_DELAY = 100; // 100 ms
+const AUTH_HEADERS = ['blind-auth', 'clear-auth']; // NUT-21/22 tokens, lowercased for comparison
 
 class CallerAbortError extends NetworkError {
   constructor(message: string) {
@@ -442,6 +469,9 @@ async function _request(options: RequestOptions): Promise<unknown> {
 
   const body = requestBody ? JSONInt.stringify(requestBody) : undefined;
   const headers = buildRequestHeaders(body, requestHeaders);
+  const carriesAuth = Object.keys(headers).some((name) =>
+    AUTH_HEADERS.includes(name.toLowerCase()),
+  );
   const callerSignal = options.signal ?? undefined;
   if (callerSignal?.aborted) {
     throw new CallerAbortError('Request aborted by caller');
@@ -485,6 +515,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
         referrer: '', // prevent leaking the embedding page URL
         referrerPolicy: 'no-referrer', // belt-and-braces for referrer across all contexts
         ...fetchOptions, // allows override of above options
+        ...(carriesAuth ? { redirect: 'error' as const } : undefined), // not overridable on auth requests
         signal, // not overridable (includes caller signal)
       });
     } catch (err) {
@@ -623,9 +654,11 @@ export default async function request<T>(options: RequestOptions): Promise<T> {
   const perRequest = options.onResponseMeta;
   const globalMeta = globalRequestOptions.onResponseMeta;
   const merged: RequestOptions = { ...options, ...globalRequestOptions };
-
-  // Default: per-request callback only
-  if (perRequest) merged.onResponseMeta = perRequest;
+  for (const key of Object.keys(PER_CALL_OPTIONS) as PerCallOption[]) {
+    if (options[key] !== undefined) (merged as Record<string, unknown>)[key] = options[key];
+  }
+  // Neither side owns the header bag: a global adds app-wide headers, per-call carries auth.
+  merged.headers = { ...globalRequestOptions.headers, ...options.headers };
 
   // Both set: wrap in safeCallback so a throw in one doesn't prevent the other from firing.
   if (perRequest && globalMeta && perRequest !== globalMeta) {

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -110,6 +110,110 @@ describe('requests', { timeout: 7500 }, () => {
     }
   });
 
+  test('global RequestInit overrides the per-request value', async () => {
+    let init: RequestInit | undefined;
+    const captureFetch: typeof fetch = async (_input, requestInit) => {
+      init = requestInit;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    vi.stubGlobal('fetch', captureFetch);
+
+    try {
+      setGlobalRequestOptions({ redirect: 'follow', cache: 'default' });
+
+      await request({ endpoint: `${mintUrl}/v1/info`, redirect: 'error', cache: 'no-cache' });
+
+      expect(init?.redirect).toBe('follow');
+      expect(init?.cache).toBe('default');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('redirect is error on requests carrying auth headers', async () => {
+    let init: RequestInit | undefined;
+    const captureFetch: typeof fetch = async (_input, requestInit) => {
+      init = requestInit;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    vi.stubGlobal('fetch', captureFetch);
+
+    try {
+      setGlobalRequestOptions({ redirect: 'follow' });
+
+      await request({
+        endpoint: `${mintUrl}/v1/info`,
+        headers: { 'Blind-auth': 'authABC' },
+        redirect: 'follow',
+      });
+
+      expect(init?.redirect).toBe('error');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('per-request library options override the global default', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    server.use(
+      http.get(endpoint, async () => {
+        await delay(3000);
+        return HttpResponse.json({ keysets: [] });
+      }),
+    );
+
+    setGlobalRequestOptions({ requestTimeout: 2000 });
+
+    const thrown = await request({ endpoint, requestTimeout: 20 }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 20ms');
+  });
+
+  test('global library options apply when the request does not set them', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    server.use(
+      http.get(endpoint, async () => {
+        await delay(3000);
+        return HttpResponse.json({ keysets: [] });
+      }),
+    );
+
+    setGlobalRequestOptions({ requestTimeout: 20 });
+
+    const thrown = await request({ endpoint }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as Error).message).toContain('Request timed out after 20ms');
+  });
+
+  test('global and per-request headers merge, per-request winning', async () => {
+    let headers: Headers;
+    server.use(
+      http.get(mintUrl + '/v1/keys', ({ request }) => {
+        headers = request.headers;
+        return HttpResponse.json({ keysets: [] });
+      }),
+    );
+
+    setGlobalRequestOptions({ headers: { 'x-app': 'global', 'x-both': 'global' } });
+
+    await request({
+      endpoint: mintUrl + '/v1/keys',
+      headers: { 'x-call': 'per-request', 'x-both': 'per-request' },
+    });
+
+    expect(headers!.get('x-app')).toBe('global');
+    expect(headers!.get('x-call')).toBe('per-request');
+    expect(headers!.get('x-both')).toBe('per-request');
+  });
+
   test('handles HttpResponseError on non-200 response', async () => {
     server.use(
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {


### PR DESCRIPTION
## TL;DR

Backport of #968: `setGlobalRequestOptions` values no longer clobber per-call values for library options; precedence now depends on the option class. Ships as **v4.9.0** via the `Release-As` footer.

## Why

Same as #968 (surfaced by #963): the global spread won every key, which is right for `RequestInit` transport policy but wrong for library semantics. v4's option set is smaller (no per-call `fetch`, `maxResponseBytes` or `idempotent`), so this is a hand-port rather than a cherry-pick.

## Changes

- `RequestInit` fields keep global-wins; library options (`requestTimeout`, `onResponseMeta`, NUT-19 policy) become defaults a per-call value overrides, with a `satisfies` guard so a new option must declare its class.
- `headers` merge (global adds app-wide headers, per-call wins per key).
- `redirect` is always `error` on requests carrying NUT-21/22 auth headers.
- Tests pin both precedence directions; capture tests stub global `fetch` since v4 has no per-call transport.

## Impact

Behaviour changes only when a global and a per-call value are both set for the same library option: the per-call value now wins. Released as a minor (4.9.0) for that reason.

Squash note: keep the `Release-As: 4.9.0` footer in the squash commit and strip the `[backport v4-dev]` title suffix.