### PR TITLE
feat(wallet): add LockBuilder and asLocked as forward-compatible names

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -824,6 +824,37 @@ export type KeysetPair = {
 };
 
 // @public
+export class LockBuilder {
+    addHashlock(hashlock: string): this;
+    // @deprecated (undocumented)
+    addLockPubkey(pk: string | string[]): this;
+    // (undocumented)
+    addMainPubkey(pk: string | string[]): this;
+    // (undocumented)
+    addRefundPubkey(pk: string | string[]): this;
+    // (undocumented)
+    addTag(key: string, values?: string[] | string): this;
+    // (undocumented)
+    addTags(tags: P2PKTag[]): this;
+    // (undocumented)
+    blindKeys(): this;
+    // (undocumented)
+    static fromOptions(p2pk: P2PKOptions): LockBuilder;
+    // (undocumented)
+    lockUntil(when: Date | number): this;
+    // @deprecated (undocumented)
+    requireLockSignatures(n: number): this;
+    // (undocumented)
+    requireMainSignatures(n: number): this;
+    // (undocumented)
+    requireRefundSignatures(n: number): this;
+    // (undocumented)
+    sigAll(): this;
+    // (undocumented)
+    toOptions(): P2PKOptions;
+}
+
+// @public
 export type LockConditions = {
     pubkeys?: string[];
     locktime?: number;
@@ -869,6 +900,8 @@ export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | '
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
     asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
@@ -1117,6 +1150,8 @@ export class MintBuilder<M extends MintMethod, HasPrivKey extends boolean = M ex
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
     asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
@@ -1602,32 +1637,11 @@ export type OutputType = ({
 // @public
 export const P2BK_DST: Uint8Array<ArrayBufferLike>;
 
-// @public (undocumented)
-export class P2PKBuilder {
-    addHashlock(hashlock: string): this;
-    // (undocumented)
-    addLockPubkey(pk: string | string[]): this;
-    // (undocumented)
-    addRefundPubkey(pk: string | string[]): this;
-    // (undocumented)
-    addTag(key: string, values?: string[] | string): this;
-    // (undocumented)
-    addTags(tags: P2PKTag[]): this;
-    // (undocumented)
-    blindKeys(): this;
-    // (undocumented)
-    static fromOptions(p2pk: P2PKOptions): P2PKBuilder;
-    // (undocumented)
-    lockUntil(when: Date | number): this;
-    // (undocumented)
-    requireLockSignatures(n: number): this;
-    // (undocumented)
-    requireRefundSignatures(n: number): this;
-    // (undocumented)
-    sigAll(): this;
-    // (undocumented)
-    toOptions(): P2PKOptions;
-}
+// @public @deprecated (undocumented)
+export const P2PKBuilder: typeof LockBuilder;
+
+// @public @deprecated (undocumented)
+export type P2PKBuilder = LockBuilder;
 
 // @public
 export type P2PKOptions = SpendingConditionsBase & LockConditions & {
@@ -1736,7 +1750,7 @@ export class PaymentRequestBuilder {
     build(): PaymentRequest_2;
     description(description: string): this;
     id(id: string): this;
-    lock(p2pk: P2PKOptions): this;
+    lock(lock: P2PKOptions | LockBuilder): this;
     mintsPreferred(preferred?: boolean): this;
     nut10(option: NUT10Option): this;
     // (undocumented)
@@ -1899,6 +1913,8 @@ export class ReceiveBuilder {
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
     asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
@@ -2009,12 +2025,16 @@ export class SendBuilder {
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
     asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     includeFees(on?: boolean): this;
     keepAsCustom(data: OutputDataLike[]): this;
     keepAsDeterministic(counter?: number, denoms?: AmountLike[]): this;
     keepAsFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
+    keepAsLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
     keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     keepAsRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
 export { Mint } from './mint';
 export { KeyChain } from './wallet/KeyChain';
 export { Keyset } from './wallet/Keyset';
-export { P2PKBuilder } from './wallet/P2PKBuilder';
+export { LockBuilder, P2PKBuilder } from './wallet/P2PKBuilder';
 export { type SelectProofs, selectProofsRGLI, selectProofsRotating } from './wallet/SelectProofs';
 export {
   serializeSwapPreview,

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -7,6 +7,7 @@ import { decodeBech32mToBytes, encodeBech32m } from '../utils/bech32m';
 import { JSONInt } from '../utils/JSONInt';
 import { decodeTLV, encodeTLV } from '../utils/tlv';
 import type { DecodedTLVPaymentRequest } from '../utils/tlv';
+import type { LockBuilder } from '../wallet/P2PKBuilder';
 import { PaymentRequestTransportType } from '../wallet/types';
 import type {
   RawPaymentRequest,
@@ -648,12 +649,16 @@ export class PaymentRequestBuilder {
   }
 
   /**
-   * Sets the `nut10` locking condition from a complete P2PK/HTLC {@link P2PKOptions} (e.g. from
-   * `P2PKBuilder.toOptions()`). Last call here or via `nut10()` wins.
+   * Sets the `nut10` locking condition from a {@link LockBuilder} or complete P2PK/HTLC
+   * {@link P2PKOptions}. Last call here or via `nut10()` wins.
    *
    * @throws If the lock is invalid or uses `blindKeys` (not expressible in a request).
    */
-  lock(p2pk: P2PKOptions): this {
+  lock(lock: P2PKOptions | LockBuilder): this {
+    const p2pk =
+      typeof (lock as LockBuilder).toOptions === 'function'
+        ? (lock as LockBuilder).toOptions()
+        : (lock as P2PKOptions);
     this._nut10 = p2pkOptionsToPRNut10(p2pk);
     return this;
   }

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -17,7 +17,14 @@ function assertUnixSeconds(seconds: number): number {
   return Math.floor(seconds);
 }
 
-export class P2PKBuilder {
+/**
+ * Builder for lock spending conditions.
+ *
+ * @remarks
+ * The v5 name for `P2PKBuilder`: adopt it (with `addMainPubkey` and `requireMainSignatures`) and
+ * the v5 upgrade keeps these call sites compiling.
+ */
+export class LockBuilder {
   // Keys are deduplicated by x-only identity and first-seen order preserved.
   private lockKeys: string[] = [];
   private refundKeys: string[] = [];
@@ -29,10 +36,17 @@ export class P2PKBuilder {
   private sigFlag?: SigFlag;
   private hashlock?: string;
 
-  addLockPubkey(pk: string | string[]) {
+  addMainPubkey(pk: string | string[]) {
     const arr = Array.isArray(pk) ? pk : [pk];
     this.lockKeys = dedupeP2PKPubkeys([...this.lockKeys, ...arr]);
     return this;
+  }
+
+  /**
+   * @deprecated Use `addMainPubkey`. Removed in v5.
+   */
+  addLockPubkey(pk: string | string[]) {
+    return this.addMainPubkey(pk);
   }
 
   addRefundPubkey(pk: string | string[]) {
@@ -54,11 +68,18 @@ export class P2PKBuilder {
     return this;
   }
 
-  requireLockSignatures(n: number) {
+  requireMainSignatures(n: number) {
     if (!Number.isInteger(n) || n < 1)
       throw new CTSError(`requiredSignatures (n_sigs) must be a positive integer, got ${n}`);
     this.nSigs = n;
     return this;
+  }
+
+  /**
+   * @deprecated Use `requireMainSignatures`. Removed in v5.
+   */
+  requireLockSignatures(n: number) {
+    return this.requireMainSignatures(n);
   }
 
   requireRefundSignatures(n: number) {
@@ -156,19 +177,19 @@ export class P2PKBuilder {
     return p2pk;
   }
 
-  static fromOptions(p2pk: P2PKOptions): P2PKBuilder {
-    const b = new P2PKBuilder();
+  static fromOptions(p2pk: P2PKOptions): LockBuilder {
+    const b = new LockBuilder();
     if (p2pk.kind === 'HTLC') {
       b.addHashlock(p2pk.data);
-      if (p2pk.pubkeys?.length) b.addLockPubkey(p2pk.pubkeys);
+      if (p2pk.pubkeys?.length) b.addMainPubkey(p2pk.pubkeys);
     } else {
-      b.addLockPubkey([p2pk.data, ...(p2pk.pubkeys ?? [])]);
+      b.addMainPubkey([p2pk.data, ...(p2pk.pubkeys ?? [])]);
     }
     // p2pk.locktime is already canonical Unix seconds; assign directly so lockUntil's
     // ms heuristic can't re-interpret a >= 1e12 second value and expire the lock.
     if (p2pk.locktime !== undefined) b.locktime = assertUnixSeconds(p2pk.locktime);
     if (p2pk.refundKeys?.length) b.addRefundPubkey(p2pk.refundKeys);
-    if (p2pk.requiredSignatures !== undefined) b.requireLockSignatures(p2pk.requiredSignatures);
+    if (p2pk.requiredSignatures !== undefined) b.requireMainSignatures(p2pk.requiredSignatures);
     if (p2pk.requiredRefundSignatures !== undefined)
       b.requireRefundSignatures(p2pk.requiredRefundSignatures);
     if (p2pk.additionalTags?.length) b.addTags(p2pk.additionalTags);
@@ -177,3 +198,12 @@ export class P2PKBuilder {
     return b;
   }
 }
+
+/**
+ * @deprecated Renamed {@link LockBuilder}. This alias is removed in v5.
+ */
+export const P2PKBuilder = LockBuilder;
+/**
+ * @deprecated Renamed {@link LockBuilder}. This alias is removed in v5.
+ */
+export type P2PKBuilder = LockBuilder;

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -15,6 +15,7 @@ import {
 import type { ProofLike } from '../model/types/proof';
 import type { Token } from '../model/types/token';
 
+import { LockBuilder } from './P2PKBuilder';
 import {
   type OutputType,
   type OutputConfig,
@@ -105,7 +106,7 @@ export class WalletOps {
     }
     // Net of input fees (NUT-18): the payee must net the requested amount after swapping.
     const builder = new SendBuilder(wallet, base.add(fee), proofs).includeFees(true);
-    return lock ? builder.asP2PK(lock) : builder;
+    return lock ? builder.asLocked(lock) : builder;
   }
   receive(token: Token | string | ProofLike[]) {
     return new ReceiveBuilder(this.wallet, token);
@@ -194,15 +195,24 @@ export class SendBuilder {
   }
 
   /**
-   * Lock the sent proofs to a NUT-11 P2PK / NUT-14 HTLC spending condition.
+   * Lock the sent proofs to a spending condition.
    *
-   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
-   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
+   * @remarks
+   * The v5 name for `asP2PK`, taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
-    this.sendOT = { type: 'p2pk', options: p2pk, denominations: denoms };
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
+    this.sendOT = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**
@@ -249,14 +259,24 @@ export class SendBuilder {
   }
 
   /**
-   * Lock the change to a NUT-11 P2PK / NUT-14 HTLC spending condition.
+   * Lock the change to a spending condition.
    *
-   * @param p2pk A complete {@link P2PKOptions} whose `kind` selects P2PK vs HTLC.
+   * @remarks
+   * The v5 name for `keepAsP2PK`, taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
-    this.keepOT = { type: 'p2pk', options: p2pk, denominations: denoms };
+  keepAsLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
+    this.keepOT = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `keepAsLocked`. Removed in v5.
+   */
+  keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.keepAsLocked(p2pk, denoms);
   }
 
   /**
@@ -468,17 +488,25 @@ export class ReceiveBuilder {
   }
 
   /**
-   * Lock the received proofs to a NUT-11 P2PK / NUT-14 HTLC spending condition.
+   * Lock the received proofs to a spending condition.
    *
    * @remarks
-   * If `denoms` is specified, `proofsWeHave()` has no effect.
-   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
-   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
+   * If `denoms` is specified, `proofsWeHave()` has no effect. This is the v5 name for `asP2PK`,
+   * taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
-    this.outputType = { type: 'p2pk', options: p2pk, denominations: denoms };
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
+    this.outputType = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**
@@ -642,17 +670,25 @@ export class MintBuilder<
   }
 
   /**
-   * Lock the minted proofs to a NUT-11 P2PK / NUT-14 HTLC spending condition.
+   * Lock the minted proofs to a spending condition.
    *
    * @remarks
-   * If `denoms` is specified, `proofsWeHave()` has no effect.
-   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
-   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
+   * If `denoms` is specified, `proofsWeHave()` has no effect. This is the v5 name for `asP2PK`,
+   * taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
-    this.outputType = { type: 'p2pk', options: p2pk, denominations: denoms };
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
+    this.outputType = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**
@@ -864,15 +900,24 @@ export class MeltBuilder<
   }
 
   /**
-   * Lock the change to a NUT-11 P2PK / NUT-14 HTLC spending condition.
+   * Lock the change to a spending condition.
    *
-   * @param p2pk A complete {@link P2PKOptions} (e.g. from {@link P2PKBuilder} or
-   *   {@link PaymentRequest.toP2PKOptions}); its `kind` selects P2PK vs HTLC.
+   * @remarks
+   * The v5 name for `asP2PK`, taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
-    this.outputType = { type: 'p2pk', options: p2pk, denominations: denoms };
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
+    this.outputType = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -2,7 +2,7 @@ import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { describe, it, expect } from 'vitest';
 
-import { P2PKBuilder, type P2PKOptions } from '../../src/';
+import { LockBuilder, P2PKBuilder, type P2PKOptions } from '../../src/';
 
 // helpers to make valid on-curve keys, deterministically derived per label char
 const X: Record<string, string> = {};
@@ -519,5 +519,14 @@ describe('P2PKBuilder.blindKeys()', () => {
 
     const round = P2PKBuilder.fromOptions(opts).toOptions();
     expect(round.blindKeys).toBe(true);
+  });
+});
+
+describe('LockBuilder aliases (v5 names)', () => {
+  it('LockBuilder is P2PKBuilder, and the v5 method names match the old ones', () => {
+    expect(P2PKBuilder).toBe(LockBuilder);
+    const a = new LockBuilder().addMainPubkey(comp('a', '02')).requireMainSignatures(1).toOptions();
+    const b = new LockBuilder().addLockPubkey(comp('a', '02')).requireLockSignatures(1).toOptions();
+    expect(a).toEqual(b);
   });
 });

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
+import { LockBuilder } from '../../src';
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import type { OutputData, OutputDataLike } from '../../src/model/OutputData';
 import { PaymentRequest } from '../../src/model/PaymentRequest';
@@ -496,6 +497,29 @@ describe('WalletOps builders', () => {
       );
     });
 
+    it('asLocked accepts a LockBuilder directly and matches asP2PK', async () => {
+      const pk = '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2';
+      const builder = new LockBuilder().addMainPubkey(pk);
+      await ops.send(7, proofs).asLocked(builder, [7]).run();
+      const [, , , outputConfig] = wallet.send.mock.calls[0];
+      expect(outputConfig).toEqual({
+        send: { type: 'p2pk', options: builder.toOptions(), denominations: [7] },
+      });
+    });
+
+    it('keepAsLocked accepts a LockBuilder directly', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.send(7, proofs).asRandom([7]).keepAsLocked(builder, []).run();
+      const [, , , outputConfig] = wallet.send.mock.calls[0];
+      expect(outputConfig?.keep).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [],
+      });
+    });
+
     it('supports sendP2PK and keepP2PK OutputTypes', async () => {
       await ops
         .send(7, proofs)
@@ -710,6 +734,19 @@ describe('WalletOps builders', () => {
       expect(outputType).toEqual({ type: 'random', denominations: [1, 2, 3] });
     });
 
+    it('asLocked accepts a LockBuilder for receive', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.receive(token).asLocked(builder, [7]).run();
+      const [, , outputType] = wallet.receive.mock.calls[0];
+      expect(outputType).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [7],
+      });
+    });
+
     it('p2pk() OutputType for receive', async () => {
       await ops.receive(token).asP2PK({ kind: 'P2PK', data: 'PUB', locktime: 42 }, [7]).run();
 
@@ -758,6 +795,19 @@ describe('WalletOps builders', () => {
       await ops.mintBolt11('10', quote).prepare();
       expect(wallet.prepareMint).toHaveBeenCalledTimes(1);
       expect(Amount.from(wallet.prepareMint.mock.calls[0][1]).equals(10)).toBeTruthy();
+    });
+
+    it('asLocked accepts a LockBuilder for mint', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.mintBolt11(10, quote).asLocked(builder, [10]).prepare();
+      const [, , , , outputType] = wallet.prepareMint.mock.calls[0];
+      expect(outputType).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [10],
+      });
     });
 
     it('calls wallet.prepareMint with custom OutputType and config', async () => {
@@ -1134,6 +1184,19 @@ describe('WalletOps builders', () => {
 
       const [, , , , ot] = wallet.prepareMelt.mock.calls[0];
       expect(ot).toEqual({ type: 'deterministic', counter: 0, denominations: [] });
+    });
+
+    it('asLocked accepts a LockBuilder for melt', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.meltBolt11(melt11, proofs).asLocked(builder, []).run();
+      const [, , , , ot] = wallet.prepareMelt.mock.calls[0];
+      expect(ot).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [],
+      });
     });
 
     it('bolt11: supports P2PK OutputType', async () => {

--- a/test/wallet/paymentRequestBuilder.test.ts
+++ b/test/wallet/paymentRequestBuilder.test.ts
@@ -1,6 +1,7 @@
 import { test, describe, expect } from 'vitest';
 
 import {
+  LockBuilder,
   P2PKBuilder,
   PaymentRequest,
   PaymentRequestBuilder,
@@ -149,6 +150,17 @@ describe('PaymentRequestBuilder', () => {
     // the payer-side parser reconstructs the same lock
     const roundTripped = pr.toP2PKOptions();
     expect(roundTripped).toEqual(builder.toOptions());
+  });
+
+  test('lock() accepts a LockBuilder directly', () => {
+    const viaBuilder = new PaymentRequestBuilder()
+      .lock(new LockBuilder().addMainPubkey(PUBKEY))
+      .build();
+    const viaOptions = new PaymentRequestBuilder()
+      .lock(new LockBuilder().addMainPubkey(PUBKEY).toOptions())
+      .build();
+    expect(viaBuilder.nut10).toEqual(viaOptions.nut10);
+    expect(viaBuilder.nut10?.data).toBe(PUBKEY);
   });
 
   test('lock() accepts raw P2PKOptions and validates them', () => {


### PR DESCRIPTION
Adds the v5 names for the lock surface beside the current ones, so code migrated now keeps compiling across the v5 upgrade.

- `LockBuilder` aliases `P2PKBuilder`, with `addMainPubkey` and `requireMainSignatures` beside the old method names
- `asLocked`/`keepAsLocked` alias `asP2PK`/`keepAsP2PK` on every WalletOps builder, and also accept the builder instance directly
- `PaymentRequestBuilder.lock()` accepts a builder instance

The old names are marked deprecated and are removed in v5. Code that passes a builder (or its fresh output) straight into `asLocked` or `lock()` upgrades without changes; only code that stores or inspects raw `P2PKOptions` needs the v5 migration guide, where `toOptions()` returns the semantic `LockOptions` type.

Please add the `backport v4-dev` label so the bot carries this to the GA line.