### PR TITLE
feat(wallet): follow keyset rotations and check melt inputs against the snapshot [backport v4-dev]

### DIFF
--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -1,0 +1,82 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Keysets & Rotation**
+
+# Keysets and mint rotation
+
+A `Wallet` is a snapshot of mint state, taken by `loadMint()` or `loadMintFromCache()`. This
+recipe covers what the snapshot does and does not track on its own, and how to keep a long-lived
+wallet correct as a mint rotates keysets (eg a periodic proof-of-liabilities rotation).
+
+## What never changes on its own
+
+Keyset metadata (active flags, `input_fee_ppk`) and the wallet's bound keyset (`wallet.keysetId`)
+are fixed at snapshot time. The mint can activate, retire, or add keysets between snapshots; the
+wallet keeps reporting what it last saw until something refreshes it.
+
+## What loads lazily
+
+Key material for a keyset id the snapshot already has as metadata may still complete
+asynchronously, inside `receive`, melt change handling, and `restore`. Keys are immutable per
+keyset id and are verified against that id once fetched, so completing them lazily is safe.
+
+This is deliberate: the inactive-keyset set only grows as a mint rotates, so eagerly fetching keys
+for every retired keyset on each `loadMint()` would cost an unbounded series of
+`/v1/keys/{id}` calls. Keys load only for the keysets an operation actually touches.
+
+## Self-repair for an unrecognized keyset id
+
+If an operation meets a proof whose keyset id is not in the snapshot at all, it refreshes once
+internally via `loadMint(true)` and retries. If the id is still unknown afterwards, the operation
+throws `UnknownKeysetError`. The same error is thrown, with the transport failure as `cause`, if
+the refresh itself fails.
+
+The repair runs at most once per operation. It exists to pick up a keyset that rotated in since
+your last `loadMint()`, not to tolerate a proof from an unrelated mint.
+
+This applies to `receive` and melt change: both resolve unrecognized keyset ids through this path.
+`restore` fetches keys directly and does not go through it, so an unknown keyset id there throws a
+plain `CTSError` with no retry.
+
+## Refreshing deliberately: `loadMint(true)`
+
+Call `loadMint(true)` yourself to follow a mint proactively, for example on a schedule in a
+long-lived service. It:
+
+- refreshes metadata (active flags, fees) from the mint,
+- keeps whatever keys the wallet already holds, rather than re-fetching them,
+- rebinds an auto-bound wallet (constructed without `keysetId`, never `bindKeyset()`-ed) to the
+  cheapest active keyset, but only once its current one is no longer usable (missing, inactive, or
+  without keys). A still-usable binding is left alone even if a cheaper keyset is now active.
+
+A wallet pinned via the `keysetId` constructor option or a `bindKeyset()` call stays pinned across
+the refresh, even if its keyset has since gone inactive.
+
+## Keeping a cache in sync
+
+Subscribe to `wallet.on.keychainUpdated` to re-persist your cached keychain when `receive` or melt
+change completion lazily loads keys or repairs an unrecognized keyset id:
+
+```ts
+wallet.on.keychainUpdated(({ cache }) => {
+  saveKeychainToDb(cache); // your atomic save, e.g. IndexedDB or a KV store
+});
+```
+
+This event does not fire for `restore`'s own lazy key fetch, or for your own explicit
+`loadMint()` / `loadMint(true)` calls: persist `wallet.keyChain.cache` yourself after those (see
+[Create Wallet](./create_wallet.md)).
+
+## Long-lived wallets
+
+A wallet that stays in memory across a mint rotation does not need proactive maintenance: the next
+`receive` or melt change that meets an unrecognized keyset id repairs itself. Call `loadMint(true)`
+yourself when you want the wallet to reflect a rotation ahead of that, eg to keep
+`wallet.getMintInfo()` current, or to rebind sooner once your current keyset stops being usable
+rather than waiting for an operation to force the issue.
+
+## Related docs
+
+- [Create Wallet](./create_wallet.md) for `loadMint()` / `loadMintFromCache()` and initial setup.
+- [WalletEvents](../wallet_events/wallet_events.md) for subscription patterns (`signal`, timeouts,
+  grouping).
+- Rotation behavior end to end:
+  [`wallet-rotation.node.test.ts`](https://github.com/cashubtc/cashu-ts/blob/main/test/wallet/wallet-rotation.node.test.ts).

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -100,4 +100,4 @@ waiting for an operation to force the issue.
 - [WalletEvents](../wallet_events/wallet_events.md) for subscription patterns (`signal`, timeouts,
   grouping).
 - Rotation behavior end to end:
-  [`wallet-rotation.node.test.ts`](https://github.com/cashubtc/cashu-ts/blob/main/test/wallet/wallet-rotation.node.test.ts).
+  [`wallet-rotation.node.test.ts`](https://github.com/cashubtc/cashu-ts/blob/v4-dev/test/wallet/wallet-rotation.node.test.ts).

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -26,8 +26,10 @@ the wallet heals, you decide what to do next.
 **An unknown keyset id.** A proof names a keyset the snapshot has never seen. Every op that reads
 input proof ids (`receive`, `send` and `prepareSwapToSend`, `prepareMelt` and the `meltProofs*`
 wrappers) and melt change refresh once, then throw `UnknownKeysetError` if the id is still unknown
-(or if the refresh itself failed, with that failure as `cause`). `restore` does not take this path:
-an unknown id there throws a plain `CTSError`.
+(or if the refresh itself failed, with that failure as `cause`). One exception: bolt11/bolt12 melts
+never consult the input keyset (no keys, no fee metadata), so an id the mint delisted but still
+honors proceeds with a warning instead of refusing. `restore` does not take this path: an unknown
+id there throws a plain `CTSError`.
 
 `UnknownKeysetError.refreshed` says how much weight to give it:
 
@@ -123,16 +125,22 @@ takes its fee reserve from `sendAmount - quote.amount` and nothing else, so a bo
 of proofs on an id the wallet did not hold went through regardless, with NUT-08 blanks bound to a
 stale keyset. `meltProofsOnchain` does price its inputs, and failed on the way with a raw
 `Could not get fee. No keyset found for keyset id: X`. All of them now resolve their input ids
-first, exactly as `receive` does, and refuse an id the mint does not know with
-`UnknownKeysetError`.
+first, exactly as `receive` does.
 
-Melting proofs from an external or restored source, on a wallet whose snapshot may predate them,
-means bringing the snapshot up to date first:
+What follows depends on the method. `meltProofsOnchain` prices its inputs from the keyset's
+`input_fee_ppk`, so an id the mint does not know throws `UnknownKeysetError`. bolt11 and bolt12
+never consult the input keyset at all, so an id still unknown after the refresh proceeds with a
+warning: whether a keyset it no longer lists is still honored is the mint's call, and refusing
+would leave those proofs with no way out. Strict mode still refuses, having never asked.
+
+Most callers need no change: the refresh finds the rotated-in keyset and the melt proceeds. If the
+mint has pruned the keyset outright, bolt11 and bolt12 melts still work; an onchain melt needs the
+snapshot brought up to date first:
 
 ```ts
 // Refresh, or resolve just the ids you are about to spend
 await wallet.ensureOperableKeysets(proofs.map((p) => p.id));
-await wallet.meltProofsBolt11(quote, proofs);
+await wallet.meltProofsOnchain(quote, proofs, feeIndex);
 ```
 
 `loadMint(true)` does the same job wholesale. Under `strictCachedKeysets` nothing is fetched for

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -65,6 +65,25 @@ This event does not fire for `restore`'s own lazy key fetch, or for your own exp
 `loadMint()` / `loadMint(true)` calls: persist `wallet.keyChain.cache` yourself after those (see
 [Create Wallet](./create_wallet.md)).
 
+## Strict cached keysets
+
+Set `strictCachedKeysets: true` in the `Wallet` constructor options if you run your own
+persistence or state layer (eg a coco-style wallet) and want CTS to operate only on the keyset
+state you load, with no network call happening behind your back. With it set, operations never
+call `/v1/keysets` or `/v1/keys` on their own; the only calls that touch the network are the ones
+you make yourself (`loadMint`, `loadMint(true)`, `keyChain.ensureKeysetKeys`). An unrecognized
+keyset id throws `UnknownKeysetError` immediately, with no repair attempt; a known keyset with
+missing keys throws the same typed errors non-strict mode throws once its own repair path is
+exhausted (eg `No keys loaded for keyset X` from receive, or `Keyset has no keys loaded` from
+`restore`). `keychainUpdated` never fires under strict mode, since nothing internal mutates the
+snapshot. Use `keyChain.ensureKeysetKeys(id)` or `loadMint(true)` to refresh deliberately; those
+keep their normal semantics, including `loadMint(true)`'s carry-forward and rebind rules.
+`restore` and `batchRestore` throw on a keyset without loaded keys under strict mode, so restoring
+across a rotation needs `keyChain.ensureKeysetKeys` called for each keyset first (or a fresh
+`loadMint`). Melt change that arrives on a keyset your snapshot holds keyless throws after the mint
+has already spent the inputs; recover with the persisted `outputData` plus an explicit
+`ensureKeysetKeys` and `createMeltChangeProofs` call, as documented on that method.
+
 ## Long-lived wallets
 
 A wallet that stays in memory across a mint rotation does not need proactive maintenance: the next

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -41,8 +41,8 @@ plain `CTSError` with no retry.
 Call `loadMint(true)` yourself to follow a mint proactively, for example on a schedule in a
 long-lived service. It:
 
-- refreshes metadata (active flags, fees) from the mint,
-- keeps whatever keys the wallet already holds, rather than re-fetching them,
+- refreshes metadata (active flags, fees) from the mint, re-fetching keys for active keysets,
+- keeps the keys the wallet already holds for any keyset the mint no longer serves,
 - rebinds an auto-bound wallet (constructed without `keysetId`, never `bindKeyset()`-ed) to the
   cheapest active keyset, but only once its current one is no longer usable (missing, inactive, or
   without keys). A still-usable binding is left alone even if a cheaper keyset is now active.

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -2,55 +2,41 @@
 
 # Keysets and mint rotation
 
-A `Wallet` is a snapshot of mint state, taken by `loadMint()` or `loadMintFromCache()`. This
-recipe covers what the snapshot does and does not track on its own, and how to keep a long-lived
-wallet correct as a mint rotates keysets (eg a periodic proof-of-liabilities rotation).
+A `Wallet` is a snapshot of mint state, taken by `loadMint()` or `loadMintFromCache()`. Mints
+rotate keysets (monthly, under proof-of-liabilities schemes), so snapshots go stale. This page is
+what the wallet does about that.
 
-## What never changes on its own
+## The snapshot
 
-Keyset metadata (active flags, `input_fee_ppk`) and the wallet's bound keyset (`wallet.keysetId`)
-are fixed at snapshot time. The mint can activate, retire, or add keysets between snapshots; the
-wallet keeps reporting what it last saw until something refreshes it.
+| Part of the snapshot                    | Changes on its own?                           |
+| --------------------------------------- | --------------------------------------------- |
+| Metadata: active flags, `input_fee_ppk` | No. Only on `loadMint(true)` or a repair.     |
+| Bound keyset (`wallet.keysetId`)        | No, same.                                     |
+| Keys for a keyset the snapshot knows    | Yes, fetched on demand by ops that need them. |
 
-## What loads lazily
+Keys load lazily because the retired-keyset set only grows: fetching every one up front would cost
+an unbounded series of `/v1/keys/{id}` calls per load. Keys are immutable per keyset id and
+verified against it, so loading them late is safe.
 
-Key material for a keyset id the snapshot already has as metadata may still complete
-asynchronously, inside `receive`, melt change handling, and `restore`. Keys are immutable per
-keyset id and are verified against that id once fetched, so completing them lazily is safe.
+## When the wallet repairs itself
 
-This is deliberate: the inactive-keyset set only grows as a mint rotates, so eagerly fetching keys
-for every retired keyset on each `loadMint()` would cost an unbounded series of
-`/v1/keys/{id}` calls. Keys load only for the keysets an operation actually touches.
+Two things count as evidence that a rotation happened. Both refresh the snapshot once, then throw:
+the wallet heals, you decide what to do next.
 
-## Self-repair for an unrecognized keyset id
+**An unknown keyset id.** A proof names a keyset the snapshot has never seen. `receive` and melt
+change refresh once, then throw `UnknownKeysetError` if the id is still unknown (or if the refresh
+itself failed, with that failure as `cause`). `restore` does not take this path: an unknown id
+there throws a plain `CTSError`.
 
-If an operation meets a proof whose keyset id is not in the snapshot at all, it refreshes once
-internally via `loadMint(true)` and retries. If the id is still unknown afterwards, the operation
-throws `UnknownKeysetError`. The same error is thrown, with the transport failure as `cause`, if
-the refresh itself fails.
+**A mint rejection.** Your snapshot still calls a retired keyset active, so outputs get built on
+it and only the mint knows better. `completeSwap`, `completeMint`, `completeBatchMint` and
+`completeMelt` treat a NUT-00 keyset error (the 12xxx class) as evidence: they refresh, then throw
+`StaleKeysetError` with the mint's error as `cause`.
 
-The repair runs at most once per operation. It exists to pick up a keyset that rotated in since
-your last `loadMint()`, not to tolerate a proof from an unrelated mint.
+`StaleKeysetError.repaired` tells you what to do:
 
-This applies to `receive` and melt change: both resolve unrecognized keyset ids through this path.
-`restore` fetches keys directly and does not go through it, so an unknown keyset id there throws a
-plain `CTSError` with no retry.
-
-## Self-repair when the mint rejects a keyset
-
-A wallet loaded before a rotation has nothing unrecognized to trip the repair above: its snapshot
-still calls the retired keyset active, so it builds outputs on it and the mint is the only party
-that knows better. When `completeSwap`, `completeMint`, `completeBatchMint`, or `completeMelt` is
-rejected with a NUT-00 keyset error (the 12xxx class: unknown, inactive, or expired keyset), the
-wallet takes that as rotation evidence, refreshes the snapshot, and throws `StaleKeysetError` with
-the mint's error as `cause`.
-
-Its `repaired` flag says whether the refresh actually ran. `true` means the snapshot is current
-again, so running your call a second time should succeed (a 12001 caused by an input proof from
-another mint refreshes cleanly and still fails). `false` means nothing changed (strict mode, a
-failed refresh, or the rate limit below) and the next move is yours. Nothing retries for you: the
-rejected outputs were built on the stale keyset, so the wallet heals the snapshot and hands the
-decision back.
+- **`true`** - snapshot is current again, run your call a second time.
+- **`false`** - nothing changed (strict mode, failed refresh, or rate limit). Your move.
 
 ```ts
 try {
@@ -61,21 +47,25 @@ try {
 }
 ```
 
-The same shape applies to the split flow: re-run your `prepare*` before completing again, since the
-outputs in hand are the rejected ones. On a seeded wallet that reserves fresh counters; the
-abandoned ones are recoverable with a NUT-09 restore.
+Using the split flow? Re-run your `prepare*` too: the outputs in hand are the rejected ones. On a
+seeded wallet that reserves fresh counters, and the abandoned ones are recoverable with a NUT-09
+restore.
 
-### Upgrading an existing handler
+One caveat on `repaired: true`: a 12001 caused by an input proof from a different mint also
+refreshes cleanly, and your retry will still fail.
 
-If you already branch on the 12xxx codes, your catch stops matching. Code that tested
-`isMintOperationError(e) && e.code === 12002`, or `e instanceof MintOperationError`, around
-`completeSwap`, `completeMint`, `completeBatchMint` or `completeMelt` now needs to test for
-`StaleKeysetError`. The mint's own error survives as `e.cause`, so whatever you read off it still
-reads the same from there.
+**Rate limit.** One repair per minute per wallet. Inside the window the wallet skips the refresh
+and throws immediately, so a service fed junk keyset ids cannot be turned into a stream of mint
+requests. Calls you make yourself are never rate limited.
 
-The class changes as well as the name. `MintOperationError` extends `HttpResponseError` and carries
-`status`; `StaleKeysetError` extends `CTSError` directly and does not. A handler reading `e.status`
-should read it from the cause instead:
+## Upgrading an existing handler
+
+Already branching on the 12xxx codes? That catch stops matching. A test for
+`isMintOperationError(e) && e.code === 12002`, or `e instanceof MintOperationError`, around the
+four complete-side ops now needs `StaleKeysetError`. The mint's error is still there as `e.cause`.
+
+The class changes too. `MintOperationError` extends `HttpResponseError` and carries `status`;
+`StaleKeysetError` extends `CTSError` and does not. Read both `code` and `status` off the cause.
 
 ```ts
 // Before
@@ -87,85 +77,78 @@ if (e instanceof StaleKeysetError && isMintOperationError(e.cause) && e.cause.co
 }
 ```
 
-### Repair rate limit
+## Refreshing on purpose
 
-Internal repairs are limited to one per minute per wallet. Inside that window the wallet skips the
-refresh and throws the terminal error immediately (`UnknownKeysetError`, or `StaleKeysetError`
-with `repaired: false`), so a service fed a stream of junk keyset ids cannot be turned into a
-stream of outbound mint requests. Refreshes you ask for yourself are never rate limited, though a
-repair triggered by `ensureOperableKeysets()` does start the window for the next internal one;
-`loadMint(true)` does not, since it never goes through the repair path.
+### `loadMint(true)`
 
-## Preparing the snapshot yourself: `ensureOperableKeysets`
+Follows the mint. Refreshes metadata, re-fetches keys for active keysets, and:
 
-`await wallet.ensureOperableKeysets(ids)` runs the same repair on demand: unknown ids get one
-`loadMint(true)`, keysets held without keys get theirs fetched, and an id the mint does not know
-throws `UnknownKeysetError`. Useful for integrations that verify proofs, or reconstruct persisted
-`outputData`, without running a wallet operation.
+- keeps keys it already holds for keysets the mint no longer serves,
+- rebinds an **auto-bound** wallet to the cheapest active keyset (newest version, then lowest fee,
+  then latest expiry),
+- leaves a **pinned** wallet alone (`keysetId` constructor option or `bindKeyset()`), even if its
+  keyset went inactive.
 
-Because it is an explicit request, it ignores both `strictCachedKeysets` and the repair rate limit:
-strict mode exists to stop network calls you did not ask for, and this is one you did. For the same
-reason it emits no `keychainUpdated`, so persist `wallet.keyChain.cache` yourself afterwards. It
-needs a loaded wallet, and says so rather than quietly doing nothing.
+### `ensureOperableKeysets(ids)`
 
-## Refreshing deliberately: `loadMint(true)`
+```ts
+await wallet.ensureOperableKeysets(proofs.map((p) => p.id));
+```
 
-Call `loadMint(true)` yourself to follow a mint proactively, for example on a schedule in a
-long-lived service. It:
+Runs the repair on demand: unknown ids get one refresh, keysets held without keys get theirs
+fetched, an id the mint does not know throws `UnknownKeysetError`. For integrations that verify
+proofs or reconstruct persisted `outputData` without running a wallet operation.
 
-- refreshes metadata (active flags, fees) from the mint, re-fetching keys for active keysets,
-- keeps the keys the wallet already holds for any keyset the mint no longer serves,
-- rebinds an auto-bound wallet (constructed without `keysetId`, never `bindKeyset()`-ed) to the
-  cheapest active keyset on every refresh, including the internal repair (newest keyset version
-  first, then lowest fee, then latest expiry).
-
-A wallet pinned via the `keysetId` constructor option or a `bindKeyset()` call stays pinned across
-the refresh, even if its keyset has since gone inactive.
+Being explicit, it ignores `strictCachedKeysets` and the rate limit, and emits no
+`keychainUpdated`. Persist `wallet.keyChain.cache` yourself afterwards. It needs a loaded wallet
+and throws if it does not have one.
 
 ## Keeping a cache in sync
 
-Subscribe to `wallet.on.keychainUpdated` to re-persist your cached keychain when `receive` or melt
-change completion lazily loads keys or repairs an unrecognized keyset id:
-
 ```ts
 wallet.on.keychainUpdated(({ cache }) => {
-  saveKeychainToDb(cache); // your atomic save, e.g. IndexedDB or a KV store
+  saveKeychainToDb(cache); // your atomic save, eg IndexedDB or a KV store
 });
 ```
 
-This event does not fire for `restore`'s own lazy key fetch, or for calls you make yourself
-(`loadMint()`, `loadMint(true)`, `ensureOperableKeysets()`): persist `wallet.keyChain.cache`
-yourself after those (see [Create Wallet](./create_wallet.md)).
+Fires when an operation loads keys or repairs the snapshot on its own. It does **not** fire for
+`restore`'s key fetch or for calls you make yourself (`loadMint()`, `loadMint(true)`,
+`ensureOperableKeysets()`) - persist after those yourself. See
+[Create Wallet](./create_wallet.md).
 
-## Strict cached keysets
+## Strict mode
 
-Set `strictCachedKeysets: true` in the `Wallet` constructor options if you run your own
-persistence or state layer (eg a coco-style wallet) and want CTS to operate only on the keyset
-state you load, with no network call happening behind your back. With it set, operations never
-call `/v1/keysets` or `/v1/keys` on their own; the only calls that touch the network are the ones
-you make yourself (`loadMint`, `loadMint(true)`, `keyChain.ensureKeysetKeys`,
-`ensureOperableKeysets`). An unrecognized keyset id throws `UnknownKeysetError` immediately, with
-no repair attempt; a known keyset with missing keys throws the same typed errors non-strict mode
-throws once its own repair path is exhausted (eg `No keys loaded for keyset X` from receive, or
-`Keyset has no keys loaded` from `restore`). A mint rejecting a keyset mid-operation throws
-`StaleKeysetError` with `repaired: false`, since strict mode does not refresh on its own.
-`keychainUpdated` never fires under strict mode, since nothing internal mutates the snapshot. Use
-`keyChain.ensureKeysetKeys(id)` or `loadMint(true)` to refresh deliberately; those keep their
-normal semantics, including `loadMint(true)`'s carry-forward and rebind rules. `restore` and
-`batchRestore` throw on a keyset without loaded keys under strict mode, so restoring across a
-rotation needs `keyChain.ensureKeysetKeys` called for each keyset first (or a fresh `loadMint`).
-Melt change that arrives on a keyset your snapshot holds keyless throws after the mint has already
-spent the inputs; recover with the persisted `outputData` plus an explicit `ensureKeysetKeys` and
-`createMeltChangeProofs` call, as documented on that method. Wallets created with `withKeyset()`
-inherit the strict flag from their parent, so derived wallets respect the same network constraints.
+```ts
+const wallet = new Wallet(mintUrl, { strictCachedKeysets: true });
+```
+
+For apps with their own persistence or state layer (eg coco-style) that want no network call
+happening behind their back. Operations never call `/v1/keysets` or `/v1/keys` on their own; only
+your calls do (`loadMint`, `loadMint(true)`, `keyChain.ensureKeysetKeys`, `ensureOperableKeysets`).
+
+What changes:
+
+| Situation                    | Strict behavior                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------- |
+| Unknown keyset id            | `UnknownKeysetError` immediately, no repair attempt.                            |
+| Known keyset, no keys loaded | `No keys loaded for keyset X` (receive), `Keyset has no keys loaded` (restore). |
+| Mint rejects a keyset        | `StaleKeysetError` with `repaired: false`.                                      |
+| `keychainUpdated`            | Never fires: nothing internal mutates the snapshot.                             |
+| `withKeyset()` derivatives   | Inherit the flag.                                                               |
+
+Two things to plan for:
+
+- `restore` and `batchRestore` throw on a keyset without loaded keys. Call
+  `keyChain.ensureKeysetKeys` per keyset (or a fresh `loadMint`) before restoring across a rotation.
+- Melt change arriving on a keyset you hold keyless throws after the mint has spent the inputs.
+  Recover with the persisted `outputData`, an explicit `ensureKeysetKeys`, and
+  `createMeltChangeProofs`.
 
 ## Long-lived wallets
 
-A wallet that stays in memory across a mint rotation does not need proactive maintenance: the next
-`receive` or melt change that meets an unrecognized keyset id repairs itself. Call `loadMint(true)`
-yourself when you want the wallet to reflect a rotation ahead of that, eg to keep
-`wallet.getMintInfo()` current, or to follow the mint's cheapest keyset immediately rather than
-waiting for an operation to force the issue.
+No maintenance needed: the next operation that meets rotation evidence repairs itself. Call
+`loadMint(true)` on a schedule if you would rather follow the mint ahead of that, eg to keep
+`wallet.getMintInfo()` current or to move onto a new keyset before an operation forces it.
 
 ## Related docs
 

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -109,14 +109,22 @@ if (e instanceof StaleKeysetError && isMintOperationError(e.cause) && e.cause.co
 
 A melt whose change could not be rebuilt threw the underlying failure, and the convenience melts
 never expose the `MeltPreview`, so the change was lost with it. `completeMelt` now throws
-`MeltChangeError` carrying what recovery needs. Wrap your melt calls and rebuild as shown above.
+`MeltChangeError` carrying what recovery needs, with the original failure as `cause`. Wrap your
+melt calls and rebuild as shown above.
+
+Read the `cause` before you retry. Keys that would not load are transient, and the rebuild works
+once they are there. An invalid DLEQ or a signature count the blanks cannot account for will not
+fix itself, and on a seeded wallet a NUT-09 restore is the real path.
 
 ### Melt inputs are checked against the snapshot
 
-`prepareMelt` and the `meltProofs*` wrappers never looked up an input proof's keyset, so proofs on
-an id the wallet did not hold were melted anyway, and priced at a fee of zero because input fees
-come from the keyset's `input_fee_ppk`. They now resolve those ids first, exactly as `receive`
-does, and refuse an id the mint does not know.
+`prepareMelt` and the `meltProofs*` wrappers never looked up an input proof's keyset. `prepareMelt`
+takes its fee reserve from `sendAmount - quote.amount` and nothing else, so a bolt11 or bolt12 melt
+of proofs on an id the wallet did not hold went through regardless, with NUT-08 blanks bound to a
+stale keyset. `meltProofsOnchain` does price its inputs, and failed on the way with a raw
+`Could not get fee. No keyset found for keyset id: X`. All of them now resolve their input ids
+first, exactly as `receive` does, and refuse an id the mint does not know with `UnknownKeysetError`
+until the snapshot is repaired.
 
 Melting proofs from an external or restored source, on a wallet whose snapshot may predate them,
 means bringing the snapshot up to date first:

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -65,6 +65,28 @@ The same shape applies to the split flow: re-run your `prepare*` before completi
 outputs in hand are the rejected ones. On a seeded wallet that reserves fresh counters; the
 abandoned ones are recoverable with a NUT-09 restore.
 
+### Upgrading an existing handler
+
+If you already branch on the 12xxx codes, your catch stops matching. Code that tested
+`isMintOperationError(e) && e.code === 12002`, or `e instanceof MintOperationError`, around
+`completeSwap`, `completeMint`, `completeBatchMint` or `completeMelt` now needs to test for
+`StaleKeysetError`. The mint's own error survives as `e.cause`, so whatever you read off it still
+reads the same from there.
+
+The class changes as well as the name. `MintOperationError` extends `HttpResponseError` and carries
+`status`; `StaleKeysetError` extends `CTSError` directly and does not. A handler reading `e.status`
+should read it from the cause instead:
+
+```ts
+// Before
+if (isMintOperationError(e) && e.code === 12002) log(e.status);
+
+// After
+if (e instanceof StaleKeysetError && isMintOperationError(e.cause) && e.cause.code === 12002) {
+  log(e.cause.status);
+}
+```
+
 ### Repair rate limit
 
 Internal repairs are limited to one per minute per wallet. Inside that window the wallet skips the

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -28,6 +28,12 @@ change refresh once, then throw `UnknownKeysetError` if the id is still unknown 
 itself failed, with that failure as `cause`). `restore` does not take this path: an unknown id
 there throws a plain `CTSError`.
 
+`UnknownKeysetError.refreshed` says how much weight to give it:
+
+- **`true`** - the wallet asked the mint and the id is not there. Final.
+- **`false`** - it never asked (strict mode, or rate limit). The id may be fine; a retry or a
+  `loadMint(true)` can still resolve it.
+
 **A mint rejection.** Your snapshot still calls a retired keyset active, so outputs get built on
 it and only the mint knows better. `completeSwap`, `completeMint`, `completeBatchMint` and
 `completeMelt` treat a NUT-00 keyset error (the 12xxx class) as evidence: they refresh, then throw
@@ -56,7 +62,9 @@ refreshes cleanly, and your retry will still fail.
 
 **Rate limit.** One repair per minute per wallet. Inside the window the wallet skips the refresh
 and throws immediately, so a service fed junk keyset ids cannot be turned into a stream of mint
-requests. Calls you make yourself are never rate limited.
+requests. Those errors report that the wallet did not check (`refreshed: false`, `repaired: false`)
+rather than blaming the id, because one junk token can burn the window for genuine post-rotation
+ones. Calls you make yourself are never rate limited.
 
 ## Upgrading an existing handler
 
@@ -130,7 +138,7 @@ What changes:
 
 | Situation                    | Strict behavior                                                                 |
 | ---------------------------- | ------------------------------------------------------------------------------- |
-| Unknown keyset id            | `UnknownKeysetError` immediately, no repair attempt.                            |
+| Unknown keyset id            | `UnknownKeysetError` with `refreshed: false`, no repair attempt.                |
 | Known keyset, no keys loaded | `No keys loaded for keyset X` (receive), `Keyset has no keys loaded` (restore). |
 | Mint rejects a keyset        | `StaleKeysetError` with `repaired: false`.                                      |
 | `keychainUpdated`            | Never fires: nothing internal mutates the snapshot.                             |

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -115,7 +115,8 @@ never expose the `MeltPreview`, so the change was lost with it. `completeMelt` n
 
 Follows the mint. Refreshes metadata, re-fetches keys for active keysets, and:
 
-- keeps keys it already holds for keysets the mint no longer serves,
+- keeps keys it already holds for keysets the mint still lists but no longer serves keys for,
+- drops any keyset the mint stops listing altogether: metadata follows mint truth,
 - rebinds an **auto-bound** wallet to the cheapest active keyset (newest version, then lowest fee,
   then latest expiry),
 - leaves a **pinned** wallet alone (`keysetId` constructor option or `bindKeyset()`), even if its

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -133,9 +133,13 @@ never consult the input keyset at all, so an id still unknown after the refresh 
 warning: whether a keyset it no longer lists is still honored is the mint's call, and refusing
 would leave those proofs with no way out. Strict mode still refuses, having never asked.
 
-Most callers need no change: the refresh finds the rotated-in keyset and the melt proceeds. If the
-mint has pruned the keyset outright, bolt11 and bolt12 melts still work; an onchain melt needs the
-snapshot brought up to date first:
+Most callers need no change. While the mint still lists the keyset, the op's own refresh finds it
+and the melt proceeds. Once the mint has pruned it, bolt11 and bolt12 melts go ahead with the
+warning above, and an onchain melt of those proofs cannot be priced, so it throws. No amount of
+refreshing changes that.
+
+Resolving the ids yourself is worth doing under `strictCachedKeysets`, where the op never asks the
+mint on your behalf, or when you want to choose where the network call happens:
 
 ```ts
 // Refresh, or resolve just the ids you are about to spend
@@ -143,8 +147,9 @@ await wallet.ensureOperableKeysets(proofs.map((p) => p.id));
 await wallet.meltProofsOnchain(quote, proofs, feeIndex);
 ```
 
-`loadMint(true)` does the same job wholesale. Under `strictCachedKeysets` nothing is fetched for
-you, so load the keysets yourself before melting.
+`loadMint(true)` does the same job wholesale. Neither brings back a keyset the mint has dropped:
+`ensureOperableKeysets` refreshes and then throws `UnknownKeysetError` for an id still missing
+afterwards.
 
 ## Refreshing on purpose
 

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -123,8 +123,8 @@ takes its fee reserve from `sendAmount - quote.amount` and nothing else, so a bo
 of proofs on an id the wallet did not hold went through regardless, with NUT-08 blanks bound to a
 stale keyset. `meltProofsOnchain` does price its inputs, and failed on the way with a raw
 `Could not get fee. No keyset found for keyset id: X`. All of them now resolve their input ids
-first, exactly as `receive` does, and refuse an id the mint does not know with `UnknownKeysetError`
-until the snapshot is repaired.
+first, exactly as `receive` does, and refuse an id the mint does not know with
+`UnknownKeysetError`.
 
 Melting proofs from an external or restored source, on a wallet whose snapshot may predate them,
 means bringing the snapshot up to date first:

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -23,10 +23,11 @@ verified against it, so loading them late is safe.
 Two things count as evidence that a rotation happened. Both refresh the snapshot once, then throw:
 the wallet heals, you decide what to do next.
 
-**An unknown keyset id.** A proof names a keyset the snapshot has never seen. `receive` and melt
-change refresh once, then throw `UnknownKeysetError` if the id is still unknown (or if the refresh
-itself failed, with that failure as `cause`). `restore` does not take this path: an unknown id
-there throws a plain `CTSError`.
+**An unknown keyset id.** A proof names a keyset the snapshot has never seen. Every op that reads
+input proof ids (`receive`, `send` and `prepareSwapToSend`, `prepareMelt` and the `meltProofs*`
+wrappers) and melt change refresh once, then throw `UnknownKeysetError` if the id is still unknown
+(or if the refresh itself failed, with that failure as `cause`). `restore` does not take this path:
+an unknown id there throws a plain `CTSError`.
 
 `UnknownKeysetError.refreshed` says how much weight to give it:
 
@@ -77,7 +78,8 @@ try {
 } catch (e) {
   if (!(e instanceof MeltChangeError)) throw e;
   const sigs = e.quote.change ?? [];
-  await wallet.keyChain.ensureKeysetKeys(sigs[0].id); // or persist e.outputData for later
+  // a permissive mint may sign change across keysets, so cover every id
+  await wallet.ensureOperableKeysets(sigs.map((s) => s.id)); // or persist e.outputData for later
   const change = wallet.createMeltChangeProofs(e.outputData, sigs);
 }
 ```
@@ -109,6 +111,25 @@ A melt whose change could not be rebuilt threw the underlying failure, and the c
 never expose the `MeltPreview`, so the change was lost with it. `completeMelt` now throws
 `MeltChangeError` carrying what recovery needs. Wrap your melt calls and rebuild as shown above.
 
+### Melt inputs are checked against the snapshot
+
+`prepareMelt` and the `meltProofs*` wrappers never looked up an input proof's keyset, so proofs on
+an id the wallet did not hold were melted anyway, and priced at a fee of zero because input fees
+come from the keyset's `input_fee_ppk`. They now resolve those ids first, exactly as `receive`
+does, and refuse an id the mint does not know.
+
+Melting proofs from an external or restored source, on a wallet whose snapshot may predate them,
+means bringing the snapshot up to date first:
+
+```ts
+// Refresh, or resolve just the ids you are about to spend
+await wallet.ensureOperableKeysets(proofs.map((p) => p.id));
+await wallet.meltProofsBolt11(quote, proofs);
+```
+
+`loadMint(true)` does the same job wholesale. Under `strictCachedKeysets` nothing is fetched for
+you, so load the keysets yourself before melting.
+
 ## Refreshing on purpose
 
 ### `loadMint(true)`
@@ -131,6 +152,10 @@ await wallet.ensureOperableKeysets(proofs.map((p) => p.id));
 Runs the repair on demand: unknown ids get one refresh, keysets held without keys get theirs
 fetched, an id the mint does not know throws `UnknownKeysetError`. For integrations that verify
 proofs or reconstruct persisted `outputData` without running a wallet operation.
+
+Key fetches for several ids settle independently. One failure rethrows as-is; two or more throw a
+`CTSError` whose `cause` is the array of failures. Either way keys that did land are kept, so
+persist the cache even when the call throws.
 
 Being explicit, it ignores `strictCachedKeysets` and the rate limit, and emits no
 `keychainUpdated`. Persist `wallet.keyChain.cache` yourself afterwards. It needs a loaded wallet

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -31,8 +31,8 @@ there throws a plain `CTSError`.
 `UnknownKeysetError.refreshed` says how much weight to give it:
 
 - **`true`** - the wallet asked the mint and the id is not there. Final.
-- **`false`** - it never asked (strict mode, or rate limit). The id may be fine; a retry or a
-  `loadMint(true)` can still resolve it.
+- **`false`** - no answer from the mint (strict mode, rate limit, or a failed refresh). The id may
+  be fine; a `loadMint(true)` or a retry can still resolve it.
 
 **A mint rejection.** Your snapshot still calls a retired keyset active, so outputs get built on
 it and only the mint knows better. `completeSwap`, `completeMint`, `completeBatchMint` and

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -70,7 +70,21 @@ abandoned ones are recoverable with a NUT-09 restore.
 Internal repairs are limited to one per minute per wallet. Inside that window the wallet skips the
 refresh and throws the terminal error immediately (`UnknownKeysetError`, or `StaleKeysetError`
 with `repaired: false`), so a service fed a stream of junk keyset ids cannot be turned into a
-stream of outbound mint requests. Refreshes you ask for yourself are never rate limited.
+stream of outbound mint requests. Refreshes you ask for yourself are never rate limited, though a
+repair triggered by `ensureOperableKeysets()` does start the window for the next internal one;
+`loadMint(true)` does not, since it never goes through the repair path.
+
+## Preparing the snapshot yourself: `ensureOperableKeysets`
+
+`await wallet.ensureOperableKeysets(ids)` runs the same repair on demand: unknown ids get one
+`loadMint(true)`, keysets held without keys get theirs fetched, and an id the mint does not know
+throws `UnknownKeysetError`. Useful for integrations that verify proofs, or reconstruct persisted
+`outputData`, without running a wallet operation.
+
+Because it is an explicit request, it ignores both `strictCachedKeysets` and the repair rate limit:
+strict mode exists to stop network calls you did not ask for, and this is one you did. For the same
+reason it emits no `keychainUpdated`, so persist `wallet.keyChain.cache` yourself afterwards. It
+needs a loaded wallet, and says so rather than quietly doing nothing.
 
 ## Refreshing deliberately: `loadMint(true)`
 
@@ -97,9 +111,9 @@ wallet.on.keychainUpdated(({ cache }) => {
 });
 ```
 
-This event does not fire for `restore`'s own lazy key fetch, or for your own explicit
-`loadMint()` / `loadMint(true)` calls: persist `wallet.keyChain.cache` yourself after those (see
-[Create Wallet](./create_wallet.md)).
+This event does not fire for `restore`'s own lazy key fetch, or for calls you make yourself
+(`loadMint()`, `loadMint(true)`, `ensureOperableKeysets()`): persist `wallet.keyChain.cache`
+yourself after those (see [Create Wallet](./create_wallet.md)).
 
 ## Strict cached keysets
 
@@ -107,20 +121,21 @@ Set `strictCachedKeysets: true` in the `Wallet` constructor options if you run y
 persistence or state layer (eg a coco-style wallet) and want CTS to operate only on the keyset
 state you load, with no network call happening behind your back. With it set, operations never
 call `/v1/keysets` or `/v1/keys` on their own; the only calls that touch the network are the ones
-you make yourself (`loadMint`, `loadMint(true)`, `keyChain.ensureKeysetKeys`). An unrecognized
-keyset id throws `UnknownKeysetError` immediately, with no repair attempt; a known keyset with
-missing keys throws the same typed errors non-strict mode throws once its own repair path is
-exhausted (eg `No keys loaded for keyset X` from receive, or `Keyset has no keys loaded` from
-`restore`). `keychainUpdated` never fires under strict mode, since nothing internal mutates the
-snapshot. Use `keyChain.ensureKeysetKeys(id)` or `loadMint(true)` to refresh deliberately; those
-keep their normal semantics, including `loadMint(true)`'s carry-forward and rebind rules.
-`restore` and `batchRestore` throw on a keyset without loaded keys under strict mode, so restoring
-across a rotation needs `keyChain.ensureKeysetKeys` called for each keyset first (or a fresh
-`loadMint`). Melt change that arrives on a keyset your snapshot holds keyless throws after the mint
-has already spent the inputs; recover with the persisted `outputData` plus an explicit
-`ensureKeysetKeys` and `createMeltChangeProofs` call, as documented on that method. Wallets created
-with `withKeyset()` inherit the strict flag from their parent, so derived wallets respect the same
-network constraints.
+you make yourself (`loadMint`, `loadMint(true)`, `keyChain.ensureKeysetKeys`,
+`ensureOperableKeysets`). An unrecognized keyset id throws `UnknownKeysetError` immediately, with
+no repair attempt; a known keyset with missing keys throws the same typed errors non-strict mode
+throws once its own repair path is exhausted (eg `No keys loaded for keyset X` from receive, or
+`Keyset has no keys loaded` from `restore`). A mint rejecting a keyset mid-operation throws
+`StaleKeysetError` with `repaired: false`, since strict mode does not refresh on its own.
+`keychainUpdated` never fires under strict mode, since nothing internal mutates the snapshot. Use
+`keyChain.ensureKeysetKeys(id)` or `loadMint(true)` to refresh deliberately; those keep their
+normal semantics, including `loadMint(true)`'s carry-forward and rebind rules. `restore` and
+`batchRestore` throw on a keyset without loaded keys under strict mode, so restoring across a
+rotation needs `keyChain.ensureKeysetKeys` called for each keyset first (or a fresh `loadMint`).
+Melt change that arrives on a keyset your snapshot holds keyless throws after the mint has already
+spent the inputs; recover with the persisted `outputData` plus an explicit `ensureKeysetKeys` and
+`createMeltChangeProofs` call, as documented on that method. Wallets created with `withKeyset()`
+inherit the strict flag from their parent, so derived wallets respect the same network constraints.
 
 ## Long-lived wallets
 

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -82,7 +82,9 @@ keep their normal semantics, including `loadMint(true)`'s carry-forward and rebi
 across a rotation needs `keyChain.ensureKeysetKeys` called for each keyset first (or a fresh
 `loadMint`). Melt change that arrives on a keyset your snapshot holds keyless throws after the mint
 has already spent the inputs; recover with the persisted `outputData` plus an explicit
-`ensureKeysetKeys` and `createMeltChangeProofs` call, as documented on that method.
+`ensureKeysetKeys` and `createMeltChangeProofs` call, as documented on that method. Wallets created
+with `withKeyset()` inherit the strict flag from their parent, so derived wallets respect the same
+network constraints.
 
 ## Long-lived wallets
 

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -44,8 +44,8 @@ long-lived service. It:
 - refreshes metadata (active flags, fees) from the mint, re-fetching keys for active keysets,
 - keeps the keys the wallet already holds for any keyset the mint no longer serves,
 - rebinds an auto-bound wallet (constructed without `keysetId`, never `bindKeyset()`-ed) to the
-  cheapest active keyset, but only once its current one is no longer usable (missing, inactive, or
-  without keys). A still-usable binding is left alone even if a cheaper keyset is now active.
+  cheapest active keyset on every refresh, including the internal repair (newest keyset version
+  first, then lowest fee, then latest expiry).
 
 A wallet pinned via the `keysetId` constructor option or a `bindKeyset()` call stays pinned across
 the refresh, even if its keyset has since gone inactive.
@@ -89,8 +89,8 @@ has already spent the inputs; recover with the persisted `outputData` plus an ex
 A wallet that stays in memory across a mint rotation does not need proactive maintenance: the next
 `receive` or melt change that meets an unrecognized keyset id repairs itself. Call `loadMint(true)`
 yourself when you want the wallet to reflect a rotation ahead of that, eg to keep
-`wallet.getMintInfo()` current, or to rebind sooner once your current keyset stops being usable
-rather than waiting for an operation to force the issue.
+`wallet.getMintInfo()` current, or to follow the mint's cheapest keyset immediately rather than
+waiting for an operation to force the issue.
 
 ## Related docs
 

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -36,6 +36,42 @@ This applies to `receive` and melt change: both resolve unrecognized keyset ids 
 `restore` fetches keys directly and does not go through it, so an unknown keyset id there throws a
 plain `CTSError` with no retry.
 
+## Self-repair when the mint rejects a keyset
+
+A wallet loaded before a rotation has nothing unrecognized to trip the repair above: its snapshot
+still calls the retired keyset active, so it builds outputs on it and the mint is the only party
+that knows better. When `completeSwap`, `completeMint`, `completeBatchMint`, or `completeMelt` is
+rejected with a NUT-00 keyset error (the 12xxx class: unknown, inactive, or expired keyset), the
+wallet takes that as rotation evidence, refreshes the snapshot, and throws `StaleKeysetError` with
+the mint's error as `cause`.
+
+Its `repaired` flag says whether the refresh actually ran. `true` means the snapshot is current
+again, so running your call a second time should succeed (a 12001 caused by an input proof from
+another mint refreshes cleanly and still fails). `false` means nothing changed (strict mode, a
+failed refresh, or the rate limit below) and the next move is yours. Nothing retries for you: the
+rejected outputs were built on the stale keyset, so the wallet heals the snapshot and hands the
+decision back.
+
+```ts
+try {
+  return await wallet.receive(token);
+} catch (e) {
+  if (!(e instanceof StaleKeysetError) || !e.repaired) throw e;
+  return wallet.receive(token); // the snapshot is current now
+}
+```
+
+The same shape applies to the split flow: re-run your `prepare*` before completing again, since the
+outputs in hand are the rejected ones. On a seeded wallet that reserves fresh counters; the
+abandoned ones are recoverable with a NUT-09 restore.
+
+### Repair rate limit
+
+Internal repairs are limited to one per minute per wallet. Inside that window the wallet skips the
+refresh and throws the terminal error immediately (`UnknownKeysetError`, or `StaleKeysetError`
+with `repaired: false`), so a service fed a stream of junk keyset ids cannot be turned into a
+stream of outbound mint requests. Refreshes you ask for yourself are never rate limited.
+
 ## Refreshing deliberately: `loadMint(true)`
 
 Call `loadMint(true)` yourself to follow a mint proactively, for example on a schedule in a

--- a/docs-src/usage/keysets.md
+++ b/docs-src/usage/keysets.md
@@ -66,7 +66,25 @@ requests. Those errors report that the wallet did not check (`refreshed: false`,
 rather than blaming the id, because one junk token can burn the window for genuine post-rotation
 ones. Calls you make yourself are never rate limited.
 
+**Melt change.** NUT-08 change is built after the mint has spent your inputs, so `completeMelt`
+cannot simply fail when the change keyset will not resolve. It throws `MeltChangeError`, which
+carries the blank `outputData` and the merged `quote`. The payment stands; rebuild the proofs once
+the keys are reachable:
+
+```ts
+try {
+  const { change } = await wallet.meltProofsBolt11(quote, proofs);
+} catch (e) {
+  if (!(e instanceof MeltChangeError)) throw e;
+  const sigs = e.quote.change ?? [];
+  await wallet.keyChain.ensureKeysetKeys(sigs[0].id); // or persist e.outputData for later
+  const change = wallet.createMeltChangeProofs(e.outputData, sigs);
+}
+```
+
 ## Upgrading an existing handler
+
+### Keyset rejections throw `StaleKeysetError`
 
 Already branching on the 12xxx codes? That catch stops matching. A test for
 `isMintOperationError(e) && e.code === 12002`, or `e instanceof MintOperationError`, around the
@@ -84,6 +102,12 @@ if (e instanceof StaleKeysetError && isMintOperationError(e.cause) && e.cause.co
   log(e.cause.status);
 }
 ```
+
+### Melt change failures throw `MeltChangeError`
+
+A melt whose change could not be rebuilt threw the underlying failure, and the convenience melts
+never expose the `MeltPreview`, so the change was lost with it. `completeMelt` now throws
+`MeltChangeError` carrying what recovery needs. Wrap your melt calls and rebuild as shown above.
 
 ## Refreshing on purpose
 
@@ -148,8 +172,8 @@ Two things to plan for:
 
 - `restore` and `batchRestore` throw on a keyset without loaded keys. Call
   `keyChain.ensureKeysetKeys` per keyset (or a fresh `loadMint`) before restoring across a rotation.
-- Melt change arriving on a keyset you hold keyless throws after the mint has spent the inputs.
-  Recover with the persisted `outputData`, an explicit `ensureKeysetKeys`, and
+- Melt change arriving on a keyset you hold keyless throws `MeltChangeError` after the mint has
+  spent the inputs. Recover with its `outputData`, an explicit `ensureKeysetKeys`, and
   `createMeltChangeProofs`.
 
 ## Long-lived wallets

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -20,20 +20,21 @@ If you are building a wallet integration from scratch, read these in order:
 
 ## Recipes
 
-| Recipe                                | Use it for                                                             |
-| :------------------------------------ | :--------------------------------------------------------------------- |
-| [Create Wallet](./create_wallet.md)   | Initialize a wallet from a mint URL or cached mint state.              |
-| [Mint Token](./mint_token.md)         | Create proofs from a paid quote, including two-step mint flows.        |
-| [Create Token](./create_token.md)     | Send standard Cashu tokens to another wallet.                          |
-| [Create P2PK](./create_p2pk.md)       | Send tokens locked to a public key.                                    |
-| [Get Token](./get_token.md)           | Inspect token metadata before wallet creation or decode it after load. |
-| [Melt Token](./melt_token.md)         | Pay BOLT11 invoices or other payment methods with wallet proofs.       |
-| [Bolt12](./bolt12.md)                 | Work with reusable BOLT12 offers for minting and melting.              |
-| [NUT-19 Cached Responses](./nut19.md) | Understand cached endpoint retries and timeout behavior.               |
-| [Logging](./logging.md)               | Enable and route library logs while debugging wallet or mint behavior. |
-| [Amounts](./amounts.md)               | Work with the `Amount` and `AmountWithUnit` value objects.             |
-| [Fees](./fees.md)                     | Pick the right fee helper: input fees, sender-pays-fees, send-max.     |
-| [Helpers](./helpers.md)               | Standalone public utility functions.                                   |
+| Recipe                                | Use it for                                                                      |
+| :------------------------------------ | :------------------------------------------------------------------------------ |
+| [Create Wallet](./create_wallet.md)   | Initialize a wallet from a mint URL or cached mint state.                       |
+| [Mint Token](./mint_token.md)         | Create proofs from a paid quote, including two-step mint flows.                 |
+| [Create Token](./create_token.md)     | Send standard Cashu tokens to another wallet.                                   |
+| [Create P2PK](./create_p2pk.md)       | Send tokens locked to a public key.                                             |
+| [Get Token](./get_token.md)           | Inspect token metadata before wallet creation or decode it after load.          |
+| [Melt Token](./melt_token.md)         | Pay BOLT11 invoices or other payment methods with wallet proofs.                |
+| [Keysets & Rotation](./keysets.md)    | What the wallet snapshot tracks, lazy key loading, and self-repair on rotation. |
+| [Bolt12](./bolt12.md)                 | Work with reusable BOLT12 offers for minting and melting.                       |
+| [NUT-19 Cached Responses](./nut19.md) | Understand cached endpoint retries and timeout behavior.                        |
+| [Logging](./logging.md)               | Enable and route library logs while debugging wallet or mint behavior.          |
+| [Amounts](./amounts.md)               | Work with the `Amount` and `AmountWithUnit` value objects.                      |
+| [Fees](./fees.md)                     | Pick the right fee helper: input fees, sender-pays-fees, send-max.              |
+| [Helpers](./helpers.md)               | Standalone public utility functions.                                            |
 
 ## Related docs
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2146,6 +2146,7 @@ export class Wallet {
     createMultiPathMeltQuote(invoice: string, millisatPartialAmount: AmountLike): Promise<MeltQuoteBolt11Response>;
     decodeToken(token: string): Token;
     defaultOutputType(): OutputType;
+    ensureOperableKeysets(ids: Array<string | undefined>): Promise<void>;
     getFeesForKeyset(nInputs: number, keysetId: string): Amount;
     getFeesForProofs(proofs: Array<Pick<Proof, 'id'>>): Amount;
     getFeesToInclude(amount: AmountLike, opts?: {

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -765,6 +765,15 @@ export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | '
 }
 
 // @public
+export class MeltChangeError extends CTSError {
+    constructor(outputData: OutputDataLike[], quote: MeltQuoteBaseResponse, options?: {
+        cause?: unknown;
+    });
+    readonly outputData: OutputDataLike[];
+    readonly quote: MeltQuoteBaseResponse;
+}
+
+// @public
 export class MeltOnchainBuilder {
     constructor(wallet: Wallet, quote: MeltQuoteOnchainResponse, proofs: ProofLike[]);
     feeIndex(index: number): this;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2045,10 +2045,11 @@ export function unblindSignature(C_: WeierstrassPoint<bigint>, r: bigint, A: Wei
 // @public
 export class UnknownKeysetError extends CTSError {
     constructor(keysetId: string, options?: {
+        refreshed?: boolean;
         cause?: unknown;
     });
-    // (undocumented)
     readonly keysetId: string;
+    readonly refreshed: boolean;
 }
 
 // @public @deprecated (undocumented)

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2083,6 +2083,7 @@ export class Wallet {
         selectProofs?: SelectProofs;
         outputDataCreator?: OutputDataCreator;
         requireSigDleq?: boolean;
+        strictCachedKeysets?: boolean;
         logger?: Logger;
     });
     batchRestore(gapLimit?: number, batchSize?: number, counter?: number, keysetId?: string): Promise<{

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1937,6 +1937,14 @@ export function sortProofsById(proofs: Proof[]): Proof[];
 export function splitAmount(value: AmountLike, keyset: Keys, split?: AmountLike[], order?: 'desc' | 'asc'): Amount[];
 
 // @public
+export class StaleKeysetError extends CTSError {
+    constructor(repaired: boolean, options?: {
+        cause?: unknown;
+    });
+    readonly repaired: boolean;
+}
+
+// @public
 export function stripDleq(proofs: Proof[]): Array<Omit<Proof, 'dleq'>>;
 
 // @public (undocumented)

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -663,6 +663,7 @@ export class KeyChain {
     getCheapestKeyset(): Keyset;
     getKeyset(id?: string): Keyset;
     getKeysets(): Keyset[];
+    hasKeyset(id?: string): boolean;
     init(forceRefresh?: boolean): Promise<void>;
     isUnitKeyset(id?: string): boolean;
     loadFromCache(cache: KeyChainCache): void;
@@ -2033,6 +2034,15 @@ export type UnblindedSignature = {
 // @public (undocumented)
 export function unblindSignature(C_: WeierstrassPoint<bigint>, r: bigint, A: WeierstrassPoint<bigint>): WeierstrassPoint<bigint>;
 
+// @public
+export class UnknownKeysetError extends CTSError {
+    constructor(keysetId: string, options?: {
+        cause?: unknown;
+    });
+    // (undocumented)
+    readonly keysetId: string;
+}
+
 // @public @deprecated (undocumented)
 export function verifyDleqIfPresent(proof: Proof, keyset: HasKeysetKeys): boolean;
 
@@ -2198,6 +2208,9 @@ export class WalletEvents {
         add: (c: CancellerLike) => CancellerLike;
         cancelled: boolean;
     };
+    keychainUpdated(cb: (payload: {
+        cache: KeyChainCache;
+    }) => void, opts?: SubscribeOpts): SubscriptionCanceller;
     meltQuotePaid(id: string, cb: (p: MeltQuoteBolt11Response) => void, err: (e: Error) => void, opts?: SubscribeOpts): Promise<SubscriptionCanceller>;
     meltQuoteUpdates(ids: string[], cb: (p: MeltQuoteBolt11Response) => void, err: (e: Error) => void, opts?: SubscribeOpts): Promise<SubscriptionCanceller>;
     mintQuotePaid(id: string, cb: (p: MintQuoteBolt11Response) => void, err: (e: Error) => void, opts?: SubscribeOpts): Promise<SubscriptionCanceller>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export { type LogLevel, ConsoleLogger, type Logger } from './logger';
 export {
   CTSError,
   isMintOperationError,
+  MeltChangeError,
   MintOperationError,
   NetworkError,
   HttpResponseError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export {
   NetworkError,
   HttpResponseError,
   RateLimitError,
+  UnknownKeysetError,
 } from './model/Errors';
 
 // Low-level helpers/types that appear in public surfaces

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export {
   NetworkError,
   HttpResponseError,
   RateLimitError,
+  StaleKeysetError,
   UnknownKeysetError,
 } from './model/Errors';
 

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -44,17 +44,32 @@ export class NetworkError extends CTSError {
 }
 
 /**
- * Thrown when a keyset id cannot be resolved against the mint, even after a refresh.
+ * Thrown when a keyset id cannot be resolved against the wallet's view of the mint.
+ *
+ * @remarks
+ * `refreshed: false` means the wallet never asked the mint (rate limited, or strict mode), so a
+ * retry or a `loadMint(true)` may still resolve the id.
  */
 export class UnknownKeysetError extends CTSError {
+  /**
+   * The keyset id that could not be resolved.
+   */
   readonly keysetId: string;
-  constructor(keysetId: string, options?: { cause?: unknown }) {
+  /**
+   * True when a refresh ran and the id was still unknown, so the mint really does not have it.
+   */
+  readonly refreshed: boolean;
+  constructor(keysetId: string, options?: { refreshed?: boolean; cause?: unknown }) {
+    const refreshed = options?.refreshed ?? false;
     const message =
       options?.cause !== undefined
         ? `Could not resolve unknown keyset '${keysetId}': mint refresh failed`
-        : `Keyset '${keysetId}' is not a keyset of this mint`;
+        : refreshed
+          ? `Keyset '${keysetId}' is not a keyset of this mint`
+          : `Keyset '${keysetId}' is not in the wallet snapshot and no refresh was attempted; retry or refresh with loadMint(true)`;
     super(message, options);
     this.keysetId = keysetId;
+    this.refreshed = refreshed;
     this.name = 'UnknownKeysetError';
     Object.setPrototypeOf(this, UnknownKeysetError.prototype);
   }

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -61,6 +61,32 @@ export class UnknownKeysetError extends CTSError {
 }
 
 /**
+ * Thrown when the mint rejects a keyset the wallet's snapshot considers current.
+ *
+ * @remarks
+ * `repaired: true` means the snapshot was refreshed before throwing: nothing retried for you, so
+ * run the operation again and it should succeed. Retrying consumes fresh counters on seeded wallets
+ * (recoverable via NUT-09 restore).
+ */
+export class StaleKeysetError extends CTSError {
+  /**
+   * True when the snapshot was refreshed before throwing, so the operation is worth running again.
+   */
+  readonly repaired: boolean;
+  constructor(repaired: boolean, options?: { cause?: unknown }) {
+    super(
+      repaired
+        ? 'Mint rejected a stale keyset; the snapshot has been refreshed, re-prepare the operation'
+        : 'Mint rejected a stale keyset; refresh the snapshot (loadMint(true)) and re-prepare',
+      options,
+    );
+    this.repaired = repaired;
+    this.name = 'StaleKeysetError';
+    Object.setPrototypeOf(this, StaleKeysetError.prototype);
+  }
+}
+
+/**
  * This error is thrown when the server responds with 429 Too Many Requests. `retryAfterMs` is the
  * parsed `Retry-After` header in milliseconds, or `undefined` when the header is absent or
  * unparseable.

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -44,6 +44,23 @@ export class NetworkError extends CTSError {
 }
 
 /**
+ * Thrown when a keyset id cannot be resolved against the mint, even after a refresh.
+ */
+export class UnknownKeysetError extends CTSError {
+  readonly keysetId: string;
+  constructor(keysetId: string, options?: { cause?: unknown }) {
+    const message =
+      options?.cause !== undefined
+        ? `Could not resolve unknown keyset '${keysetId}': mint refresh failed`
+        : `Keyset '${keysetId}' is not a keyset of this mint`;
+    super(message, options);
+    this.keysetId = keysetId;
+    this.name = 'UnknownKeysetError';
+    Object.setPrototypeOf(this, UnknownKeysetError.prototype);
+  }
+}
+
+/**
  * This error is thrown when the server responds with 429 Too Many Requests. `retryAfterMs` is the
  * parsed `Retry-After` header in milliseconds, or `undefined` when the header is absent or
  * unparseable.

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -1,3 +1,6 @@
+import type { OutputDataLike } from './OutputData';
+import type { MeltQuoteBaseResponse } from './types/NUT05';
+
 /**
  * Base error for errors raised by cashu-ts itself.
  */
@@ -72,6 +75,39 @@ export class UnknownKeysetError extends CTSError {
     this.refreshed = refreshed;
     this.name = 'UnknownKeysetError';
     Object.setPrototypeOf(this, UnknownKeysetError.prototype);
+  }
+}
+
+/**
+ * Thrown when a melt went through but its NUT-08 change could not be reconstructed.
+ *
+ * @remarks
+ * The inputs are spent and the payment stands. Load the change keyset's keys (see
+ * `keyChain.ensureKeysetKeys`), then pass `outputData` and the quote's `change` signatures to
+ * `wallet.createMeltChangeProofs()` to recover the proofs.
+ */
+export class MeltChangeError extends CTSError {
+  /**
+   * The melt's blank outputs, the input to change recovery.
+   */
+  readonly outputData: OutputDataLike[];
+  /**
+   * The melt quote, merged from the preview and the mint's response.
+   */
+  readonly quote: MeltQuoteBaseResponse;
+  constructor(
+    outputData: OutputDataLike[],
+    quote: MeltQuoteBaseResponse,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      "Melt completed but its change could not be reconstructed; recover the proofs with this error's outputData and createMeltChangeProofs()",
+      options,
+    );
+    this.outputData = outputData;
+    this.quote = quote;
+    this.name = 'MeltChangeError';
+    Object.setPrototypeOf(this, MeltChangeError.prototype);
   }
 }
 

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -47,8 +47,8 @@ export class NetworkError extends CTSError {
  * Thrown when a keyset id cannot be resolved against the wallet's view of the mint.
  *
  * @remarks
- * `refreshed: false` means the wallet never asked the mint (rate limited, or strict mode), so a
- * retry or a `loadMint(true)` may still resolve the id.
+ * `refreshed: false` means the wallet has no answer from the mint (rate limited, strict mode, or a
+ * failed refresh), so a retry or a `loadMint(true)` may still resolve the id.
  */
 export class UnknownKeysetError extends CTSError {
   /**
@@ -66,7 +66,7 @@ export class UnknownKeysetError extends CTSError {
         ? `Could not resolve unknown keyset '${keysetId}': mint refresh failed`
         : refreshed
           ? `Keyset '${keysetId}' is not a keyset of this mint`
-          : `Keyset '${keysetId}' is not in the wallet snapshot and no refresh was attempted; retry or refresh with loadMint(true)`;
+          : `Keyset '${keysetId}' is not in the wallet snapshot and no refresh was attempted; call loadMint(true), or retry once the repair cooldown clears`;
     super(message, options);
     this.keysetId = keysetId;
     this.refreshed = refreshed;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -718,7 +718,8 @@ function mapShortKeysetIds(proofs: Proof[], keysetIds: readonly string[]): Proof
  * @param opts.require Default `true`. When `false`, a proof without a DLEQ payload returns `true`
  *   (NUT-12 "MUST verify-if-present"). The default flips to `false` in v5.0.
  * @returns True if verification succeeded, false otherwise.
- * @throws Throws if the proof amount does not match any key in the provided keyset.
+ * @throws CTSError if the proof amount is not a denomination in the keyset, checked before the
+ *   missing-DLEQ shortcut so a keyless keyset is reported rather than silently passed.
  */
 export function hasValidDleq(
   proof: Proof,
@@ -726,13 +727,17 @@ export function hasValidDleq(
   opts?: { require?: boolean },
 ): boolean {
   const require = opts?.require ?? true;
+  if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
+    // An empty keyset means keys were never loaded (eg rotated-out keyset per NUT-01),
+    // not that the denomination is missing. Say so: the two failures have different fixes.
+    const message =
+      Object.keys(keyset.keys).length === 0
+        ? `No keys loaded for keyset ${keyset.id}`
+        : `Undefined key for amount ${proof.amount.toString()} in keyset ${keyset.id}`;
+    throw new CTSError(message);
+  }
   if (proof?.dleq == undefined) {
     return !require;
-  }
-  if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
-    throw new CTSError(
-      `Undefined key for amount ${proof.amount.toString()} in keyset ${keyset.id}`,
-    );
   }
   const key = keyset.keys[proof.amount.toString()];
   try {

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -28,6 +28,14 @@ export const ABSOLUTE_MAX_BATCH_SIZE = 100;
 export const MAX_KEYSET_DENOMINATIONS = 256;
 
 /**
+ * Minimum gap between two internal snapshot repairs (`loadMint(true)` fired from inside an
+ * operation). Rotations are rare, so a wallet that keeps meeting keyset ids the mint rejects is
+ * being fed garbage: without this, each bad token would cost three outbound mint requests,
+ * repeatably. Explicit consumer refreshes are not rate limited.
+ */
+export const REPAIR_COOLDOWN_MS = 60_000;
+
+/**
  * Upper bound on entries we process from a mint-advertised list (NUT-04/05 `methods`, NUT-21/22
  * `protected_endpoints`). Real mints advertise tens; the transport 8 MiB cap still admits ~100k
  * small records, so an unbounded map/clone/sort over them is a memory-amplification vector. Lists

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -166,7 +166,11 @@ export class KeyChain {
    * @param allKeys Keys data from mint.getKeys() API.
    */
   private buildKeychain(allKeysets: MintKeyset[], allKeys: MintKeys[]): void {
-    // Clear existing keysets to avoid stale data (null-proto, see the field declaration)
+    // Keep a reference to the outgoing snapshot so verified keys survive a refresh.
+    // NUT-01 only serves keys for active keysets, so a rebuild would otherwise blank
+    // every keyset that has rotated out. Keys are immutable per id (id commits to
+    // the key hash), so carrying them forward cannot go stale.
+    const previous = this.keysets;
     this.keysets = Object.create(null) as { [id: string]: Keyset };
 
     const keysMap = new Map<string, MintKeys>(allKeys.map((k) => [k.id, k]));
@@ -178,6 +182,12 @@ export class KeyChain {
       // Discard unverified keys
       if (!keyset.verify()) {
         keyset.keys = {};
+      }
+
+      // Carry forward previously verified keys for a keyset the mint no longer serves
+      const prior = previous[meta.id];
+      if (!keyset.hasKeys && prior?.hasKeys) {
+        keyset.keys = prior.keys;
       }
 
       this.keysets[keyset.id] = keyset;

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -311,6 +311,16 @@ export class KeyChain {
   }
 
   /**
+   * True if `id` is a keyset this KeyChain knows about, any unit.
+   *
+   * @remarks
+   * O(1) and non-throwing, unlike `getKeyset(id)`. False for an uninitialized chain.
+   */
+  hasKeyset(id?: string): boolean {
+    return !!id && this.keysets[id] !== undefined;
+  }
+
+  /**
    * Returns all the keys in this KeyChain across all units.
    *
    * @returns Array of MintKeys objects.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -577,11 +577,13 @@ class Wallet {
    * Make the keychain usable for these keyset ids, at op entry or where the ids first become known.
    *
    * @remarks
-   * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} if still
-   * unknown; known-but-keyless ids get keys fetched. Implicit (op-driven) calls honor
-   * `strictCachedKeysets`, where unknown ids throw immediately and keyless ids are left for the
-   * caller, and the repair cooldown, and emit `keychainUpdated` for anything they change. Explicit
-   * calls do the full pass and emit nothing: the consumer who asked persists the cache.
+   * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} with
+   * `refreshed: true` if still unknown; known-but-keyless ids get keys fetched. Calls that never
+   * reach the mint (strict mode, rate limited) throw it with `refreshed: false`. Implicit
+   * (op-driven) calls honor `strictCachedKeysets`, where unknown ids throw immediately and keyless
+   * ids are left for the caller, and the repair cooldown, and emit `keychainUpdated` for anything
+   * they change. Explicit calls do the full pass and emit nothing: the consumer who asked persists
+   * the cache.
    */
   private async _ensureOperableKeysets(
     ids: Array<string | undefined>,
@@ -598,7 +600,7 @@ class Wallet {
     if (opts.implicit && this._strictCachedKeysets) {
       const strictUnknown = wanted.filter((id) => !this._keyChain.hasKeyset(id));
       if (strictUnknown.length > 0) {
-        throw new UnknownKeysetError(strictUnknown[0]);
+        throw new UnknownKeysetError(strictUnknown[0]); // not refreshed: strict never asks the mint
       }
       return; // no backfill: downstream key checks report keyless keysets
     }
@@ -609,7 +611,8 @@ class Wallet {
     if (unknown.length > 0) {
       const repair = this.startRepair(opts.implicit);
       if (!repair) {
-        throw new UnknownKeysetError(unknown[0]); // rate limited: terminal for this op
+        // Rate limited: terminal for this op, and not refreshed, so the id may well be genuine.
+        throw new UnknownKeysetError(unknown[0]);
       }
       try {
         await repair;
@@ -623,7 +626,7 @@ class Wallet {
         if (opts.implicit) {
           this.on._emitKeychainUpdated();
         }
-        throw new UnknownKeysetError(still[0]);
+        throw new UnknownKeysetError(still[0], { refreshed: true });
       }
     }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3279,8 +3279,16 @@ class Wallet {
       feeIndex,
       feeOptions: meltQuote.fee_options.map((o) => o.fee_index),
     });
-    // Ensure we have enough proofs
     const normalizedProofs = normalizeProofAmounts(proofsToSend);
+
+    // Rotation evidence check: repair the snapshot and load any missing keys before the
+    // input fee lookup relies on it. prepareMelt checks again below, a no-op by then.
+    await this._ensureOperableKeysets(
+      normalizedProofs.map((p) => p.id),
+      { implicit: true },
+    );
+
+    // Ensure we have enough proofs
     const inputFee = this.getFeesForProofs(normalizedProofs);
     const sendAmount = sumProofs(normalizedProofs);
     const totalRequired = meltQuote.amount.add(feeOption.fee_reserve).add(inputFee);

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -555,7 +555,15 @@ class Wallet {
       (id) => this._keyChain.isUnitKeyset(id) && !this._keyChain.getKeyset(id).hasKeys,
     );
     if (keyless.length > 0) {
-      await Promise.all(keyless.map((id) => this._keyChain.ensureKeysetKeys(id)));
+      try {
+        await Promise.all(keyless.map((id) => this._keyChain.ensureKeysetKeys(id)));
+      } catch (e) {
+        if (changed) {
+          // A repair above already succeeded and is worth persisting even though this fetch failed.
+          this.on._emitKeychainUpdated();
+        }
+        throw e;
+      }
       changed = true;
     }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -159,6 +159,7 @@ class Wallet {
   private _secretsPolicy: SecretsPolicy = 'auto';
   private _counterSource: CounterSource;
   private _boundKeysetId: string = PENDING_KEYSET_ID;
+  private _explicitBind: boolean = false;
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
   private _requireSigDleq = false;
@@ -230,6 +231,7 @@ class Wallet {
         : mint;
     this._unit = options?.unit ?? this._unit;
     this._boundKeysetId = options?.keysetId ?? this._boundKeysetId;
+    this._explicitBind = options?.keysetId !== undefined;
     if (options?.bip39seed) {
       // failIf forwards this context to the logger, so pass the type, never the seed.
       this.failIf(
@@ -368,8 +370,8 @@ class Wallet {
           err: (e as Error).message,
         });
       }
-    } else {
-      // Keyset ID was bound in wallet constructor, so ensure it exists and unit
+    } else if (this._explicitBind) {
+      // Keyset ID was pinned by the caller, so ensure it exists and unit
       // matches, but do NOT require keys yet. It may be an inactive keyset for
       // restore, and if so, keys will be fetched async later.
       const k = this._keyChain.getKeyset(this._boundKeysetId);
@@ -378,6 +380,29 @@ class Wallet {
         unit: k.unit,
         walletUnit: this._unit,
       });
+    } else {
+      // Auto-bound previously: follow the mint when the binding is no longer usable.
+      const current = this._keyChain.hasKeyset(this._boundKeysetId)
+        ? this._keyChain.getKeyset(this._boundKeysetId)
+        : undefined;
+      if (!current || !current.isActive || !current.hasKeys) {
+        try {
+          this._boundKeysetId = this._keyChain.getCheapestKeyset().id;
+          this._logger.info('Wallet rebound to active keyset after refresh', {
+            keysetId: this._boundKeysetId,
+          });
+        } catch (e) {
+          // No active replacement: keep a still-known binding (melt stays possible),
+          // unbind only if the keyset vanished from the mint entirely.
+          if (!current) {
+            this._boundKeysetId = PENDING_KEYSET_ID;
+          }
+          this._logger.warn('Bound keyset is stale and no active keyset is available', {
+            unit: this._unit,
+            err: (e as Error).message,
+          });
+        }
+      }
     }
 
     // Go Mintinfo?
@@ -646,6 +671,7 @@ class Wallet {
     });
     this.failIf(!ks.hasKeys, 'Keyset has no keys loaded', { keyset: ks.id });
     this._boundKeysetId = ks.id;
+    this._explicitBind = true;
     this._logger.debug('Wallet bound to keyset', {
       keysetId: ks.id,
       unit: ks.unit,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -523,6 +523,12 @@ class Wallet {
    * foreign-unit id is left for `assertProofsInWalletUnit` to reject). Emits `keychainUpdated`.
    */
   private async ensureOperableKeysets(ids: Array<string | undefined>): Promise<void> {
+    // Never-loaded wallet: an empty keychain is not rotation evidence. Let the op's own
+    // assertions report initialization instead of a hidden loadMint(true) here.
+    if (!this._mintInfo) {
+      return;
+    }
+
     const wanted = [...new Set(ids.filter((id): id is string => !!id))];
     const unknown = wanted.filter((id) => !this._keyChain.hasKeyset(id));
     let changed = false;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -777,6 +777,7 @@ class Wallet {
       requireSigDleq: this._requireSigDleq,
       logger: this._logger,
       counterSource: opts?.counterSource ?? this._counterSource,
+      strictCachedKeysets: this._strictCachedKeysets,
     });
     // Load mint info from our caches
     newWallet.loadMintFromCache(this.getMintInfo().cache, this._keyChain.cache);

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -515,7 +515,7 @@ class Wallet {
   }
 
   /**
-   * Make the keychain usable for these keyset ids before an op takes decisions on it.
+   * Make the keychain usable for these keyset ids, at op entry or where the ids first become known.
    *
    * @remarks
    * Unknown ids trigger one shared `loadMint(true)` regardless of unit; still-unknown ids throw

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -578,12 +578,12 @@ class Wallet {
    *
    * @remarks
    * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} with
-   * `refreshed: true` if still unknown; known-but-keyless ids get keys fetched. Calls that never
-   * reach the mint (strict mode, rate limited) throw it with `refreshed: false`. Implicit
-   * (op-driven) calls honor `strictCachedKeysets`, where unknown ids throw immediately and keyless
-   * ids are left for the caller, and the repair cooldown, and emit `keychainUpdated` for anything
-   * they change. Explicit calls do the full pass and emit nothing: the consumer who asked persists
-   * the cache.
+   * `refreshed: true` if still unknown; known-but-keyless ids get keys fetched. Calls left without
+   * an answer (strict mode, rate limited, failed refresh) throw it with `refreshed: false`.
+   * Implicit (op-driven) calls honor `strictCachedKeysets`, where unknown ids throw immediately and
+   * keyless ids are left for the caller, and the repair cooldown, and emit `keychainUpdated` for
+   * anything they change. Explicit calls do the full pass and emit nothing: the consumer who asked
+   * persists the cache.
    */
   private async _ensureOperableKeysets(
     ids: Array<string | undefined>,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -655,7 +655,7 @@ class Wallet {
           throw failed[0].reason;
         }
         throw new CTSError(`Could not load keys for ${failed.length} keysets`, {
-          cause: failed.map((f) => f.reason),
+          cause: failed.map((f): unknown => f.reason),
         });
       }
     }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3287,8 +3287,13 @@ class Wallet {
       meltPayload,
     );
 
-    // Create any change Proofs
-    const change = this.createMeltChangeProofs(meltPreview.outputData, meltResponse.change ?? []);
+    // Create any change Proofs. Change may arrive on a rotated-out keyset, and a
+    // permissive mint may sign change on a keyset other than the blanks' (NUT-08).
+    const changeSigs = meltResponse.change ?? [];
+    if (changeSigs.length > 0) {
+      await this.ensureOperableKeysets(changeSigs.map((s) => s.id));
+    }
+    const change = this.createMeltChangeProofs(meltPreview.outputData, changeSigs);
 
     const changeAmounts = change.map((p) => p.amount.toString());
     if (completeOptions.preferAsync) {
@@ -3311,9 +3316,9 @@ class Wallet {
    * Constructs melt change proofs from prepared OutputData and mint returned Change Signatures.
    *
    * @remarks
-   * Called internally by `completeMelt`; also useful for NUT-06 async melts and any other path that
-   * defers change construction (crash recovery, process hand-off). Keyset lookup is per-signature
-   * so multi-keyset responses (e.g. a permissive CDK mint) work transparently.
+   * Synchronous by design and called internally by `completeMelt` (which ensures keys first);
+   * direct callers deferring change construction (NUT-06 async melts, crash recovery) should `await
+   * wallet.keyChain.ensureKeysetKeys(id)` per signature keyset first.
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted OutputData.
    * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -317,8 +317,8 @@ class Wallet {
    *
    * @remarks
    * Must be called before other methods, unless loading from cache (`loadMintFromCache`). With
-   * `forceRefresh`, metadata refreshes, held keys are kept, and an auto-bound wallet rebinds to the
-   * cheapest active keyset only if its current one is unusable; pinned wallets stay pinned.
+   * `forceRefresh`, metadata refreshes, held keys are kept, and an auto-bound wallet re-applies
+   * cheapest-keyset selection on every refresh; pinned wallets stay pinned.
    * @param forceRefresh If true, re-fetches data even if cached.
    * @throws If fetching mint info, keysets, or keys fails.
    */
@@ -389,27 +389,29 @@ class Wallet {
         walletUnit: this._unit,
       });
     } else {
-      // Auto-bound previously: follow the mint when the binding is no longer usable.
+      // Auto-bound: re-apply keyset selection so the binding tracks mint truth.
+      // getCheapestKeyset prefers the newest version, then lowest fee, then latest expiry.
       const current = this._keyChain.hasKeyset(this._boundKeysetId)
         ? this._keyChain.getKeyset(this._boundKeysetId)
         : undefined;
-      if (!current || !current.isActive || !current.hasKeys) {
-        try {
-          this._boundKeysetId = this._keyChain.getCheapestKeyset().id;
-          this._logger.info('Wallet rebound to active keyset after refresh', {
-            keysetId: this._boundKeysetId,
-          });
-        } catch (e) {
-          // No active replacement: keep a still-known binding (melt stays possible),
-          // unbind only if the keyset vanished from the mint entirely.
-          if (!current) {
-            this._boundKeysetId = PENDING_KEYSET_ID;
-          }
-          this._logger.warn('Bound keyset is stale and no active keyset is available', {
-            unit: this._unit,
-            err: (e as Error).message,
+      try {
+        const next = this._keyChain.getCheapestKeyset().id;
+        if (next !== this._boundKeysetId) {
+          this._boundKeysetId = next;
+          this._logger.info('Wallet rebound to cheapest active keyset after refresh', {
+            keysetId: next,
           });
         }
+      } catch (e) {
+        // No active replacement: keep a still-known binding (melt stays possible),
+        // unbind only if the keyset vanished from the mint entirely.
+        if (!current) {
+          this._boundKeysetId = PENDING_KEYSET_ID;
+        }
+        this._logger.warn('No active keyset available after refresh', {
+          unit: this._unit,
+          err: (e as Error).message,
+        });
       }
     }
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -164,6 +164,7 @@ class Wallet {
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
   private _requireSigDleq = false;
+  private _strictCachedKeysets: boolean = false;
   private _logger: Logger;
 
   /**
@@ -202,6 +203,9 @@ class Wallet {
    * @param options.requireSigDleq Fail mint/swap/melt responses when the mint advertises NUT-12
    *   support but omits DLEQ proofs on returned blinded signatures. This is a fail-fast consistency
    *   check, not protection against a malicious mint already consuming inputs or payments.
+   * @param options.strictCachedKeysets Never fetch keyset data inside operations; only the snapshot
+   *   you load is used. Insufficient state throws the same typed errors as non-strict mode's
+   *   terminal cases. Default false.
    * @param options.logger Logger instance, default null logger.
    */
   constructor(
@@ -218,6 +222,7 @@ class Wallet {
       selectProofs?: SelectProofs; // optional override
       outputDataCreator?: OutputDataCreator;
       requireSigDleq?: boolean;
+      strictCachedKeysets?: boolean;
       logger?: Logger;
     },
   ) {
@@ -252,6 +257,7 @@ class Wallet {
     this._keyChain = new KeyChain(this.mint, this._unit);
     this._denominationTarget = options?.denominationTarget ?? this._denominationTarget;
     this._requireSigDleq = options?.requireSigDleq ?? this._requireSigDleq;
+    this._strictCachedKeysets = options?.strictCachedKeysets ?? this._strictCachedKeysets;
   }
 
   // Convenience wrappers for "log and throw"
@@ -518,9 +524,9 @@ class Wallet {
    * Make the keychain usable for these keyset ids, at op entry or where the ids first become known.
    *
    * @remarks
-   * Unknown ids trigger one shared `loadMint(true)` regardless of unit; still-unknown ids throw
-   * {@link UnknownKeysetError}. Known-but-keyless ids in the wallet's unit get keys fetched (a
-   * foreign-unit id is left for `assertProofsInWalletUnit` to reject). Emits `keychainUpdated`.
+   * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} if still
+   * unknown; known-but-keyless ids get keys fetched. Both paths emit `keychainUpdated`. Under
+   * `strictCachedKeysets`, unknown ids throw immediately and keyless ids are left for the caller.
    */
   private async ensureOperableKeysets(ids: Array<string | undefined>): Promise<void> {
     // Never-loaded wallet: an empty keychain is not rotation evidence. Let the op's own
@@ -530,6 +536,15 @@ class Wallet {
     }
 
     const wanted = [...new Set(ids.filter((id): id is string => !!id))];
+
+    if (this._strictCachedKeysets) {
+      const strictUnknown = wanted.filter((id) => !this._keyChain.hasKeyset(id));
+      if (strictUnknown.length > 0) {
+        throw new UnknownKeysetError(strictUnknown[0]);
+      }
+      return; // no backfill: downstream key checks report keyless keysets
+    }
+
     const unknown = wanted.filter((id) => !this._keyChain.hasKeyset(id));
     let changed = false;
 
@@ -1807,8 +1822,11 @@ class Wallet {
     this.failIfNullish(this._seed, 'Cashu Wallet must be initialized with a seed to use restore');
     const { keysetId } = config || {};
 
-    // Ensure we have keys - wallet only loads active keysets by default
-    await this._keyChain.ensureKeysetKeys(keysetId ?? this.keysetId);
+    // Ensure we have keys - wallet only loads active keysets by default.
+    // Under strictCachedKeysets, skip the fetch: getKeyset below reports a keyless keyset.
+    if (!this._strictCachedKeysets) {
+      await this._keyChain.ensureKeysetKeys(keysetId ?? this.keysetId);
+    }
     const keyset = this.getKeyset(keysetId); // specified or wallet keyset
 
     // create deterministic blank outputs for unknown restore amounts

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1142,7 +1142,7 @@ class Wallet {
     }
 
     // Rotation evidence check: repair the snapshot and load any missing keys before
-    // any assertion or fee math relies on it. See the keyset rotation design spec.
+    // any assertion or fee math relies on it.
     await this.ensureOperableKeysets(proofs.map((p) => p.id));
 
     // Validate all proof keyset IDs use this wallet's unit

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -20,7 +20,7 @@ import { signMintQuoteAmended } from '../crypto/NUT20';
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';
 import { Amount, type AmountLike } from '../model/Amount';
-import { CTSError, isMintOperationError } from '../model/Errors';
+import { CTSError, UnknownKeysetError, isMintOperationError } from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import { OutputData, type OutputDataLike } from '../model/OutputData';
 import { DefaultOutputDataCreator, type OutputDataCreator } from '../model/OutputDataCreator';
@@ -159,6 +159,7 @@ class Wallet {
   private _secretsPolicy: SecretsPolicy = 'auto';
   private _counterSource: CounterSource;
   private _boundKeysetId: string = PENDING_KEYSET_ID;
+  private _pendingRepair: Promise<void> | null = null;
   private _explicitBind: boolean = false;
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
@@ -510,6 +511,50 @@ class Wallet {
       keyset: keyset.id,
     });
     return keyset;
+  }
+
+  /**
+   * Make the keychain usable for these keyset ids before an op takes decisions on it.
+   *
+   * @remarks
+   * Unknown ids trigger one shared `loadMint(true)` regardless of unit; still-unknown ids throw
+   * {@link UnknownKeysetError}. Known-but-keyless ids in the wallet's unit get keys fetched (a
+   * foreign-unit id is left for `assertProofsInWalletUnit` to reject). Emits `keychainUpdated`.
+   */
+  private async ensureOperableKeysets(ids: Array<string | undefined>): Promise<void> {
+    const wanted = [...new Set(ids.filter((id): id is string => !!id))];
+    const unknown = wanted.filter((id) => !this._keyChain.hasKeyset(id));
+    let changed = false;
+
+    if (unknown.length > 0) {
+      this._pendingRepair ??= this.loadMint(true).finally(() => {
+        this._pendingRepair = null;
+      });
+      try {
+        await this._pendingRepair;
+      } catch (e) {
+        throw new UnknownKeysetError(unknown[0], { cause: e });
+      }
+      changed = true;
+      const still = unknown.filter((id) => !this._keyChain.hasKeyset(id));
+      if (still.length > 0) {
+        // The refresh itself succeeded and is worth persisting before we fail the op.
+        this.on._emitKeychainUpdated();
+        throw new UnknownKeysetError(still[0]);
+      }
+    }
+
+    const keyless = wanted.filter(
+      (id) => this._keyChain.isUnitKeyset(id) && !this._keyChain.getKeyset(id).hasKeys,
+    );
+    if (keyless.length > 0) {
+      await Promise.all(keyless.map((id) => this._keyChain.ensureKeysetKeys(id)));
+      changed = true;
+    }
+
+    if (changed) {
+      this.on._emitKeychainUpdated();
+    }
   }
 
   /**
@@ -1063,6 +1108,10 @@ class Wallet {
       // Token object may come from JSON.parse/localStorage and need runtime rehydration.
       proofs = normalizeProofAmounts(decodedToken.proofs);
     }
+
+    // Rotation evidence check: repair the snapshot and load any missing keys before
+    // any assertion or fee math relies on it. See the keyset rotation design spec.
+    await this.ensureOperableKeysets(proofs.map((p) => p.id));
 
     // Validate all proof keyset IDs use this wallet's unit
     this.assertProofsInWalletUnit(proofs);

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -20,7 +20,12 @@ import { signMintQuoteAmended } from '../crypto/NUT20';
 import { type Logger, NULL_LOGGER, fail, failIf, failIfNullish, safeCallback } from '../logger';
 import { Mint } from '../mint';
 import { Amount, type AmountLike } from '../model/Amount';
-import { CTSError, UnknownKeysetError, isMintOperationError } from '../model/Errors';
+import {
+  CTSError,
+  StaleKeysetError,
+  UnknownKeysetError,
+  isMintOperationError,
+} from '../model/Errors';
 import { MintInfo } from '../model/MintInfo';
 import { OutputData, type OutputDataLike } from '../model/OutputData';
 import { DefaultOutputDataCreator, type OutputDataCreator } from '../model/OutputDataCreator';
@@ -59,6 +64,7 @@ import {
   sumProofs,
   verifyDleqIfPresent,
   ABSOLUTE_MAX_BATCH_SIZE,
+  REPAIR_COOLDOWN_MS,
 } from '../utils';
 
 import { ceilLog2, getKeepAmounts, stringifyOutputTypeForLog } from './_internal';
@@ -160,6 +166,7 @@ class Wallet {
   private _counterSource: CounterSource;
   private _boundKeysetId: string = PENDING_KEYSET_ID;
   private _pendingRepair: Promise<void> | null = null;
+  private _lastRepairAt = 0;
   private _explicitBind: boolean = false;
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
@@ -523,14 +530,40 @@ class Wallet {
   }
 
   /**
+   * Start, or join, the shared snapshot repair refresh.
+   *
+   * @remarks
+   * Returns null when an implicit repair falls inside the cooldown window, which the caller must
+   * treat as terminal. A repair already in flight is always joined, cooldown or not, so concurrent
+   * ops still share one refresh.
+   */
+  private startRepair(implicit: boolean): Promise<void> | null {
+    if (this._pendingRepair) {
+      return this._pendingRepair;
+    }
+    if (implicit && Date.now() - this._lastRepairAt < REPAIR_COOLDOWN_MS) {
+      return null;
+    }
+    this._lastRepairAt = Date.now();
+    this._pendingRepair = this.loadMint(true).finally(() => {
+      this._pendingRepair = null;
+    });
+    return this._pendingRepair;
+  }
+
+  /**
    * Make the keychain usable for these keyset ids, at op entry or where the ids first become known.
    *
    * @remarks
    * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} if still
-   * unknown; known-but-keyless ids get keys fetched. Both paths emit `keychainUpdated`. Under
-   * `strictCachedKeysets`, unknown ids throw immediately and keyless ids are left for the caller.
+   * unknown; known-but-keyless ids get keys fetched. Both paths emit `keychainUpdated`. Implicit
+   * (op-driven) calls honor `strictCachedKeysets`, where unknown ids throw immediately and keyless
+   * ids are left for the caller, and the repair cooldown.
    */
-  private async ensureOperableKeysets(ids: Array<string | undefined>): Promise<void> {
+  private async _ensureOperableKeysets(
+    ids: Array<string | undefined>,
+    opts: { implicit: boolean },
+  ): Promise<void> {
     // Never-loaded wallet: an empty keychain is not rotation evidence. Let the op's own
     // assertions report initialization instead of a hidden loadMint(true) here.
     if (!this._mintInfo) {
@@ -539,7 +572,7 @@ class Wallet {
 
     const wanted = [...new Set(ids.filter((id): id is string => !!id))];
 
-    if (this._strictCachedKeysets) {
+    if (opts.implicit && this._strictCachedKeysets) {
       const strictUnknown = wanted.filter((id) => !this._keyChain.hasKeyset(id));
       if (strictUnknown.length > 0) {
         throw new UnknownKeysetError(strictUnknown[0]);
@@ -551,11 +584,12 @@ class Wallet {
     let changed = false;
 
     if (unknown.length > 0) {
-      this._pendingRepair ??= this.loadMint(true).finally(() => {
-        this._pendingRepair = null;
-      });
+      const repair = this.startRepair(opts.implicit);
+      if (!repair) {
+        throw new UnknownKeysetError(unknown[0]); // rate limited: terminal for this op
+      }
       try {
-        await this._pendingRepair;
+        await repair;
       } catch (e) {
         throw new UnknownKeysetError(unknown[0], { cause: e });
       }
@@ -586,6 +620,58 @@ class Wallet {
 
     if (changed) {
       this.on._emitKeychainUpdated();
+    }
+  }
+
+  /**
+   * Refresh the snapshot after the mint rejected a keyset the wallet considered current.
+   *
+   * @returns True when the refresh ran, so the caller's operation is worth running again.
+   */
+  private async repairStaleSnapshot(): Promise<boolean> {
+    if (this._strictCachedKeysets) {
+      return false; // the snapshot is the consumer's to manage
+    }
+    const repair = this.startRepair(true);
+    if (!repair) {
+      return false; // rate limited
+    }
+    try {
+      await repair;
+    } catch (e) {
+      this._logger.warn('Snapshot refresh after a mint keyset rejection failed', {
+        err: (e as Error).message,
+      });
+      return false;
+    }
+    this.on._emitKeychainUpdated();
+    return true;
+  }
+
+  /**
+   * Run a mint request, treating a keyset rejection as evidence the snapshot is stale.
+   *
+   * @remarks
+   * Repairs the snapshot once and rethrows as {@link StaleKeysetError}. Nothing retries: the outputs
+   * were built on the rejected keyset, so the caller runs the operation again.
+   */
+  private async withStaleKeysetRepair<T>(request: () => Promise<T>): Promise<T> {
+    try {
+      return await request();
+    } catch (e) {
+      // NUT-00 reserves 12xxx for keyset errors (12001 unknown, 12002 inactive, 12003 expired).
+      // Mints that answer without a structured code are unaffected, as are look-alike errors from
+      // a custom request layer whose `code` is not a finite number (`Number(undefined)` is NaN):
+      // every range comparison against those is false, so check before comparing.
+      if (
+        !isMintOperationError(e) ||
+        !Number.isFinite(e.code) ||
+        e.code < 12000 ||
+        e.code >= 13000
+      ) {
+        throw e;
+      }
+      throw new StaleKeysetError(await this.repairStaleSnapshot(), { cause: e });
     }
   }
 
@@ -1144,7 +1230,10 @@ class Wallet {
 
     // Rotation evidence check: repair the snapshot and load any missing keys before
     // any assertion or fee math relies on it.
-    await this.ensureOperableKeysets(proofs.map((p) => p.id));
+    await this._ensureOperableKeysets(
+      proofs.map((p) => p.id),
+      { implicit: true },
+    );
 
     // Validate all proof keyset IDs use this wallet's unit
     this.assertProofsInWalletUnit(proofs);
@@ -1463,6 +1552,7 @@ class Wallet {
    * @param swapPreview With metadata for swap transaction.
    * @param privkey The private key(s) for signing.
    * @returns SendResponse with keep/send proofs.
+   * @throws {@link StaleKeysetError} If the mint rejects the outputs' keyset.
    */
   async completeSwap(swapPreview: SwapPreview, privkey?: string | string[]): Promise<SendResponse> {
     const keepOutputs: OutputDataLike[] = swapPreview?.keepOutputs ? swapPreview.keepOutputs : [];
@@ -1487,7 +1577,9 @@ class Wallet {
     );
 
     // Execute swap and validate result
-    const { signatures } = await this.mint.swap(swapTransaction.payload);
+    const { signatures } = await this.withStaleKeysetRepair(() =>
+      this.mint.swap(swapTransaction.payload),
+    );
     this.failIf(
       signatures.length !== swapTransaction.outputData.length,
       `Mint returned ${signatures.length} signatures, expected ${swapTransaction.outputData.length}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
@@ -2553,16 +2645,19 @@ class Wallet {
    * mint flow and is also what the named convenience helpers use internally.
    * @param mintPreview Preview returned by prepareMint.
    * @returns Minted proofs.
+   * @throws {@link StaleKeysetError} If the mint rejects the outputs' keyset.
    */
   async completeMint(
     mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
     const { payload, outputData, keysetId, method, legacySignature } = mintPreview;
     // TODO: Remove legacy message support
-    const { signatures } = await this.withLegacyQuoteSigFallback(
-      legacySignature !== undefined,
-      () => this.mint.mint(method, payload),
-      () => this.mint.mint(method, { ...payload, signature: legacySignature }),
+    const { signatures } = await this.withStaleKeysetRepair(() =>
+      this.withLegacyQuoteSigFallback(
+        legacySignature !== undefined,
+        () => this.mint.mint(method, payload),
+        () => this.mint.mint(method, { ...payload, signature: legacySignature }),
+      ),
     );
     this.failIf(
       signatures.length !== outputData.length,
@@ -2723,6 +2818,7 @@ class Wallet {
    * Use with a `BatchMintPreview` returned by `prepareBatchMint()`.
    * @param batchPreview Preview returned by prepareBatchMint.
    * @returns Minted proofs.
+   * @throws {@link StaleKeysetError} If the mint rejects the outputs' keyset.
    * @experimental only supported by CDK mint >= 0.16.0
    */
   async completeBatchMint(
@@ -2730,10 +2826,12 @@ class Wallet {
   ): Promise<Proof[]> {
     const { method, payload, outputData, keysetId, legacySignatures } = batchPreview;
     // TODO: Remove legacy message support
-    const { signatures: sigs } = await this.withLegacyQuoteSigFallback(
-      legacySignatures !== undefined,
-      () => this.mint.mintBatch(method, payload),
-      () => this.mint.mintBatch(method, { ...payload, signatures: legacySignatures! }),
+    const { signatures: sigs } = await this.withStaleKeysetRepair(() =>
+      this.withLegacyQuoteSigFallback(
+        legacySignatures !== undefined,
+        () => this.mint.mintBatch(method, payload),
+        () => this.mint.mintBatch(method, { ...payload, signatures: legacySignatures! }),
+      ),
     );
     this.failIf(
       sigs.length !== outputData.length,
@@ -3264,6 +3362,7 @@ class Wallet {
    * @param options Optional override to request NUT-06 asynchronous melt or method-specific fields.
    * @returns Updated MeltProofsResponse.
    * @throws If melt fails or signatures don't match output count.
+   * @throws {@link StaleKeysetError} If the mint rejects the outputs' keyset.
    */
   async completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(
     meltPreview: MeltPreview<TQuote>,
@@ -3318,16 +3417,18 @@ class Wallet {
     };
 
     // Execute melt and validate result
-    const meltResponse: MeltQuoteBaseResponse = await this.mint.melt<TQuote>(
-      meltPreview.method,
-      meltPayload,
+    const meltResponse: MeltQuoteBaseResponse = await this.withStaleKeysetRepair(() =>
+      this.mint.melt<TQuote>(meltPreview.method, meltPayload),
     );
 
     // Create any change Proofs. Change may arrive on a rotated-out keyset, and a
     // permissive mint may sign change on a keyset other than the blanks' (NUT-08).
     const changeSigs = meltResponse.change ?? [];
     if (changeSigs.length > 0) {
-      await this.ensureOperableKeysets(changeSigs.map((s) => s.id));
+      await this._ensureOperableKeysets(
+        changeSigs.map((s) => s.id),
+        { implicit: true },
+      );
     }
     const change = this.createMeltChangeProofs(meltPreview.outputData, changeSigs);
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -557,17 +557,19 @@ class Wallet {
    * @remarks
    * Returns null when an implicit repair falls inside the cooldown window, which the caller must
    * treat as terminal. A repair already in flight is always joined, cooldown or not, so concurrent
-   * ops still share one refresh. Explicit repairs are never blocked, but do stamp the window; a
-   * consumer's own `loadMint(true)` does not, since it never comes through here.
+   * ops still share one refresh. The window covers implicit repairs only: an explicit one neither
+   * waits for it nor starts it, so a consumer's call never suppresses the wallet's own repair.
    */
   private startRepair(implicit: boolean): Promise<void> | null {
     if (this._pendingRepair) {
       return this._pendingRepair;
     }
-    if (implicit && Date.now() - this._lastRepairAt < REPAIR_COOLDOWN_MS) {
-      return null;
+    if (implicit) {
+      if (Date.now() - this._lastRepairAt < REPAIR_COOLDOWN_MS) {
+        return null;
+      }
+      this._lastRepairAt = Date.now();
     }
-    this._lastRepairAt = Date.now();
     this._pendingRepair = this.loadMint(true).finally(() => {
       this._pendingRepair = null;
     });

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -537,10 +537,12 @@ class Wallet {
    * Repairs unknown ids with one `loadMint(true)` and loads any missing keys. An explicit call is
    * the consumer's own request, so it ignores `strictCachedKeysets` and the internal repair rate
    * limit. It emits no `keychainUpdated`: persist `keyChain.cache` yourself afterwards, as with
-   * `loadMint`. Aimed at integrations that verify proofs without running wallet ops.
+   * `loadMint`, and after a throw too, since keys for the other ids may still have landed. Aimed at
+   * integrations that verify proofs without running wallet ops.
    * @param ids Keyset ids to make operable. Undefined entries are ignored.
    * @throws {@link UnknownKeysetError} For an id the mint does not know, or if the refresh fails.
-   * @throws {@link CTSError} If the wallet has never loaded mint info.
+   * @throws {@link CTSError} If the wallet has never loaded mint info, or if several key fetches
+   *   fail, with the individual failures as `cause`. A lone failure is rethrown as-is.
    */
   public async ensureOperableKeysets(ids: Array<string | undefined>): Promise<void> {
     this.failIf(!Array.isArray(ids), 'ensureOperableKeysets: ids must be an array');

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -530,12 +530,34 @@ class Wallet {
   }
 
   /**
+   * Make the snapshot usable for these keyset ids, without running an operation.
+   *
+   * @remarks
+   * Repairs unknown ids with one `loadMint(true)` and loads any missing keys. An explicit call is
+   * the consumer's own request, so it ignores `strictCachedKeysets` and the internal repair rate
+   * limit. It emits no `keychainUpdated`: persist `keyChain.cache` yourself afterwards, as with
+   * `loadMint`. Aimed at integrations that verify proofs without running wallet ops.
+   * @param ids Keyset ids to make operable. Undefined entries are ignored.
+   * @throws {@link UnknownKeysetError} For an id the mint does not know, or if the refresh fails.
+   * @throws {@link CTSError} If the wallet has never loaded mint info.
+   */
+  public async ensureOperableKeysets(ids: Array<string | undefined>): Promise<void> {
+    this.failIf(!Array.isArray(ids), 'ensureOperableKeysets: ids must be an array');
+    this.failIf(
+      !this._mintInfo,
+      'Mint info not initialized; call loadMint or loadMintFromCache first',
+    );
+    return this._ensureOperableKeysets(ids, { implicit: false });
+  }
+
+  /**
    * Start, or join, the shared snapshot repair refresh.
    *
    * @remarks
    * Returns null when an implicit repair falls inside the cooldown window, which the caller must
    * treat as terminal. A repair already in flight is always joined, cooldown or not, so concurrent
-   * ops still share one refresh.
+   * ops still share one refresh. Explicit repairs are never blocked, but do stamp the window; a
+   * consumer's own `loadMint(true)` does not, since it never comes through here.
    */
   private startRepair(implicit: boolean): Promise<void> | null {
     if (this._pendingRepair) {
@@ -556,9 +578,10 @@ class Wallet {
    *
    * @remarks
    * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} if still
-   * unknown; known-but-keyless ids get keys fetched. Both paths emit `keychainUpdated`. Implicit
-   * (op-driven) calls honor `strictCachedKeysets`, where unknown ids throw immediately and keyless
-   * ids are left for the caller, and the repair cooldown.
+   * unknown; known-but-keyless ids get keys fetched. Implicit (op-driven) calls honor
+   * `strictCachedKeysets`, where unknown ids throw immediately and keyless ids are left for the
+   * caller, and the repair cooldown, and emit `keychainUpdated` for anything they change. Explicit
+   * calls do the full pass and emit nothing: the consumer who asked persists the cache.
    */
   private async _ensureOperableKeysets(
     ids: Array<string | undefined>,
@@ -597,7 +620,9 @@ class Wallet {
       const still = unknown.filter((id) => !this._keyChain.hasKeyset(id));
       if (still.length > 0) {
         // The refresh itself succeeded and is worth persisting before we fail the op.
-        this.on._emitKeychainUpdated();
+        if (opts.implicit) {
+          this.on._emitKeychainUpdated();
+        }
         throw new UnknownKeysetError(still[0]);
       }
     }
@@ -609,7 +634,7 @@ class Wallet {
       try {
         await Promise.all(keyless.map((id) => this._keyChain.ensureKeysetKeys(id)));
       } catch (e) {
-        if (changed) {
+        if (changed && opts.implicit) {
           // A repair above already succeeded and is worth persisting even though this fetch failed.
           this.on._emitKeychainUpdated();
         }
@@ -618,7 +643,8 @@ class Wallet {
       changed = true;
     }
 
-    if (changed) {
+    // Explicit callers get no event: they asked for the change, so they persist the cache.
+    if (changed && opts.implicit) {
       this.on._emitKeychainUpdated();
     }
   }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1495,6 +1495,13 @@ class Wallet {
     const normalizedProofs = normalizeProofAmounts(proofs);
     const { keysetId, includeFees = false, onCountersReserved } = config || {};
 
+    // Rotation evidence check: repair the snapshot and load any missing keys before
+    // any assertion or fee math relies on it.
+    await this._ensureOperableKeysets(
+      normalizedProofs.map((p) => p.id),
+      { implicit: true },
+    );
+
     // Fallback to policy defaults if no outputConfig
     outputConfig = outputConfig ?? {
       send: this.defaultOutputType(),
@@ -3319,6 +3326,15 @@ class Wallet {
     this.validateMeltQuote(meltQuote);
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
     const { keysetId, onCountersReserved, nut08Change = true } = config || {};
+
+    // Rotation evidence check: repair the snapshot and load any missing keys before
+    // any assertion or fee math relies on it. Ids are read pre-normalization; the
+    // amounts change, the ids do not.
+    await this._ensureOperableKeysets(
+      proofsToSend.map((p) => p.id),
+      { implicit: true },
+    );
+
     // Plain getKeyset: melting needs no new outputs, so an inactive/legacy keyset must not
     // block withdrawal. A mint unwinding liabilities deactivates keysets but
     // keeps melt open; gate output creation below, not the melt itself.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -22,6 +22,7 @@ import { Mint } from '../mint';
 import { Amount, type AmountLike } from '../model/Amount';
 import {
   CTSError,
+  MeltChangeError,
   StaleKeysetError,
   UnknownKeysetError,
   isMintOperationError,
@@ -3392,6 +3393,8 @@ class Wallet {
    * @returns Updated MeltProofsResponse.
    * @throws If melt fails or signatures don't match output count.
    * @throws {@link StaleKeysetError} If the mint rejects the outputs' keyset.
+   * @throws {@link MeltChangeError} If the melt went through but its change could not be built.
+   *   Carries the `outputData` and quote needed to recover the change later.
    */
   async completeMelt<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse>(
     meltPreview: MeltPreview<TQuote>,
@@ -3450,16 +3453,25 @@ class Wallet {
       this.mint.melt<TQuote>(meltPreview.method, meltPayload),
     );
 
+    // Merge preview quote with response to protect against incomplete response.
+    const mergedQuote = { ...meltPreview.quote, ...meltResponse };
+
     // Create any change Proofs. Change may arrive on a rotated-out keyset, and a
     // permissive mint may sign change on a keyset other than the blanks' (NUT-08).
+    // The inputs are spent by now, so a failure here must hand back what recovery needs.
     const changeSigs = meltResponse.change ?? [];
-    if (changeSigs.length > 0) {
-      await this._ensureOperableKeysets(
-        changeSigs.map((s) => s.id),
-        { implicit: true },
-      );
+    let change: Proof[];
+    try {
+      if (changeSigs.length > 0) {
+        await this._ensureOperableKeysets(
+          changeSigs.map((s) => s.id),
+          { implicit: true },
+        );
+      }
+      change = this.createMeltChangeProofs(meltPreview.outputData, changeSigs);
+    } catch (e) {
+      throw new MeltChangeError(meltPreview.outputData, mergedQuote, { cause: e });
     }
-    const change = this.createMeltChangeProofs(meltPreview.outputData, changeSigs);
 
     const changeAmounts = change.map((p) => p.amount.toString());
     if (completeOptions.preferAsync) {
@@ -3468,9 +3480,7 @@ class Wallet {
       this._logger.debug('MELT COMPLETED', { changeAmounts });
     }
 
-    // Merge preview quote with response to protect against incomplete response.
     // Retain outputData if no change was returned, so async/onchain can recover it later.
-    const mergedQuote = { ...meltPreview.quote, ...meltResponse } as TQuote;
     return {
       quote: mergedQuote,
       change,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -583,16 +583,17 @@ class Wallet {
    *
    * @remarks
    * Unknown ids repair once via `loadMint(true)`, throwing {@link UnknownKeysetError} with
-   * `refreshed: true` if still unknown; known-but-keyless ids get keys fetched. Calls left without
-   * an answer (strict mode, rate limited, failed refresh) throw it with `refreshed: false`.
-   * Implicit (op-driven) calls honor `strictCachedKeysets`, where unknown ids throw immediately and
-   * keyless ids are left for the caller, and the repair cooldown, and emit `keychainUpdated` for
-   * anything they change. Explicit calls do the full pass and emit nothing: the consumer who asked
-   * persists the cache.
+   * `refreshed: true` if still unknown; known-but-keyless ids get keys fetched unless
+   * `opts.fetchKeys` is false, which spend-side ops pass because their inputs need only the
+   * keyset's fee metadata, never its keys. Calls left without an answer (strict mode, rate limited,
+   * failed refresh) throw it with `refreshed: false`. Implicit (op-driven) calls honor
+   * `strictCachedKeysets`, where unknown ids throw immediately and keyless ids are left for the
+   * caller, and the repair cooldown, and emit `keychainUpdated` for anything they change. Explicit
+   * calls do the full pass and emit nothing: the consumer who asked persists the cache.
    */
   private async _ensureOperableKeysets(
     ids: Array<string | undefined>,
-    opts: { implicit: boolean },
+    opts: { implicit: boolean; fetchKeys?: boolean },
   ): Promise<void> {
     // Never-loaded wallet: an empty keychain is not rotation evidence. Let the op's own
     // assertions report initialization instead of a hidden loadMint(true) here.
@@ -635,9 +636,12 @@ class Wallet {
       }
     }
 
-    const keyless = wanted.filter(
-      (id) => this._keyChain.isUnitKeyset(id) && !this._keyChain.getKeyset(id).hasKeys,
-    );
+    const keyless =
+      opts.fetchKeys === false
+        ? []
+        : wanted.filter(
+            (id) => this._keyChain.isUnitKeyset(id) && !this._keyChain.getKeyset(id).hasKeys,
+          );
     if (keyless.length > 0) {
       // allSettled, not all: a sibling failure must not hide the keys that did land, or the
       // consumer never learns to persist them and refetches on every op.
@@ -1497,11 +1501,11 @@ class Wallet {
     const normalizedProofs = normalizeProofAmounts(proofs);
     const { keysetId, includeFees = false, onCountersReserved } = config || {};
 
-    // Rotation evidence check: repair the snapshot and load any missing keys before
-    // any assertion or fee math relies on it.
+    // Rotation evidence check: repair the snapshot before any assertion or fee math
+    // relies on it. Inputs are priced from keyset metadata, so keys are not fetched.
     await this._ensureOperableKeysets(
       normalizedProofs.map((p) => p.id),
-      { implicit: true },
+      { implicit: true, fetchKeys: false },
     );
 
     // Fallback to policy defaults if no outputConfig
@@ -3283,11 +3287,12 @@ class Wallet {
     });
     const normalizedProofs = normalizeProofAmounts(proofsToSend);
 
-    // Rotation evidence check: repair the snapshot and load any missing keys before the
-    // input fee lookup relies on it. prepareMelt checks again below, a no-op by then.
+    // Rotation evidence check: repair the snapshot before the input fee lookup relies on
+    // it. Inputs are priced from keyset metadata, so keys are not fetched. prepareMelt
+    // checks again below, a no-op by then.
     await this._ensureOperableKeysets(
       normalizedProofs.map((p) => p.id),
-      { implicit: true },
+      { implicit: true, fetchKeys: false },
     );
 
     // Ensure we have enough proofs
@@ -3337,13 +3342,23 @@ class Wallet {
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
     const { keysetId, onCountersReserved, nut08Change = true } = config || {};
 
-    // Rotation evidence check: repair the snapshot and load any missing keys before
-    // any assertion or fee math relies on it. Ids are read pre-normalization; the
-    // amounts change, the ids do not.
-    await this._ensureOperableKeysets(
-      proofsToSend.map((p) => p.id),
-      { implicit: true },
-    );
+    // Rotation evidence check: repair the snapshot so the output binding is current.
+    // bolt11/bolt12 melts never consult the input keyset (no keys, no fee metadata), so an
+    // id the mint delisted but still honors must not block the withdrawal: proceed and let
+    // the mint judge. Strict mode still refuses; so do non-keyset errors.
+    try {
+      await this._ensureOperableKeysets(
+        proofsToSend.map((p) => p.id),
+        { implicit: true, fetchKeys: false },
+      );
+    } catch (e) {
+      if (this._strictCachedKeysets || !(e instanceof UnknownKeysetError)) {
+        throw e;
+      }
+      this._logger.warn('Melt input keyset is not listed by the mint; proceeding anyway', {
+        keyset: e.keysetId,
+      });
+    }
 
     // Plain getKeyset: melting needs no new outputs, so an inactive/legacy keyset must not
     // block withdrawal. A mint unwinding liabilities deactivates keysets but

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -637,16 +637,27 @@ class Wallet {
       (id) => this._keyChain.isUnitKeyset(id) && !this._keyChain.getKeyset(id).hasKeys,
     );
     if (keyless.length > 0) {
-      try {
-        await Promise.all(keyless.map((id) => this._keyChain.ensureKeysetKeys(id)));
-      } catch (e) {
+      // allSettled, not all: a sibling failure must not hide the keys that did land, or the
+      // consumer never learns to persist them and refetches on every op.
+      const fetches = await Promise.allSettled(
+        keyless.map((id) => this._keyChain.ensureKeysetKeys(id)),
+      );
+      const failed = fetches.filter((f): f is PromiseRejectedResult => f.status === 'rejected');
+      if (failed.length < fetches.length) {
+        changed = true;
+      }
+      if (failed.length > 0) {
         if (changed && opts.implicit) {
-          // A repair above already succeeded and is worth persisting even though this fetch failed.
+          // Whatever landed (a repair above, or a sibling fetch) is worth persisting first.
           this.on._emitKeychainUpdated();
         }
-        throw e;
+        if (failed.length === 1) {
+          throw failed[0].reason;
+        }
+        throw new CTSError(`Could not load keys for ${failed.length} keysets`, {
+          cause: failed.map((f) => f.reason),
+        });
       }
-      changed = true;
     }
 
     // Explicit callers get no event: they asked for the change, so they persist the cache.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -310,8 +310,9 @@ class Wallet {
    * Load mint information, keysets, and keys.
    *
    * @remarks
-   * Must be called before using other methods, unless loading mint from cache. See:
-   * `loadMintFromCache`.
+   * Must be called before other methods, unless loading from cache (`loadMintFromCache`). With
+   * `forceRefresh`, metadata refreshes, held keys are kept, and an auto-bound wallet rebinds to the
+   * cheapest active keyset only if its current one is unusable; pinned wallets stay pinned.
    * @param forceRefresh If true, re-fetches data even if cached.
    * @throws If fetching mint info, keysets, or keys fails.
    */

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -9,6 +9,7 @@ import type {
   MeltQuoteBolt11Response,
   MintQuoteBolt11Response,
 } from '../model/types';
+import type { KeyChainCache } from '../model/types/keyset';
 
 import { type OperationCounters } from './CounterSource';
 import type { Wallet } from './Wallet';
@@ -67,6 +68,9 @@ export class WalletEvents {
 
   // Callbacks registered for Counters Reserved events
   private countersReservedHandlers = new Set<(payload: OperationCounters) => void>();
+
+  // Callbacks registered for Keychain Updated events
+  private keychainUpdatedHandlers = new Set<(payload: { cache: KeyChainCache }) => void>();
 
   // Binds an abort signal to each subscription canceller
   private withAbort(
@@ -188,6 +192,37 @@ export class WalletEvents {
   public _emitCountersReserved(payload: OperationCounters) {
     for (const h of this.countersReservedHandlers) {
       safeCallback(h, payload, this.wallet.logger, { event: 'countersReserved' });
+    }
+  }
+
+  /**
+   * Register a callback that fires when the wallet updates its keychain from the network inside an
+   * operation (eg after repairing an unknown keyset, or lazily loading keys).
+   *
+   * Typical use: re-persist `payload.cache` so your stored copy stays complete.
+   *
+   * @param cb Handler called with { cache }.
+   * @returns A function that unsubscribes the handler.
+   */
+  public keychainUpdated(
+    cb: (payload: { cache: KeyChainCache }) => void,
+    opts?: SubscribeOpts,
+  ): SubscriptionCanceller {
+    this.keychainUpdatedHandlers.add(cb);
+    const cancel = () => this.keychainUpdatedHandlers.delete(cb);
+    return this.withAbort(opts?.signal, cancel);
+  }
+
+  /**
+   * @internal
+   */
+  public _emitKeychainUpdated(): void {
+    if (this.keychainUpdatedHandlers.size === 0) {
+      return; // cache getter allocates; skip when nobody listens
+    }
+    const payload = { cache: this.wallet.keyChain.cache };
+    for (const h of this.keychainUpdatedHandlers) {
+      safeCallback(h, payload, this.wallet.logger, { event: 'keychainUpdated' });
     }
   }
 

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -737,7 +737,8 @@ export class MintBuilder<
    *
    * @remarks
    * This is equivalent to `const preview = await prepare(); await wallet.completeMint(preview)`.
-   * This method can only be called for bolt12 quotes when `.privkey()` is set.
+   * This method can only be called for bolt12 quotes when `.privkey()` is set. Builders are single
+   * use: run a fresh one after a `StaleKeysetError` with `repaired` true.
    * @returns The newly minted proofs.
    */
   async run(this: MintBuilder<M, true>) {
@@ -882,6 +883,8 @@ export class MeltBuilder<
   /**
    * Execute the melt against the quote.
    *
+   * @remarks
+   * Builders are single use: run a fresh one after a `StaleKeysetError` with `repaired` true.
    * @returns The melt result: `{ quote, change, outputData }`.
    */
   async run(): Promise<MeltProofsResponse<TQuote>> {

--- a/test/model/Errors.test.ts
+++ b/test/model/Errors.test.ts
@@ -147,7 +147,7 @@ describe('UnknownKeysetError', () => {
     expect(e.refreshed).toBe(false);
     expect(e.message).toBe(
       "Keyset '00deadbeefdeadbe' is not in the wallet snapshot and no refresh was attempted; " +
-        'retry or refresh with loadMint(true)',
+        'call loadMint(true), or retry once the repair cooldown clears',
     );
     expect(e.message).not.toContain('not a keyset of this mint');
     expect(e.cause).toBeUndefined();

--- a/test/model/Errors.test.ts
+++ b/test/model/Errors.test.ts
@@ -7,6 +7,7 @@ import {
   MintOperationError,
   NetworkError,
   RateLimitError,
+  StaleKeysetError,
   UnknownKeysetError,
 } from '../../src/model/Errors';
 
@@ -152,6 +153,29 @@ describe('UnknownKeysetError', () => {
     const e = new UnknownKeysetError('00deadbeefdeadbe', { cause });
     expect(e.message).toBe(
       "Could not resolve unknown keyset '00deadbeefdeadbe': mint refresh failed",
+    );
+    expect(e.cause).toBe(cause);
+  });
+});
+
+describe('StaleKeysetError', () => {
+  test('reports a repaired snapshot and extends CTSError', () => {
+    const e = new StaleKeysetError(true);
+    expect(e).toBeInstanceOf(CTSError);
+    expect(e.name).toBe('StaleKeysetError');
+    expect(e.repaired).toBe(true);
+    expect(e.message).toBe(
+      'Mint rejected a stale keyset; the snapshot has been refreshed, re-prepare the operation',
+    );
+    expect(e.cause).toBeUndefined();
+  });
+
+  test('tells the caller to refresh when nothing was repaired', () => {
+    const cause = new MintOperationError(12002, 'Keyset is inactive, cannot sign messages');
+    const e = new StaleKeysetError(false, { cause });
+    expect(e.repaired).toBe(false);
+    expect(e.message).toBe(
+      'Mint rejected a stale keyset; refresh the snapshot (loadMint(true)) and re-prepare',
     );
     expect(e.cause).toBe(cause);
   });

--- a/test/model/Errors.test.ts
+++ b/test/model/Errors.test.ts
@@ -7,6 +7,7 @@ import {
   MintOperationError,
   NetworkError,
   RateLimitError,
+  UnknownKeysetError,
 } from '../../src/model/Errors';
 
 describe('CTSError', () => {
@@ -133,5 +134,25 @@ describe('isMintOperationError', () => {
     expect(isMintOperationError(new Error('MintOperationError'))).toBe(false);
     expect(isMintOperationError({ name: 'MintOperationError', code: 20008 })).toBe(false);
     expect(isMintOperationError(undefined)).toBe(false);
+  });
+});
+
+describe('UnknownKeysetError', () => {
+  test('carries the keyset id and extends CTSError', () => {
+    const e = new UnknownKeysetError('00deadbeefdeadbe');
+    expect(e).toBeInstanceOf(CTSError);
+    expect(e.name).toBe('UnknownKeysetError');
+    expect(e.keysetId).toBe('00deadbeefdeadbe');
+    expect(e.message).toBe("Keyset '00deadbeefdeadbe' is not a keyset of this mint");
+    expect(e.cause).toBeUndefined();
+  });
+
+  test('names the refresh failure when a cause is given', () => {
+    const cause = new Error('offline');
+    const e = new UnknownKeysetError('00deadbeefdeadbe', { cause });
+    expect(e.message).toBe(
+      "Could not resolve unknown keyset '00deadbeefdeadbe': mint refresh failed",
+    );
+    expect(e.cause).toBe(cause);
   });
 });

--- a/test/model/Errors.test.ts
+++ b/test/model/Errors.test.ts
@@ -139,11 +139,23 @@ describe('isMintOperationError', () => {
 });
 
 describe('UnknownKeysetError', () => {
-  test('carries the keyset id and extends CTSError', () => {
+  test('says the wallet never checked when no refresh ran', () => {
     const e = new UnknownKeysetError('00deadbeefdeadbe');
     expect(e).toBeInstanceOf(CTSError);
     expect(e.name).toBe('UnknownKeysetError');
     expect(e.keysetId).toBe('00deadbeefdeadbe');
+    expect(e.refreshed).toBe(false);
+    expect(e.message).toBe(
+      "Keyset '00deadbeefdeadbe' is not in the wallet snapshot and no refresh was attempted; " +
+        'retry or refresh with loadMint(true)',
+    );
+    expect(e.message).not.toContain('not a keyset of this mint');
+    expect(e.cause).toBeUndefined();
+  });
+
+  test('blames the mint only once a refresh has run', () => {
+    const e = new UnknownKeysetError('00deadbeefdeadbe', { refreshed: true });
+    expect(e.refreshed).toBe(true);
     expect(e.message).toBe("Keyset '00deadbeefdeadbe' is not a keyset of this mint");
     expect(e.cause).toBeUndefined();
   });
@@ -154,6 +166,7 @@ describe('UnknownKeysetError', () => {
     expect(e.message).toBe(
       "Could not resolve unknown keyset '00deadbeefdeadbe': mint refresh failed",
     );
+    expect(e.refreshed).toBe(false); // the refresh was attempted, but told us nothing
     expect(e.cause).toBe(cause);
   });
 });

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -695,6 +695,12 @@ describe('test zero-knowledge utilities', () => {
     };
     expect(() => hasValidDleq(serializedProof, keyset)).toThrow(/Undefined key for amount/);
   });
+  test('hasValidDleq names key loading when the keyset is keyless', () => {
+    const keylessKeyset = { id: '00bd033559de27d0', unit: 'sat', keys: {} };
+    expect(() => hasValidDleq(serializedProof, keylessKeyset)).toThrow(
+      'No keys loaded for keyset 00bd033559de27d0',
+    );
+  });
 
   describe('verifyDleqIfPresent', () => {
     const keyset = {

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Amount } from '../../src';
 import { hashToCurve } from '../../src/crypto';
 import type { Proof } from '../../src/model/types';
+import type { KeyChainCache } from '../../src/model/types/keyset';
 import { type OperationCounters } from '../../src/wallet';
 import { WalletEvents } from '../../src/wallet/WalletEvents';
 
@@ -1315,6 +1316,42 @@ describe('WalletEvents', () => {
         'callback failed',
         expect.objectContaining({ event: 'countersReserved' }),
       );
+    });
+  });
+
+  describe('WalletEvents.keychainUpdated', () => {
+    it('keychainUpdated delivers the current cache and unsubscribes cleanly', () => {
+      const we = new WalletEvents({} as any);
+
+      const cache: KeyChainCache = {
+        keysets: [
+          {
+            id: '00bd033559de27d0',
+            unit: 'sat',
+            active: true,
+            keys: { '1': 'key1', '2': 'key2' },
+          },
+        ],
+        mintUrl: 'https://example.com',
+        savedAt: Date.now(),
+      };
+
+      // Mock the wallet's keyChain.cache property
+      Object.defineProperty(we['wallet'], 'keyChain', {
+        value: { cache },
+        writable: true,
+      });
+
+      const seen: KeyChainCache[] = [];
+      const cancel = we.keychainUpdated(({ cache: c }) => seen.push(c));
+
+      (we as any)._emitKeychainUpdated();
+      expect(seen).toHaveLength(1);
+      expect(seen[0].keysets.map((k) => k.id)).toContain('00bd033559de27d0');
+
+      cancel();
+      (we as any)._emitKeychainUpdated();
+      expect(seen).toHaveLength(1);
     });
   });
 });

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -489,7 +489,13 @@ describe('Wallet (BOLT12) – wrappers', () => {
       unit: 'sat',
       request: 'lno1offer...',
     };
-    const proof: Proof = { amount: Amount.from(128), secret: 'secret1', C: 'C1', id: 'foo' };
+    // A real cached keyset id: melt makes its input ids operable before anything else.
+    const proof: Proof = {
+      amount: Amount.from(128),
+      secret: 'secret1',
+      C: 'C1',
+      id: '00bd033559de27d0',
+    };
     const res = await wallet.meltProofsBolt12(meltQuote as any, [proof]);
     expect(res.quote.quote).toEqual('m1');
     expect(res.change).toEqual([]);

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -381,6 +381,15 @@ describe('KeyChain getters', () => {
     expect(multiChain.isUnitKeyset(undefined)).toBe(false);
   });
 
+  test('hasKeyset is a non-throwing existence check', async () => {
+    const keyChain = new KeyChain(mint, unit);
+    expect(keyChain.hasKeyset('009a1f293253e41e')).toBe(false); // uninitialized: no throw
+    await keyChain.init();
+    expect(keyChain.hasKeyset('009a1f293253e41e')).toBe(true);
+    expect(keyChain.hasKeyset('00deadbeefdeadbe')).toBe(false);
+    expect(keyChain.hasKeyset(undefined)).toBe(false);
+  });
+
   test('should throw getters if not initialized', () => {
     const uninitChain = new KeyChain(mint, unit);
     expect(() => uninitChain.getKeyset('any')).toThrow("Keyset 'any' not found");

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -10,6 +10,12 @@ const mintUrl = 'http://localhost:3338';
 const mint = new Mint(mintUrl);
 const unit = 'sat';
 
+// Rotation fixtures: mint starts with A active, then A goes inactive and B appears.
+const keysetA: MintKeyset = { ...DUMMY_TEST_KEYSET };
+const keysetAInactive: MintKeyset = { ...DUMMY_TEST_KEYSET, active: false };
+const keysetB: MintKeyset = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
+const keysB: MintKeys = { ...keysetB, keys: PUBKEYS };
+
 const dummyKeysResp: { keysets: MintKeys[] } = {
   keysets: [
     DUMMY_TEST_KEYS,
@@ -229,6 +235,69 @@ describe('KeyChain initialization', () => {
     await expect(keyChain.init()).resolves.toBeUndefined(); // init itself succeeds
     expect(() => keyChain.getCheapestKeyset()).toThrow('KeyChain not initialized');
     expect(() => keyChain.getKeysets()).toThrow('KeyChain not initialized');
+  });
+
+  test('init(true) keeps keys for a keyset the mint no longer serves keys for', async () => {
+    const keyChain = new KeyChain(mint, unit);
+    // Pre-rotation: A active with keys
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetA] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] })),
+    );
+    await keyChain.init();
+    expect(keyChain.getKeyset('00bd033559de27d0').hasKeys).toBe(true);
+
+    // Rotation: A inactive and gone from /v1/keys, B active
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({ keysets: [keysetAInactive, keysetB] }),
+      ),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    );
+    await keyChain.init(true);
+
+    expect(keyChain.getKeyset('00bd033559de27d0').hasKeys).toBe(true); // carried forward
+    expect(keyChain.getKeyset('00bd033559de27d0').isActive).toBe(false); // metadata is fresh
+    expect(keyChain.getKeyset('009a1f293253e41e').hasKeys).toBe(true);
+  });
+
+  test('init(true) drops a keyset absent from the fresh metadata', async () => {
+    const keyChain = new KeyChain(mint, unit);
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetA] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] })),
+    );
+    await keyChain.init();
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetB] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    );
+    await keyChain.init(true);
+    expect(keyChain.hasKeyset('00bd033559de27d0')).toBe(false);
+  });
+
+  test('init(true) discards unverifiable fresh keys and carries forward prior verified keys', async () => {
+    const keyChain = new KeyChain(mint, unit);
+    // Pre-rotation: A active with valid DUMMY_TEST_KEYS
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetA] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] })),
+    );
+    await keyChain.init();
+    expect(keyChain.getKeyset('00bd033559de27d0').hasKeys).toBe(true);
+
+    // Refresh: A still active but /v1/keys serves PUBKEYS (wrong keys for A's id, fail verification)
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetA] })),
+      http.get(mintUrl + '/v1/keys', () =>
+        HttpResponse.json({ keysets: [{ ...DUMMY_TEST_KEYSET, keys: PUBKEYS }] }),
+      ),
+    );
+    await keyChain.init(true);
+
+    // Prior verified keys carried forward (not replaced by bad fresh keys)
+    expect(keyChain.getKeyset('00bd033559de27d0').hasKeys).toBe(true);
+    expect(keyChain.getKeyset('00bd033559de27d0').keys).toEqual(DUMMY_TEST_KEYS.keys);
   });
 
   test('should preload from cache and match original cache', async () => {

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -1,4 +1,5 @@
 import { HttpResponse, http } from 'msw';
+import type { SetupServer } from 'msw/node';
 import { test, describe, expect, vi } from 'vitest';
 
 import {
@@ -11,9 +12,11 @@ import {
   MintInfo,
   Amount,
   setGlobalRequestOptions,
+  type MintKeyset,
+  type MintKeys,
 } from '../../src';
 import { NULL_LOGGER } from '../../src/logger';
-import { MINTCACHE } from '../consts';
+import { MINTCACHE, DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
 
 import {
   mintUrl,
@@ -27,6 +30,24 @@ import {
 } from './_setup';
 
 const server = useTestServer();
+
+// Rotation fixtures: mint starts with A active, then A goes inactive and B appears.
+const keysetAInactive: MintKeyset = { ...DUMMY_TEST_KEYSET, active: false };
+const keysetB: MintKeyset = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
+const keysB: MintKeys = { ...keysetB, keys: PUBKEYS };
+
+function useRotatedMint(server: SetupServer) {
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () => {
+      return HttpResponse.json({ keysets: [keysetAInactive, keysetB] });
+    }),
+    http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => {
+      return HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] });
+    }),
+    http.get(mintUrl + '/v1/keys/009a1f293253e41e', () => HttpResponse.json({ keysets: [keysB] })),
+  );
+}
 
 describe('test wallet init', () => {
   test('should initialize with mint instance and load mint info, keys, and keysets', async () => {
@@ -590,6 +611,48 @@ describe('bindKeyset & withKeyset', () => {
     const bound = wallet.keysetId;
     const k = wallet.getKeyset();
     expect(k.id).toBe(bound);
+  });
+});
+
+describe('rebind on refresh', () => {
+  test('auto-bound wallet follows the mint after a rotation', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('009a1f293253e41e');
+  });
+
+  test('pinned wallet stays put after a rotation', async () => {
+    const wallet = new Wallet(mint, { unit, keysetId: '00bd033559de27d0' });
+    await wallet.loadMint();
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+  });
+
+  test('bindKeyset makes the binding explicit', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    wallet.bindKeyset('00bd033559de27d0');
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+  });
+
+  test('auto-bound wallet keeps its binding when the mint has no active replacement', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetAInactive] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [] })),
+    );
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0'); // still there; melt remains possible
   });
 });
 

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -1,5 +1,4 @@
 import { HttpResponse, http } from 'msw';
-import type { SetupServer } from 'msw/node';
 import { test, describe, expect, vi } from 'vitest';
 
 import {
@@ -12,11 +11,9 @@ import {
   MintInfo,
   Amount,
   setGlobalRequestOptions,
-  type MintKeyset,
-  type MintKeys,
 } from '../../src';
 import { NULL_LOGGER } from '../../src/logger';
-import { MINTCACHE, DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
+import { MINTCACHE } from '../consts';
 
 import {
   mintUrl,
@@ -30,24 +27,6 @@ import {
 } from './_setup';
 
 const server = useTestServer();
-
-// Rotation fixtures: mint starts with A active, then A goes inactive and B appears.
-const keysetAInactive: MintKeyset = { ...DUMMY_TEST_KEYSET, active: false };
-const keysetB: MintKeyset = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
-const keysB: MintKeys = { ...keysetB, keys: PUBKEYS };
-
-function useRotatedMint(server: SetupServer) {
-  server.use(
-    http.get(mintUrl + '/v1/keysets', () => {
-      return HttpResponse.json({ keysets: [keysetAInactive, keysetB] });
-    }),
-    http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
-    http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => {
-      return HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] });
-    }),
-    http.get(mintUrl + '/v1/keys/009a1f293253e41e', () => HttpResponse.json({ keysets: [keysB] })),
-  );
-}
 
 describe('test wallet init', () => {
   test('should initialize with mint instance and load mint info, keys, and keysets', async () => {
@@ -611,48 +590,6 @@ describe('bindKeyset & withKeyset', () => {
     const bound = wallet.keysetId;
     const k = wallet.getKeyset();
     expect(k.id).toBe(bound);
-  });
-});
-
-describe('rebind on refresh', () => {
-  test('auto-bound wallet follows the mint after a rotation', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint();
-    expect(wallet.keysetId).toBe('00bd033559de27d0');
-
-    useRotatedMint(server);
-    await wallet.loadMint(true);
-    expect(wallet.keysetId).toBe('009a1f293253e41e');
-  });
-
-  test('pinned wallet stays put after a rotation', async () => {
-    const wallet = new Wallet(mint, { unit, keysetId: '00bd033559de27d0' });
-    await wallet.loadMint();
-
-    useRotatedMint(server);
-    await wallet.loadMint(true);
-    expect(wallet.keysetId).toBe('00bd033559de27d0');
-  });
-
-  test('bindKeyset makes the binding explicit', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint();
-    wallet.bindKeyset('00bd033559de27d0');
-
-    useRotatedMint(server);
-    await wallet.loadMint(true);
-    expect(wallet.keysetId).toBe('00bd033559de27d0');
-  });
-
-  test('auto-bound wallet keeps its binding when the mint has no active replacement', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint();
-    server.use(
-      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetAInactive] })),
-      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [] })),
-    );
-    await wallet.loadMint(true);
-    expect(wallet.keysetId).toBe('00bd033559de27d0'); // still there; melt remains possible
   });
 });
 

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -4,6 +4,7 @@ import { test, describe, expect, vi } from 'vitest';
 
 import {
   Wallet,
+  MeltChangeError,
   type Proof,
   type ProofLike,
   type MeltQuoteBolt11Response,
@@ -192,7 +193,10 @@ describe('melt proofs', () => {
       },
     ];
 
-    await expect(wallet.meltProofsBolt11(meltQuote, proofsToSend)).rejects.toThrow(
+    // The melt itself went through, so the failure arrives wrapped with the recovery data
+    const err = await wallet.meltProofsBolt11(meltQuote, proofsToSend).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MeltChangeError);
+    expect(((err as MeltChangeError).cause as Error).message).toContain(
       'Mint supports NUT-12, but returned a signature without DLEQ proof',
     );
   });
@@ -758,7 +762,11 @@ describe('melt proofs', () => {
     ];
     const result = await wallet.meltProofsBolt11(meltQuote, proofsToSend).catch((e) => e);
 
-    expect(result.message).toContain('Mint returned 3 signatures, but only 1 blanks were provided');
+    expect(result).toBeInstanceOf(MeltChangeError);
+    expect((result.cause as Error).message).toContain(
+      'Mint returned 3 signatures, but only 1 blanks were provided',
+    );
+    expect(result.outputData.length).toBeGreaterThan(0); // still recoverable
   });
 });
 

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -1,5 +1,6 @@
 import { hexToBytes } from '@noble/curves/utils.js';
 import { HttpResponse, http } from 'msw';
+import type { SetupServer } from 'msw/node';
 import { test, describe, expect } from 'vitest';
 
 import {
@@ -7,14 +8,42 @@ import {
   getDecodedToken,
   OutputData,
   Amount,
+  UnknownKeysetError,
   type AmountLike,
   type HasKeysetKeys,
   type ProofLike,
+  type KeyChainCache,
+  type MintKeyset,
+  type MintKeys,
 } from '../../src';
+import { DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
 
 import { mint, unit, token3sat, mintUrl, logger, useTestServer } from './_setup';
 
 const server = useTestServer();
+
+// Rotation fixtures: mint starts with A active, then A goes inactive and B appears.
+const keysetAInactive: MintKeyset = { ...DUMMY_TEST_KEYSET, active: false };
+const keysetB: MintKeyset = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
+const keysB: MintKeys = { ...keysetB, keys: PUBKEYS };
+
+function useRotatedMint(server: SetupServer) {
+  let keysetsRequests = 0;
+  let keysARequests = 0;
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () => {
+      keysetsRequests++;
+      return HttpResponse.json({ keysets: [keysetAInactive, keysetB] });
+    }),
+    http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => {
+      keysARequests++;
+      return HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] });
+    }),
+    http.get(mintUrl + '/v1/keys/009a1f293253e41e', () => HttpResponse.json({ keysets: [keysB] })),
+  );
+  return { counts: () => ({ keysetsRequests, keysARequests }) };
+}
 
 describe('receive', () => {
   const tokenInput =
@@ -86,6 +115,9 @@ describe('receive', () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
 
+    // Fully unknown keyset id: ensureOperableKeysets repairs the snapshot (still unmocked
+    // beyond the default handlers) and reports it as an UnknownKeysetError, not a plain
+    // unit-mismatch rejection.
     await expect(
       wallet.receive([
         {
@@ -95,11 +127,14 @@ describe('receive', () => {
           C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
         },
       ]),
-    ).rejects.toThrow('Proof has unrecognised keyset');
+    ).rejects.toThrow(UnknownKeysetError);
   });
 
   test('receive Proof[] - wrong-unit keyset ID throws', async () => {
-    const usdKeysetId = '009a1f293253e41f';
+    // Known but keyless usd keyset: ensureOperableKeysets must not spend a /v1/keys/{id} request
+    // resolving a foreign-unit id before the unit check gets a chance to reject it.
+    const usdKeysetId = '009a1f293253e41e';
+    let usdKeysRequests = 0;
     server.use(
       http.get(mintUrl + '/v1/keysets', () =>
         HttpResponse.json({
@@ -109,6 +144,10 @@ describe('receive', () => {
           ],
         }),
       ),
+      http.get(mintUrl + '/v1/keys/' + usdKeysetId, () => {
+        usdKeysRequests++;
+        return HttpResponse.json({ keysets: [{ id: usdKeysetId, unit: 'usd', keys: PUBKEYS }] });
+      }),
     );
     const wallet = new Wallet(mint, { unit }); // sat wallet
     await wallet.loadMint();
@@ -123,7 +162,8 @@ describe('receive', () => {
           C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
         },
       ]),
-    ).rejects.toThrow('Proof has unrecognised keyset');
+    ).rejects.toThrow('is not a sat keyset from this mint');
+    expect(usdKeysRequests).toBe(0); // foreign-unit keyless id: no key fetch attempted
   });
 
   test('test receive token from wrong mint', async () => {
@@ -713,5 +753,78 @@ describe('receive', () => {
     ]);
     expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
+  });
+});
+
+describe('receive across a rotation', () => {
+  const proofOnA: ProofLike = {
+    id: '00bd033559de27d0',
+    amount: 1,
+    secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
+    C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
+  };
+  const proofOnB: ProofLike = { ...proofOnA, id: '009a1f293253e41e' };
+  const proofOnAlien: ProofLike = { ...proofOnA, id: '00deadbeefdeadbe' };
+
+  test('receives a pre-rotation token by loading the old keys once', async () => {
+    const { counts } = useRotatedMint(server);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // first ever load, post-rotation: A inactive and keyless, B active
+    expect(counts().keysARequests).toBe(0); // baseline: loadMint alone doesn't fetch A's keys
+
+    const preview = await wallet.prepareSwapToReceive([proofOnA]);
+    expect(preview.keysetId).toBe('009a1f293253e41e'); // outputs on the active keyset
+    expect(counts().keysARequests).toBe(1); // one /v1/keys/A fetch, then cached
+
+    await wallet.prepareSwapToReceive([proofOnA]);
+    expect(counts().keysARequests).toBe(1); // still one: ensure is idempotent
+  });
+
+  test('repairs a stale snapshot once when a proof names an unknown keyset', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A
+    const { counts } = useRotatedMint(server);
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    const preview = await wallet.prepareSwapToReceive([proofOnB]);
+    expect(preview.keysetId).toBe('009a1f293253e41e');
+    expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
+    expect(updates).toHaveLength(1);
+    expect(updates[0].keysets.map((k) => k.id)).toContain('009a1f293253e41e');
+  });
+
+  test('concurrent ops share one repair refresh', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    await Promise.all([
+      wallet.prepareSwapToReceive([proofOnB]),
+      wallet.prepareSwapToReceive([proofOnB]),
+    ]);
+    expect(counts().keysetsRequests).toBe(1);
+  });
+
+  test('a genuinely alien keyset id throws UnknownKeysetError after the repair', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    const err = await wallet.prepareSwapToReceive([proofOnAlien]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).keysetId).toBe('00deadbeefdeadbe');
+    expect(counts().keysetsRequests).toBe(1); // it did try
+  });
+
+  test('a failed repair surfaces UnknownKeysetError with the transport failure as cause', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    server.use(http.get(mintUrl + '/v1/keysets', () => HttpResponse.error()));
+
+    const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).cause).toBeDefined();
   });
 });

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -1,6 +1,5 @@
 import { hexToBytes } from '@noble/curves/utils.js';
 import { HttpResponse, http } from 'msw';
