### PR TITLE
fix(wallet): keep large proofs in the close-match selection pool

### DIFF
--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -180,7 +180,11 @@ export function selectProofsRGLI(
       const rightIndex = binarySearchIndex(spendableProofs, targetAmountBig + 1n, true);
       endIndex = rightIndex !== null ? rightIndex + 1 : 0;
     } else {
-      const biggerIndex = binarySearchIndex(spendableProofs, targetAmountBig, false);
+      // The same floor-vs-ceil slack as exact match above: a proof with exFee equal to
+      // the target can net a sat under it, so the smallest guaranteed cover is exFee
+      // >= target + 1. Without the slack that proof caps the pool and, when it cannot
+      // cover, selection returns empty despite larger proofs being available.
+      const biggerIndex = binarySearchIndex(spendableProofs, targetAmountBig + 1n, false);
       if (biggerIndex !== null) {
         const nextBiggerExFee = spendableProofs[biggerIndex].exFee;
         const rightIndex = binarySearchIndex(spendableProofs, nextBiggerExFee, true);

--- a/src/wallet/SelectProofs.ts
+++ b/src/wallet/SelectProofs.ts
@@ -169,10 +169,11 @@ export function selectProofsRGLI(
   spendableProofs.sort((a, b) => (a.exFee < b.exFee ? -1 : a.exFee > b.exFee ? 1 : 0));
 
   // Remove proofs too large to be useful and adjust totals
-  // Exact Match: Keep proofs where exFee <= amountToSend + 1. exFee floors the
-  // proof's own fee while the real fee ceils once per selection, so the net can
-  // sit up to a sat below exFee: a 6 sat proof at 500ppk has exFee 6 yet nets
-  // 6 - 1 = 5, an exact match that a bound of exFee <= amountToSend misses
+  // Both bounds sit at amountToSend + 1: exFee floors the proof's own fee while the
+  // real fee ceils once per selection, so the net can sit up to a sat below exFee.
+  // A 6 sat proof at 500ppk has exFee 6 yet nets 5, so it neither matches a target
+  // of 6 exactly nor covers it as the pool's largest candidate
+  // Exact Match: Keep proofs where exFee <= amountToSend + 1
   // Close Match: Keep proofs where exFee <= nextBiggerExFee
   if (spendableProofs.length > 0) {
     let endIndex;
@@ -180,10 +181,6 @@ export function selectProofsRGLI(
       const rightIndex = binarySearchIndex(spendableProofs, targetAmountBig + 1n, true);
       endIndex = rightIndex !== null ? rightIndex + 1 : 0;
     } else {
-      // The same floor-vs-ceil slack as exact match above: a proof with exFee equal to
-      // the target can net a sat under it, so the smallest guaranteed cover is exFee
-      // >= target + 1. Without the slack that proof caps the pool and, when it cannot
-      // cover, selection returns empty despite larger proofs being available.
       const biggerIndex = binarySearchIndex(spendableProofs, targetAmountBig + 1n, false);
       if (biggerIndex !== null) {
         const nextBiggerExFee = spendableProofs[biggerIndex].exFee;

--- a/test/wallet/selectProofsRGLI.test.ts
+++ b/test/wallet/selectProofsRGLI.test.ts
@@ -73,6 +73,19 @@ describe('selectProofsRGLI, focused unit tests', () => {
     expect(res.send.length).toBeGreaterThan(0);
   });
 
+  test('close match, a proof matching the target gross cannot cap the pool when fees make it net short', () => {
+    // With 100ppk fees an 8 sat proof has exFee 8 but nets 7, so it cannot cover a
+    // target of 8 alone; the 32 sat proof must stay in the pool and be selected.
+    const proofs: Proof[] = [
+      { id: 'A', amount: Amount.from(32), secret: 's1', C: 'C1' },
+      { id: 'A', amount: Amount.from(8), secret: 's2', C: 'C2' },
+    ];
+    const kc = keychainStub({ A: 100 });
+    const res = selectProofsRGLI(proofs, 8, kc, true, false);
+    expect(res.send.length).toBeGreaterThan(0);
+    expect(sumProofs(res.send).toNumber()).toBeGreaterThanOrEqual(9); // 8 + 1 sat fee
+  });
+
   test('accepts AmountLike target amount', () => {
     const proofs: Proof[] = [
       { id: 'A', amount: Amount.from(3), secret: 's1', C: 'C1' },


### PR DESCRIPTION
Proof selection can return an empty send on a fee-charging mint even when the wallet holds ample funds.

`selectProofsRGLI` pre-trims proofs that are too large to be useful. For a close match it kept proofs with `exFee <= amountToSend`. But `exFee` floors the proof's own fee, while the real fee ceils once over the whole selection, so a proof whose `exFee` equals the target can net a unit below it. Such a proof capped the pool, every larger proof was trimmed away, and the trial loop then had nothing that could cover the target.

Concrete case, a mint at 100 ppk, wallet holding a 32 and an 8:

```ts
wallet.selectProofsToSend(proofs, 8, true); // includeFees
// before: { send: [] }
// after:  { send: [32] }
```

The 8 has `exFee` 8 but nets 7 against a target of 8, so the 32 is the only workable input. Callers see this as `Not enough funds available to send` from `send`/`prepareSwapToSend`, which is misleading: the funds are there.

The exact-match branch immediately above already trims against `amountToSend + 1`, with a comment describing this same floor-versus-ceil slack. This applies the same bound to the close-match branch.

Found while testing a wallet against a 100 ppk mint; it is not specific to any keyset version.

### Tests

New case in `test/wallet/selectProofsRGLI.test.ts` pinning the `[32, 8]` shape at 100 ppk. `npm run prtasks` green.
