### PR TITLE
docs: drop the TL;DR heading from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,8 @@
      lands in, e.g. [NUT-29](https://github.com/cashubtc/nuts/blob/main/29.md), rather than
      the PR number: PRs get squashed and renumbered, the NUT is the stable home. -->
 
-## TL;DR
-
-<!-- One or two lines, the outcome. What this is, for someone reading nothing else. -->
+<!-- Open with a TL;DR: one or two lines of prose, no heading. The outcome, for
+     someone reading nothing else. -->
 
 ## Why
 


### PR DESCRIPTION
The `## TL;DR` heading was never wanted in the rendered description, only the summary it asked for. This drops the heading and moves its hint into a comment, so a PR opens with one or two lines of prose and then goes straight to `## Why`.

## Why

A heading that every PR carries but no reader needs is noise, and it made the opening summary look like a section to fill rather than the description's first line.

## Changes

- `## TL;DR` heading removed; its guidance now sits in the comment above `## Why`.
- The rest of the template is unchanged.

## Impact

Template only.