-import type { SetupServer } from 'msw/node';
 import { test, describe, expect } from 'vitest';
 
 import {
@@ -12,38 +11,12 @@ import {
   type AmountLike,
   type HasKeysetKeys,
   type ProofLike,
-  type KeyChainCache,
-  type MintKeyset,
-  type MintKeys,
 } from '../../src';
-import { DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
+import { PUBKEYS } from '../consts';
 
 import { mint, unit, token3sat, mintUrl, logger, useTestServer } from './_setup';
 
 const server = useTestServer();
-
-// Rotation fixtures: mint starts with A active, then A goes inactive and B appears.
-const keysetAInactive: MintKeyset = { ...DUMMY_TEST_KEYSET, active: false };
-const keysetB: MintKeyset = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
-const keysB: MintKeys = { ...keysetB, keys: PUBKEYS };
-
-function useRotatedMint(server: SetupServer) {
-  let keysetsRequests = 0;
-  let keysARequests = 0;
-  server.use(
-    http.get(mintUrl + '/v1/keysets', () => {
-      keysetsRequests++;
-      return HttpResponse.json({ keysets: [keysetAInactive, keysetB] });
-    }),
-    http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
-    http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => {
-      keysARequests++;
-      return HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] });
-    }),
-    http.get(mintUrl + '/v1/keys/009a1f293253e41e', () => HttpResponse.json({ keysets: [keysB] })),
-  );
-  return { counts: () => ({ keysetsRequests, keysARequests }) };
-}
 
 describe('receive', () => {
   const tokenInput =
@@ -753,78 +726,5 @@ describe('receive', () => {
     ]);
     expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
-  });
-});
-
-describe('receive across a rotation', () => {
-  const proofOnA: ProofLike = {
-    id: '00bd033559de27d0',
-    amount: 1,
-    secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
-    C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
-  };
-  const proofOnB: ProofLike = { ...proofOnA, id: '009a1f293253e41e' };
-  const proofOnAlien: ProofLike = { ...proofOnA, id: '00deadbeefdeadbe' };
-
-  test('receives a pre-rotation token by loading the old keys once', async () => {
-    const { counts } = useRotatedMint(server);
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint(); // first ever load, post-rotation: A inactive and keyless, B active
-    expect(counts().keysARequests).toBe(0); // baseline: loadMint alone doesn't fetch A's keys
-
-    const preview = await wallet.prepareSwapToReceive([proofOnA]);
-    expect(preview.keysetId).toBe('009a1f293253e41e'); // outputs on the active keyset
-    expect(counts().keysARequests).toBe(1); // one /v1/keys/A fetch, then cached
-
-    await wallet.prepareSwapToReceive([proofOnA]);
-    expect(counts().keysARequests).toBe(1); // still one: ensure is idempotent
-  });
-
-  test('repairs a stale snapshot once when a proof names an unknown keyset', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint(); // knows only A
-    const { counts } = useRotatedMint(server);
-
-    const updates: KeyChainCache[] = [];
-    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
-
-    const preview = await wallet.prepareSwapToReceive([proofOnB]);
-    expect(preview.keysetId).toBe('009a1f293253e41e');
-    expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
-    expect(updates).toHaveLength(1);
-    expect(updates[0].keysets.map((k) => k.id)).toContain('009a1f293253e41e');
-  });
-
-  test('concurrent ops share one repair refresh', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint();
-    const { counts } = useRotatedMint(server);
-
-    await Promise.all([
-      wallet.prepareSwapToReceive([proofOnB]),
-      wallet.prepareSwapToReceive([proofOnB]),
-    ]);
-    expect(counts().keysetsRequests).toBe(1);
-  });
-
-  test('a genuinely alien keyset id throws UnknownKeysetError after the repair', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint();
-    const { counts } = useRotatedMint(server);
-
-    const err = await wallet.prepareSwapToReceive([proofOnAlien]).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(UnknownKeysetError);
-    expect((err as UnknownKeysetError).keysetId).toBe('00deadbeefdeadbe');
-    expect(counts().keysetsRequests).toBe(1); // it did try
-  });
-
-  test('a failed repair surfaces UnknownKeysetError with the transport failure as cause', async () => {
-    const wallet = new Wallet(mint, { unit });
-    await wallet.loadMint();
-    server.use(http.get(mintUrl + '/v1/keysets', () => HttpResponse.error()));
-
-    const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(UnknownKeysetError);
-    expect((err as UnknownKeysetError).cause).toBeDefined();
   });
 });

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -253,6 +253,12 @@ describe('receive across a rotation', () => {
     await expect(wallet.receive([proofOnA])).rejects.toThrow(/unrecognised keyset/i);
     expect(spyKeySets).not.toHaveBeenCalled(); // no hidden loadMint(true)
 
+    // The public entry point says so outright rather than quietly doing nothing
+    await expect(wallet.ensureOperableKeysets(['00bd033559de27d0'])).rejects.toThrow(
+      /Mint info not initialized; call loadMint/,
+    );
+    expect(spyKeySets).not.toHaveBeenCalled();
+
     spyKeySets.mockRestore();
   });
 });
