### PR TITLE
chore(deps): let Dependabot manage npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,29 @@
 version: 2
 updates:
+  # npm dependencies. The seven day soak in .npmrc only governs local installs:
+  # Dependabot resolves versions itself and never reads it, so the cooldown here
+  # is what keeps an hours-old release out of an automated PR.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      # @noble/* and @scure/* pin each other exactly, so they move as one PR
+      noble-scure:
+        patterns: ['@noble/*', '@scure/*']
+      # Dev majors (vitest, typescript, stryker, api-extractor) tend to need
+      # source changes, so they arrive individually rather than in the batch
+      dev-tooling:
+        dependency-type: development
+        update-types: ['minor', 'patch']
+
   # Keeps action pins in .github/workflows current (Node-runtime deprecations,
-  # security fixes). npm deps are managed manually; mint Docker images are
-  # handled by the nightly renovate.yml script.
+  # security fixes). Mint Docker images are handled by the nightly renovate.yml
+  # script.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Keep in-range updates to the lockfile: the default widens a library's
+    # ranges, which would let a noble major claim support for two incompatible
+    # majors at once
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 7
       semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
-  # npm dependencies. The seven day soak in .npmrc only governs local installs:
-  # Dependabot resolves versions itself and never reads it, so the cooldown here
-  # is what keeps an hours-old release out of an automated PR.
+  # npm dependencies. Dependabot floors these values at min-release-age from
+  # .npmrc, so the seven day soak holds either way and the cooldown mainly buys
+  # the longer window for majors. Security updates bypass both.
   - package-ecosystem: npm
     directory: /
     schedule:

--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -15,6 +15,8 @@ npm run test:prepare
 Node requirement: see `package.json` (currently `>=22.4.0`).
 Local installs configure Husky hooks automatically.
 
+`.npmrc` sets `min-release-age=7`, so a fresh resolve will not pull a release published in the last week. It needs npm 11.10 or newer (older npm ignores the setting without saying so), and it applies to `npm install` only: `npm ci` installs the lockfile as written, whatever the age.
+
 ## Repo map
 
 - `src/` core library source

--- a/AGENTS-CONTRIBUTING.md
+++ b/AGENTS-CONTRIBUTING.md
@@ -15,7 +15,7 @@ npm run test:prepare
 Node requirement: see `package.json` (currently `>=22.4.0`).
 Local installs configure Husky hooks automatically.
 
-`.npmrc` sets `min-release-age=7`, so a fresh resolve will not pull a release published in the last week. It needs npm 11.10 or newer (older npm ignores the setting without saying so), and it applies to `npm install` only: `npm ci` installs the lockfile as written, whatever the age.
+`.npmrc` sets `min-release-age=7`, so a fresh resolve will not pull a release published in the last week. It needs npm 11.10 or newer; older npm does not enforce it, though recent versions warn about the unknown key. It applies to `npm install` only: `npm ci` installs the lockfile as written, whatever the age.
 
 ## Repo map
 


### PR DESCRIPTION
Dependabot now opens npm dependency PRs, with a seven day cooldown so a release published hours ago is not proposed straight away.

## Why

`.github/dependabot.yml` declared only the `github-actions` ecosystem, so no PR was ever opened for `@noble/*`, `@scure/*` or the dev tooling.

Dependabot reads `min-release-age` from `.npmrc` and floors every cooldown field at it, so the seven day window applies whether or not this config exists. Declaring it buys the longer window for majors and makes the policy explicit. The soak has no effect on `npm ci`, which installs the lockfile as written, so CI sits outside the window whatever npm version it runs.

## Changes

- npm block: weekly, five open PRs, cooldown of seven days, fourteen for majors. Security updates bypass the cooldown.
- `@noble/*` and `@scure/*` in one group: they pin each other exactly.
- Dev tooling grouped at minor and patch, so dev majors arrive on their own.
- `versioning-strategy: increase-if-necessary`, as the default widens a library's ranges across two incompatible majors.
- `AGENTS-CONTRIBUTING.md` records what the window covers: `npm install` on npm 11.10 or newer, never `npm ci`.

## Impact

CI and repo tooling only. No source, no published surface.
