### PR TITLE
fix(utils): make base64 and CBOR payload decoding consistent across platforms

### DIFF
--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -86,17 +86,24 @@ export class Bytes {
   }
 
   static fromBase64(base64: string): Uint8Array {
-    base64 = base64.trim();
-    // normalize base64url to base64 and pad
-    let normalizedBase64 = base64.replace(/-/g, '+').replace(/_/g, '/');
-    while (normalizedBase64.length % 4) {
-      normalizedBase64 += '=';
+    // Normalize: trim, strip ASCII whitespace (line-wrapped input is common),
+    // map base64url to base64, drop trailing padding.
+    const unpadded = base64
+      .trim()
+      .replace(/[\t\n\f\r ]+/g, '')
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .replace(/={1,2}$/, '');
+    if (/[^A-Za-z0-9+/]/.test(unpadded) || unpadded.length % 4 === 1) {
+      throw new CTSError('Invalid base64 string');
     }
+    // Re-pad canonically so both decoder backends see the same validated string.
+    const normalized = unpadded + '='.repeat((4 - (unpadded.length % 4)) % 4);
     const bufferConstructor = getBufferConstructor();
     if (bufferConstructor) {
-      return new Uint8Array(bufferConstructor.from(normalizedBase64, 'base64'));
+      return new Uint8Array(bufferConstructor.from(normalized, 'base64'));
     }
-    return new Uint8Array([...atob(normalizedBase64)].map((c) => c.charCodeAt(0)));
+    return new Uint8Array([...atob(normalized)].map((c) => c.charCodeAt(0)));
   }
   // NOTE: MUST remain a constant-time implementation (full byte check)
   // because callers rely on it (e.g. deriveP2BKSecretKey, verifyDLEQProof).

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -6,10 +6,7 @@ function encodeUint8toBase64(uint8array: Uint8Array): string {
 }
 
 function encodeUint8toBase64Url(bytes: Uint8Array): string {
-  return Bytes.toBase64(bytes)
-    .replace(/\+/g, '-') // Replace + with -
-    .replace(/\//g, '_') // Replace / with _
-    .replace(/=+$/, ''); // Remove padding characters
+  return base64urlFromBase64(Bytes.toBase64(bytes));
 }
 
 /**
@@ -50,18 +47,12 @@ function encodeJsonToBase64(jsonObj: unknown): string {
  * {@link encodeJsonToBase64}.
  */
 function encodeBase64ToJson<T extends object>(base64String: string): T {
-  const jsonString = Bytes.toString(Bytes.fromBase64(base64urlToBase64(base64String)));
+  const jsonString = Bytes.toString(Bytes.fromBase64(base64String));
   return JSONInt.parse(jsonString) as T;
 }
 
-function base64urlToBase64(str: string) {
-  return str.replace(/-/g, '+').replace(/_/g, '/').split('=')[0];
-  // .replace(/./g, '=');
-}
-
 function base64urlFromBase64(str: string) {
-  return str.replace(/\+/g, '-').replace(/\//g, '_').split('=')[0];
-  // .replace(/=/g, '.');
+  return str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 function isBase64String(s: string): boolean {
@@ -87,7 +78,7 @@ function isBase64String(s: string): boolean {
 
     // Re-encode and compare to the original (allowing either standard or url-safe representation)
     const reStandard = Bytes.toBase64(decoded);
-    const reUrl = reStandard.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const reUrl = base64urlFromBase64(reStandard);
 
     // Also compare against original normalized-without-padding variant
     const originalNoPad = normalized.replace(/=+$/, '');

--- a/src/utils/cbor.ts
+++ b/src/utils/cbor.ts
@@ -311,6 +311,10 @@ function encodeObject(value: Record<string, unknown>, buffer: number[]) {
 export function decodeCBOR(data: Uint8Array): ResultValue {
   const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
   const result = decodeItem(view, 0);
+  // A complete payload consumes the whole buffer; reject trailing bytes.
+  if (result.offset !== data.byteLength) {
+    throw new CTSError('CBOR data has trailing bytes');
+  }
   return result.value;
 }
 

--- a/test/utils/base64.test.ts
+++ b/test/utils/base64.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, expect } from 'vitest';
+import { test, describe, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
   encodeBase64ToJson,
@@ -152,4 +152,39 @@ describe('isBase64String', () => {
   test('invalid: empty string', () => {
     expect(isBase64String('')).toBe(false);
   });
+});
+describe.each(['Buffer', 'atob fallback'])('strict base64 decoding (%s)', (backend) => {
+  const dec = new TextDecoder();
+
+  beforeEach(() => {
+    if (backend === 'atob fallback') vi.stubGlobal('Buffer', undefined);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test.each([
+    ['mid-string padding', 'dGVz=dA=='],
+    ['invalid characters', 'dGVz$dA='],
+    ['excess padding', 'dGVzdA==='],
+    ['a length no padding can complete', 'dGVzd'],
+  ])('rejects %s', (_label, input) => {
+    expect(() => encodeBase64toUint8(input)).toThrow(/Invalid base64/);
+  });
+
+  test.each([
+    ['padded input', 'dGVzdA==', 'test'],
+    ['unpadded input', 'dGVzdA', 'test'],
+    ['short padding', 'dGVzdA=', 'test'],
+    ['spurious padding', 'dGVz=', 'tes'],
+    ['padding-only input', '==', ''],
+    ['line-wrapped input', 'dGVz\ndA==\n', 'test'],
+    ['edge Unicode whitespace', '\u00a0\ufeffdGVzdA==\u3000', 'test'],
+  ])('decodes %s', (_label, input, expected) => {
+    expect(dec.decode(encodeBase64toUint8(input))).toBe(expected);
+  });
+});
+
+test('v3 token path rejects excess padding', () => {
+  expect(() => encodeBase64ToJson('eyJhIjoxfQ===')).toThrow(/Invalid base64/);
 });

--- a/test/utils/cbor.test.ts
+++ b/test/utils/cbor.test.ts
@@ -115,6 +115,15 @@ describe('cbor decoder', () => {
     expect(() => decodeCBOR(buf)).toThrow(/nesting exceeds the maximum depth/);
   });
 
+  test('trailing bytes after a complete item are rejected', () => {
+    const encoded = encodeCBOR({ a: 1 });
+    const withJunk = new Uint8Array(encoded.length + 1);
+    withJunk.set(encoded);
+    withJunk[encoded.length] = 0x00;
+    expect(decodeCBOR(encoded)).toStrictEqual({ a: 1 });
+    expect(() => decodeCBOR(withJunk)).toThrow(/trailing bytes/);
+  });
+
   test('decode float16 (0xf9) and float32 (0xfa) paths', () => {
     // float16 0x3c00 -> 1.0
     const f16 = new Uint8Array([0xf9, 0x3c, 0x00]);


### PR DESCRIPTION
## TLDR

Base64 and CBOR payload decoding now gives the same verdict on Node and in browsers: well-formed input decodes, malformed input throws `CTSError`.

## Why

The two platform decoders (`Buffer`, `atob`) disagree on some edge cases, so the same string could decode on one platform and fail on the other. #967 validates scanned text candidates by decoding them, so verdicts must be uniform across platforms; this PR is sequenced ahead of it.

## Changes

- `Bytes.fromBase64` normalizes (trim, whitespace strip, base64url mapping, padding) and validates in one place, then decodes the validated string, so both backends see identical input.
- `decodeCBOR` requires a payload to consume the whole buffer.
- `encodeBase64ToJson` delegates to `Bytes.fromBase64` directly; the redundant private pre-mapping helper is removed and the base64url output mapping has a single implementation.
- Tests run a shared accept/reject corpus under both decoder backends.

## Impact

`getDecodedToken`, `getDecodedTokenBinary` and `PaymentRequest.fromEncodedRequest` throw `CTSError` for malformed payloads on every platform. Line-wrapped, unpadded, and edge-whitespace input still decodes. Full suite and prtasks pass. v5 only, as it may now throw on platforms that once passed.
