### PR TITLE
feat(wallet): add LockBuilder and asLocked as forward-compatible names [backport v4-dev]

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -725,6 +725,37 @@ export type KeysetPair = {
     privKeys: RawMintKeys;
 };
 
+// @public
+export class LockBuilder {
+    addHashlock(hashlock: string): this;
+    // @deprecated (undocumented)
+    addLockPubkey(pk: string | string[]): this;
+    // (undocumented)
+    addMainPubkey(pk: string | string[]): this;
+    // (undocumented)
+    addRefundPubkey(pk: string | string[]): this;
+    // (undocumented)
+    addTag(key: string, values?: string[] | string): this;
+    // (undocumented)
+    addTags(tags: P2PKTag[]): this;
+    // (undocumented)
+    blindKeys(): this;
+    // (undocumented)
+    static fromOptions(opts: P2PKOptions): LockBuilder;
+    // (undocumented)
+    lockUntil(when: Date | number): this;
+    // @deprecated (undocumented)
+    requireLockSignatures(n: number): this;
+    // (undocumented)
+    requireMainSignatures(n: number): this;
+    // (undocumented)
+    requireRefundSignatures(n: number): this;
+    // (undocumented)
+    sigAll(): this;
+    // (undocumented)
+    toOptions(): P2PKOptions;
+}
+
 // @public (undocumented)
 export type LockState = 'PERMANENT' | 'ACTIVE' | 'EXPIRED';
 