@@ -508,6 +514,75 @@ describe('repair rate limit', () => {
     expect((err as StaleKeysetError).repaired).toBe(false);
     expect(counts().keysetsRequests).toBe(1); // rate limited, no refresh
     expect(swaps).toBe(1);
+  });
+});
+
+describe('public ensureOperableKeysets', () => {
+  test('backfills keys for a strict wallet on request', async () => {
+    const { counts } = useRotatedMint(server);
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint(); // single load against rotated handlers: A known-but-keyless
+    server.use(
+      http.post(mintUrl + '/v1/swap', () =>
+        HttpResponse.json({
+          signatures: [
+            {
+              id: '009a1f293253e41e',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    await wallet.ensureOperableKeysets(['00bd033559de27d0']);
+    expect(counts().keysARequests).toBe(1); // explicit call, so strict mode does not block it
+    expect(updates).toHaveLength(0); // the caller asked, so the caller persists
+
+    const proofs = await wallet.receive([proofOnA]);
+    expect(proofs[0].id).toBe('009a1f293253e41e');
+    expect(counts().keysARequests).toBe(1); // the op itself fetched nothing
+    expect(counts().keysetsRequests).toBe(1); // just the initial load
+    expect(updates).toHaveLength(0);
+  });
+
+  test('repairs an unknown id for a strict wallet', async () => {
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint(); // pre-rotation: knows only A
+    const { counts } = useRotatedMint(server);
+
+    await wallet.ensureOperableKeysets(['009a1f293253e41e']);
+    expect(counts().keysetsRequests).toBe(1);
+    expect(wallet.keyChain.hasKeyset('009a1f293253e41e')).toBe(true);
+  });
+
+  test('bypasses the repair cooldown', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    await expect(wallet.receive([{ ...proofOnA, id: '00deadbeefdeadbe' }])).rejects.toThrow(
+      UnknownKeysetError,
+    );
+    expect(counts().keysetsRequests).toBe(1); // implicit repair, which starts the window
+
+    await expect(wallet.ensureOperableKeysets(['00c0ffeec0ffee00'])).rejects.toThrow(
+      UnknownKeysetError,
+    );
+    expect(counts().keysetsRequests).toBe(2); // asked for, so not rate limited
+  });
+
+  test('rejects a non-array argument', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(
+      wallet.ensureOperableKeysets('00bd033559de27d0' as unknown as string[]),
+    ).rejects.toThrow(/must be an array/);
   });
 });
 

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -89,6 +89,37 @@ describe('rebind on refresh', () => {
     await wallet.loadMint(true);
     expect(wallet.keysetId).toBe('00bd033559de27d0'); // still there; melt remains possible
   });
+
+  test('auto-bound wallet unbinds when its keyset vanishes and no active replacement exists', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [] })),
+    );
+    await wallet.loadMint(true);
+    expect(() => wallet.keysetId).toThrow(/no bound keyset/i);
+  });
+
+  test('auto-bound wallet stays put when still usable, even if a cheaper active keyset appears', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+
+    // A stays active; B is a cheaper active keyset per getCheapestKeyset's ordering
+    // (see the rotation fixtures above, where the existing suite rebinds to B once
+    // A goes inactive). A still-usable binding must not chase it.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, keysetB] }),
+      ),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    );
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+  });
 });
 
 describe('receive across a rotation', () => {

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -5,6 +5,7 @@
 // Wallet.ensureOperableKeysets). When you add such an op, add its rotation
 // scenario to this file.
 
+import { randomBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import type { SetupServer } from 'msw/node';
 import { test, describe, expect, vi } from 'vitest';
@@ -49,6 +50,16 @@ function useRotatedMint(server: SetupServer) {
   );
   return { counts: () => ({ keysetsRequests, keysARequests }) };
 }
+
+// Shared across describes below: a proof on the pre-rotation keyset (A) and its
+// counterpart on the post-rotation keyset (B).
+const proofOnA: ProofLike = {
+  id: '00bd033559de27d0',
+  amount: 1,
+  secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
+  C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
+};
+const proofOnB: ProofLike = { ...proofOnA, id: '009a1f293253e41e' };
 
 describe('rebind on refresh', () => {
   test('auto-bound wallet follows the mint after a rotation', async () => {
@@ -124,13 +135,6 @@ describe('rebind on refresh', () => {
 });
 
 describe('receive across a rotation', () => {
-  const proofOnA: ProofLike = {
-    id: '00bd033559de27d0',
-    amount: 1,
-    secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
-    C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
-  };
-  const proofOnB: ProofLike = { ...proofOnA, id: '009a1f293253e41e' };
   const proofOnAlien: ProofLike = { ...proofOnA, id: '00deadbeefdeadbe' };
 
   test('receives a pre-rotation token by loading the old keys once', async () => {
@@ -282,5 +286,61 @@ describe('melt change across a rotation', () => {
     const { change } = await wallet.completeMelt(preview);
     expect(change.length).toBeGreaterThan(0);
     expect(counts().keysARequests).toBe(1); // keys were fetched, not assumed
+  });
+});
+
+describe('strictCachedKeysets', () => {
+  test('unknown id throws typed, zero fetches', async () => {
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint(); // pre-rotation defaults: knows only A
+
+    const { counts } = useRotatedMint(server);
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).keysetId).toBe('009a1f293253e41e');
+    expect(counts().keysetsRequests).toBe(0); // strict mode never repairs
+    expect(updates).toHaveLength(0); // nothing internal mutated the snapshot
+  });
+
+  test('keyless receive throws legibly, zero fetches', async () => {
+    const { counts } = useRotatedMint(server);
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint(); // single load against rotated handlers: A known-but-keyless
+
+    await expect(wallet.prepareSwapToReceive([proofOnA])).rejects.toThrow(
+      /No keys loaded for keyset 00bd033559de27d0/,
+    );
+    expect(counts().keysARequests).toBe(0); // strict mode never backfills keys
+  });
+
+  test('explicit backfill still works', async () => {
+    const { counts } = useRotatedMint(server);
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint();
+
+    await wallet.keyChain.ensureKeysetKeys('00bd033559de27d0'); // consumer's explicit call
+    expect(counts().keysARequests).toBe(1);
+
+    const preview = await wallet.prepareSwapToReceive([proofOnA]);
+    expect(preview.keysetId).toBe('009a1f293253e41e');
+    expect(counts().keysARequests).toBe(1); // no extra fetch from the op itself
+  });
+
+  test('strict restore surfaces keyless', async () => {
+    const { counts } = useRotatedMint(server);
+    const wallet = new Wallet(mint, {
+      unit,
+      bip39seed: randomBytes(32),
+      strictCachedKeysets: true,
+    });
+    await wallet.loadMint(); // single load against rotated handlers: A known-but-keyless
+
+    await expect(wallet.restore(0, 5, { keysetId: '00bd033559de27d0' })).rejects.toThrow(
+      /Keyset has no keys loaded/,
+    );
+    expect(counts().keysARequests).toBe(0); // strict mode never backfills keys
   });
 });

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -115,14 +115,15 @@ describe('rebind on refresh', () => {
     expect(() => wallet.keysetId).toThrow(/no bound keyset/i);
   });
 
-  test('auto-bound wallet stays put when still usable, even if a cheaper active keyset appears', async () => {
+  test('auto-bound wallet follows the cheapest active keyset on refresh', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();
     expect(wallet.keysetId).toBe('00bd033559de27d0');
 
-    // A stays active; B is a cheaper active keyset per getCheapestKeyset's ordering
-    // (see the rotation fixtures above, where the existing suite rebinds to B once
-    // A goes inactive). A still-usable binding must not chase it.
+    // A stays active alongside B: same version, same fee, but B has no final_expiry
+    // (never expiring) while A does, so getCheapestKeyset's expiry tie-break prefers
+    // B. Re-selection on every refresh means the wallet follows it even though A is
+    // still perfectly usable.
     server.use(
       http.get(mintUrl + '/v1/keysets', () =>
         HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, keysetB] }),
@@ -130,7 +131,7 @@ describe('rebind on refresh', () => {
       http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
     );
     await wallet.loadMint(true);
-    expect(wallet.keysetId).toBe('00bd033559de27d0');
+    expect(wallet.keysetId).toBe('009a1f293253e41e');
   });
 });
 

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -25,6 +25,7 @@ import {
   type ProofLike,
   type Proof,
   type MeltQuoteBolt11Response,
+  type MeltQuoteOnchainResponse,
   type MintQuoteBolt11Response,
 } from '../../src';
 import { DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
@@ -911,6 +912,35 @@ describe('send and melt inputs across a rotation', () => {
     expect(preview.inputs).toHaveLength(2);
     expect(preview.keysetId).toBe('009a1f293253e41e'); // NUT-08 blanks on the repaired binding
     expect(counts().keysetsRequests).toBe(1);
+  });
+
+  test('meltProofsOnchain repairs the snapshot before its own fee check', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A
+    const { counts } = useRotatedMint(server);
+
+    const onchainQuote: MeltQuoteOnchainResponse = {
+      quote: 'melt-onchain-inputs',
+      request: 'bc1qrecipient',
+      amount: Amount.from(10),
+      unit: 'sat',
+      fee_options: [{ fee_index: 0, fee_reserve: Amount.from(2), estimated_blocks: 6 }],
+      selected_fee_index: null,
+      state: MeltQuoteState.UNPAID,
+      expiry: 3600,
+      outpoint: null,
+    };
+
+    // This wrapper does its own input fee math before delegating, so it needs the
+    // repair of its own. Deliberately underfunded: reaching the wrapper's amount
+    // check means the fee lookup found the repaired keyset, and the suite has no
+    // onchain melt endpoint to run past it.
+    const err = await wallet
+      .meltProofsOnchain(onchainQuote, [{ ...proofOnB, amount: 5 }], 0)
+      .catch((e: unknown) => e);
+
+    expect((err as Error).message).toContain('Not enough proofs to cover amount + fee');
+    expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
   });
 
   test('a complete snapshot fetches nothing on either path', async () => {

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -12,6 +12,7 @@ import { test, describe, expect, vi } from 'vitest';
 
 import {
   Wallet,
+  MeltChangeError,
   MintOperationError,
   StaleKeysetError,
   UnknownKeysetError,
@@ -668,6 +669,51 @@ describe('melt change across a rotation', () => {
     const { change } = await wallet.completeMelt(preview);
     expect(change.length).toBeGreaterThan(0);
     expect(counts().keysARequests).toBe(1); // keys were fetched, not assumed
+  });
+
+  // The inputs are spent by the time change is built, so a failure here has to hand back
+  // enough to rebuild the change later, which the convenience melts otherwise swallow.
+  async function meltWithUnreachableChangeKeys() {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const preview = await wallet.prepareMelt('bolt11', meltQuote, proofsForMelt);
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    wallet.keyChain.getKeyset('00bd033559de27d0').keys = {}; // A is known but keyless
+    server.use(
+      http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => HttpResponse.error()), // and stays that way
+      http.post(mintUrl + '/v1/melt/bolt11', () => HttpResponse.json(paidResponseWithChangeOnA)),
+    );
+
+    const err = await wallet.completeMelt(preview).catch((e: unknown) => e);
+    return { wallet, err };
+  }
+
+  test('unreachable change keys reject with the data recovery needs', async () => {
+    const { err } = await meltWithUnreachableChangeKeys();
+
+    expect(err).toBeInstanceOf(MeltChangeError);
+    expect((err as MeltChangeError).outputData.length).toBeGreaterThan(0);
+    expect((err as MeltChangeError).quote.quote).toBe('melt-rotation');
+    expect((err as MeltChangeError).quote.state).toBe(MeltQuoteState.PAID);
+    expect((err as MeltChangeError).cause).toBeDefined(); // the fetch failure that caused it
+  });
+
+  test('the change is recoverable from that error once the keys arrive', async () => {
+    const { wallet, err } = await meltWithUnreachableChangeKeys();
+    const { outputData, quote } = err as MeltChangeError;
+
+    server.use(
+      http.get(mintUrl + '/v1/keys/00bd033559de27d0', () =>
+        HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] }),
+      ),
+    );
+    await wallet.keyChain.ensureKeysetKeys('00bd033559de27d0');
+
+    const change = wallet.createMeltChangeProofs(outputData, quote.change ?? []);
+    expect(change).toHaveLength(2);
+    expect(change.every((p) => p.id === '00bd033559de27d0')).toBe(true);
   });
 });
 

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -601,6 +601,23 @@ describe('public ensureOperableKeysets', () => {
     expect(counts().keysetsRequests).toBe(2); // asked for, so not rate limited
   });
 
+  test('leaves the wallet free to repair on its own afterwards', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A
+    const { counts } = useRotatedMint(server);
+
+    await wallet.ensureOperableKeysets(['009a1f293253e41e']); // explicit repair
+    expect(counts().keysetsRequests).toBe(1);
+
+    // The window covers the wallet's own repairs, so this one must still run
+    const err = await wallet
+      .receive([{ ...proofOnA, id: '00deadbeefdeadbe' }])
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).refreshed).toBe(true); // it refreshed, not rate limited
+    expect(counts().keysetsRequests).toBe(2);
+  });
+
   test('rejects a non-array argument', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -191,6 +191,8 @@ describe('receive across a rotation', () => {
     const err = await wallet.prepareSwapToReceive([proofOnAlien]).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(UnknownKeysetError);
     expect((err as UnknownKeysetError).keysetId).toBe('00deadbeefdeadbe');
+    expect((err as UnknownKeysetError).refreshed).toBe(true); // asked the mint, so this is final
+    expect((err as UnknownKeysetError).message).toContain('is not a keyset of this mint');
     expect(counts().keysetsRequests).toBe(1); // it did try
   });
 
@@ -478,13 +480,35 @@ describe('repair rate limit', () => {
       .receive([{ ...proofOnA, id: '00deadbeefdeadbe' }])
       .catch((e: unknown) => e);
     expect(first).toBeInstanceOf(UnknownKeysetError);
+    expect((first as UnknownKeysetError).refreshed).toBe(true);
     expect(counts().keysetsRequests).toBe(1);
 
     const second = await wallet
       .receive([{ ...proofOnA, id: '00c0ffeec0ffee00' }])
       .catch((e: unknown) => e);
     expect(second).toBeInstanceOf(UnknownKeysetError);
+    expect((second as UnknownKeysetError).refreshed).toBe(false); // skipped, so nothing was checked
     expect(counts().keysetsRequests).toBe(1); // no second refresh for the second alien id
+  });
+
+  test('a genuine post-rotation id inside the window says the wallet did not check', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // pre-rotation: knows only A
+
+    // One junk token burns the window against a mint that has not rotated yet
+    const junk = await wallet
+      .receive([{ ...proofOnA, id: '00deadbeefdeadbe' }])
+      .catch((e: unknown) => e);
+    expect((junk as UnknownKeysetError).refreshed).toBe(true);
+
+    const { counts } = useRotatedMint(server); // the rotation lands after that refresh
+    const genuine = await wallet.receive([proofOnB]).catch((e: unknown) => e);
+    expect(genuine).toBeInstanceOf(UnknownKeysetError);
+    expect((genuine as UnknownKeysetError).keysetId).toBe('009a1f293253e41e');
+    expect((genuine as UnknownKeysetError).refreshed).toBe(false);
+    // The id is perfectly good: the wallet may not say otherwise on the strength of a stale snapshot
+    expect((genuine as UnknownKeysetError).message).not.toContain('not a keyset of this mint');
+    expect(counts().keysetsRequests).toBe(0); // rate limited, so it never looked
   });
 
   test('the cooldown also gates the repair a mint rejection asks for', async () => {
@@ -659,6 +683,7 @@ describe('strictCachedKeysets', () => {
     const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(UnknownKeysetError);
     expect((err as UnknownKeysetError).keysetId).toBe('009a1f293253e41e');
+    expect((err as UnknownKeysetError).refreshed).toBe(false); // strict never asks the mint
     expect(counts().keysetsRequests).toBe(0); // strict mode never repairs
     expect(updates).toHaveLength(0); // nothing internal mutated the snapshot
   });

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -344,4 +344,18 @@ describe('strictCachedKeysets', () => {
     );
     expect(counts().keysARequests).toBe(0); // strict mode never backfills keys
   });
+
+  test('withKeyset derivative inherits strictCachedKeysets', async () => {
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint(); // pre-rotation defaults: A active with keys
+    const { counts } = useRotatedMint(server); // now A is inactive, B is active
+
+    const derived = wallet.withKeyset('00bd033559de27d0'); // seeded from the parent's cache
+    const err = await derived
+      .prepareSwapToReceive([proofOnB], { keysetId: '009a1f293253e41e' })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect(counts().keysetsRequests).toBe(0); // strict inherited: no repair fired
+  });
 });

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -6,7 +6,7 @@
 
 import { HttpResponse, http } from 'msw';
 import type { SetupServer } from 'msw/node';
