### PR TITLE
feat(model): expose NUT-06 urls, time and tos_url on MintInfo [backport v4-dev]

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -452,6 +452,9 @@ export type GetInfoResponse = {
     description?: string;
     description_long?: string;
     icon_url?: string;
+    urls?: string[];
+    time?: number;
+    tos_url?: string;
     max_array_length?: number;
     contact: MintContactInfo[];
     nuts: {
@@ -1049,6 +1052,8 @@ export class MintInfo {
     // (undocumented)
     get description_long(): string | undefined;
     // (undocumented)
+    get icon_url(): string | undefined;
+    // (undocumented)
     isSupported(num: 4 | 5): {
         disabled: boolean;
         params: SwapMethod[];
@@ -1158,6 +1163,10 @@ export class MintInfo {
     supportsAmountless(method?: string, unit?: string): boolean;
     supportsMintMeltMethod(op: 'mint' | 'melt', method: string, unit: string): boolean;
     supportsNut04Description(method: 'bolt11' | 'bolt12', unit?: string): boolean;
+    get time(): number | undefined;
+    // (undocumented)
+    get tos_url(): string | undefined;
+    get urls(): string[] | undefined;
     // (undocumented)
     get version(): string;
 }

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -450,6 +450,25 @@ export class MintInfo {
   get motd() {
     return this._mintInfo.motd;
   }
+  get icon_url() {
+    return this._mintInfo.icon_url;
+  }
+  /**
+   * Endpoint URLs the mint advertises for itself. Informational only: whether to trust or switch to
+   * any of them is the consumer's decision.
+   */
+  get urls() {
+    return MintInfo.snapshot(this._mintInfo.urls);
+  }
+  /**
+   * Current server time as a Unix timestamp in seconds.
+   */
+  get time() {
+    return this._mintInfo.time;
+  }
+  get tos_url() {
+    return this._mintInfo.tos_url;
+  }
   /**
    * NUT-06: max length the mint accepts for any array in a request (`inputs`, `outputs`, `Ys`).
    * Always a usable number: the library default when the mint advertises none.

--- a/src/model/types/NUT06.ts
+++ b/src/model/types/NUT06.ts
@@ -13,6 +13,15 @@ export type GetInfoResponse = {
   description_long?: string;
   icon_url?: string;
   /**
+   * Endpoint URLs where the mint is reachable (eg clearnet and Tor mirrors).
+   */
+  urls?: string[];
+  /**
+   * Current server time as a Unix timestamp in seconds.
+   */
+  time?: number;
+  tos_url?: string;
+  /**
    * Max length the mint accepts for any array in a request (`inputs`, `outputs`, `Ys`).
    */
   max_array_length?: number;

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -838,3 +838,32 @@ describe('MintInfo max_array_length (NUT-06)', () => {
     },
   );
 });
+
+describe('MintInfo NUT-06 informational fields', () => {
+  it('exposes urls, time, tos_url and icon_url and preserves them in cache', () => {
+    const urls = ['https://mint.host', 'http://mint.onion'];
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      icon_url: 'https://mint.host/icon.jpg',
+      urls,
+      time: 1725304480,
+      tos_url: 'https://mint.host/tos',
+    });
+    expect(info.icon_url).toBe('https://mint.host/icon.jpg');
+    expect(info.urls).toEqual(urls);
+    expect(info.urls).not.toBe(urls);
+    expect(info.time).toBe(1725304480);
+    expect(info.tos_url).toBe('https://mint.host/tos');
+    expect(info.cache.urls).toEqual(urls);
+    expect(info.cache.tos_url).toBe('https://mint.host/tos');
+  });
+
+  it('returns undefined when the mint omits them', () => {
+    // The fixture carries a real `time`; strip the optional fields for the omitted case.
+    const { time: _time, urls: _urls, tos_url: _tos, ...rest } = MINTINFORESP;
+    const info = new MintInfo(rest);
+    expect(info.urls).toBeUndefined();
+    expect(info.time).toBeUndefined();
+    expect(info.tos_url).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Description
Backport of #1003 to `v4-dev`.