@@ -759,7 +790,9 @@ export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | '
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
@@ -987,7 +1020,9 @@ export class MintBuilder<M extends MintMethod, HasPrivKey extends boolean = M ex
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
@@ -1463,32 +1498,11 @@ export type OutputType = ({
 // @public
 export const P2BK_DST: Uint8Array<ArrayBufferLike>;
 
-// @public (undocumented)
-export class P2PKBuilder {
-    addHashlock(hashlock: string): this;
-    // (undocumented)
-    addLockPubkey(pk: string | string[]): this;
-    // (undocumented)
-    addRefundPubkey(pk: string | string[]): this;
-    // (undocumented)
-    addTag(key: string, values?: string[] | string): this;
-    // (undocumented)
-    addTags(tags: P2PKTag[]): this;
-    // (undocumented)
-    blindKeys(): this;
-    // (undocumented)
-    static fromOptions(opts: P2PKOptions): P2PKBuilder;
-    // (undocumented)
-    lockUntil(when: Date | number): this;
-    // (undocumented)
-    requireLockSignatures(n: number): this;
-    // (undocumented)
-    requireRefundSignatures(n: number): this;
-    // (undocumented)
-    sigAll(): this;
-    // (undocumented)
-    toOptions(): P2PKOptions;
-}
+// @public @deprecated (undocumented)
+export const P2PKBuilder: typeof LockBuilder;
+
+// @public @deprecated (undocumented)
+export type P2PKBuilder = LockBuilder;
 
 // @public
 export type P2PKOptions = {
@@ -1695,7 +1709,9 @@ export class ReceiveBuilder {
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
@@ -1796,13 +1812,17 @@ export class SendBuilder {
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    asP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
+    asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     asRandom(denoms?: AmountLike[]): this;
     includeFees(on?: boolean): this;
     keepAsCustom(data: OutputDataLike[]): this;
     keepAsDeterministic(counter?: number, denoms?: AmountLike[]): this;
     keepAsFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;
-    keepAsP2PK(options: P2PKOptions, denoms?: AmountLike[]): this;
+    keepAsLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]): this;
+    // @deprecated (undocumented)
+    keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]): this;
     keepAsRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     offlineCloseMatch(requireDleq?: boolean): this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
 export { Mint } from './mint';
 export { KeyChain } from './wallet/KeyChain';
 export { Keyset } from './wallet/Keyset';
-export { P2PKBuilder } from './wallet/P2PKBuilder';
+export { LockBuilder, P2PKBuilder } from './wallet/P2PKBuilder';
 export { type SelectProofs, selectProofsRGLI, selectProofsRotating } from './wallet/SelectProofs';
 export {
   serializeSwapPreview,

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -7,7 +7,14 @@ function toUnixSeconds(input: Date | number): number {
   return input < 1e12 ? Math.floor(input) : Math.floor(input / 1000); // > 1e12 = ms
 }
 
-export class P2PKBuilder {
+/**
+ * Builder for lock spending conditions.
+ *
+ * @remarks
+ * The v5 name for `P2PKBuilder`: adopt it (with `addMainPubkey` and `requireMainSignatures`) and
+ * the v5 upgrade keeps these call sites compiling.
+ */
+export class LockBuilder {
   // Keys are deduplicated by x-only identity and first-seen order preserved.
   private lockKeys: string[] = [];
   private refundKeys: string[] = [];
@@ -19,10 +26,17 @@ export class P2PKBuilder {
   private sigFlag?: SigFlag;
   private hashlock?: string;
 
-  addLockPubkey(pk: string | string[]) {
+  addMainPubkey(pk: string | string[]) {
     const arr = Array.isArray(pk) ? pk : [pk];
     this.lockKeys = dedupeP2PKPubkeys([...this.lockKeys, ...arr]);
     return this;
+  }
+
+  /**
+   * @deprecated Use `addMainPubkey`. Removed in v5.
+   */
+  addLockPubkey(pk: string | string[]) {
+    return this.addMainPubkey(pk);
   }
 
   addRefundPubkey(pk: string | string[]) {
@@ -36,11 +50,18 @@ export class P2PKBuilder {
     return this;
   }
 
-  requireLockSignatures(n: number) {
+  requireMainSignatures(n: number) {
     if (!Number.isInteger(n) || n < 1)
       throw new CTSError(`requiredSignatures (n_sigs) must be a positive integer, got ${n}`);
     this.nSigs = n;
     return this;
+  }
+
+  /**
+   * @deprecated Use `requireMainSignatures`. Removed in v5.
+   */
+  requireLockSignatures(n: number) {
+    return this.requireMainSignatures(n);
   }
 
   requireRefundSignatures(n: number) {
@@ -121,13 +142,13 @@ export class P2PKBuilder {
     return p2pk;
   }
 
-  static fromOptions(opts: P2PKOptions): P2PKBuilder {
-    const b = new P2PKBuilder();
+  static fromOptions(opts: P2PKOptions): LockBuilder {
+    const b = new LockBuilder();
     const locks = Array.isArray(opts.pubkey) ? opts.pubkey : [opts.pubkey];
-    b.addLockPubkey(locks);
+    b.addMainPubkey(locks);
     if (opts.locktime !== undefined) b.lockUntil(opts.locktime);
     if (opts.refundKeys?.length) b.addRefundPubkey(opts.refundKeys);
-    if (opts.requiredSignatures !== undefined) b.requireLockSignatures(opts.requiredSignatures);
+    if (opts.requiredSignatures !== undefined) b.requireMainSignatures(opts.requiredSignatures);
     if (opts.requiredRefundSignatures !== undefined)
       b.requireRefundSignatures(opts.requiredRefundSignatures);
     if (opts.additionalTags?.length) b.addTags(opts.additionalTags);
@@ -137,3 +158,12 @@ export class P2PKBuilder {
     return b;
   }
 }
+
+/**
+ * @deprecated Renamed {@link LockBuilder}. This alias is removed in v5.
+ */
+export const P2PKBuilder = LockBuilder;
+/**
+ * @deprecated Renamed {@link LockBuilder}. This alias is removed in v5.
+ */
+export type P2PKBuilder = LockBuilder;

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -14,6 +14,7 @@ import {
 import type { ProofLike } from '../model/types/proof';
 import type { Token } from '../model/types/token';
 
+import { LockBuilder } from './P2PKBuilder';
 import {
   type OutputType,
   type OutputConfig,
@@ -135,14 +136,24 @@ export class SendBuilder {
   }
 
   /**
-   * Use P2PK locked outputs for the sent proofs.
+   * Lock the sent proofs to a spending condition.
    *
-   * @param options NUT 11 options like pubkey and locktime.
+   * @remarks
+   * The v5 name for `asP2PK`, taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
     this.sendOT = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**
@@ -189,14 +200,24 @@ export class SendBuilder {
   }
 
   /**
-   * Use P2PK locked change (NUT 11).
+   * Lock the change to a spending condition.
    *
-   * @param options Locking options applied to the kept proofs.
+   * @remarks
+   * The v5 name for `keepAsP2PK`, taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  keepAsP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
+  keepAsLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
     this.keepOT = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `keepAsLocked`. Removed in v5.
+   */
+  keepAsP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.keepAsLocked(p2pk, denoms);
   }
 
   /**
@@ -408,16 +429,25 @@ export class ReceiveBuilder {
   }
 
   /**
-   * Use P2PK locked outputs for the received proofs.
+   * Lock the received proofs to a spending condition.
    *
    * @remarks
-   * If denoms specified, proofsWeHave() will have no effect.
-   * @param options NUT 11 options like pubkey and locktime.
+   * If `denoms` is specified, `proofsWeHave()` has no effect. This is the v5 name for `asP2PK`,
+   * taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
     this.outputType = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**
@@ -581,16 +611,25 @@ export class MintBuilder<
   }
 
   /**
-   * Use P2PK locked outputs for the minted proofs.
+   * Lock the minted proofs to a spending condition.
    *
    * @remarks
-   * If denoms specified, proofsWeHave() will have no effect.
-   * @param options NUT 11 options like pubkey and locktime.
+   * If `denoms` is specified, `proofsWeHave()` has no effect. This is the v5 name for `asP2PK`,
+   * taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
     this.outputType = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**
@@ -802,14 +841,24 @@ export class MeltBuilder<
   }
 
   /**
-   * Use P2PK-locked change (NUT-11).
+   * Lock the change to a spending condition.
    *
-   * @param options NUT-11 locking options (e.g., pubkey, locktime).
+   * @remarks
+   * The v5 name for `asP2PK`, taking a {@link LockBuilder} directly or its options.
+   * @param lock A {@link LockBuilder}, or complete {@link P2PKOptions}.
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
-  asP2PK(options: P2PKOptions, denoms?: AmountLike[]) {
+  asLocked(lock: P2PKOptions | LockBuilder, denoms?: AmountLike[]) {
+    const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
     this.outputType = { type: 'p2pk', options, denominations: denoms };
     return this;
+  }
+
+  /**
+   * @deprecated Use `asLocked`. Removed in v5.
+   */
+  asP2PK(p2pk: P2PKOptions, denoms?: AmountLike[]) {
+    return this.asLocked(p2pk, denoms);
   }
 
   /**

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { P2PKBuilder, type P2PKOptions } from '../../src/';
+import { LockBuilder, P2PKBuilder, type P2PKOptions } from '../../src/';
 
 // helpers to make valid hex keys
 const xonly = (ch: string) => ch.repeat(64); // 32-byte X-only
@@ -449,5 +449,14 @@ describe('P2PKBuilder.blindKeys()', () => {
 
     const round = P2PKBuilder.fromOptions(opts).toOptions();
     expect(round.blindKeys).toBe(true);
+  });
+});
+
+describe('LockBuilder aliases (v5 names)', () => {
+  it('LockBuilder is P2PKBuilder, and the v5 method names match the old ones', () => {
+    expect(P2PKBuilder).toBe(LockBuilder);
+    const a = new LockBuilder().addMainPubkey(comp('a', '02')).requireMainSignatures(1).toOptions();
+    const b = new LockBuilder().addLockPubkey(comp('a', '02')).requireLockSignatures(1).toOptions();
+    expect(a).toEqual(b);
   });
 });

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
+import { LockBuilder } from '../../src';
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import type { OutputData, OutputDataLike } from '../../src/model/OutputData';
 import type {
@@ -372,6 +373,29 @@ describe('WalletOps builders', () => {
       );
     });
 
+    it('asLocked accepts a LockBuilder directly and matches asP2PK', async () => {
+      const pk = '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2';
+      const builder = new LockBuilder().addMainPubkey(pk);
+      await ops.send(7, proofs).asLocked(builder, [7]).run();
+      const [, , , outputConfig] = wallet.send.mock.calls[0];
+      expect(outputConfig).toEqual({
+        send: { type: 'p2pk', options: builder.toOptions(), denominations: [7] },
+      });
+    });
+
+    it('keepAsLocked accepts a LockBuilder directly', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.send(7, proofs).asRandom([7]).keepAsLocked(builder, []).run();
+      const [, , , outputConfig] = wallet.send.mock.calls[0];
+      expect(outputConfig?.keep).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [],
+      });
+    });
+
     it('supports sendP2PK and keepP2PK OutputTypes', async () => {
       await ops
         .send(7, proofs)
@@ -578,6 +602,19 @@ describe('WalletOps builders', () => {
       expect(outputType).toEqual({ type: 'random', denominations: [1, 2, 3] });
     });
 
+    it('asLocked accepts a LockBuilder for receive', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.receive(token).asLocked(builder, [7]).run();
+      const [, , outputType] = wallet.receive.mock.calls[0];
+      expect(outputType).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [7],
+      });
+    });
+
     it('p2pk() OutputType for receive', async () => {
       await ops.receive(token).asP2PK({ pubkey: 'PUB', locktime: 42 }, [7]).run();
 
@@ -626,6 +663,19 @@ describe('WalletOps builders', () => {
       await ops.mintBolt11('10', quote).prepare();
       expect(wallet.prepareMint).toHaveBeenCalledTimes(1);
       expect(Amount.from(wallet.prepareMint.mock.calls[0][1]).equals(10)).toBeTruthy();
+    });
+
+    it('asLocked accepts a LockBuilder for mint', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.mintBolt11(10, quote).asLocked(builder, [10]).prepare();
+      const [, , , , outputType] = wallet.prepareMint.mock.calls[0];
+      expect(outputType).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [10],
+      });
     });
 
     it('calls wallet.prepareMint with custom OutputType and config', async () => {
@@ -980,6 +1030,19 @@ describe('WalletOps builders', () => {
 
       const [, , , , ot] = wallet.prepareMelt.mock.calls[0];
       expect(ot).toEqual({ type: 'deterministic', counter: 0, denominations: [] });
+    });
+
+    it('asLocked accepts a LockBuilder for melt', async () => {
+      const builder = new LockBuilder().addMainPubkey(
+        '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+      );
+      await ops.meltBolt11(melt11, proofs).asLocked(builder, []).run();
+      const [, , , , ot] = wallet.prepareMelt.mock.calls[0];
+      expect(ot).toEqual({
+        type: 'p2pk',
+        options: builder.toOptions(),
+        denominations: [],
+      });
     });
 
     it('bolt11: supports P2PK OutputType', async () => {


### PR DESCRIPTION
# Description
Backport of #995 to `v4-dev`.

https://github.com/cashubtc/cashu-ts/pull/950 changes the semantics for spending conditions, so this PR forward names the builder in anticipation.