### PR TITLE
chore(lint): ban double assertions through unknown/any in src

### DIFF
--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -103,6 +103,7 @@ DEV=1 make nutshell-stable-down
 - Tests are linted too, with a relaxed override block (fixture `any`s allowed, but promise correctness and vitest hygiene — no `.only`, no assertion-free tests — are enforced). `test/tsconfig.json` exists so typed rules cover test files.
 - `npm run check-types` type checks the test tree (and, via its imports, `src/`). Vitest strips types without checking them, so this is the only thing that catches fixtures drifting from the library types.
 - `any` is not allowed (prefer explicit types, generics, or `unknown` with narrowing).
+- No double assertions through `unknown`/`any` in `src/` (`no-restricted-syntax`). Tests are exempt, but reserve casts for deliberately malformed inputs: a fixture that represents a valid protocol object must typecheck without assertions.
 - Type-only imports/exports are required (`@typescript-eslint/consistent-type-imports`).
 - No Node-only modules in library code (`import/no-nodejs-modules`).
 - Empty functions are disallowed (`@typescript-eslint/no-empty-function`).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,6 +81,17 @@ export default tseslint.config(
       'n/no-unsupported-features/node-builtins': ['error', { ignores: ['CloseEvent'] }],
       // Ensure no node-only modules are used (as we support browsers too)
       'import/no-nodejs-modules': ['error'],
+      // Ban double assertions through unknown/any: they hide type drift.
+      // Relaxed for tests below (deliberately malformed fixtures need them).
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'TSAsExpression > TSAsExpression[typeAnnotation.type=/TSUnknownKeyword|TSAnyKeyword/]',
+          message:
+            'No double assertion through unknown/any. Type the value honestly, or eslint-disable with a reason.',
+        },
+      ],
       // Keep imports grouped and alphabetized within groups
       'import/order': [
         'error',
@@ -118,6 +129,9 @@ export default tseslint.config(
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
       ],
+      // Deliberately malformed fixtures need double assertions; valid fixtures
+      // should typecheck without them (reviewed, not linted)
+      'no-restricted-syntax': 'off',
       // mock-socket message types defeat string-ness proofs; runtime is fine
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -505,6 +505,7 @@ function stringify(
         try {
           if (Array.isArray(val)) {
             const parts: string[] = [];
+            // eslint-disable-next-line no-restricted-syntax -- array-as-record view for the shared index walk
             const arrayHolder = val as unknown as Record<string, unknown>;
             for (let i = 0; i < val.length; i += 1) {
               const item = serialize(arrayHolder, String(i));


### PR DESCRIPTION
## TL;DR

Lint now rejects `x as unknown as Y` (and `as any as`) in `src/`. Tests keep their relaxed fixture ergonomics, with the boundary written down in AGENTS-CONTRIBUTING.md.

## Why

A double assertion launders any value into any type, so a fixture or internal object can drift from the real shape without `check-types` noticing. Review of #969 caught one hiding exactly that. A targeted syntax ban keeps the honest escape hatch (`eslint-disable` with a stated reason) visible in diffs.

## Changes

- `no-restricted-syntax` entry in the main lint block matching an `as unknown`/`as any` assertion nested inside another assertion; off in the test override.
- The one existing src occurrence (JSONInt's array-as-record view) gets a reasoned disable.
- AGENTS-CONTRIBUTING.md states the test-side norm: casts are for deliberately malformed inputs; a fixture representing a valid protocol object must typecheck without assertions.

## Impact

None for consumers; dev-time lint only. `src/` has a single (allowed) occurrence, so no code changes.