-import { test, describe, expect } from 'vitest';
+import { test, describe, expect, vi } from 'vitest';
 
 import {
   Wallet,
@@ -161,6 +161,16 @@ describe('receive across a rotation', () => {
     const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(UnknownKeysetError);
     expect((err as UnknownKeysetError).cause).toBeDefined();
+  });
+
+  test('a never-loaded wallet rejects honestly, without a hidden repair', async () => {
+    const wallet = new Wallet(mint, { unit });
+    const spyKeySets = vi.spyOn(wallet.mint, 'getKeySets');
+
+    await expect(wallet.receive([proofOnA])).rejects.toThrow(/unrecognised keyset/i);
+    expect(spyKeySets).not.toHaveBeenCalled(); // no hidden loadMint(true)
+
+    spyKeySets.mockRestore();
   });
 });
 

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -628,6 +628,60 @@ describe('public ensureOperableKeysets', () => {
   });
 });
 
+describe('partial keyless fetches', () => {
+  // Two retired keysets in one op: the snapshot holds both keyless, and only one
+  // of the two key fetches comes back.
+  const keysetC: MintKeyset = {
+    id: '00ffffffffffffff',
+    unit: 'sat',
+    active: false,
+    input_fee_ppk: 0,
+  };
+  const proofOnC: ProofLike = { ...proofOnA, id: keysetC.id };
+
+  function useTwoRetiredKeysets(server: SetupServer, failing: string[]) {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({ keysets: [keysetAInactive, keysetC, keysetB] }),
+      ),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+      http.get(mintUrl + '/v1/keys/00bd033559de27d0', () =>
+        failing.includes('00bd033559de27d0')
+          ? HttpResponse.error()
+          : HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] }),
+      ),
+      http.get(mintUrl + '/v1/keys/' + keysetC.id, () => HttpResponse.error()),
+    );
+  }
+
+  test('emits for the keys that landed before failing the op', async () => {
+    useTwoRetiredKeysets(server, [keysetC.id]);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // A and C known but keyless, B active
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    await expect(wallet.prepareSwapToReceive([proofOnA, proofOnC])).rejects.toThrow();
+    expect(updates).toHaveLength(1); // A's keys landed and are worth persisting
+    expect(wallet.keyChain.getKeyset('00bd033559de27d0').hasKeys).toBe(true);
+  });
+
+  test('reports both failures when no keys land at all', async () => {
+    useTwoRetiredKeysets(server, ['00bd033559de27d0', keysetC.id]);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    await expect(wallet.prepareSwapToReceive([proofOnA, proofOnC])).rejects.toThrow(
+      /Could not load keys for 2 keysets/,
+    );
+    expect(updates).toHaveLength(0); // nothing changed, nothing to persist
+  });
+});
+
 describe('melt change across a rotation', () => {
   const meltQuote: MeltQuoteBolt11Response = {
     quote: 'melt-rotation',

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -914,6 +914,42 @@ describe('send and melt inputs across a rotation', () => {
     expect(counts().keysetsRequests).toBe(1);
   });
 
+  test('prepareMelt proceeds past a delisted input keyset with a warning', async () => {
+    // The mint delists A entirely: it is not in /v1/keysets, but the mint still
+    // honors its proofs. A wallet loaded now knows only B.
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetB] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only B
+
+    const warn = vi.spyOn(wallet.logger, 'warn');
+    const preview = await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id));
+    expect(preview.inputs).toHaveLength(2);
+    expect(preview.keysetId).toBe('009a1f293253e41e'); // change blanks on the active keyset
+    expect(warn).toHaveBeenCalledWith(
+      'Melt input keyset is not listed by the mint; proceeding anyway',
+      { keyset: proofOnA.id },
+    );
+  });
+
+  test('prepareMelt still refuses a delisted input keyset in strict mode', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetB] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    );
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint(); // knows only B
+
+    const err = await wallet
+      .prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id))
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).keysetId).toBe(proofOnA.id);
+    expect((err as UnknownKeysetError).refreshed).toBe(false); // strict never asks the mint
+  });
+
   test('meltProofsOnchain repairs the snapshot before its own fee check', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint(); // knows only A
@@ -951,5 +987,23 @@ describe('send and melt inputs across a rotation', () => {
     await wallet.prepareSwapToSend(1, [proofOnA]);
     await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id));
     expect(counts()).toEqual({ keysetsRequests: 0, keysARequests: 0 });
+  });
+
+  test('a failing key fetch does not block send or melt inputs', async () => {
+    // Post-rotation load: A is known but keyless, B is active and bound. Inputs sit on
+    // A. Spend-side ops price inputs from metadata, so the unused key fetch is skipped
+    // and its failure cannot fail the op.
+    const { counts } = useRotatedMint(server);
+    server.use(http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => HttpResponse.error()));
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // A known-but-keyless, bound to B
+
+    const sendPreview = await wallet.prepareSwapToSend(1, [proofOnA]);
+    expect(sendPreview.keysetId).toBe('009a1f293253e41e');
+
+    const meltPreview = await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id));
+    expect(meltPreview.keysetId).toBe('009a1f293253e41e');
+
+    expect(counts().keysARequests).toBe(0); // never attempted
   });
 });

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -12,15 +12,19 @@ import { test, describe, expect, vi } from 'vitest';
 
 import {
   Wallet,
+  MintOperationError,
+  StaleKeysetError,
   UnknownKeysetError,
   Amount,
   MeltQuoteState,
+  MintQuoteState,
   type KeyChainCache,
   type MintKeyset,
   type MintKeys,
   type ProofLike,
   type Proof,
   type MeltQuoteBolt11Response,
+  type MintQuoteBolt11Response,
 } from '../../src';
 import { DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
 
@@ -250,6 +254,260 @@ describe('receive across a rotation', () => {
     expect(spyKeySets).not.toHaveBeenCalled(); // no hidden loadMint(true)
 
     spyKeySets.mockRestore();
+  });
+});
+
+describe('mint rejection as rotation evidence', () => {
+  // A wallet loaded before the rotation has no unknown id to trip the repair: its
+  // snapshot still calls A active, so the outputs are built on A and the mint is the
+  // only thing that knows better.
+  function useRejectingSwap(server: SetupServer) {
+    let swapRequests = 0;
+    server.use(
+      http.post(mintUrl + '/v1/swap', () => {
+        swapRequests++;
+        if (swapRequests === 1) {
+          return HttpResponse.json(
+            { detail: 'Keyset is inactive, cannot sign messages', code: 12002 },
+            { status: 400 },
+          );
+        }
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '009a1f293253e41e',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        });
+      }),
+    );
+    return { swaps: () => swapRequests };
+  }
+
+  test('receive heals the snapshot and succeeds when the caller runs it again', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // pre-rotation: A is active and bound
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+
+    const { counts } = useRotatedMint(server); // the mint has moved on, the snapshot has not
+    const { swaps } = useRejectingSwap(server);
+
+    const err = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleKeysetError);
+    expect((err as StaleKeysetError).repaired).toBe(true);
+    expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
+    expect(wallet.keysetId).toBe('009a1f293253e41e');
+
+    const proofs = await wallet.receive([proofOnA]); // the caller's retry, on the fresh snapshot
+    expect(proofs[0].id).toBe('009a1f293253e41e');
+    expect(counts().keysetsRequests).toBe(1); // nothing refreshed a second time
+    expect(swaps()).toBe(2);
+  });
+
+  test('a retry that meets the same rejection reports an unrepaired snapshot', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    let swaps = 0;
+    server.use(
+      http.post(mintUrl + '/v1/swap', () => {
+        swaps++;
+        return HttpResponse.json(
+          { detail: 'Keyset is inactive, cannot sign messages', code: 12002 },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const first = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect((first as StaleKeysetError).repaired).toBe(true);
+
+    const second = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect(second).toBeInstanceOf(StaleKeysetError);
+    expect((second as StaleKeysetError).repaired).toBe(false); // rate limited, so nothing changed
+    expect(swaps).toBe(2);
+    expect(counts().keysetsRequests).toBe(1);
+  });
+
+  test('completeBatchMint reports a rejected batch as a stale keyset', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // pre-rotation: the batch outputs are built on A
+
+    const quote = (id: string): MintQuoteBolt11Response => ({
+      quote: id,
+      request: 'lnbc...',
+      amount: Amount.from(2),
+      unit: 'sat',
+      state: MintQuoteState.PAID,
+      amount_paid: Amount.from(2),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+      expiry: null,
+    });
+    const preview = await wallet.prepareBatchMint('bolt11', [
+      { amount: 2, quote: quote('batch-a') },
+      { amount: 2, quote: quote('batch-b') },
+    ]);
+
+    const { counts } = useRotatedMint(server);
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11/batch', () =>
+        HttpResponse.json(
+          { detail: 'Keyset is inactive, cannot sign messages', code: 12002 },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const err = await wallet.completeBatchMint(preview).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleKeysetError);
+    expect((err as StaleKeysetError).repaired).toBe(true);
+    expect(counts().keysetsRequests).toBe(1);
+    expect(wallet.keysetId).toBe('009a1f293253e41e'); // ready for a re-prepared batch
+  });
+
+  test('completeSwap hands the split flow a repaired snapshot to re-prepare against', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+    const { swaps } = useRejectingSwap(server);
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    const stale = await wallet.prepareSwapToReceive([proofOnA]); // outputs on A
+    const err = await wallet.completeSwap(stale).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleKeysetError);
+    expect((err as StaleKeysetError).repaired).toBe(true);
+    expect((err as StaleKeysetError).cause).toBeInstanceOf(MintOperationError);
+    expect(((err as StaleKeysetError).cause as MintOperationError).code).toBe(12002);
+    expect(counts().keysetsRequests).toBe(1);
+    expect(updates).toHaveLength(1); // the refreshed snapshot is worth persisting
+    expect(wallet.keyChain.hasKeyset('009a1f293253e41e')).toBe(true);
+    expect(wallet.keysetId).toBe('009a1f293253e41e');
+
+    const fresh = await wallet.prepareSwapToReceive([proofOnA]); // outputs on B
+    const { keep } = await wallet.completeSwap(fresh);
+    expect(keep[0].id).toBe('009a1f293253e41e');
+    expect(swaps()).toBe(2);
+  });
+
+  test('strict wallets report the rejection without repairing', async () => {
+    const wallet = new Wallet(mint, { unit, strictCachedKeysets: true });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+    const { swaps } = useRejectingSwap(server);
+
+    const err = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleKeysetError);
+    expect((err as StaleKeysetError).repaired).toBe(false);
+    expect(((err as StaleKeysetError).cause as MintOperationError).code).toBe(12002);
+    expect(counts().keysetsRequests).toBe(0);
+    expect(swaps()).toBe(1); // one attempt, and the caller is told not to bother repeating it
+  });
+
+  test('a failed refresh reports the rejection as unrepaired', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { swaps } = useRejectingSwap(server);
+    server.use(http.get(mintUrl + '/v1/keysets', () => HttpResponse.error()));
+
+    const err = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleKeysetError);
+    expect((err as StaleKeysetError).repaired).toBe(false);
+    expect(swaps()).toBe(1);
+  });
+
+  test('a rejection outside the keyset error class propagates untouched', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+    server.use(
+      http.post(mintUrl + '/v1/swap', () =>
+        HttpResponse.json({ detail: 'Token already spent', code: 11001 }, { status: 400 }),
+      ),
+    );
+
+    const err = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MintOperationError);
+    expect((err as MintOperationError).code).toBe(11001);
+    expect(counts().keysetsRequests).toBe(0);
+  });
+
+  test('a look-alike error with a non-finite code propagates untouched', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    // A custom request layer can raise a MintOperationError look-alike whose code never got
+    // parsed: absent, or NaN from a `Number(body.code)` on a missing field. isMintOperationError
+    // accepts both by name, and every range comparison against them is false, so without the
+    // finite check they would read as a keyset rejection.
+    for (const code of [undefined, NaN]) {
+      const lookAlike = Object.assign(new Error('mint said no'), {
+        name: 'MintOperationError',
+        code,
+      });
+      const spy = vi.spyOn(wallet.mint, 'swap').mockRejectedValue(lookAlike);
+
+      const err = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+      expect(err).toBe(lookAlike); // not wrapped in StaleKeysetError
+      expect(counts().keysetsRequests).toBe(0); // and no repair fired
+
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('repair rate limit', () => {
+  test('a second implicit repair inside the cooldown window is skipped', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    const first = await wallet
+      .receive([{ ...proofOnA, id: '00deadbeefdeadbe' }])
+      .catch((e: unknown) => e);
+    expect(first).toBeInstanceOf(UnknownKeysetError);
+    expect(counts().keysetsRequests).toBe(1);
+
+    const second = await wallet
+      .receive([{ ...proofOnA, id: '00c0ffeec0ffee00' }])
+      .catch((e: unknown) => e);
+    expect(second).toBeInstanceOf(UnknownKeysetError);
+    expect(counts().keysetsRequests).toBe(1); // no second refresh for the second alien id
+  });
+
+  test('the cooldown also gates the repair a mint rejection asks for', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    // Spend the window on an alien id, then meet a rejection on the way out
+    await expect(wallet.receive([{ ...proofOnA, id: '00deadbeefdeadbe' }])).rejects.toThrow(
+      UnknownKeysetError,
+    );
+    expect(counts().keysetsRequests).toBe(1);
+
+    let swaps = 0;
+    server.use(
+      http.post(mintUrl + '/v1/swap', () => {
+        swaps++;
+        return HttpResponse.json(
+          { detail: 'Keyset is inactive, cannot sign messages', code: 12002 },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const err = await wallet.receive([proofOnA]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleKeysetError);
+    expect((err as StaleKeysetError).repaired).toBe(false);
+    expect(counts().keysetsRequests).toBe(1); // rate limited, no refresh
+    expect(swaps).toBe(1);
   });
 });
 

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -218,6 +218,30 @@ describe('receive across a rotation', () => {
     expect(updates[0].keysets.map((k) => k.id)).toContain('009a1f293253e41e');
   });
 
+  test('a keyless fetch failure without a prior repair emits nothing', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // pre-rotation defaults: A active with keys
+    wallet.keyChain.getKeyset('00bd033559de27d0').keys = {}; // A is now known but keyless
+
+    let keysetsRequests = 0;
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => {
+        keysetsRequests++;
+        return HttpResponse.json({ keysets: [] });
+      }),
+      http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => HttpResponse.error()),
+    );
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    // proofOnA names a known keyset, so no unknown-id repair fires; the keyless
+    // fetch fails with nothing having changed beforehand.
+    await expect(wallet.prepareSwapToReceive([proofOnA])).rejects.toThrow();
+    expect(updates).toHaveLength(0); // no repair ran, nothing to persist
+    expect(keysetsRequests).toBe(0); // the unknown-id repair path was never invoked
+  });
+
   test('a never-loaded wallet rejects honestly, without a hidden repair', async () => {
     const wallet = new Wallet(mint, { unit });
     const spyKeySets = vi.spyOn(wallet.mint, 'getKeySets');

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -11,10 +11,14 @@ import { test, describe, expect } from 'vitest';
 import {
   Wallet,
   UnknownKeysetError,
+  Amount,
+  MeltQuoteState,
   type KeyChainCache,
   type MintKeyset,
   type MintKeys,
   type ProofLike,
+  type Proof,
+  type MeltQuoteBolt11Response,
 } from '../../src';
 import { DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
 
@@ -157,5 +161,66 @@ describe('receive across a rotation', () => {
     const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(UnknownKeysetError);
     expect((err as UnknownKeysetError).cause).toBeDefined();
+  });
+});
+
+describe('melt change across a rotation', () => {
+  const meltQuote: MeltQuoteBolt11Response = {
+    quote: 'melt-rotation',
+    amount: Amount.from(10),
+    fee_reserve: Amount.from(3),
+    request: 'bolt11request',
+    state: MeltQuoteState.UNPAID,
+    expiry: 1234567890,
+    payment_preimage: null,
+    unit: 'sat',
+  };
+  const proofsForMelt: Proof[] = [
+    { id: '00bd033559de27d0', amount: Amount.from(8), secret: 'secret1', C: 'C1' },
+    { id: '00bd033559de27d0', amount: Amount.from(5), secret: 'secret2', C: 'C2' },
+  ]; // sum=13, feeReserve=3, amount=10
+  const paidResponseWithChangeOnA = {
+    quote: 'melt-rotation',
+    amount: 10,
+    unit: 'sat',
+    fee_reserve: 3,
+    state: MeltQuoteState.PAID,
+    expiry: 1234567890,
+    payment_preimage: 'preimage',
+    request: 'bolt11request',
+    change: [
+      {
+        id: '00bd033559de27d0',
+        amount: 1,
+        C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+      {
+        id: '00bd033559de27d0',
+        amount: 2,
+        C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+    ],
+  };
+
+  test('completeMelt reconstructs change on a keyset it holds keyless', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const preview = await wallet.prepareMelt('bolt11', meltQuote, proofsForMelt);
+
+    // Rotate underneath the in-flight melt: A goes inactive and keyless in the snapshot
+    const { counts } = useRotatedMint(server);
+    await wallet.loadMint(true);
+    // Sanity: the refresh kept A's keys (Task 2); blank them to simulate a wallet
+    // built fresh from post-rotation data, which is the failing production case.
+    wallet.keyChain.getKeyset('00bd033559de27d0').keys = {};
+
+    // Mint answers with change signed on A (the keyset the blanks were built on)
+    server.use(
+      http.post(mintUrl + '/v1/melt/bolt11', () => HttpResponse.json(paidResponseWithChangeOnA)),
+    );
+
+    const { change } = await wallet.completeMelt(preview);
+    expect(change.length).toBeGreaterThan(0);
+    expect(counts().keysARequests).toBe(1); // keys were fetched, not assumed
   });
 });

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -1,0 +1,161 @@
+// Rotation suite: what happens to a live Wallet when the mint rotates keysets.
+//
+// Contract: every async wallet op that consumes keyset ids must make the
+// snapshot operable at op entry (see Wallet.ensureOperableKeysets). When you
+// add such an op, add its rotation scenario to this file.
+
+import { HttpResponse, http } from 'msw';
+import type { SetupServer } from 'msw/node';
+import { test, describe, expect } from 'vitest';
+
+import {
+  Wallet,
+  UnknownKeysetError,
+  type KeyChainCache,
+  type MintKeyset,
+  type MintKeys,
+  type ProofLike,
+} from '../../src';
+import { DUMMY_TEST_KEYSET, DUMMY_TEST_KEYS, PUBKEYS } from '../consts';
+
+import { mintUrl, mint, unit, useTestServer } from './_setup';
+
+const server = useTestServer();
+
+// Rotation fixtures: mint starts with A active, then A goes inactive and B appears.
+const keysetAInactive: MintKeyset = { ...DUMMY_TEST_KEYSET, active: false };
+const keysetB: MintKeyset = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
+const keysB: MintKeys = { ...keysetB, keys: PUBKEYS };
+
+function useRotatedMint(server: SetupServer) {
+  let keysetsRequests = 0;
+  let keysARequests = 0;
+  server.use(
+    http.get(mintUrl + '/v1/keysets', () => {
+      keysetsRequests++;
+      return HttpResponse.json({ keysets: [keysetAInactive, keysetB] });
+    }),
+    http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [keysB] })),
+    http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => {
+      keysARequests++;
+      return HttpResponse.json({ keysets: [DUMMY_TEST_KEYS] });
+    }),
+    http.get(mintUrl + '/v1/keys/009a1f293253e41e', () => HttpResponse.json({ keysets: [keysB] })),
+  );
+  return { counts: () => ({ keysetsRequests, keysARequests }) };
+}
+
+describe('rebind on refresh', () => {
+  test('auto-bound wallet follows the mint after a rotation', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('009a1f293253e41e');
+  });
+
+  test('pinned wallet stays put after a rotation', async () => {
+    const wallet = new Wallet(mint, { unit, keysetId: '00bd033559de27d0' });
+    await wallet.loadMint();
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+  });
+
+  test('bindKeyset makes the binding explicit', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    wallet.bindKeyset('00bd033559de27d0');
+
+    useRotatedMint(server);
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0');
+  });
+
+  test('auto-bound wallet keeps its binding when the mint has no active replacement', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [keysetAInactive] })),
+      http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [] })),
+    );
+    await wallet.loadMint(true);
+    expect(wallet.keysetId).toBe('00bd033559de27d0'); // still there; melt remains possible
+  });
+});
+
+describe('receive across a rotation', () => {
+  const proofOnA: ProofLike = {
+    id: '00bd033559de27d0',
+    amount: 1,
+    secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
+    C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
+  };
+  const proofOnB: ProofLike = { ...proofOnA, id: '009a1f293253e41e' };
+  const proofOnAlien: ProofLike = { ...proofOnA, id: '00deadbeefdeadbe' };
+
+  test('receives a pre-rotation token by loading the old keys once', async () => {
+    const { counts } = useRotatedMint(server);
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // first ever load, post-rotation: A inactive and keyless, B active
+    expect(counts().keysARequests).toBe(0); // baseline: loadMint alone doesn't fetch A's keys
+
+    const preview = await wallet.prepareSwapToReceive([proofOnA]);
+    expect(preview.keysetId).toBe('009a1f293253e41e'); // outputs on the active keyset
+    expect(counts().keysARequests).toBe(1); // one /v1/keys/A fetch, then cached
+
+    await wallet.prepareSwapToReceive([proofOnA]);
+    expect(counts().keysARequests).toBe(1); // still one: ensure is idempotent
+  });
+
+  test('repairs a stale snapshot once when a proof names an unknown keyset', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A
+    const { counts } = useRotatedMint(server);
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    const preview = await wallet.prepareSwapToReceive([proofOnB]);
+    expect(preview.keysetId).toBe('009a1f293253e41e');
+    expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
+    expect(updates).toHaveLength(1);
+    expect(updates[0].keysets.map((k) => k.id)).toContain('009a1f293253e41e');
+  });
+
+  test('concurrent ops share one repair refresh', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    await Promise.all([
+      wallet.prepareSwapToReceive([proofOnB]),
+      wallet.prepareSwapToReceive([proofOnB]),
+    ]);
+    expect(counts().keysetsRequests).toBe(1);
+  });
+
+  test('a genuinely alien keyset id throws UnknownKeysetError after the repair', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    const err = await wallet.prepareSwapToReceive([proofOnAlien]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).keysetId).toBe('00deadbeefdeadbe');
+    expect(counts().keysetsRequests).toBe(1); // it did try
+  });
+
+  test('a failed repair surfaces UnknownKeysetError with the transport failure as cause', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    server.use(http.get(mintUrl + '/v1/keysets', () => HttpResponse.error()));
+
+    const err = await wallet.prepareSwapToReceive([proofOnB]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).cause).toBeDefined();
+  });
+});

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -163,6 +163,24 @@ describe('receive across a rotation', () => {
     expect((err as UnknownKeysetError).cause).toBeDefined();
   });
 
