### PR TITLE
feat(nutroot): adapt NIP-07 browser signers to both lock families

### DIFF
--- a/docs-src/usage/create_p2pk.md
+++ b/docs-src/usage/create_p2pk.md
@@ -21,3 +21,6 @@ const receiveProofs = await wallet2.receive(token, {privkey});
 
 > Tip: derive `pubkey`/`privkey` deterministically from the wallet seed so the lock key is
 > recoverable without a separate backup. See [Derive Keys](./derive_keys.md).
+
+> Signing with a NIP-07 browser extension instead of a pasted key: see
+> [Browser Signers](./nip07_signers.md).

--- a/docs-src/usage/nip07_signers.md
+++ b/docs-src/usage/nip07_signers.md
@@ -52,6 +52,19 @@ if (leaf) {
 
 `CashuNip07.signTransaction(messageHex, containerHex, secretKey)` is the reference implementation of `nip60.signTransaction`, for the extension side of that contract and for tests: it takes the private key, which the page never has, so a page cannot use it in place of the extension's method. It refuses any message without the domain tag and any container the message does not carry, then derives the input digest, signs BIP-340 and returns `{ hash, sig, pubkey }`, the shape `nip60.signSecret` already uses.
 
+## Locked mint quotes: `signQuote`
+
+A mint quote locked to the extension's key (eg a [Cashu Gift](../wallet_ops/mint.md#4-locked-bolt11-quote-signing) to someone's nostr identity) can be claimed without the key ever entering the page:
+
+```ts
+const proofs = await wallet.ops
+  .mintBolt11(quote.amount, quote)
+  .sign(CashuNip07.signQuote(nostr))
+  .run();
+```
+
+`signQuote` is a [`MintProofsConfig.sign`](../wallet_ops/mint.md#4-locked-bolt11-quote-signing) callback with the same preference as `cosign`: on a v3 keyset the quote is a transaction input, so the extension gets the tagged transaction message and the quote's input container through `nip60.signTransaction` and derives the digest itself; on a pre-v3 keyset there is no transcript, only the NUT-20 digest, so only `signSchnorr` can help. The extension can sign only for a quote locked to its own key: compare `quote.pubkey` with `CashuNip07.pubkey(nostr)` (by x-coordinate) before offering the button, and fall back to the [NIP-60 wallet keys](#nip-60-wallet-keys) for a quote locked to a nutzap key.
+
 ## NIP-60 wallet keys
 
 ```ts

--- a/docs-src/usage/nip07_signers.md
+++ b/docs-src/usage/nip07_signers.md
@@ -36,7 +36,7 @@ Adds the extension's signature to every `SIG_INPUTS` proof that lists its key an
 A nutroot witness signs its input's digest, so the extension can help only where its key appears verbatim in a disclosed leaf: the [auditable lock](../wallet_ops/spend_locked.md#auditable-locks), an unblinded refund or multisig leaf. Blinded leaf keys and the key path (receiver-keyed or tweaked) never match.
 
 ```ts
-const { script } = await wallet.spendOptions(proof);
+const { script } = wallet.spendOptions(proof);
 const leaf = script.find((o) => CashuNip07.completes(o, pubkey)); // one more signature satisfies it
 if (leaf) {
   await wallet.ops

--- a/docs-src/usage/nip07_signers.md
+++ b/docs-src/usage/nip07_signers.md
@@ -33,7 +33,7 @@ Adds the extension's signature to every `SIG_INPUTS` proof that lists its key an
 
 ## Nutroot proofs (v3 keysets): `completes` and `cosign`
 
-A nutroot witness signs the transaction digest, so the extension can help only where its key appears verbatim in a disclosed leaf: the [auditable lock](../wallet_ops/spend_locked.md#auditable-locks), an unblinded refund or multisig leaf. Blinded leaf keys and the key path (receiver-keyed or tweaked) never match.
+A nutroot witness signs its input's digest, so the extension can help only where its key appears verbatim in a disclosed leaf: the [auditable lock](../wallet_ops/spend_locked.md#auditable-locks), an unblinded refund or multisig leaf. Blinded leaf keys and the key path (receiver-keyed or tweaked) never match.
 
 ```ts
 const { script } = await wallet.spendOptions(proof);
@@ -48,9 +48,9 @@ if (leaf) {
 }
 ```
 
-`cosign` is a [`ScriptPathPlan.cosign`](../wallet_ops/spend_locked.md#script-path-scriptpathplans) hook. It prefers `nip60.signTransaction(messageHex)`: the extension receives the tagged pre-hash message (`"Cashu_Transaction_v1" || transcript`), hashes it itself, and can refuse anything else, so an event id can never pass through it. The reply's `hash` must equal the digest cts computed. Without it, the hook falls back to `signSchnorr` over the digest.
+`cosign` is a [`ScriptPathPlan.cosign`](../wallet_ops/spend_locked.md#script-path-scriptpathplans) hook. It prefers `nip60.signTransaction(messageHex, containerHex)`: the extension receives the tagged pre-hash message (`"Cashu_Transaction_v1" || transcript`) and the input's own container record, derives the input digest itself, and can refuse anything else, so an event id can never pass through it. The reply's `hash` must equal the input digest cts computed. Without it, the hook falls back to `signSchnorr` over the digest.
 
-`CashuNip07.signTransaction(messageHex, secretKey)` is the reference implementation of `nip60.signTransaction`, for the extension side of that contract and for tests: it takes the private key, which the page never has, so a page cannot use it in place of the extension's method. It refuses any message without the domain tag, then hashes, signs BIP-340 and returns `{ hash, sig, pubkey }`, the shape `nip60.signSecret` already uses.
+`CashuNip07.signTransaction(messageHex, containerHex, secretKey)` is the reference implementation of `nip60.signTransaction`, for the extension side of that contract and for tests: it takes the private key, which the page never has, so a page cannot use it in place of the extension's method. It refuses any message without the domain tag and any container the message does not carry, then derives the input digest, signs BIP-340 and returns `{ hash, sig, pubkey }`, the shape `nip60.signSecret` already uses.
 
 ## NIP-60 wallet keys
 

--- a/docs-src/usage/nip07_signers.md
+++ b/docs-src/usage/nip07_signers.md
@@ -1,0 +1,61 @@
+# <a href="/">Documents</a> › [Usage Examples](../usage/usage_index.md) › **Browser Signers (NIP-07)**
+
+# Signing with a browser extension: `CashuNip07`
+
+A NIP-07 extension (`window.nostr`) holds a Nostr key the page never sees. `CashuNip07` adapts what such extensions expose to both Cashu lock families, without pulling any nostr code into the library: no relays, no events, only `window.nostr`.
+
+```ts
+import { CashuNip07, type Nip07Like } from '@cashu/cashu-ts';
+const nostr: Nip07Like = window.nostr; // every member optional; the adapter degrades to what is present
+const pubkey = await CashuNip07.pubkey(nostr); // 02-prefixed, as locks list it
+```
+
+## What the extension can do
+
+| Extension method             | Who ships it | Cashu use                                                               |
+| :--------------------------- | :----------- | :---------------------------------------------------------------------- |
+| `getPublicKey`               | everyone     | which lock keys are the extension's                                     |
+| `nip44.decrypt`              | most         | unlock a NIP-60 wallet's keys ([`nip60Keys`](#nip-60-wallet-keys))      |
+| `nip60.signSecret(secret)`   | nos2x, ...   | NUT-11 `SIG_INPUTS` signature over `sha256(secret)`                     |
+| `signString(secret)`         | AKA Profiles | the same, under its older name                                          |
+| `nip60.signTransaction(msg)` | proposed     | nutroot witness; the signer hashes and checks the tagged message itself |
+| `signSchnorr(digest)`        | Alby         | either, over a bare 32-byte digest; most signers refuse to ship this    |
+
+`signEvent` is never usable: it signs an event id, which can never equal a Cashu digest.
+
+## NUT-11 proofs (pre-v3 keysets): `signP2PK`
+
+```ts
+const signed = await CashuNip07.signP2PK(nostr, proofs);
+```
+
+Adds the extension's signature to every `SIG_INPUTS` proof that lists its key and does not already carry its signature. `nip60.signSecret` (or its older name `signString`) is preferred, and its reply is checked against the secret's hash and the extension's key; `signSchnorr` over the hash is the fallback. `SIG_ALL` proofs are skipped (that message covers the transaction: use the SigAll package), blinded (P2BK) keys never match, and v3 proofs pass through untouched, so one call serves a mixed token.
+
+## Nutroot proofs (v3 keysets): `completes` and `cosign`
+
+A nutroot witness signs the transaction digest, so the extension can help only where its key appears verbatim in a disclosed leaf: the [auditable lock](../wallet_ops/spend_locked.md#auditable-locks), an unblinded refund or multisig leaf. Blinded leaf keys and the key path (receiver-keyed or tweaked) never match.
+
+```ts
+const { script } = await wallet.spendOptions(proof);
+const leaf = script.find((o) => CashuNip07.completes(o, pubkey)); // one more signature satisfies it
+if (leaf) {
+  await wallet.ops
+    .receive([proof])
+    .scriptPath([
+      { secret: proof.secret, leafIndex: leaf.leafIndex, cosign: CashuNip07.cosign(nostr) },
+    ])
+    .run();
+}
+```
+
+`cosign` is a [`ScriptPathPlan.cosign`](../wallet_ops/spend_locked.md#script-path-scriptpathplans) hook. It prefers `nip60.signTransaction(messageHex)`: the extension receives the tagged pre-hash message (`"Cashu_Transaction_v1" || transcript`), hashes it itself, and can refuse anything else, so an event id can never pass through it. The reply's `hash` must equal the digest cts computed. Without it, the hook falls back to `signSchnorr` over the digest.
+
+`CashuNip07.signTransaction(messageHex, secretKey)` is the reference implementation of `nip60.signTransaction`, for the extension side of that contract and for tests: it takes the private key, which the page never has, so a page cannot use it in place of the extension's method. It refuses any message without the domain tag, then hashes, signs BIP-340 and returns `{ hash, sig, pubkey }`, the shape `nip60.signSecret` already uses.
+
+## NIP-60 wallet keys
+
+```ts
+const { privkeys, mints } = await CashuNip07.nip60Keys(nostr, xOnlyPubkey, walletEvent.content);
+```
+
+Decrypts a NIP-60 wallet event's content through the extension's `nip44` and reads its `privkey` and `mint` tags. Fetching the event is the caller's business. The keys then go into `receive({ privkey })`, `spendOptions({ privkeys })` and `planScriptPaths({ privkeys })` like any other, which covers the locks the extension's own key cannot: blinded keys, and the nutroot key path.

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -29,6 +29,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [Create Token](./create_token.md)                   | Send standard Cashu tokens to another wallet.                                   |
 | [Create P2PK](./create_p2pk.md)                     | Send tokens locked to a public key.                                             |
 | [Derive Keys](./derive_keys.md)                     | Derive recoverable P2PK / NUT-20 keys deterministically from the wallet seed.   |
+| [Browser Signers](./nip07_signers.md)               | Sign NUT-11 and nutroot spends with a NIP-07 extension (`CashuNip07`).          |
 | [Get Token](./get_token.md)                         | Inspect token metadata before wallet creation or decode it after load.          |
 | [Melt Token](./melt_token.md)                       | Pay BOLT11 invoices or other payment methods with wallet proofs.                |
 | [Payment Requests](./payment_requests.md)           | Decode, price (fees), fulfil, and create NUT-18 / NUT-26 payment requests.      |

--- a/docs-src/wallet_ops/mint.md
+++ b/docs-src/wallet_ops/mint.md
@@ -50,6 +50,12 @@ const newProofs = await wallet.ops
   .run();
 ```
 
+When the key lives elsewhere (a NIP-07 extension, a hardware signer), pass `.sign(fn)` instead:
+`fn` receives `{ digest, quoteId, outputs }` (plus `transactionMessage` and `inputContainer` for a
+v3 quote) and returns BIP-340 signature hex over `digest`. The wallet checks it against the quote's
+pubkey before sending. No legacy NUT-20 fallback signature is produced this way. See
+[Browser Signers](../usage/nip07_signers.md#locked-mint-quotes-signquote) for the extension case.
+
 A seeded wallet that lost the key can re-derive it with
 `wallet.recoverQuoteLockKey(quote.pubkey)`. For a quote that will never be paid (eg a fee
 estimation), `createQuoteLockKey({ random: true })` forces a random key even on a seeded wallet:

--- a/docs-src/wallet_ops/spend_locked.md
+++ b/docs-src/wallet_ops/spend_locked.md
@@ -93,6 +93,10 @@ Plans are keyed by `secret`, not input index: proof selection decides input orde
 
 **Cosigning.** A leaf whose other keys live elsewhere takes a `cosign` hook. It runs once the transaction is fixed and its input digest known (the digest covers the outputs, so it cannot exist earlier), and returns BIP-340 signature hex over `digest`. `message` is the tagged transaction message and `container` the input's own transcript record; `digest = tagged_hash("Cashu_TransactionInput", SHA256(message) || SHA256(container))`, so a signer can recompute what it signs. It is awaited mid-flight: fine for a remote signer measured in seconds, not for approval ceremonies measured in days. Duplicate and non-verifying signatures are trimmed; the leaf still needs `n` valid ones or the spend fails.
 
+## Browser signers
+
+A NIP-07 extension can complete a script path spend where its key appears verbatim in a leaf, and unlock NIP-60 wallet keys for everything else: see [Browser Signers](../usage/nip07_signers.md).
+
 ## Auditable locks
 
 Nutroot locks are private by default: only the key holder can prove who a receiver-keyed proof belongs to. When a payment wants the opposite (a public tip anyone can attest, eg a nostr Nutzap), lock it **auditable**: NUMS internal key, one threshold leaf of one key, with `disclosure` so the spend's witness is published too. Any lock can be disclosed the same way with `LockBuilder.disclose()` or `disclosure: true`. A pre-v3 lock needs no flag: its secret is plaintext and NUT-07 returns its witness, so it is disclosed by nature.

--- a/docs-src/wallet_ops/spend_locked.md
+++ b/docs-src/wallet_ops/spend_locked.md
@@ -69,8 +69,8 @@ type ScriptPathPlan = {
   extraKeys?: string[]; // signing keys beyond those the wallet recovers itself
   cosign?: (request: {
     digest: Uint8Array;
-    message: Uint8Array;
-    container: Uint8Array;
+    transactionMessage: Uint8Array;
+    inputContainer: Uint8Array;
     leaf: NutrootLeaf;
   }) => Promise<string[]>;
 };
@@ -91,7 +91,7 @@ For the common policy (first satisfiable leaf per proof the key path cannot spen
 
 Plans are keyed by `secret`, not input index: proof selection decides input order. Everything except the signatures is checked when the transaction is prepared, so a plan that cannot be honored (undisclosed leaf, missing preimage, key shortfall with no cosigner) fails before any request is built.
 
-**Cosigning.** A leaf whose other keys live elsewhere takes a `cosign` hook. It runs once the transaction is fixed and its input digest known (the digest covers the outputs, so it cannot exist earlier), and returns BIP-340 signature hex over `digest`. `message` is the tagged transaction message and `container` the input's own transcript record; `digest = tagged_hash("Cashu_TransactionInput", SHA256(message) || SHA256(container))`, so a signer can recompute what it signs. It is awaited mid-flight: fine for a remote signer measured in seconds, not for approval ceremonies measured in days. Duplicate and non-verifying signatures are trimmed; the leaf still needs `n` valid ones or the spend fails.
+**Cosigning.** A leaf whose other keys live elsewhere takes a `cosign` hook. It runs once the transaction is fixed and its input digest known (the digest covers the outputs, so it cannot exist earlier), and returns BIP-340 signature hex over `digest`. `transactionMessage` is the tagged pre-hash transcript and `inputContainer` the input's own TLV container record (NUT-10); `digest = tagged_hash("Cashu_TransactionInput", SHA256(transactionMessage) || SHA256(inputContainer))`, so a signer can recompute what it signs. It is awaited mid-flight: fine for a remote signer measured in seconds, not for approval ceremonies measured in days. Duplicate and non-verifying signatures are trimmed; the leaf still needs `n` valid ones or the spend fails.
 
 ## Browser signers
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -276,6 +276,24 @@ export function bytesToHex(bytes: Uint8Array): string;
 export type CancellerLike = SubscriptionCanceller | Promise<SubscriptionCanceller>;
 
 // @public
+export const CashuNip07: CashuNip07Api;
+
+// @public (undocumented)
+export type CashuNip07Api = {
+    pubkey(nostr: Nip07Like): Promise<string>;
+    canSign(nostr: Nip07Like): boolean;
+    canSignP2PK(nostr: Nip07Like): boolean;
+    signP2PK(nostr: Nip07Like, proofs: Proof[]): Promise<Proof[]>;
+    cosign(nostr: Nip07Like): NonNullable<ScriptPathPlan['cosign']>;
+    completes(option: SpendOption, pubkey: string): boolean;
+    nip60Keys(nostr: Nip07Like, pubkey: string, content: string): Promise<{
+        privkeys: string[];
+        mints: string[];
+    }>;
+    signTransaction(messageHex: string, inputContainerHex: string, secretKey: string | Uint8Array): Nip07SignedHash;
+};
+
+// @public
 export type CashuPayloadKind = 'token' | 'paymentRequest';
 
 // @public
@@ -1534,6 +1552,27 @@ export class NetworkError extends CTSError {
         cause?: unknown;
     });
 }
+
+// @public
+export type Nip07Like = {
+    getPublicKey?: () => Promise<string>;
+    signSchnorr?: (digestHex: string) => Promise<string>;
+    signString?: (secret: string) => Promise<Nip07SignedHash>;
+    nip44?: {
+        decrypt: (pubkey: string, ciphertext: string) => Promise<string>;
+    };
+    nip60?: {
+        signSecret?: (secret: string) => Promise<Nip07SignedHash>;
+        signTransaction?: (messageHex: string, inputContainerHex: string) => Promise<Nip07SignedHash>;
+    };
+};
+
+// @public
+export type Nip07SignedHash = {
+    hash: string;
+    sig: string;
+    pubkey: string;
+};
 
 // @public
 export function normalizeMintUrl(url: string): string;

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -285,6 +285,7 @@ export type CashuNip07Api = {
     canSignP2PK(nostr: Nip07Like): boolean;
     signP2PK(nostr: Nip07Like, proofs: Proof[]): Promise<Proof[]>;
     cosign(nostr: Nip07Like): NonNullable<ScriptPathPlan['cosign']>;
+    signQuote(nostr: Nip07Like): NonNullable<MintProofsConfig['sign']>;
     completes(option: SpendOption, pubkey: string): boolean;
     nip60Keys(nostr: Nip07Like, pubkey: string, content: string): Promise<{
         privkeys: string[];
@@ -366,8 +367,8 @@ export function constructUnblindedSignatureBls(blindSig: BlindSignature, r: bigi
 // @public
 export type CosignRequest = {
     digest: Uint8Array;
-    message: Uint8Array;
-    container: Uint8Array;
+    transactionMessage: Uint8Array;
+    inputContainer: Uint8Array;
     leaf: NutrootLeaf;
 };
 
@@ -1268,6 +1269,7 @@ export class MintBuilder<M extends MintMethod, HasPrivKey extends boolean = M ex
     privkey(k: string): MintBuilder<M, true>;
     proofsWeHave(p: Array<Pick<ProofLike, 'amount'>>): this;
     run(this: MintBuilder<M, true>): Promise<Proof[]>;
+    sign(fn: NonNullable<MintProofsConfig['sign']>): MintBuilder<M, true>;
 }
 
 // @public (undocumented)
@@ -1453,6 +1455,7 @@ export interface MintPreview<TQuote extends Pick<MintQuoteBaseResponse, 'quote'>
 export type MintProofsConfig = {
     keysetId?: string;
     privkey?: string | string[];
+    sign?: (request: MintQuoteSignRequest) => Promise<string>;
     proofsWeHave?: Array<Pick<ProofLike, 'amount'>>;
     onCountersReserved?: OnCountersReserved;
 };
@@ -1516,6 +1519,15 @@ export type MintQuoteOnchainRequest = MintQuoteBaseRequest & {
 // @public
 export type MintQuoteOnchainResponse = MintQuoteBaseResponse & {
     pubkey: string;
+};
+
+// @public
+export type MintQuoteSignRequest = {
+    digest: Uint8Array;
+    quoteId: string;
+    outputs: SerializedBlindedMessage[];
+    transactionMessage?: Uint8Array;
+    inputContainer?: Uint8Array;
 };
 
 // @public (undocumented)

--- a/src/crypto/NUT20.ts
+++ b/src/crypto/NUT20.ts
@@ -55,6 +55,16 @@ function isCompressedPubkey(pubkey: string): boolean {
   return pubkey.length === 66;
 }
 
+/**
+ * The NUT-20 digest a locked quote's key signs, for signers that hold the key elsewhere.
+ */
+export function mintQuoteDigest(
+  quote: string,
+  blindedMessages: SerializedBlindedMessage[],
+): Uint8Array {
+  return constructMessage(quote, blindedMessages);
+}
+
 export function signMintQuote(
   privkey: string,
   quote: string,

--- a/src/crypto/transcript.ts
+++ b/src/crypto/transcript.ts
@@ -208,7 +208,7 @@ export function inputDigest(transactionDigest: Uint8Array, container: Uint8Array
 /**
  * One input's signing context: its transcript container record and the digest it signs.
  */
-export type TransactionInputContext = { container: Uint8Array; digest: Uint8Array };
+export type TransactionInputContext = { inputContainer: Uint8Array; digest: Uint8Array };
 
 /**
  * Every input's signing context, plus the shared message and digest.
@@ -219,7 +219,7 @@ export type TransactionInputContext = { container: Uint8Array; digest: Uint8Arra
  * family because identical text denotes raw point bytes in v3 and UTF-8 bytes in v0-v2.
  */
 export function transactionInputs(tx: TransactionShape): {
-  message: Uint8Array;
+  transactionMessage: Uint8Array;
   transactionDigest: Uint8Array;
   proofs: Map<string, TransactionInputContext>;
   quotes: Map<string, TransactionInputContext>;
@@ -229,14 +229,17 @@ export function transactionInputs(tx: TransactionShape): {
   const proofs = new Map<string, TransactionInputContext>();
   const quotes = new Map<string, TransactionInputContext>();
   for (const p of tx.proofInputs ?? []) {
-    const container = proofInputContainer(p);
-    proofs.set(proofInputContextKey(p), { container, digest: inputDigest(digest, container) });
+    const inputContainer = proofInputContainer(p);
+    proofs.set(proofInputContextKey(p), {
+      inputContainer,
+      digest: inputDigest(digest, inputContainer),
+    });
   }
   for (const q of tx.mintQuoteInputs ?? []) {
-    const container = quoteContainer(CONTAINER_MINT_QUOTE_INPUT, q);
-    quotes.set(q.quoteId, { container, digest: inputDigest(digest, container) });
+    const inputContainer = quoteContainer(CONTAINER_MINT_QUOTE_INPUT, q);
+    quotes.set(q.quoteId, { inputContainer, digest: inputDigest(digest, inputContainer) });
   }
-  return { message, transactionDigest: digest, proofs, quotes };
+  return { transactionMessage: message, transactionDigest: digest, proofs, quotes };
 }
 
 type PayloadShape = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,12 @@ export {
   type SigAllSigningPackage,
 } from './model/SigAll';
 export {
+  CashuNip07,
+  type CashuNip07Api,
+  type Nip07Like,
+  type Nip07SignedHash,
+} from './model/CashuNip07';
+export {
   ScriptPath,
   type ScriptPathApi,
   type ScriptPathSigningPackage,

--- a/src/model/CashuNip07.ts
+++ b/src/model/CashuNip07.ts
@@ -13,7 +13,7 @@ import {
 } from '../crypto/NUT11';
 import { inputDigest, TRANSCRIPT_DOMAIN_TAG } from '../crypto/transcript';
 import { bytesToHex, hexToBytes } from '../utils';
-import type { ScriptPathPlan, SpendOption } from '../wallet/types';
+import type { MintProofsConfig, ScriptPathPlan, SpendOption } from '../wallet/types';
 
 import { CTSError } from './Errors';
 import type { Proof } from './types';
@@ -89,6 +89,15 @@ export type CashuNip07Api = {
    */
   cosign(nostr: Nip07Like): NonNullable<ScriptPathPlan['cosign']>;
   /**
+   * A {@link MintProofsConfig.sign} callback that signs a locked mint quote through the extension.
+   *
+   * @remarks
+   * Same preference as `cosign`: `nip60.signTransaction` when the quote is a v3 transaction input
+   * (the request carries the transaction message and input container), else `signSchnorr` over the
+   * digest. The extension can only sign for a quote locked to its own key.
+   */
+  signQuote(nostr: Nip07Like): NonNullable<MintProofsConfig['sign']>;
+  /**
    * Whether one signature from `pubkey` turns this leaf satisfiable: the leaf lists the key
    * verbatim (matched by x-coordinate; a blinded slot never matches), it is not already held, and
    * one more signature meets `n`.
@@ -125,6 +134,33 @@ const DOMAIN_TAG = utf8ToBytes(TRANSCRIPT_DOMAIN_TAG);
 // BIP-340 verifies on x alone, and a leaf may list the key with either parity, so matching is
 // by x-coordinate; NIP-07 hands out x-only keys, presented with the conventional 02 prefix.
 const xOnly = (pubkey: string): string => pubkey.toLowerCase().slice(-64);
+
+/**
+ * One input digest through the extension: `nip60.signTransaction` when the tagged transaction
+ * message and input container are known (the signer derives and checks the digest itself), else
+ * `signSchnorr`.
+ */
+async function signDigest(
+  nostr: Nip07Like,
+  digest: Uint8Array,
+  transactionMessage: Uint8Array | undefined,
+  inputContainer: Uint8Array | undefined,
+  what: string,
+): Promise<string> {
+  const digestHex = bytesToHex(digest);
+  if (transactionMessage && inputContainer && nostr.nip60?.signTransaction) {
+    const signed = await nostr.nip60.signTransaction(
+      bytesToHex(transactionMessage),
+      bytesToHex(inputContainer),
+    );
+    if (signed.hash.toLowerCase() !== digestHex) {
+      throw new CTSError('NIP-07 signer signed a different message');
+    }
+    return signed.sig;
+  }
+  if (nostr.signSchnorr) return nostr.signSchnorr(digestHex);
+  throw new CTSError(`NIP-07 signer cannot sign ${what}`);
+}
 
 /**
  * Adapts a NIP-07 browser signer to nutroot spending: no relays, no events, only `window.nostr`.
@@ -199,21 +235,14 @@ export const CashuNip07: CashuNip07Api = {
   },
 
   cosign(nostr) {
-    return async ({ digest, message, container }) => {
-      const digestHex = bytesToHex(digest);
-      if (nostr.nip60?.signTransaction) {
-        const signed = await nostr.nip60.signTransaction(
-          bytesToHex(message),
-          bytesToHex(container),
-        );
-        if (signed.hash.toLowerCase() !== digestHex) {
-          throw new CTSError('NIP-07 signer signed a different message');
-        }
-        return [signed.sig];
-      }
-      if (nostr.signSchnorr) return [await nostr.signSchnorr(digestHex)];
-      throw new CTSError('NIP-07 signer cannot sign a nutroot transaction');
-    };
+    return async ({ digest, transactionMessage, inputContainer }) => [
+      await signDigest(nostr, digest, transactionMessage, inputContainer, 'a nutroot transaction'),
+    ];
+  },
+
+  signQuote(nostr) {
+    return ({ digest, transactionMessage, inputContainer }) =>
+      signDigest(nostr, digest, transactionMessage, inputContainer, 'a mint quote');
   },
 
   completes(option, pubkey) {

--- a/src/model/CashuNip07.ts
+++ b/src/model/CashuNip07.ts
@@ -51,7 +51,7 @@ export type Nip07Like = {
      * anything not carrying the `Cashu_Transaction_v1` tag. See
      * {@link CashuNip07Api.signTransaction}.
      */
-    signTransaction?: (messageHex: string, containerHex: string) => Promise<Nip07SignedHash>;
+    signTransaction?: (messageHex: string, inputContainerHex: string) => Promise<Nip07SignedHash>;
   };
 };
 
@@ -114,7 +114,7 @@ export type CashuNip07Api = {
    */
   signTransaction(
     messageHex: string,
-    containerHex: string,
+    inputContainerHex: string,
     secretKey: string | Uint8Array,
   ): Nip07SignedHash;
 };
@@ -245,7 +245,7 @@ export const CashuNip07: CashuNip07Api = {
     return { privkeys: values('privkey'), mints: values('mint') };
   },
 
-  signTransaction(messageHex, containerHex, secretKey) {
+  signTransaction(messageHex, inputContainerHex, secretKey) {
     const message = Bytes.fromHex(messageHex);
     const tagged =
       message.length > DOMAIN_TAG.length &&
@@ -253,8 +253,8 @@ export const CashuNip07: CashuNip07Api = {
     if (!tagged) throw new CTSError('Refusing to sign: not a Cashu transaction message');
     // The signed value is the input digest, derived here rather than trusted: the container must
     // be a record of the transcript this message carries, or the signature covers nothing real.
-    const container = Bytes.fromHex(containerHex);
-    if (Bytes.toHex(message).indexOf(containerHex.toLowerCase(), DOMAIN_TAG.length * 2) < 0) {
+    const container = Bytes.fromHex(inputContainerHex);
+    if (Bytes.toHex(message).indexOf(inputContainerHex.toLowerCase(), DOMAIN_TAG.length * 2) < 0) {
       throw new CTSError('Refusing to sign: input container is not part of this transaction');
     }
     const hash = inputDigest(sha256(message), container);

--- a/src/model/CashuNip07.ts
+++ b/src/model/CashuNip07.ts
@@ -10,7 +10,7 @@ import {
   hasP2PKSignedProof,
   parseWitnessData,
 } from '../crypto/NUT11';
-import { TRANSCRIPT_DOMAIN_TAG } from '../crypto/transcript';
+import { inputDigest, TRANSCRIPT_DOMAIN_TAG } from '../crypto/transcript';
 import { Bytes } from '../utils';
 import type { ScriptPathPlan, SpendOption } from '../wallet/types';
 
@@ -46,11 +46,12 @@ export type Nip07Like = {
      */
     signSecret?: (secret: string) => Promise<Nip07SignedHash>;
     /**
-     * Sign a nutroot transaction message (NUT-10): the signer hashes it itself and can refuse
+     * Sign one input of a nutroot transaction (NUT-10): the signer derives the input digest from
+     * the tagged transaction message and the input's own container record, so it can refuse
      * anything not carrying the `Cashu_Transaction_v1` tag. See
      * {@link CashuNip07Api.signTransaction}.
      */
-    signTransaction?: (messageHex: string) => Promise<Nip07SignedHash>;
+    signTransaction?: (messageHex: string, containerHex: string) => Promise<Nip07SignedHash>;
   };
 };
 
@@ -111,7 +112,11 @@ export type CashuNip07Api = {
    * not a substitute for calling the extension. Refuses any message that does not start with the
    * transaction domain tag, so an event id (or anything else) can never pass through it.
    */
-  signTransaction(messageHex: string, secretKey: string | Uint8Array): Nip07SignedHash;
+  signTransaction(
+    messageHex: string,
+    containerHex: string,
+    secretKey: string | Uint8Array,
+  ): Nip07SignedHash;
 };
 
 const DOMAIN_TAG = utf8ToBytes(TRANSCRIPT_DOMAIN_TAG);
@@ -189,10 +194,13 @@ export const CashuNip07: CashuNip07Api = {
   },
 
   cosign(nostr) {
-    return async ({ digest, message }) => {
+    return async ({ digest, message, container }) => {
       const digestHex = Bytes.toHex(digest);
       if (nostr.nip60?.signTransaction) {
-        const signed = await nostr.nip60.signTransaction(Bytes.toHex(message));
+        const signed = await nostr.nip60.signTransaction(
+          Bytes.toHex(message),
+          Bytes.toHex(container),
+        );
         if (signed.hash.toLowerCase() !== digestHex) {
           throw new CTSError('NIP-07 signer signed a different message');
         }
@@ -233,13 +241,19 @@ export const CashuNip07: CashuNip07Api = {
     return { privkeys: values('privkey'), mints: values('mint') };
   },
 
-  signTransaction(messageHex, secretKey) {
+  signTransaction(messageHex, containerHex, secretKey) {
     const message = Bytes.fromHex(messageHex);
     const tagged =
       message.length > DOMAIN_TAG.length &&
       Bytes.equals(message.subarray(0, DOMAIN_TAG.length), DOMAIN_TAG);
     if (!tagged) throw new CTSError('Refusing to sign: not a Cashu transaction message');
-    const hash = sha256(message);
+    // The signed value is the input digest, derived here rather than trusted: the container must
+    // be a record of the transcript this message carries, or the signature covers nothing real.
+    const container = Bytes.fromHex(containerHex);
+    if (Bytes.toHex(message).indexOf(containerHex.toLowerCase(), DOMAIN_TAG.length * 2) < 0) {
+      throw new CTSError('Refusing to sign: input container is not part of this transaction');
+    }
+    const hash = inputDigest(sha256(message), container);
     const key = typeof secretKey === 'string' ? Bytes.fromHex(secretKey) : secretKey;
     return {
       hash: Bytes.toHex(hash),

--- a/src/model/CashuNip07.ts
+++ b/src/model/CashuNip07.ts
@@ -1,3 +1,4 @@
+import { equalBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { utf8ToBytes } from '@noble/hashes/utils.js';
 
@@ -11,7 +12,7 @@ import {
   parseWitnessData,
 } from '../crypto/NUT11';
 import { inputDigest, TRANSCRIPT_DOMAIN_TAG } from '../crypto/transcript';
-import { Bytes } from '../utils';
+import { bytesToHex, hexToBytes } from '../utils';
 import type { ScriptPathPlan, SpendOption } from '../wallet/types';
 
 import { CTSError } from './Errors';
@@ -199,11 +200,11 @@ export const CashuNip07: CashuNip07Api = {
 
   cosign(nostr) {
     return async ({ digest, message, container }) => {
-      const digestHex = Bytes.toHex(digest);
+      const digestHex = bytesToHex(digest);
       if (nostr.nip60?.signTransaction) {
         const signed = await nostr.nip60.signTransaction(
-          Bytes.toHex(message),
-          Bytes.toHex(container),
+          bytesToHex(message),
+          bytesToHex(container),
         );
         if (signed.hash.toLowerCase() !== digestHex) {
           throw new CTSError('NIP-07 signer signed a different message');
@@ -246,23 +247,23 @@ export const CashuNip07: CashuNip07Api = {
   },
 
   signTransaction(messageHex, inputContainerHex, secretKey) {
-    const message = Bytes.fromHex(messageHex);
+    const message = hexToBytes(messageHex);
     const tagged =
       message.length > DOMAIN_TAG.length &&
-      Bytes.equals(message.subarray(0, DOMAIN_TAG.length), DOMAIN_TAG);
+      equalBytes(message.subarray(0, DOMAIN_TAG.length), DOMAIN_TAG);
     if (!tagged) throw new CTSError('Refusing to sign: not a Cashu transaction message');
     // The signed value is the input digest, derived here rather than trusted: the container must
     // be a record of the transcript this message carries, or the signature covers nothing real.
-    const container = Bytes.fromHex(inputContainerHex);
-    if (Bytes.toHex(message).indexOf(inputContainerHex.toLowerCase(), DOMAIN_TAG.length * 2) < 0) {
+    const container = hexToBytes(inputContainerHex);
+    if (bytesToHex(message).indexOf(inputContainerHex.toLowerCase(), DOMAIN_TAG.length * 2) < 0) {
       throw new CTSError('Refusing to sign: input container is not part of this transaction');
     }
     const hash = inputDigest(sha256(message), container);
-    const key = typeof secretKey === 'string' ? Bytes.fromHex(secretKey) : secretKey;
+    const key = typeof secretKey === 'string' ? hexToBytes(secretKey) : secretKey;
     return {
-      hash: Bytes.toHex(hash),
+      hash: bytesToHex(hash),
       sig: schnorrSignDigest(hash, key),
-      pubkey: Bytes.toHex(getPubKeyFromPrivKey(key).subarray(1)),
+      pubkey: bytesToHex(getPubKeyFromPrivKey(key).subarray(1)),
     };
   },
 };

--- a/src/model/CashuNip07.ts
+++ b/src/model/CashuNip07.ts
@@ -1,0 +1,250 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
+
+import { computeMessageDigest, schnorrSignDigest, schnorrVerifyDigest } from '../crypto/core';
+import { isV3PointSecret } from '../crypto/curve_bls';
+import { getPubKeyFromPrivKey } from '../crypto/curve_secp';
+import {
+  getP2PKExpectedWitnessPubkeys,
+  getP2PKSigFlag,
+  hasP2PKSignedProof,
+  parseWitnessData,
+} from '../crypto/NUT11';
+import { TRANSCRIPT_DOMAIN_TAG } from '../crypto/transcript';
+import { Bytes } from '../utils';
+import type { ScriptPathPlan, SpendOption } from '../wallet/types';
+
+import { CTSError } from './Errors';
+import type { Proof } from './types';
+
+/**
+ * What an extension returns from `nip60.signSecret`, `signString` and `nip60.signTransaction`: the
+ * hash it signed, the signature, and its x-only pubkey, all hex.
+ */
+export type Nip07SignedHash = { hash: string; sig: string; pubkey: string };
+
+/**
+ * The slice of a NIP-07 `window.nostr` this adapter reads. Every member is optional: extensions
+ * differ, and the adapter degrades to whatever is present.
+ */
+export type Nip07Like = {
+  getPublicKey?: () => Promise<string>;
+  /**
+   * Sign an arbitrary 32-byte digest, hex in and hex out. Alby ships this; most signers refuse it
+   * because it also signs event ids, which is why `nip60.signTransaction` exists.
+   */
+  signSchnorr?: (digestHex: string) => Promise<string>;
+  /**
+   * Sign `sha256(secret)` for a NUT-11 proof: the older name of `nip60.signSecret`, as shipped by
+   * AKA Profiles.
+   */
+  signString?: (secret: string) => Promise<Nip07SignedHash>;
+  nip44?: { decrypt: (pubkey: string, ciphertext: string) => Promise<string> };
+  nip60?: {
+    /**
+     * Sign `sha256(secret)` for a NUT-11 proof (NIP-60), returning the hash it signed and its key.
+     */
+    signSecret?: (secret: string) => Promise<Nip07SignedHash>;
+    /**
+     * Sign a nutroot transaction message (NUT-10): the signer hashes it itself and can refuse
+     * anything not carrying the `Cashu_Transaction_v1` tag. See
+     * {@link CashuNip07Api.signTransaction}.
+     */
+    signTransaction?: (messageHex: string) => Promise<Nip07SignedHash>;
+  };
+};
+
+export type CashuNip07Api = {
+  /**
+   * The extension's key as a 02-prefixed compressed pubkey, the form nutroot leaves list.
+   */
+  pubkey(nostr: Nip07Like): Promise<string>;
+  /**
+   * Whether the extension can sign a nutroot transaction at all.
+   */
+  canSign(nostr: Nip07Like): boolean;
+  /**
+   * Whether the extension can sign a NUT-11 secret at all.
+   */
+  canSignP2PK(nostr: Nip07Like): boolean;
+  /**
+   * Adds the extension's NUT-11 signature to every proof that wants one (pre-v3 keysets).
+   *
+   * @remarks
+   * Prefers `nip60.signSecret` (or its older name `signString`), whose reply is checked against the
+   * secret's hash and the extension's key, then `signSchnorr` over the hash. Skips proofs that do
+   * not list the key, already carry its signature, or are `SIG_ALL` (that message covers the
+   * transaction: use the SigAll package). Blinded (P2BK) keys never match. v3 proofs pass through
+   * untouched.
+   */
+  signP2PK(nostr: Nip07Like, proofs: Proof[]): Promise<Proof[]>;
+  /**
+   * A {@link ScriptPathPlan.cosign} hook that signs through the extension.
+   *
+   * @remarks
+   * Prefers `nip60.signTransaction` (the signer sees the tagged message and checks it), falling
+   * back to `signSchnorr` over the digest. Throws if the extension offers neither.
+   */
+  cosign(nostr: Nip07Like): NonNullable<ScriptPathPlan['cosign']>;
+  /**
+   * Whether one signature from `pubkey` turns this leaf satisfiable: the leaf lists the key
+   * verbatim (matched by x-coordinate; a blinded slot never matches), it is not already held, and
+   * one more signature meets `n`.
+   */
+  completes(option: SpendOption, pubkey: string): boolean;
+  /**
+   * The private keys and mints of a NIP-60 wallet event, decrypted by the extension.
+   *
+   * @param pubkey The wallet owner's x-only pubkey, as `nip44.decrypt` expects.
+   * @param content The wallet event's encrypted `content`; fetching the event is the caller's.
+   */
+  nip60Keys(
+    nostr: Nip07Like,
+    pubkey: string,
+    content: string,
+  ): Promise<{ privkeys: string[]; mints: string[] }>;
+  /**
+   * Reference implementation of `nip60.signTransaction`, for extension authors and tests.
+   *
+   * @remarks
+   * Takes the private key, which a page never has: this is the extension's side of the contract,
+   * not a substitute for calling the extension. Refuses any message that does not start with the
+   * transaction domain tag, so an event id (or anything else) can never pass through it.
+   */
+  signTransaction(messageHex: string, secretKey: string | Uint8Array): Nip07SignedHash;
+};
+
+const DOMAIN_TAG = utf8ToBytes(TRANSCRIPT_DOMAIN_TAG);
+
+// BIP-340 verifies on x alone, and a leaf may list the key with either parity, so matching is
+// by x-coordinate; NIP-07 hands out x-only keys, presented with the conventional 02 prefix.
+const xOnly = (pubkey: string): string => pubkey.toLowerCase().slice(-64);
+
+/**
+ * Adapts a NIP-07 browser signer to nutroot spending: no relays, no events, only `window.nostr`.
+ */
+export const CashuNip07: CashuNip07Api = {
+  async pubkey(nostr) {
+    if (!nostr.getPublicKey) throw new CTSError('NIP-07 signer has no getPublicKey');
+    return `02${xOnly(await nostr.getPublicKey())}`;
+  },
+
+  canSign(nostr) {
+    return Boolean(nostr.nip60?.signTransaction ?? nostr.signSchnorr);
+  },
+
+  canSignP2PK(nostr) {
+    return Boolean(nostr.nip60?.signSecret ?? nostr.signString ?? nostr.signSchnorr);
+  },
+
+  async signP2PK(nostr, proofs) {
+    const pubkey = await this.pubkey(nostr);
+    const x = xOnly(pubkey);
+    const signSecret = nostr.nip60?.signSecret ?? nostr.signString;
+    const out: Proof[] = [];
+    for (const proof of proofs) {
+      if (isV3PointSecret(proof.secret)) {
+        out.push(proof);
+        continue;
+      }
+      let expected: string[];
+      try {
+        expected = getP2PKExpectedWitnessPubkeys(proof.secret);
+      } catch {
+        out.push(proof); // not a P2PK secret
+        continue;
+      }
+      if (
+        getP2PKSigFlag(proof.secret) === 'SIG_ALL' ||
+        !expected.some((k) => xOnly(k) === x) ||
+        hasP2PKSignedProof(pubkey, proof)
+      ) {
+        out.push(proof);
+        continue;
+      }
+      const digestHex = computeMessageDigest(proof.secret, true);
+      let sig: string;
+      if (signSecret) {
+        const signed = await signSecret(proof.secret);
+        if (signed.hash.toLowerCase() !== digestHex || xOnly(signed.pubkey) !== x) {
+          throw new CTSError('NIP-07 signer signed a different secret or key');
+        }
+        sig = signed.sig;
+      } else if (nostr.signSchnorr) {
+        sig = await nostr.signSchnorr(digestHex);
+      } else {
+        throw new CTSError('NIP-07 signer cannot sign a NUT-11 secret');
+      }
+      if (!schnorrVerifyDigest(sig, digestHex, pubkey)) {
+        throw new CTSError('NIP-07 signature does not verify for its key');
+      }
+      const witness = parseWitnessData(proof.witness);
+      const signatures: string[] = witness?.signatures ?? [];
+      out.push({
+        ...proof,
+        witness: { ...witness, signatures: [...signatures, sig] },
+      });
+    }
+    return out;
+  },
+
+  cosign(nostr) {
+    return async ({ digest, message }) => {
+      const digestHex = Bytes.toHex(digest);
+      if (nostr.nip60?.signTransaction) {
+        const signed = await nostr.nip60.signTransaction(Bytes.toHex(message));
+        if (signed.hash.toLowerCase() !== digestHex) {
+          throw new CTSError('NIP-07 signer signed a different message');
+        }
+        return [signed.sig];
+      }
+      if (nostr.signSchnorr) return [await nostr.signSchnorr(digestHex)];
+      throw new CTSError('NIP-07 signer cannot sign a nutroot transaction');
+    };
+  },
+
+  completes(option, pubkey) {
+    const x = xOnly(pubkey);
+    const keyIndex = option.leaf.keys.findIndex((k) => xOnly(k) === x);
+    if (keyIndex < 0 || option.keys.some((k) => k.keyIndex === keyIndex)) return false;
+    return (
+      !option.satisfiable &&
+      option.blockedBy === 'threshold' &&
+      option.keys.length + 1 >= option.leaf.n
+    );
+  },
+
+  async nip60Keys(nostr, pubkey, content) {
+    if (!nostr.nip44?.decrypt) throw new CTSError('NIP-07 signer has no nip44.decrypt');
+    let tags: unknown;
+    try {
+      tags = JSON.parse(await nostr.nip44.decrypt(pubkey, content));
+    } catch (e) {
+      throw new CTSError('NIP-60 wallet content did not decrypt to JSON', { cause: e });
+    }
+    if (!Array.isArray(tags)) throw new CTSError('NIP-60 wallet content is not a tag list');
+    const values = (name: string) =>
+      tags
+        .filter(
+          (t): t is [string, string] =>
+            Array.isArray(t) && t[0] === name && typeof t[1] === 'string',
+        )
+        .map((t) => t[1]);
+    return { privkeys: values('privkey'), mints: values('mint') };
+  },
+
+  signTransaction(messageHex, secretKey) {
+    const message = Bytes.fromHex(messageHex);
+    const tagged =
+      message.length > DOMAIN_TAG.length &&
+      Bytes.equals(message.subarray(0, DOMAIN_TAG.length), DOMAIN_TAG);
+    if (!tagged) throw new CTSError('Refusing to sign: not a Cashu transaction message');
+    const hash = sha256(message);
+    const key = typeof secretKey === 'string' ? Bytes.fromHex(secretKey) : secretKey;
+    return {
+      hash: Bytes.toHex(hash),
+      sig: schnorrSignDigest(hash, key),
+      pubkey: Bytes.toHex(getPubKeyFromPrivKey(key).subarray(1)),
+    };
+  },
+};

--- a/src/model/CashuNip07.ts
+++ b/src/model/CashuNip07.ts
@@ -3,7 +3,7 @@ import { utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { computeMessageDigest, schnorrSignDigest, schnorrVerifyDigest } from '../crypto/core';
 import { isV3PointSecret } from '../crypto/curve_bls';
-import { getPubKeyFromPrivKey } from '../crypto/curve_secp';
+import { getPubKeyFromPrivKey, normalizeSecpPubkey } from '../crypto/curve_secp';
 import {
   getP2PKExpectedWitnessPubkeys,
   getP2PKSigFlag,
@@ -131,7 +131,11 @@ const xOnly = (pubkey: string): string => pubkey.toLowerCase().slice(-64);
 export const CashuNip07: CashuNip07Api = {
   async pubkey(nostr) {
     if (!nostr.getPublicKey) throw new CTSError('NIP-07 signer has no getPublicKey');
-    return `02${xOnly(await nostr.getPublicKey())}`;
+    const pubkey = await nostr.getPublicKey();
+    if (!/^[0-9a-f]{64}$/i.test(pubkey)) {
+      throw new CTSError('NIP-07 getPublicKey must return a 32-byte hex public key');
+    }
+    return normalizeSecpPubkey(`02${pubkey}`);
   },
 
   canSign(nostr) {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -8,6 +8,7 @@
 import { type AuthProvider } from '../auth/AuthProvider';
 import {
   schnorrSignDigest,
+  schnorrVerifyDigest,
   signMintQuote,
   findSigningKey,
   signP2PKProofs as cryptoSignP2PKProofs,
@@ -24,7 +25,7 @@ import {
 import { getPubKeyFromPrivKey, normalizeSecpPubkey } from '../crypto/curve_secp';
 import { p2pkOptionsToPRNut10, type P2PKOptions } from '../crypto/NUT11';
 import { verifyHTLCHash } from '../crypto/NUT14';
-import { signMintQuoteLegacy } from '../crypto/NUT20';
+import { mintQuoteDigest, signMintQuoteLegacy } from '../crypto/NUT20';
 import {
   NUTROOT_NUMS_KEY,
   recoverLeafKeySecretKeys,
@@ -136,6 +137,7 @@ import {
   type SpendReceipt,
   type ScriptPathPlan,
   type SpendOptions,
+  type MintQuoteSignRequest,
   type RestoreConfig,
   type BatchRestoreConfig,
   type RestoreAllConfig,
@@ -3121,29 +3123,38 @@ class Wallet {
       quote: quote.quote,
     };
 
-    // Sign whenever a privkey is provided — quote.pubkey may be absent if only the
-    // quote ID was stored, but the caller still needs to produce a NUT-20 signature
+    // Sign whenever a privkey or sign callback is provided — quote.pubkey may be absent if only
+    // the quote ID was stored, but the caller still needs to produce a NUT-20 signature
     let legacySignature: string | undefined;
     // The key is caller state, passed in config; nothing is recovered implicitly
     // (recoverQuoteLockKey is the explicit tool for a seeded wallet that lost it).
-    if ('pubkey' in quote && quote.pubkey) {
+    const sign = privkey ? undefined : config?.sign;
+    const quotePubkey = 'pubkey' in quote ? (quote.pubkey as string | undefined) : undefined;
+    if (quotePubkey) {
       this.failIf(
-        !privkey,
-        'Can not sign locked quote without private key (see recoverQuoteLockKey)',
+        !privkey && !sign,
+        'Can not sign locked quote without private key or sign callback (see recoverQuoteLockKey)',
       );
     }
-    if (privkey) {
-      const quotePubkey = 'pubkey' in quote ? (quote.pubkey as string | undefined) : undefined;
-      this.failIf(
-        !quotePubkey && Array.isArray(privkey),
-        `prepareMint: multiple privkeys supplied for a quote without pubkey`,
-      );
-      const signingKey = quotePubkey
-        ? findSigningKey(quotePubkey, privkey)
-        : Array.isArray(privkey)
-          ? privkey[0]
-          : privkey;
-      this.failIf(!signingKey, 'prepareMint: privkey is empty or correct privkey not provided');
+    if (privkey || sign) {
+      let signingKey: string | undefined;
+      if (privkey) {
+        this.failIf(
+          !quotePubkey && Array.isArray(privkey),
+          `prepareMint: multiple privkeys supplied for a quote without pubkey`,
+        );
+        signingKey = quotePubkey
+          ? findSigningKey(quotePubkey, privkey)
+          : Array.isArray(privkey)
+            ? privkey[0]
+            : privkey;
+        this.failIf(!signingKey, 'prepareMint: privkey is empty or correct privkey not provided');
+      }
+      const request: MintQuoteSignRequest = {
+        digest: new Uint8Array(),
+        quoteId: quote.quote,
+        outputs: blindedMessages,
+      };
       if (isBlsKeyset(keyset.id)) {
         // V3 (nutroot secrets): the quote is a transaction input; its lock key signs the
         // quote input digest (NUT-10). No legacy fallback on v3 keysets.
@@ -3155,16 +3166,35 @@ class Wallet {
           quoteAmount === undefined && method === 'bolt11',
           'prepareMint: quote object lacks its amount; pass the full mint quote',
         );
-        const digest = inputsForPayload({
+        const tx = inputsForPayload({
           mintQuotes: [{ quoteId: quote.quote, amount: quoteAmount ?? 0 }],
           outputs: blindedMessages,
-        }).quotes.get(quote.quote)!.digest;
-        mintPayload.signature = schnorrSignDigest(digest, signingKey);
+        });
+        const { digest, inputContainer } = tx.quotes.get(quote.quote)!;
+        Object.assign(request, {
+          digest,
+          transactionMessage: tx.transactionMessage,
+          inputContainer,
+        });
       } else {
-        // Sign the amended (nuts#375) message by default and keep a legacy signature over the same
-        // outputs as a fallback for not-yet-upgraded mints — see completeMint().
-        mintPayload.signature = signMintQuote(signingKey, quote.quote, blindedMessages);
-        legacySignature = signMintQuoteLegacy(signingKey, quote.quote, blindedMessages);
+        request.digest = mintQuoteDigest(quote.quote, blindedMessages);
+      }
+      if (signingKey) {
+        mintPayload.signature = schnorrSignDigest(request.digest, signingKey);
+        // Keep a legacy (pre nuts#375) signature over the same outputs as a fallback for
+        // not-yet-upgraded mints — see completeMint(). Never on v3 keysets.
+        if (!isBlsKeyset(keyset.id)) {
+          legacySignature = signMintQuoteLegacy(signingKey, quote.quote, blindedMessages);
+        }
+      } else {
+        const signature = await sign!(request);
+        // A wrong signer fails here, not at the mint; without a quote pubkey there is nothing
+        // to check against, as with a bare privkey.
+        this.failIf(
+          !!quotePubkey && !schnorrVerifyDigest(signature, request.digest, quotePubkey),
+          'prepareMint: the sign callback returned a signature the quote pubkey does not verify',
+        );
+        mintPayload.signature = signature;
       }
     }
 

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -753,6 +753,16 @@ export class MintBuilder<
   }
 
   /**
+   * Sign a locked mint quote through a callback that holds the key, eg a NIP-07 extension.
+   *
+   * @param fn See {@link MintProofsConfig.sign}; ignored when `.privkey()` is also set.
+   */
+  sign(fn: NonNullable<MintProofsConfig['sign']>): MintBuilder<M, true> {
+    this.config.sign = fn;
+    return this as MintBuilder<M, true>;
+  }
+
+  /**
    * Provide existing proofs to help optimise denomination selection.
    *
    * @remarks

--- a/src/wallet/nutroot.ts
+++ b/src/wallet/nutroot.ts
@@ -82,7 +82,7 @@ export async function attachTransactionWitnesses(
   const v3Inputs = payload.inputs.filter((p) => isBlsKeyset(p.id) && isV3PointSecret(p.secret));
   if (v3Inputs.length === 0) return [];
   // Each input signs its own input digest over the shared transcript (NUT-10).
-  const { message, proofs: inputContexts } = inputsForPayload({
+  const { transactionMessage, proofs: inputContexts } = inputsForPayload({
     inputs: payload.inputs,
     outputs: payload.outputs ?? [],
     ...(meltQuote && { meltQuote }),
@@ -95,7 +95,7 @@ export async function attachTransactionWitnesses(
     if (!input) {
       fail('Script path plan names a secret not in this transaction', state.logger);
     }
-    const { digest, container } = inputContexts.get(
+    const { digest, inputContainer } = inputContexts.get(
       proofInputContextKey({ keysetId: input.id, secret: input.secret }),
     )!;
     const mine = spend.keys.map((k: string) => schnorrSignDigest(digest, k));
@@ -103,7 +103,12 @@ export async function attachTransactionWitnesses(
     // caller could have supplied up front: the digest covers the outputs, and those are only
     // fixed (and ordered) once the transaction is built.
     const theirs = spend.cosign
-      ? await spend.cosign({ digest, message, container, leaf: spend.leaf })
+      ? await spend.cosign({
+          digest,
+          transactionMessage,
+          inputContainer,
+          leaf: spend.leaf,
+        })
       : [];
     const signatures = selectRequiredLeafSignatures(spend.leaf, digest, [
       ...mine,

--- a/src/wallet/nutroot.ts
+++ b/src/wallet/nutroot.ts
@@ -143,7 +143,7 @@ export async function attachTransactionWitnesses(
   }
   // The receipt is the spender's copy of what NUT-07 commits to: nothing here is secret to the
   // wallet, and nothing but the wallet ever holds all of it together.
-  const transcript = bytesToHex(message);
+  const transcript = bytesToHex(transactionMessage);
   const enc = new TextEncoder();
   return v3Inputs.map((input) => {
     const { digest } = inputContexts.get(

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -1,6 +1,7 @@
 import { type NutrootLeaf } from '../../crypto/nutroot';
 import { type AmountLike } from '../../model/Amount';
 import { type OutputDataFactory, type OutputDataLike } from '../../model/OutputData';
+import type { SerializedBlindedMessage } from '../../model/types/blinded';
 import type { ProofLike } from '../../model/types/proof';
 import { type OperationCounters } from '../CounterSource';
 import { type LockOptions } from '../lock';
@@ -188,14 +189,14 @@ export type ScriptPathPlan = {
  *
  * @remarks
  * `digest` is what gets signed: the input digest, `tagged_hash("Cashu_TransactionInput",
- * SHA256(message) || SHA256(container))`. `message` is the tagged transaction message and
- * `container` the input's own transcript record, so a signer can recompute the digest and refuse
- * anything it cannot verify.
+ * SHA256(transactionMessage) || SHA256(inputContainer))` (NUT-10). `transactionMessage` is the
+ * tagged pre-hash transcript and `inputContainer` the input's own TLV container record, so a signer
+ * can recompute the digest and refuse anything it cannot verify.
  */
 export type CosignRequest = {
   digest: Uint8Array;
-  message: Uint8Array;
-  container: Uint8Array;
+  transactionMessage: Uint8Array;
+  inputContainer: Uint8Array;
   leaf: NutrootLeaf;
 };
 
@@ -233,11 +234,34 @@ export type ReceiveConfig = {
 };
 
 /**
+ * What a {@link MintProofsConfig.sign} callback receives: the digest to sign and what it covers.
+ *
+ * @remarks
+ * A v3 quote also carries the tagged `transactionMessage` and the quote's `inputContainer` (as
+ * {@link CosignRequest}), so a NIP-60 `signTransaction` signer can derive the digest itself and
+ * refuse anything else.
+ */
+export type MintQuoteSignRequest = {
+  digest: Uint8Array;
+  quoteId: string;
+  outputs: SerializedBlindedMessage[];
+  transactionMessage?: Uint8Array;
+  inputContainer?: Uint8Array;
+};
+
+/**
  * Configuration for minting operations.
  */
 export type MintProofsConfig = {
   keysetId?: string;
   privkey?: string | string[];
+  /**
+   * Signs a locked quote whose key is not in the page (eg a NIP-07 extension): BIP-340 signature
+   * hex over `request.digest`. Ignored when `privkey` is given. The quote's single signer, unlike a
+   * script path `cosign`, which adds signatures beside the wallet's own. No legacy NUT-20 fallback
+   * signature is produced this way, so the mint must accept the amended message.
+   */
+  sign?: (request: MintQuoteSignRequest) => Promise<string>;
   proofsWeHave?: Array<Pick<ProofLike, 'amount'>>;
   onCountersReserved?: OnCountersReserved;
 };

--- a/test/crypto/transcript.test.ts
+++ b/test/crypto/transcript.test.ts
@@ -73,7 +73,7 @@ describe('transaction transcript (vectors)', () => {
     const context = proofs.get(
       proofInputContextKey({ keysetId: tv.swap.tx.proof_inputs[0].keyset_id, secret }),
     )!;
-    expect(bytesToHex(sha256(context.container))).toBe(tv.swap.input_id);
+    expect(bytesToHex(sha256(context.inputContainer))).toBe(tv.swap.input_id);
     expect(bytesToHex(context.digest)).toBe(tv.swap.input_digest);
     expect(
       schnorr.verify(hexToBytes(tv.swap.signature), context.digest, hexToBytes(secret).subarray(1)),
@@ -105,7 +105,7 @@ describe('transaction transcript (vectors)', () => {
         proofInputContextKey({ keysetId: proof.keyset_id, secret: proof.secret }),
       )!;
       const expected = vector.inputs[index];
-      expect(bytesToHex(sha256(context.container))).toBe(expected.input_id);
+      expect(bytesToHex(sha256(context.inputContainer))).toBe(expected.input_id);
       expect(bytesToHex(context.digest)).toBe(expected.input_digest);
       expect(
         schnorr.verify(
@@ -128,7 +128,7 @@ describe('transaction transcript (vectors)', () => {
       const expected = vector.inputs[index];
       expect(expected.quote_id).toBe(quote.quote_id);
       const context = contexts.quotes.get(quote.quote_id)!;
-      expect(bytesToHex(sha256(context.container))).toBe(expected.input_id);
+      expect(bytesToHex(sha256(context.inputContainer))).toBe(expected.input_id);
       expect(bytesToHex(context.digest)).toBe(expected.input_digest);
       expect(
         schnorr.verify(
@@ -152,7 +152,7 @@ describe('transaction transcript (vectors)', () => {
     )!;
     expect(bytesToHex(buildTransactionTranscript(tx))).toBe(aud.transcript);
     expect(bytesToHex(transactionDigest(tx))).toBe(aud.digest);
-    expect(bytesToHex(sha256(context.container))).toBe(aud.input_id);
+    expect(bytesToHex(sha256(context.inputContainer))).toBe(aud.input_id);
     expect(bytesToHex(context.digest)).toBe(aud.input_digest);
   });
 
@@ -522,7 +522,7 @@ describe('input uniqueness and spend commitments (vectors)', () => {
   test('the mint quote input derives its digest from its own container', () => {
     const { quotes } = transactionInputs(fromVectorTx(tv.mint.tx));
     const context = quotes.get(tv.mint.tx.mint_quote_inputs[0].quote_id)!;
-    expect(bytesToHex(sha256(context.container))).toBe(tv.mint.input_id);
+    expect(bytesToHex(sha256(context.inputContainer))).toBe(tv.mint.input_id);
     expect(bytesToHex(context.digest)).toBe(tv.mint.input_digest);
   });
 

--- a/test/model/CashuNip07.node.test.ts
+++ b/test/model/CashuNip07.node.test.ts
@@ -126,26 +126,26 @@ describe('CashuNip07', () => {
   });
 
   test('signTransaction refuses anything without the domain tag or a foreign container', () => {
-    const containerHex = Bytes.toHex(CONTAINER);
+    const inputContainerHex = Bytes.toHex(CONTAINER);
     // An event id, or any other 32 bytes, must never come out signed.
-    expect(() => CashuNip07.signTransaction('00'.repeat(32), containerHex, PRIV)).toThrow(
+    expect(() => CashuNip07.signTransaction('00'.repeat(32), inputContainerHex, PRIV)).toThrow(
       'not a Cashu transaction',
     );
     expect(() =>
-      CashuNip07.signTransaction(Bytes.toHex(MESSAGE.subarray(1)), containerHex, PRIV),
+      CashuNip07.signTransaction(Bytes.toHex(MESSAGE.subarray(1)), inputContainerHex, PRIV),
     ).toThrow();
     // A container the message does not carry signs nothing: the derived digest would cover an
     // input of some other transaction.
     expect(() => CashuNip07.signTransaction(Bytes.toHex(MESSAGE), '01000411223344', PRIV)).toThrow(
       'not part of this transaction',
     );
-    const signed = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), containerHex, PRIV);
+    const signed = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), inputContainerHex, PRIV);
     expect(signed.hash).toBe(Bytes.toHex(DIGEST));
     expect(signed.pubkey).toBe(XONLY);
     // A byte key signs the same as its hex form.
     const bytesKey = CashuNip07.signTransaction(
       Bytes.toHex(MESSAGE),
-      containerHex,
+      inputContainerHex,
       Bytes.fromHex(PRIV),
     );
     expect(schnorr.verify(Bytes.fromHex(bytesKey.sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);

--- a/test/model/CashuNip07.node.test.ts
+++ b/test/model/CashuNip07.node.test.ts
@@ -1,5 +1,4 @@
 import { schnorr } from '@noble/curves/secp256k1.js';
-import { sha256 } from '@noble/hashes/sha2.js';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -10,7 +9,7 @@ import {
 import { getPubKeyFromPrivKey } from '../../src/crypto/curve_secp';
 import { createP2PKsecret } from '../../src/crypto/NUT11';
 import type { NutrootLeaf } from '../../src/crypto/nutroot';
-import { messageForPayload } from '../../src/crypto/transcript';
+import { inputsForPayload, proofInputContextKey } from '../../src/crypto/transcript';
 import { Amount } from '../../src/model/Amount';
 import { CashuNip07, type Nip07Like } from '../../src/model/CashuNip07';
 import type { Proof } from '../../src/model/types';
@@ -25,16 +24,20 @@ const XONLY = PUB.slice(2);
 const OTHER = Bytes.toHex(getPubKeyFromPrivKey(Bytes.fromHex('22'.repeat(32))));
 
 const LEAF: NutrootLeaf = { type: 'threshold', n: 1, keys: [PUB] };
-const MESSAGE = messageForPayload({
-  inputs: [{ amount: 1, id: KEYSET, secret: `02${'33'.repeat(32)}`, C: 'aa'.repeat(48) }],
+const SECRET = `02${'33'.repeat(32)}`;
+const inputs = inputsForPayload({
+  inputs: [{ amount: 1, id: KEYSET, secret: SECRET, C: 'aa'.repeat(48) }],
   outputs: [{ amount: 1, id: KEYSET, B_: 'bb'.repeat(48) }],
 });
-const DIGEST = sha256(MESSAGE);
+const MESSAGE = inputs.message;
+const { container: CONTAINER, digest: DIGEST } = inputs.proofs.get(
+  proofInputContextKey({ keysetId: KEYSET, secret: SECRET }),
+)!;
 
 // An extension that implements the safe method through the reference signer.
 const safeSigner: Nip07Like = {
   getPublicKey: async () => XONLY,
-  nip60: { signTransaction: async (m) => CashuNip07.signTransaction(m, PRIV) },
+  nip60: { signTransaction: async (m, c) => CashuNip07.signTransaction(m, c, PRIV) },
 };
 // Alby-style: raw digest signing only.
 const rawSigner: Nip07Like = {
@@ -84,6 +87,7 @@ describe('CashuNip07', () => {
       digest: DIGEST,
       leaf: LEAF,
       message: MESSAGE,
+      container: CONTAINER,
     });
     expect(schnorr.verify(Bytes.fromHex(sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
   });
@@ -93,10 +97,11 @@ describe('CashuNip07', () => {
       digest: DIGEST,
       leaf: LEAF,
       message: MESSAGE,
+      container: CONTAINER,
     });
     expect(schnorr.verify(Bytes.fromHex(sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
     await expect(
-      CashuNip07.cosign({})({ digest: DIGEST, leaf: LEAF, message: MESSAGE }),
+      CashuNip07.cosign({})({ digest: DIGEST, leaf: LEAF, message: MESSAGE, container: CONTAINER }),
     ).rejects.toThrow('cannot sign');
   });
 
@@ -105,21 +110,38 @@ describe('CashuNip07', () => {
       nip60: { signTransaction: async () => ({ hash: '00'.repeat(32), sig: '', pubkey: XONLY }) },
     };
     await expect(
-      CashuNip07.cosign(liar)({ digest: DIGEST, leaf: LEAF, message: MESSAGE }),
+      CashuNip07.cosign(liar)({
+        digest: DIGEST,
+        leaf: LEAF,
+        message: MESSAGE,
+        container: CONTAINER,
+      }),
     ).rejects.toThrow('different message');
   });
 
-  test('signTransaction refuses anything without the domain tag', () => {
+  test('signTransaction refuses anything without the domain tag or a foreign container', () => {
+    const containerHex = Bytes.toHex(CONTAINER);
     // An event id, or any other 32 bytes, must never come out signed.
-    expect(() => CashuNip07.signTransaction('00'.repeat(32), PRIV)).toThrow(
+    expect(() => CashuNip07.signTransaction('00'.repeat(32), containerHex, PRIV)).toThrow(
       'not a Cashu transaction',
     );
-    expect(() => CashuNip07.signTransaction(Bytes.toHex(MESSAGE.subarray(1)), PRIV)).toThrow();
-    const signed = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), PRIV);
+    expect(() =>
+      CashuNip07.signTransaction(Bytes.toHex(MESSAGE.subarray(1)), containerHex, PRIV),
+    ).toThrow();
+    // A container the message does not carry signs nothing: the derived digest would cover an
+    // input of some other transaction.
+    expect(() => CashuNip07.signTransaction(Bytes.toHex(MESSAGE), '01000411223344', PRIV)).toThrow(
+      'not part of this transaction',
+    );
+    const signed = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), containerHex, PRIV);
     expect(signed.hash).toBe(Bytes.toHex(DIGEST));
     expect(signed.pubkey).toBe(XONLY);
     // A byte key signs the same as its hex form.
-    const bytesKey = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), Bytes.fromHex(PRIV));
+    const bytesKey = CashuNip07.signTransaction(
+      Bytes.toHex(MESSAGE),
+      containerHex,
+      Bytes.fromHex(PRIV),
+    );
     expect(schnorr.verify(Bytes.fromHex(bytesKey.sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
   });
 

--- a/test/model/CashuNip07.node.test.ts
+++ b/test/model/CashuNip07.node.test.ts
@@ -29,8 +29,8 @@ const inputs = inputsForPayload({
   inputs: [{ amount: 1, id: KEYSET, secret: SECRET, C: 'aa'.repeat(48) }],
   outputs: [{ amount: 1, id: KEYSET, B_: 'bb'.repeat(48) }],
 });
-const MESSAGE = inputs.message;
-const { container: CONTAINER, digest: DIGEST } = inputs.proofs.get(
+const MESSAGE = inputs.transactionMessage;
+const { inputContainer: CONTAINER, digest: DIGEST } = inputs.proofs.get(
   proofInputContextKey({ keysetId: KEYSET, secret: SECRET }),
 )!;
 
@@ -92,8 +92,8 @@ describe('CashuNip07', () => {
     const [sig] = await CashuNip07.cosign(safeSigner)({
       digest: DIGEST,
       leaf: LEAF,
-      message: MESSAGE,
-      container: CONTAINER,
+      transactionMessage: MESSAGE,
+      inputContainer: CONTAINER,
     });
     expect(schnorr.verify(hexToBytes(sig), DIGEST, hexToBytes(XONLY))).toBe(true);
   });
@@ -102,12 +102,17 @@ describe('CashuNip07', () => {
     const [sig] = await CashuNip07.cosign(rawSigner)({
       digest: DIGEST,
       leaf: LEAF,
-      message: MESSAGE,
-      container: CONTAINER,
+      transactionMessage: MESSAGE,
+      inputContainer: CONTAINER,
     });
     expect(schnorr.verify(hexToBytes(sig), DIGEST, hexToBytes(XONLY))).toBe(true);
     await expect(
-      CashuNip07.cosign({})({ digest: DIGEST, leaf: LEAF, message: MESSAGE, container: CONTAINER }),
+      CashuNip07.cosign({})({
+        digest: DIGEST,
+        leaf: LEAF,
+        transactionMessage: MESSAGE,
+        inputContainer: CONTAINER,
+      }),
     ).rejects.toThrow('cannot sign');
   });
 
@@ -119,10 +124,68 @@ describe('CashuNip07', () => {
       CashuNip07.cosign(liar)({
         digest: DIGEST,
         leaf: LEAF,
-        message: MESSAGE,
-        container: CONTAINER,
+        transactionMessage: MESSAGE,
+        inputContainer: CONTAINER,
       }),
     ).rejects.toThrow('different message');
+  });
+
+  test('signQuote signs a v3 quote through signTransaction and a legacy one through signSchnorr', async () => {
+    const quote = inputsForPayload({
+      mintQuotes: [{ quoteId: 'q1', amount: 1 }],
+      outputs: [{ amount: 1, id: KEYSET, B_: 'bb'.repeat(48) }],
+    });
+    const { digest, inputContainer } = quote.quotes.get('q1')!;
+    const v3 = {
+      digest,
+      quoteId: 'q1',
+      outputs: [],
+      transactionMessage: quote.transactionMessage,
+      inputContainer,
+    };
+    const sig = await CashuNip07.signQuote(safeSigner)(v3);
+    expect(schnorr.verify(hexToBytes(sig), digest, hexToBytes(XONLY))).toBe(true);
+    // A legacy quote carries no transcript, so only a raw digest signer can help.
+    const legacy = { digest: hexToBytes('cc'.repeat(32)), quoteId: 'q2', outputs: [] };
+    expect(
+      schnorr.verify(
+        hexToBytes(await CashuNip07.signQuote(rawSigner)(legacy)),
+        legacy.digest,
+        hexToBytes(XONLY),
+      ),
+    ).toBe(true);
+    await expect(CashuNip07.signQuote(safeSigner)(legacy)).rejects.toThrow(
+      /cannot sign a mint quote/,
+    );
+    await expect(CashuNip07.signQuote(secretSigner)(v3)).rejects.toThrow(
+      /cannot sign a mint quote/,
+    );
+  });
+
+  test('signQuote rejects a signer that hashed something else', async () => {
+    const quote = inputsForPayload({
+      mintQuotes: [{ quoteId: 'q1', amount: 1 }],
+      outputs: [{ amount: 1, id: KEYSET, B_: 'bb'.repeat(48) }],
+    });
+    const { digest, inputContainer } = quote.quotes.get('q1')!;
+    const liar: Nip07Like = {
+      nip60: {
+        signTransaction: async () => ({
+          hash: '00'.repeat(32),
+          sig: '00'.repeat(64),
+          pubkey: XONLY,
+        }),
+      },
+    };
+    await expect(
+      CashuNip07.signQuote(liar)({
+        digest,
+        quoteId: 'q1',
+        outputs: [],
+        transactionMessage: quote.transactionMessage,
+        inputContainer,
+      }),
+    ).rejects.toThrow(/different message/);
   });
 
   test('signTransaction refuses anything without the domain tag or a foreign container', () => {

--- a/test/model/CashuNip07.node.test.ts
+++ b/test/model/CashuNip07.node.test.ts
@@ -1,0 +1,217 @@
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { describe, expect, test } from 'vitest';
+
+import {
+  computeMessageDigest,
+  schnorrSignDigest,
+  schnorrVerifyMessage,
+} from '../../src/crypto/core';
+import { getPubKeyFromPrivKey } from '../../src/crypto/curve_secp';
+import { createP2PKsecret } from '../../src/crypto/NUT11';
+import type { NutrootLeaf } from '../../src/crypto/nutroot';
+import { messageForPayload } from '../../src/crypto/transcript';
+import { Amount } from '../../src/model/Amount';
+import { CashuNip07, type Nip07Like } from '../../src/model/CashuNip07';
+import type { Proof } from '../../src/model/types';
+import { Bytes } from '../../src/utils';
+import type { SpendOption } from '../../src/wallet/types';
+import vectors from '../vectors/nutroot-v3.json';
+
+const KEYSET = vectors.nut13_v3.keyset_id;
+const PRIV = '11'.repeat(32);
+const PUB = Bytes.toHex(getPubKeyFromPrivKey(Bytes.fromHex(PRIV)));
+const XONLY = PUB.slice(2);
+const OTHER = Bytes.toHex(getPubKeyFromPrivKey(Bytes.fromHex('22'.repeat(32))));
+
+const LEAF: NutrootLeaf = { type: 'threshold', n: 1, keys: [PUB] };
+const MESSAGE = messageForPayload({
+  inputs: [{ amount: 1, id: KEYSET, secret: `02${'33'.repeat(32)}`, C: 'aa'.repeat(48) }],
+  outputs: [{ amount: 1, id: KEYSET, B_: 'bb'.repeat(48) }],
+});
+const DIGEST = sha256(MESSAGE);
+
+// An extension that implements the safe method through the reference signer.
+const safeSigner: Nip07Like = {
+  getPublicKey: async () => XONLY,
+  nip60: { signTransaction: async (m) => CashuNip07.signTransaction(m, PRIV) },
+};
+// Alby-style: raw digest signing only.
+const rawSigner: Nip07Like = {
+  getPublicKey: async () => XONLY,
+  signSchnorr: async (h) => schnorrSignDigest(h, PRIV),
+};
+// nos2x-style: nip60.signSecret only.
+const signSecret = async (secret: string) => {
+  const hash = computeMessageDigest(secret, true);
+  return { hash, sig: schnorrSignDigest(hash, PRIV), pubkey: XONLY };
+};
+const secretSigner: Nip07Like = { getPublicKey: async () => XONLY, nip60: { signSecret } };
+
+const p2pkProof = (secret: string, witness?: Proof['witness']): Proof => ({
+  id: `00${'11'.repeat(3)}`,
+  amount: Amount.from(1),
+  secret,
+  C: `02${'44'.repeat(32)}`,
+  ...(witness && { witness }),
+});
+const signaturesOf = (proof: Proof) =>
+  (proof.witness as { signatures?: string[] } | undefined)?.signatures ?? [];
+
+const option = (over: Partial<SpendOption>): SpendOption => ({
+  leafIndex: 0,
+  leaf: LEAF,
+  keys: [],
+  satisfiable: false,
+  blockedBy: 'threshold',
+  ...over,
+});
+
+describe('CashuNip07', () => {
+  test('pubkey is the 02-prefixed form leaves list', async () => {
+    expect(await CashuNip07.pubkey(safeSigner)).toBe(`02${XONLY}`);
+    await expect(CashuNip07.pubkey({})).rejects.toThrow('getPublicKey');
+  });
+
+  test('canSign needs signTransaction or signSchnorr', () => {
+    expect(CashuNip07.canSign(safeSigner)).toBe(true);
+    expect(CashuNip07.canSign(rawSigner)).toBe(true);
+    expect(CashuNip07.canSign({ getPublicKey: async () => XONLY })).toBe(false);
+  });
+
+  test('cosign prefers signTransaction and verifies over the digest', async () => {
+    const [sig] = await CashuNip07.cosign(safeSigner)({
+      digest: DIGEST,
+      leaf: LEAF,
+      message: MESSAGE,
+    });
+    expect(schnorr.verify(Bytes.fromHex(sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
+  });
+
+  test('cosign falls back to signSchnorr, and refuses with neither', async () => {
+    const [sig] = await CashuNip07.cosign(rawSigner)({
+      digest: DIGEST,
+      leaf: LEAF,
+      message: MESSAGE,
+    });
+    expect(schnorr.verify(Bytes.fromHex(sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
+    await expect(
+      CashuNip07.cosign({})({ digest: DIGEST, leaf: LEAF, message: MESSAGE }),
+    ).rejects.toThrow('cannot sign');
+  });
+
+  test('cosign rejects a signer that hashed something else', async () => {
+    const liar: Nip07Like = {
+      nip60: { signTransaction: async () => ({ hash: '00'.repeat(32), sig: '', pubkey: XONLY }) },
+    };
+    await expect(
+      CashuNip07.cosign(liar)({ digest: DIGEST, leaf: LEAF, message: MESSAGE }),
+    ).rejects.toThrow('different message');
+  });
+
+  test('signTransaction refuses anything without the domain tag', () => {
+    // An event id, or any other 32 bytes, must never come out signed.
+    expect(() => CashuNip07.signTransaction('00'.repeat(32), PRIV)).toThrow(
+      'not a Cashu transaction',
+    );
+    expect(() => CashuNip07.signTransaction(Bytes.toHex(MESSAGE.subarray(1)), PRIV)).toThrow();
+    const signed = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), PRIV);
+    expect(signed.hash).toBe(Bytes.toHex(DIGEST));
+    expect(signed.pubkey).toBe(XONLY);
+    // A byte key signs the same as its hex form.
+    const bytesKey = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), Bytes.fromHex(PRIV));
+    expect(schnorr.verify(Bytes.fromHex(bytesKey.sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
+  });
+
+  test('completes: listed, not held, one short of n, and only then', () => {
+    expect(CashuNip07.completes(option({}), PUB)).toBe(true);
+    expect(CashuNip07.completes(option({}), XONLY)).toBe(true); // x-only accepted
+    expect(CashuNip07.completes(option({}), `02${XONLY}`)).toBe(true); // either parity prefix
+    expect(CashuNip07.completes(option({}), OTHER)).toBe(false); // not listed
+    expect(CashuNip07.completes(option({ satisfiable: true, blockedBy: undefined }), PUB)).toBe(
+      false,
+    );
+    expect(CashuNip07.completes(option({ blockedBy: 'locktime' }), PUB)).toBe(false);
+    expect(
+      CashuNip07.completes(option({ keys: [{ keyIndex: 0, pubkey: PUB, blinded: false }] }), PUB),
+    ).toBe(false); // already held
+    const twoOfThree: NutrootLeaf = {
+      type: 'threshold',
+      n: 2,
+      keys: [PUB, OTHER, `02${'44'.repeat(32)}`],
+    };
+    expect(CashuNip07.completes(option({ leaf: twoOfThree }), PUB)).toBe(false); // two short
+    expect(
+      CashuNip07.completes(
+        option({ leaf: twoOfThree, keys: [{ keyIndex: 1, pubkey: OTHER, blinded: false }] }),
+        PUB,
+      ),
+    ).toBe(true);
+  });
+
+  test('signP2PK signs a NUT-11 secret through signSecret, signString or signSchnorr', async () => {
+    const proof = p2pkProof(createP2PKsecret(PUB));
+    for (const nostr of [
+      secretSigner,
+      { getPublicKey: async () => XONLY, signString: signSecret },
+      rawSigner,
+    ]) {
+      const [signed] = await CashuNip07.signP2PK(nostr, [proof]);
+      expect(signaturesOf(signed)).toHaveLength(1);
+      expect(schnorrVerifyMessage(signaturesOf(signed)[0], proof.secret, PUB)).toBe(true);
+    }
+    expect(CashuNip07.canSignP2PK(secretSigner)).toBe(true);
+    expect(CashuNip07.canSignP2PK({ getPublicKey: async () => XONLY })).toBe(false);
+  });
+
+  test('signP2PK leaves alone what it should not touch', async () => {
+    const mine = p2pkProof(createP2PKsecret(PUB));
+    const [once] = await CashuNip07.signP2PK(secretSigner, [mine]);
+    const [twice] = await CashuNip07.signP2PK(secretSigner, [once]); // already signed
+    expect(signaturesOf(twice)).toHaveLength(1);
+    const untouched = [
+      p2pkProof(createP2PKsecret(OTHER)), // not my key
+      p2pkProof(createP2PKsecret(PUB, [['sigflag', 'SIG_ALL']])), // transaction message
+      p2pkProof('plain-secret'), // no conditions
+      p2pkProof(`02${'33'.repeat(32)}`), // v3 point secret
+    ];
+    const out = await CashuNip07.signP2PK(secretSigner, untouched);
+    expect(out).toEqual(untouched);
+    await expect(CashuNip07.signP2PK({ getPublicKey: async () => XONLY }, [mine])).rejects.toThrow(
+      'cannot sign',
+    );
+  });
+
+  test('signP2PK rejects a signer that hashed something else or signed with another key', async () => {
+    const proof = p2pkProof(createP2PKsecret(PUB));
+    const wrongHash: Nip07Like = {
+      getPublicKey: async () => XONLY,
+      nip60: { signSecret: async (s) => ({ ...(await signSecret(s)), hash: '00'.repeat(32) }) },
+    };
+    await expect(CashuNip07.signP2PK(wrongHash, [proof])).rejects.toThrow('different secret');
+    const badSig: Nip07Like = {
+      getPublicKey: async () => XONLY,
+      signSchnorr: async () => '00'.repeat(64),
+    };
+    await expect(CashuNip07.signP2PK(badSig, [proof])).rejects.toThrow('does not verify');
+  });
+
+  test('nip60Keys reads privkey and mint tags from the decrypted content', async () => {
+    const nostr: Nip07Like = {
+      nip44: {
+        decrypt: async (pubkey, content) =>
+          pubkey === XONLY && content === 'ct'
+            ? JSON.stringify([['privkey', PRIV], ['mint', 'https://m'], ['other', 'x'], 'junk'])
+            : 'nope',
+      },
+    };
+    expect(await CashuNip07.nip60Keys(nostr, XONLY, 'ct')).toEqual({
+      privkeys: [PRIV],
+      mints: ['https://m'],
+    });
+    await expect(CashuNip07.nip60Keys(nostr, XONLY, 'bad')).rejects.toThrow('JSON');
+    const object: Nip07Like = { nip44: { decrypt: async () => '{"privkey":"x"}' } };
+    await expect(CashuNip07.nip60Keys(object, XONLY, 'ct')).rejects.toThrow('tag list');
+    await expect(CashuNip07.nip60Keys({}, XONLY, 'ct')).rejects.toThrow('nip44');
+  });
+});

--- a/test/model/CashuNip07.node.test.ts
+++ b/test/model/CashuNip07.node.test.ts
@@ -13,15 +13,15 @@ import { inputsForPayload, proofInputContextKey } from '../../src/crypto/transcr
 import { Amount } from '../../src/model/Amount';
 import { CashuNip07, type Nip07Like } from '../../src/model/CashuNip07';
 import type { Proof } from '../../src/model/types';
-import { Bytes } from '../../src/utils';
+import { bytesToHex, hexToBytes } from '../../src/utils';
 import type { SpendOption } from '../../src/wallet/types';
 import vectors from '../vectors/nutroot-v3.json';
 
 const KEYSET = vectors.nut13_v3.keyset_id;
 const PRIV = '11'.repeat(32);
-const PUB = Bytes.toHex(getPubKeyFromPrivKey(Bytes.fromHex(PRIV)));
+const PUB = bytesToHex(getPubKeyFromPrivKey(hexToBytes(PRIV)));
 const XONLY = PUB.slice(2);
-const OTHER = Bytes.toHex(getPubKeyFromPrivKey(Bytes.fromHex('22'.repeat(32))));
+const OTHER = bytesToHex(getPubKeyFromPrivKey(hexToBytes('22'.repeat(32))));
 
 const LEAF: NutrootLeaf = { type: 'threshold', n: 1, keys: [PUB] };
 const SECRET = `02${'33'.repeat(32)}`;
@@ -95,7 +95,7 @@ describe('CashuNip07', () => {
       message: MESSAGE,
       container: CONTAINER,
     });
-    expect(schnorr.verify(Bytes.fromHex(sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
+    expect(schnorr.verify(hexToBytes(sig), DIGEST, hexToBytes(XONLY))).toBe(true);
   });
 
   test('cosign falls back to signSchnorr, and refuses with neither', async () => {
@@ -105,7 +105,7 @@ describe('CashuNip07', () => {
       message: MESSAGE,
       container: CONTAINER,
     });
-    expect(schnorr.verify(Bytes.fromHex(sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
+    expect(schnorr.verify(hexToBytes(sig), DIGEST, hexToBytes(XONLY))).toBe(true);
     await expect(
       CashuNip07.cosign({})({ digest: DIGEST, leaf: LEAF, message: MESSAGE, container: CONTAINER }),
     ).rejects.toThrow('cannot sign');
@@ -126,29 +126,29 @@ describe('CashuNip07', () => {
   });
 
   test('signTransaction refuses anything without the domain tag or a foreign container', () => {
-    const inputContainerHex = Bytes.toHex(CONTAINER);
+    const inputContainerHex = bytesToHex(CONTAINER);
     // An event id, or any other 32 bytes, must never come out signed.
     expect(() => CashuNip07.signTransaction('00'.repeat(32), inputContainerHex, PRIV)).toThrow(
       'not a Cashu transaction',
     );
     expect(() =>
-      CashuNip07.signTransaction(Bytes.toHex(MESSAGE.subarray(1)), inputContainerHex, PRIV),
+      CashuNip07.signTransaction(bytesToHex(MESSAGE.subarray(1)), inputContainerHex, PRIV),
     ).toThrow();
     // A container the message does not carry signs nothing: the derived digest would cover an
     // input of some other transaction.
-    expect(() => CashuNip07.signTransaction(Bytes.toHex(MESSAGE), '01000411223344', PRIV)).toThrow(
+    expect(() => CashuNip07.signTransaction(bytesToHex(MESSAGE), '01000411223344', PRIV)).toThrow(
       'not part of this transaction',
     );
-    const signed = CashuNip07.signTransaction(Bytes.toHex(MESSAGE), inputContainerHex, PRIV);
-    expect(signed.hash).toBe(Bytes.toHex(DIGEST));
+    const signed = CashuNip07.signTransaction(bytesToHex(MESSAGE), inputContainerHex, PRIV);
+    expect(signed.hash).toBe(bytesToHex(DIGEST));
     expect(signed.pubkey).toBe(XONLY);
     // A byte key signs the same as its hex form.
     const bytesKey = CashuNip07.signTransaction(
-      Bytes.toHex(MESSAGE),
+      bytesToHex(MESSAGE),
       inputContainerHex,
-      Bytes.fromHex(PRIV),
+      hexToBytes(PRIV),
     );
-    expect(schnorr.verify(Bytes.fromHex(bytesKey.sig), DIGEST, Bytes.fromHex(XONLY))).toBe(true);
+    expect(schnorr.verify(hexToBytes(bytesKey.sig), DIGEST, hexToBytes(XONLY))).toBe(true);
   });
 
   test('completes: listed, not held, one short of n, and only then', () => {

--- a/test/model/CashuNip07.node.test.ts
+++ b/test/model/CashuNip07.node.test.ts
@@ -74,6 +74,12 @@ describe('CashuNip07', () => {
   test('pubkey is the 02-prefixed form leaves list', async () => {
     expect(await CashuNip07.pubkey(safeSigner)).toBe(`02${XONLY}`);
     await expect(CashuNip07.pubkey({})).rejects.toThrow('getPublicKey');
+    await expect(CashuNip07.pubkey({ getPublicKey: async () => 'not-hex' })).rejects.toThrow(
+      /32-byte hex/,
+    );
+    await expect(CashuNip07.pubkey({ getPublicKey: async () => 'ff'.repeat(32) })).rejects.toThrow(
+      /not a valid secp256k1 point/,
+    );
   });
 
   test('canSign needs signTransaction or signSchnorr', () => {

--- a/test/wallet/nutroot.node.test.ts
+++ b/test/wallet/nutroot.node.test.ts
@@ -367,10 +367,10 @@ describe('attachTransactionWitnesses', () => {
     expect(r.inputDigest).toBe(bytesToHex(digestOf(inputs, undefined, input.secret)));
     expect(r.commitment).toBe(spendCommitment(r.Y, hexToBytes(r.inputDigest), r.witness));
     // A holder of the proof rebuilds the input digest from the transcript alone (NUT-07).
-    const { container } = transactionInputsOf(inputs).proofs.get(
+    const { inputContainer } = transactionInputsOf(inputs).proofs.get(
       proofInputContextKey({ keysetId: input.id, secret: input.secret }),
     )!;
-    expect(bytesToHex(inputDigest(sha256(hexToBytes(r.transcript)), container))).toBe(
+    expect(bytesToHex(inputDigest(sha256(hexToBytes(r.transcript)), inputContainer))).toBe(
       r.inputDigest,
     );
     expect(verifyTransactionInputWitness(hexToBytes(r.inputDigest), PUB_B, r.witness)).toBe(true);

--- a/test/wallet/nutroot.node.test.ts
+++ b/test/wallet/nutroot.node.test.ts
@@ -570,10 +570,10 @@ describe('attachTransactionWitnesses', () => {
       makeState(undefined),
     );
     expect(seen!.leaf.keys).toEqual([PUB_A, PUB_B]);
-    expect(bytesToUtf8(seen!.message.subarray(0, 20))).toBe('Cashu_Transaction_v1');
+    expect(bytesToUtf8(seen!.transactionMessage.subarray(0, 20))).toBe('Cashu_Transaction_v1');
     // digest = tagged_hash(input tag, SHA256(message) || SHA256(container)): recomputable, so a
     // signer can refuse anything it cannot verify.
-    expect(bytesToHex(inputDigest(sha256(seen!.message), seen!.container))).toBe(
+    expect(bytesToHex(inputDigest(sha256(seen!.transactionMessage), seen!.inputContainer))).toBe(
       bytesToHex(seen!.digest),
     );
     expect(bytesToHex(seen!.digest)).toBe(bytesToHex(digestOf([input])));

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -14,16 +14,20 @@ import {
   MeltQuoteState,
   MintQuoteState,
   type MintQuoteBolt11Response,
+  type MintQuoteSignRequest,
   Amount,
   type AmountLike,
   Mint,
   MintOperationError,
   type RequestFn,
 } from '../../src';
-import { verifyMintQuoteSignature } from '../../src/crypto';
+import { schnorrSignDigest, verifyMintQuoteSignature } from '../../src/crypto';
+import { getPubKeyFromPrivKey } from '../../src/crypto/curve_secp';
 import { verifyMintQuoteSignatureLegacy } from '../../src/crypto/NUT20';
+import { inputsForPayload } from '../../src/crypto/transcript';
 import request from '../../src/transport';
 import { sumProofs } from '../../src/utils';
+import { NUT02_V3_VECTOR1_KEYS, NUT02_V3_VECTOR1_KEYSET } from '../consts';
 
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp, invoice } from './_setup';
 
@@ -555,6 +559,105 @@ describe('requestTokens', () => {
     // Should still produce a signature using the provided privkey
     expect(preview.payload.signature).toBeDefined();
     expect(typeof preview.payload.signature).toBe('string');
+  });
+
+  describe('prepareMint signs a locked quote through a sign callback', () => {
+    const privkey = '0000000000000000000000000000000000000000000000000000000000000002';
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(hexToBytes(privkey)));
+    const lockedQuote = (): MintQuoteBolt11Response => ({
+      quote: 'callback-quote',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      method: 'bolt11',
+      state: MintQuoteState.PAID,
+      amount_paid: Amount.from(1),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+      expiry: null,
+      pubkey,
+    });
+
+    test('the callback signs the amended NUT-20 digest, with no legacy fallback', async () => {
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+      const seen: MintQuoteSignRequest[] = [];
+      const sign = async (request: MintQuoteSignRequest) => {
+        seen.push(request);
+        return schnorrSignDigest(request.digest, privkey);
+      };
+      const preview = await wallet.prepareMint('bolt11', 1, lockedQuote(), { sign });
+      expect(seen).toHaveLength(1);
+      expect(seen[0].quoteId).toBe('callback-quote');
+      expect(seen[0].outputs).toEqual(preview.payload.outputs);
+      // A pre-v3 quote has no transaction transcript to hand a signer.
+      expect(seen[0].transactionMessage).toBeUndefined();
+      expect(
+        verifyMintQuoteSignature(
+          pubkey,
+          'callback-quote',
+          preview.payload.outputs,
+          preview.payload.signature!,
+        ),
+      ).toBe(true);
+      expect(preview.legacySignature).toBeUndefined();
+    });
+
+    test('a signature the quote pubkey does not verify is refused before the mint sees it', async () => {
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+      const other = '0000000000000000000000000000000000000000000000000000000000000003';
+      const sign = async ({ digest }: MintQuoteSignRequest) => schnorrSignDigest(digest, other);
+      await expect(wallet.prepareMint('bolt11', 1, lockedQuote(), { sign })).rejects.toThrow(
+        /does not verify/,
+      );
+    });
+
+    test('privkey takes precedence, and a locked quote needs one or the other', async () => {
+      const wallet = new Wallet(mint, { unit });
+      await wallet.loadMint();
+      const sign = vi.fn(async ({ digest }: MintQuoteSignRequest) =>
+        schnorrSignDigest(digest, privkey),
+      );
+      const preview = await wallet.prepareMint('bolt11', 1, lockedQuote(), { privkey, sign });
+      expect(sign).not.toHaveBeenCalled();
+      expect(preview.legacySignature).toBeDefined();
+      await expect(wallet.prepareMint('bolt11', 1, lockedQuote())).rejects.toThrow(
+        /without private key or sign callback/,
+      );
+    });
+
+    test('a v3 quote hands the signer the tagged message and its container', async () => {
+      // A v3 keyset whose id verifies against its keys, else the keychain drops it.
+      const v3Keyset = NUT02_V3_VECTOR1_KEYSET;
+      const v3Keys = NUT02_V3_VECTOR1_KEYS;
+      server.use(
+        http.get(mintUrl + '/v1/keysets', () => HttpResponse.json({ keysets: [v3Keyset] })),
+        http.get(mintUrl + '/v1/keys', () => HttpResponse.json({ keysets: [v3Keys] })),
+        http.get(mintUrl + '/v1/keys/' + v3Keyset.id, () =>
+          HttpResponse.json({ keysets: [v3Keys] }),
+        ),
+      );
+      const wallet = new Wallet(mintUrl, { unit });
+      await wallet.loadMint();
+      let seen: MintQuoteSignRequest | undefined;
+      const sign = async (request: MintQuoteSignRequest) => {
+        seen = request;
+        return schnorrSignDigest(request.digest, privkey);
+      };
+      const preview = await wallet.prepareMint('bolt11', 1, lockedQuote(), { sign });
+      expect(seen?.transactionMessage).toBeDefined();
+      expect(seen?.inputContainer).toBeDefined();
+      // The digest is the quote's input digest under the transaction transcript (NUT-10), so the
+      // signer can recompute it from transaction message and input container alone.
+      const tx = inputsForPayload({
+        mintQuotes: [{ quoteId: 'callback-quote', amount: 1 }],
+        outputs: preview.payload.outputs,
+      });
+      expect(bytesToHex(seen!.digest)).toBe(bytesToHex(tx.quotes.get('callback-quote')!.digest));
+      expect(bytesToHex(seen!.transactionMessage!)).toBe(bytesToHex(tx.transactionMessage));
+      expect(preview.legacySignature).toBeUndefined();
+    });
   });
 
   test('prepareMint fails when multiple privkeys and no quote pubkey', async () => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -25,6 +25,7 @@
     "docs-src/usage/logging.md",
     "docs-src/usage/fees.md",
     "docs-src/usage/helpers.md",
+    "docs-src/usage/nip07_signers.md",
     "docs-src/wallet_ops/wallet_ops.md",
     "docs-src/wallet_ops/send.md",
     "docs-src/wallet_ops/receive.md",


### PR DESCRIPTION
Stacked on #950. Adds `CashuNip07`, an adapter from a NIP-07 `window.nostr` to Cashu signing, with no nostr code in the library (no relays, no events; only the object the extension injects).

## WHY

It gives a consistent interface for consumers as there have been various NIP-07 signing protocols that have emerged over the last few years, implemented sporadically.

## Changes

**NUT-11 (pre-v3 keysets):** `signP2PK(nostr, proofs)` adds the extension's signature to every `SIG_INPUTS` proof that lists its key, through `nip60.signSecret` (nos2x), `signString` (AKA Profiles) or `signSchnorr` (Alby). Replies are checked against the secret's hash and the extension's key. `SIG_ALL` proofs and blinded keys are skipped; v3 proofs pass through, so one call serves a mixed token.

**Nutroot (v3 keysets):** `completes(option, pubkey)` says whether one signature from the extension turns a leaf satisfiable (its key listed verbatim, matched by x-coordinate), and `cosign(nostr)` is a `ScriptPathPlan.cosign` hook. It prefers a proposed `nip60.signTransaction(messageHex, containerHex)`: the extension receives the tagged pre-hash transaction message and the input's own transcript container, derives the input digest itself (`tagged_hash("Cashu_TransactionInput", SHA256(message) || SHA256(container))`, NUT-10), and refuses a message without the domain tag or a container the message does not carry, so an event id can never pass and a signature covers exactly one input of one transaction. Without it, the hook falls back to `signSchnorr` over the digest. `signTransaction` is the reference implementation of that method for extension authors and tests; it takes the key, which a page never has.

**NIP-60:** `nip60Keys(nostr, pubkey, content)` decrypts a wallet event's keys through the extension's `nip44` for the locks the extension's own key cannot sign (blinded keys, the nutroot key path). Fetching the event stays with the app.

Gates for UI: `canSign` (nutroot) and `canSignP2PK` (NUT-11).

Docs: new `docs-src/usage/nip07_signers.md`, linked from the usage index, the P2PK page and the spend-locked page.
