### PR TITLE
chore(docker): update CDK_IMAGE to cashubtc/mintd:0.17.5 [backport v4-dev]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RATE_LIMIT_PM ?= 200
 # Pin versions
 # ------------------------
 CDK_IMAGE_RC ?= cashubtc/mintd:0.17.3-rc.0
-CDK_IMAGE ?= cashubtc/mintd:0.17.4
+CDK_IMAGE ?= cashubtc/mintd:0.17.5
 CDK_NAME ?= cashu-dev-cdk
 
 NUT_IMAGE_RC ?= cashubtc/nutshell:0.18.2


### PR DESCRIPTION
# Description
Backport of #982 to `v4-dev`.