+  test('a completed repair still emits when the trailing keyless fetch fails', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A, with keys
+    wallet.keyChain.getKeyset('00bd033559de27d0').keys = {}; // A is now known but keyless
+    const { counts } = useRotatedMint(server); // B is unknown until the repair
+    server.use(http.get(mintUrl + '/v1/keys/00bd033559de27d0', () => HttpResponse.error()));
+
+    const updates: KeyChainCache[] = [];
+    wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
+
+    // proofOnB forces the unknown-keyset repair; proofOnA then needs a keyless
+    // fetch that fails, after the repair already succeeded.
+    await expect(wallet.prepareSwapToReceive([proofOnA, proofOnB])).rejects.toThrow();
+    expect(counts().keysetsRequests).toBe(1); // repair ran once
+    expect(updates).toHaveLength(1); // repair's change was still persisted
+    expect(updates[0].keysets.map((k) => k.id)).toContain('009a1f293253e41e');
+  });
+
   test('a never-loaded wallet rejects honestly, without a hidden repair', async () => {
     const wallet = new Wallet(mint, { unit });
     const spyKeySets = vi.spyOn(wallet.mint, 'getKeySets');

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -1,8 +1,9 @@
 // Rotation suite: what happens to a live Wallet when the mint rotates keysets.
 //
 // Contract: every async wallet op that consumes keyset ids must make the
-// snapshot operable at op entry (see Wallet.ensureOperableKeysets). When you
-// add such an op, add its rotation scenario to this file.
+// snapshot operable at op entry, or where the ids first become known (see
+// Wallet.ensureOperableKeysets). When you add such an op, add its rotation
+// scenario to this file.
 
 import { HttpResponse, http } from 'msw';
 import type { SetupServer } from 'msw/node';

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -858,3 +858,68 @@ describe('strictCachedKeysets', () => {
     expect(counts().keysetsRequests).toBe(0); // strict inherited: no repair fired
   });
 });
