### PR TITLE
feat(wallet): add swap preview serialize helpers and persistence docs [backport v4-dev]

### DIFF
--- a/docs-src/usage/nut19.md
+++ b/docs-src/usage/nut19.md
@@ -87,10 +87,13 @@ try {
 
 If the controller aborts, the request fails immediately instead of being retried.
 
-## Persist previews for replay-safe mint and melt flows
+## Persist previews for replay-safe mint, melt and swap flows
 
-NUT-19 helps with transport-level retries, but wallet apps should still persist previews for
-operations that create blinded outputs.
+NUT-19 helps with transport-level retries, but those retries only cover failures inside a
+running process. Wallet apps should also persist previews for operations that create blinded
+outputs: replaying a persisted preview after a restart posts an identical request body, which
+hits the mint's cache and returns the original signatures. The window is bounded by the mint
+advertising the endpoint in `cached_endpoints` and by its TTL.
 
 ### Mint
 
@@ -110,20 +113,54 @@ const proofs = await wallet.completeMint(mintPreview);
 
 ### Melt
 
+A melt keeps a server-side handle (the quote), so the full preview does not need persisting:
+quote state is recoverable from the mint, the inputs are your own proofs, and once the quote
+pays, the NUT-08 change signatures ride on it. Persist the quote id plus the serialized change
+blanks (the only client-side state you cannot rebuild), then reconstruct change with
+`wallet.createMeltChangeProofs` once the quote is paid:
+
 ```ts
+import { OutputData } from '@cashu/cashu-ts';
+
 const meltPreview = await wallet.prepareMelt('bolt11', meltQuote, proofsToSend, {
   includeFees: true,
 });
 
-// Persist an app-defined serialized snapshot here.
-// Do not call JSON.stringify(meltPreview) directly; preview objects contain
-// Amount, bigint, Uint8Array, and class instances that need explicit rehydration.
+// Persist before completing.
+const stored = JSON.stringify({
+  quote: meltQuote.quote,
+  blanks: meltPreview.outputData.map((o) => OutputData.serialize(o)),
+});
+
 const result = await wallet.completeMelt(meltPreview);
 ```
+
+See [Melt § 4 (async melt change recovery)](../wallet_ops/melt.md) for the full
+recover-after-restart lifecycle.
+
+### Swap
+
+```ts
+import { deserializeSwapPreview, serializeSwapPreview } from '@cashu/cashu-ts';
+
+const receivePreview = await wallet.prepareSwapToReceive(token);
+const sendPreview = await wallet.prepareSwapToSend(21, proofs, { includeFees: true });
+
+// Swap previews have a serialize helper: persist the JSON-safe form, then
+// rehydrate it with deserializeSwapPreview to replay after a restart.
+const stored = JSON.stringify(serializeSwapPreview(receivePreview));
+const { keep } = await wallet.completeSwap(deserializeSwapPreview(JSON.parse(stored)));
+```
+
+`completeSwap` builds its request purely from the preview, so a replayed preview posts a
+byte-identical `/v1/swap` body. See [Receive § 5](../wallet_ops/receive.md) and
+[Send § 7](../wallet_ops/send.md) for the full serialize-and-rehydrate round trip.
 
 Use the same pattern with `wallet.ops`:
 
 ```ts
 const mintPreview = await wallet.ops.mintBolt11(64, quoteId).prepare();
 const meltPreview = await wallet.ops.meltBolt11(meltQuote, proofsToSend).prepare();
+const receivePreview = await wallet.ops.receive(token).prepare();
+const sendPreview = await wallet.ops.send(21, myProofs).prepare();
 ```

--- a/docs-src/wallet_ops/receive.md
+++ b/docs-src/wallet_ops/receive.md
@@ -57,3 +57,35 @@ const proofsB = await wallet.ops
   .asCustom(prebuiltRxOutputs) // amounts must sum to final received amount after fees
   .run();
 ```
+
+## 5) Crash-safe receive: persist the preview
+
+A one-shot `run()` that dies between the mint's reply and your storage write has spent the
+inputs without you ever seeing the new proofs. Persisting the preview closes that window:
+`completeSwap` builds its request purely from the preview, so replaying a persisted preview
+posts a byte-identical `/v1/swap` body, and a mint that caches the endpoint (NUT-19) returns
+the original signatures.
+
+```ts
+import { deserializeSwapPreview, serializeSwapPreview } from '@cashu/cashu-ts';
+
+const preview = await wallet.ops.receive(token).prepare();
+
+// Persist before completing. Previews contain Amount, bigint and Uint8Array values,
+// so use the helper rather than calling JSON.stringify(preview) directly.
+const stored = JSON.stringify(serializeSwapPreview(preview));
+
+const { keep } = await wallet.completeSwap(preview);
+
+// ... after a restart: load the mint again, then replay the same preview ...
+const { keep: recovered } = await wallet.completeSwap(deserializeSwapPreview(JSON.parse(stored)));
+```
+
+The replay window has bounds:
+
+- The mint must advertise `/v1/swap` in its NUT-19 `cached_endpoints`, and the replay must
+  happen inside the advertised TTL. See [NUT-19 Cached Responses](../usage/nut19.md).
+- Automatic NUT-19 retries only cover failures inside a running process. The persisted
+  preview is what covers a process restart.
+- A preview and a seed protect different windows: the preview covers a restart inside the
+  TTL; deterministic secrets plus NUT-09 restore cover loss after it.

--- a/docs-src/wallet_ops/send.md
+++ b/docs-src/wallet_ops/send.md
@@ -87,3 +87,40 @@ const { keep, send } = await wallet.ops
 > Offline modes **cannot** be combined with custom output types (`asXXXX/keepAsXXXX`).
 > The builder will throw:
 > `Offline selection cannot be combined with custom output types. Remove send/keep output configuration, or use an online swap.`
+
+## 7) Crash-safe send: persist the preview
+
+A one-shot `run()` that dies between the mint's reply and your storage write has spent the
+inputs without you ever seeing the new proofs. Persisting the preview closes that window:
+`completeSwap` builds its request purely from the preview, so replaying a persisted preview
+posts a byte-identical `/v1/swap` body, and a mint that caches the endpoint (NUT-19) returns
+the original signatures.
+
+```ts
+import { deserializeSwapPreview, serializeSwapPreview } from '@cashu/cashu-ts';
+
+const preview = await wallet.ops.send(21, myProofs).prepare();
+
+// Unselected proofs can go back to storage now; they are not part of the replay.
+const backToStorage = preview.unselectedProofs ?? [];
+
+// Persist before completing. Previews contain Amount, bigint and Uint8Array values,
+// so use the helper rather than calling JSON.stringify(preview) directly.
+const stored = JSON.stringify(serializeSwapPreview(preview));
+
+const { keep, send } = await wallet.completeSwap(preview);
+
+// ... after a restart: load the mint again, then replay the same preview ...
+const { keep: change, send: recovered } = await wallet.completeSwap(
+  deserializeSwapPreview(JSON.parse(stored)),
+);
+```
+
+The replay window has bounds:
+
+- The mint must advertise `/v1/swap` in its NUT-19 `cached_endpoints`, and the replay must
+  happen inside the advertised TTL. See [NUT-19 Cached Responses](../usage/nut19.md).
+- Automatic NUT-19 retries only cover failures inside a running process. The persisted
+  preview is what covers a process restart.
+- A preview and a seed protect different windows: the preview covers a restart inside the
+  TTL; deterministic secrets plus NUT-09 restore cover loss after it.

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -395,6 +395,9 @@ export function deserializeMintKeys(serializedMintKeys: SerializedMintKeys): Raw
 // @public
 export function deserializeProofs(json: string | string[] | ProofLike[]): Proof[];
 
+// @public
+export function deserializeSwapPreview(serialized: SerializedSwapPreview): SwapPreview;
+
 // @public (undocumented)
 export type DeviceStartResponse = {
     device_code: string;
@@ -1864,11 +1867,30 @@ export type SerializedOutputData = {
     ephemeralE?: string;
 };
 
+// @public
+export type SerializedProof = Omit<Proof, 'amount'> & {
+    amount: string;
+};
+
+// @public
+export type SerializedSwapPreview = {
+    amount: string;
+    fees: string;
+    keysetId: string;
+    inputs: SerializedProof[];
+    sendOutputs?: SerializedOutputData[];
+    keepOutputs?: SerializedOutputData[];
+    unselectedProofs?: SerializedProof[];
+};
+
 // @public (undocumented)
 export function serializeMintKeys(mintKeys: RawMintKeys): SerializedMintKeys;
 
 // @public
 export function serializeProofs(proofs: Proof | Proof[]): string[];
+
+// @public
+export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPreview;
 
 // @public
 export function setGlobalRequestOptions(options: Partial<RequestOptions>): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,12 @@ export { KeyChain } from './wallet/KeyChain';
 export { Keyset } from './wallet/Keyset';
 export { P2PKBuilder } from './wallet/P2PKBuilder';
 export { type SelectProofs, selectProofsRGLI, selectProofsRotating } from './wallet/SelectProofs';
+export {
+  serializeSwapPreview,
+  deserializeSwapPreview,
+  type SerializedProof,
+  type SerializedSwapPreview,
+} from './wallet/SwapPreview';
 export { Wallet } from './wallet/Wallet';
 export { WalletCounters } from './wallet/WalletCounters';
 export { WalletEvents } from './wallet/WalletEvents';

--- a/src/wallet/SwapPreview.ts
+++ b/src/wallet/SwapPreview.ts
@@ -1,0 +1,83 @@
+import { Amount } from '../model/Amount';
+import { CTSError } from '../model/Errors';
+import { OutputData, type SerializedOutputData } from '../model/OutputData';
+import type { Proof } from '../model/types/proof';
+import { normalizeProofAmounts } from '../utils';
+
+import { type SwapPreview } from './types/payloads';
+
+/**
+ * A {@link Proof} with its amount as a decimal string; JSON-safe.
+ */
+export type SerializedProof = Omit<Proof, 'amount'> & { amount: string };
+
+/**
+ * JSON-safe representation of a {@link SwapPreview}.
+ */
+export type SerializedSwapPreview = {
+  amount: string;
+  fees: string;
+  keysetId: string;
+  inputs: SerializedProof[];
+  sendOutputs?: SerializedOutputData[];
+  keepOutputs?: SerializedOutputData[];
+  unselectedProofs?: SerializedProof[];
+};
+
+function serializeProof(proof: Proof): SerializedProof {
+  return { ...proof, amount: proof.amount.toString() };
+}
+
+/**
+ * Converts a swap preview to a JSON-safe form for persistence.
+ *
+ * @remarks
+ * Persist the result before `completeSwap` to support NUT-19 replay safety: a preview rehydrated
+ * with {@link deserializeSwapPreview} replays a byte-identical swap request.
+ */
+export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPreview {
+  return {
+    amount: preview.amount.toString(),
+    fees: preview.fees.toString(),
+    keysetId: preview.keysetId,
+    inputs: preview.inputs.map(serializeProof),
+    ...(preview.sendOutputs && {
+      sendOutputs: preview.sendOutputs.map((o) => OutputData.serialize(o)),
+    }),
+    ...(preview.keepOutputs && {
+      keepOutputs: preview.keepOutputs.map((o) => OutputData.serialize(o)),
+    }),
+    ...(preview.unselectedProofs && {
+      unselectedProofs: preview.unselectedProofs.map(serializeProof),
+    }),
+  };
+}
+
+/**
+ * Reconstructs a {@link SwapPreview} from its JSON-safe representation.
+ *
+ * @throws {@link CTSError} If any field fails validation (malformed amounts, proofs, or output
+ *   data).
+ */
+export function deserializeSwapPreview(serialized: SerializedSwapPreview): SwapPreview {
+  try {
+    return {
+      amount: Amount.from(serialized.amount),
+      fees: Amount.from(serialized.fees),
+      keysetId: serialized.keysetId,
+      inputs: normalizeProofAmounts(serialized.inputs),
+      ...(serialized.sendOutputs && {
+        sendOutputs: serialized.sendOutputs.map((s) => OutputData.deserialize(s)),
+      }),
+      ...(serialized.keepOutputs && {
+        keepOutputs: serialized.keepOutputs.map((s) => OutputData.deserialize(s)),
+      }),
+      ...(serialized.unselectedProofs && {
+        unselectedProofs: normalizeProofAmounts(serialized.unselectedProofs),
+      }),
+    };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new CTSError(`Invalid SerializedSwapPreview: ${message}`, { cause: e });
+  }
+}

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -994,7 +994,8 @@ class Wallet {
    *
    * @remarks
    * Allows you to preview fees for a receive, get concrete outputs for P2PK SIG_ALL transactions,
-   * and do any pre-swap tasks (such as marking proofs in-flight etc)
+   * and do any pre-swap tasks (such as marking proofs in-flight etc). Persist this preview
+   * (`serializeSwapPreview`) to support NUT-19 replay safety.
    * @example
    *
    * ```typescript
@@ -1227,7 +1228,8 @@ class Wallet {
    *
    * @remarks
    * Allows you to preview fees for a send, get concrete outputs for P2PK SIG_ALL transactions, and
-   * do any pre-swap tasks (such as marking proofs in-flight etc)
+   * do any pre-swap tasks (such as marking proofs in-flight etc). Persist this preview
+   * (`serializeSwapPreview`) to support NUT-19 replay safety.
    * @example
    *
    * ```typescript

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -4,6 +4,7 @@ export * from './KeyChain';
 export * from './Keyset';
 export * from './P2PKBuilder';
 export * from './SelectProofs';
+export * from './SwapPreview';
 export * from './Wallet';
 export * from './WalletCounters';
 export * from './WalletEvents';

--- a/src/wallet/types/payloads.ts
+++ b/src/wallet/types/payloads.ts
@@ -130,7 +130,8 @@ export type SwapTransaction = {
  * Preview of a swap transaction created by prepareSend / prepareReceive.
  *
  * @remarks
- * Contains JSON-unsafe values (`bigint`, `Uint8Array`). Not intended for direct serialization.
+ * Contains JSON-unsafe values (`bigint`, `Uint8Array`); persist via `serializeSwapPreview` and
+ * rehydrate with `deserializeSwapPreview`.
  */
 export type SwapPreview = {
   /**

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -11,6 +11,7 @@ import {
   type CounterSource,
   serializeSwapPreview,
   deserializeSwapPreview,
+  type SerializedProof,
   type SerializedSwapPreview,
   type Proof,
   type ProofLike,
@@ -336,6 +337,21 @@ describe('send', () => {
       ],
     };
     expect(() => deserializeSwapPreview(bad)).toThrow(CTSError);
+  });
+
+  test('deserializeSwapPreview wraps non-Error throws', () => {
+    const bad: SerializedSwapPreview = {
+      amount: '1',
+      fees: '0',
+      keysetId: '00bd033559de27d0',
+      get inputs(): SerializedProof[] {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- exercising the non-Error path
+        throw 'not-an-error';
+      },
+    };
+    expect(() => deserializeSwapPreview(bad)).toThrow(
+      'Invalid SerializedSwapPreview: not-an-error',
+    );
   });
 
   test('rejects missing DLEQ on swap when mint advertises NUT-12', async () => {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -289,22 +289,25 @@ describe('send', () => {
     const bodies: string[] = [];
     server.use(
       http.post(mintUrl + '/v1/swap', async ({ request }) => {
-        bodies.push(await request.text());
+        const body = await request.text();
+        bodies.push(body);
+        const { outputs } = JSON.parse(body) as { outputs: Array<{ id: string; amount: number }> };
         return HttpResponse.json({
-          signatures: [
-            {
-              id: '00bd033559de27d0',
-              amount: 1,
-              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
-            },
-          ],
+          signatures: outputs.map((o) => ({
+            id: o.id,
+            amount: o.amount,
+            C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+          })),
         });
       }),
     );
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
-    const preview = await wallet.prepareSwapToSend(1, proofs);
+    // A 3-sat input sending 1 produces change, so keepOutputs round trips too.
+    const threeSat: Proof[] = [{ ...proofs[0], amount: Amount.from(3) }];
+    const preview = await wallet.prepareSwapToSend(1, threeSat);
+    expect(preview.keepOutputs?.length).toBeGreaterThan(0);
     const stored = JSON.stringify(serializeSwapPreview(preview));
     const revived = deserializeSwapPreview(JSON.parse(stored) as SerializedSwapPreview);
 

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -9,6 +9,9 @@ import {
   OutputData,
   createEphemeralCounterSource,
   type CounterSource,
+  serializeSwapPreview,
+  deserializeSwapPreview,
+  type SerializedSwapPreview,
   type Proof,
   type ProofLike,
   type OutputConfig,
@@ -280,6 +283,56 @@ describe('send', () => {
     expect(result.send[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
     expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
+  });
+
+  test('swap preview round trips through serialize/deserialize and replays identically', async () => {
+    const bodies: string[] = [];
+    server.use(
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        bodies.push(await request.text());
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareSwapToSend(1, proofs);
+    const stored = JSON.stringify(serializeSwapPreview(preview));
+    const revived = deserializeSwapPreview(JSON.parse(stored) as SerializedSwapPreview);
+
+    const first = await wallet.completeSwap(preview);
+    const replayed = await wallet.completeSwap(revived);
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1]).toBe(bodies[0]);
+    expect(replayed.send).toHaveLength(1);
+    expect(replayed.send[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+    expect(first.send[0].secret).toBe(replayed.send[0].secret);
+  });
+
+  test('deserializeSwapPreview rejects malformed output data', () => {
+    const bad: SerializedSwapPreview = {
+      amount: '1',
+      fees: '0',
+      keysetId: '00bd033559de27d0',
+      inputs: [],
+      sendOutputs: [
+        {
+          blindedMessage: { amount: '1', B_: '02beef', id: '00bd033559de27d0' },
+          blindingFactor: 'not-a-number',
+          secret: 'abcd',
+        },
+      ],
+    };
+    expect(() => deserializeSwapPreview(bad)).toThrow(CTSError);
   });
 
   test('rejects missing DLEQ on swap when mint advertises NUT-12', async () => {


### PR DESCRIPTION
## TL;DR

Backport of #972: `serializeSwapPreview` / `deserializeSwapPreview` plus the swap persistence docs.

## Why

Same as #972 (surfaced by #963): the persist-the-preview pattern was documented for melt but absent for swap, and a swap has no quote to reconcile against after a crash, so the persisted preview is the only handle.

## Changes

Cherry-pick of the main commit with one adaptation: v4's send-test import list also carries `type CounterSource`. Everything else applied as-is, including the docs and the API report (regenerating on v4 produces zero drift).

## Impact

Purely additive API (four new public exports), no behaviour changes; `feat` gives the minor bump alongside the queued 4.9.0.

Squash note: strip the `[backport v4-dev]` title suffix.