+
+describe('send and melt inputs across a rotation', () => {
+  // Both ops resolve an output keyset of their own, so only the input proofs can
+  // carry an id the snapshot has never seen: a wallet restored from a stale cache
+  // holding proofs another device minted after that cache was written.
+  const proofOnAlien: ProofLike = { ...proofOnA, id: '00deadbeefdeadbe' };
+  const meltQuote: MeltQuoteBolt11Response = {
+    quote: 'melt-inputs',
+    amount: Amount.from(10),
+    fee_reserve: Amount.from(3),
+    request: 'bolt11request',
+    state: MeltQuoteState.UNPAID,
+    expiry: 1234567890,
+    payment_preimage: null,
+    unit: 'sat',
+  };
+  const meltProofsOn = (id: string): ProofLike[] => [
+    { ...proofOnA, id, amount: 8, secret: 'secret1', C: 'C1' },
+    { ...proofOnA, id, amount: 5, secret: 'secret2', C: 'C2' },
+  ]; // sum=13, feeReserve=3, amount=10
+
+  test('prepareSwapToSend repairs a stale snapshot before the fee math', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A
+    const { counts } = useRotatedMint(server);
+
+    const preview = await wallet.prepareSwapToSend(1, [proofOnB]);
+    expect(preview.inputs[0].id).toBe('009a1f293253e41e');
+    expect(preview.keysetId).toBe('009a1f293253e41e'); // outputs on the repaired binding
+    expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
+  });
+
+  test('prepareSwapToSend reports a genuinely alien input id', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { counts } = useRotatedMint(server);
+
+    const err = await wallet.prepareSwapToSend(1, [proofOnAlien]).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(UnknownKeysetError);
+    expect((err as UnknownKeysetError).keysetId).toBe('00deadbeefdeadbe');
+    expect((err as UnknownKeysetError).refreshed).toBe(true); // asked the mint, so this is final
+    expect(counts().keysetsRequests).toBe(1);
+  });
+
+  test('prepareMelt repairs a stale snapshot for its input proofs', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // knows only A
+    const { counts } = useRotatedMint(server);
+
+    const preview = await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(keysetB.id));
+    expect(preview.inputs).toHaveLength(2);
+    expect(preview.keysetId).toBe('009a1f293253e41e'); // NUT-08 blanks on the repaired binding
+    expect(counts().keysetsRequests).toBe(1);
+  });
+
+  test('a complete snapshot fetches nothing on either path', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint(); // pre-rotation: A active, with keys
+    const { counts } = useRotatedMint(server); // would answer, if anything asked
+
+    await wallet.prepareSwapToSend(1, [proofOnA]);
+    await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id));
+    expect(counts()).toEqual({ keysetsRequests: 0, keysARequests: 0 });
+  });
+});


### PR DESCRIPTION
## TL;DR

Full backport of #978: a mint keyset rotation left live wallets unable to receive pre-rotation tokens, reconstruct melt change, or follow the mint at all once their snapshot went stale. The wallet now handles rotation end to end, with the opt-in `strictCachedKeysets` mode for apps that manage keyset state themselves.

## Why

[NUT-01](https://github.com/cashubtc/nuts/blob/main/01.md) serves keys for active keysets only, so the keychain holds rotated-out keysets keyless, and only `restore()` backfilled them. Receive (DLEQ verification) and melt-change reconstruction also need those keys and failed with a misleading error; a refresh blanked keys the wallet already held and never rebound it. Minibits' rotation surfaced this in production on v4 apps, and proof-of-liabilities schemes will make rotations routine, so the fix ships on the LTS branch with the same semantics as v5.

## Changes

Identical to #978, ported commit by commit. One v4-specific adaptation: `hasValidDleq` checks key presence before the DLEQ-presence early return, matching v5. On v4's old ordering, a proof without a DLEQ against a keyless keyset passed verification under `requireDleq: false`; it now reports the missing keys instead.

## Impact

No breaking API changes; additions: `UnknownKeysetError`, `StaleKeysetError`, `KeyChain.hasKeyset`, `Wallet.ensureOperableKeysets`, the `keychainUpdated` event, and the `strictCachedKeysets` option. Behavior notes for v4 consumers, since this is an LTS minor:

- completing ops (`completeSwap`, `completeMint`, `completeBatchMint`, `completeMelt`) that met a mint keyset error (NUT-00 codes 12xxx) previously surfaced the raw `MintOperationError`. They now repair the snapshot once and throw `StaleKeysetError`, with the mint's error as `cause`. Handlers matching `isMintOperationError(e) && e.code === 12002`, or catching `HttpResponseError` to read `.status`, need updating: `StaleKeysetError` extends `CTSError` directly, so both live on `e.cause`. `repaired: true` means the wallet has healed and the call can be run again
- **melt inputs are now checked against the snapshot.** The bolt11 and bolt12 paths never resolved the input keyset, so melting proofs the wallet did not know went ahead with change blanks bound to a stale keyset; the onchain wrapper failed with a raw fee error. All of them now refuse at prepare time with `UnknownKeysetError` until the snapshot is repaired. This is the change most likely to affect a working integration: wallets melting restored or externally sourced proofs, or talking to a mint that prunes keysets from `/v1/keysets`
- a melt whose change cannot be rebuilt now throws `MeltChangeError` carrying the `outputData` and quote, so the change stays recoverable instead of being lost with the error
- an unknown keyset id on receive now triggers one snapshot refresh, then throws `UnknownKeysetError`; anyone matching the old `Proof has unrecognised keyset` message should update
- receive and the completing ops may fetch keyset data when they meet rotation evidence, rate limited to one repair a minute; `strictCachedKeysets: true` disables all implicit fetching
- `loadMint(true)` now re-applies keyset selection for auto-bound wallets (newest version, then lowest fee); wallets pinned via `keysetId` or `bindKeyset()` are unaffected
- `hasValidDleq` throws for keysets with no loaded keys where it previously returned the `require` default
