### PR TITLE
chore(deps): split dependency groups and surface runtime bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     # ranges, which would let a noble major claim support for two incompatible
     # majors at once
     versioning-strategy: increase-if-necessary
+    # Runtime deps ship to consumers, so their bumps go in the changelog under
+    # Dependencies (see changelog-sections in release-please-config.json).
+    # Dev bumps keep the chore prefix release-please ignores.
+    commit-message:
+      prefix: deps
+      prefix-development: chore(deps-dev)
     cooldown:
       default-days: 7
       semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,32 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    # A dependency joins the FIRST group it matches, so order matters here:
+    # the families come before the dependency-type catch-all.
     groups:
       # @noble/* and @scure/* pin each other exactly, so they move as one PR
       noble-scure:
         patterns: ['@noble/*', '@scure/*']
-      # Dev majors (vitest, typescript, stryker, api-extractor) tend to need
-      # source changes, so they arrive individually rather than in the batch
+      # A prettier bump reformats the tree, so the PR cannot go green until
+      # someone commits `npm run format`. On its own that chore blocks nothing.
+      prettier:
+        patterns: ['prettier', 'prettier-plugin-*']
+      # The eslint family pins itself through peer ranges (@eslint/js 10 will
+      # not install against eslint 9), and a bump here means new rules firing.
+      # Before the vitest group so @vitest/eslint-plugin lands with eslint.
+      eslint:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'eslint-*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+          - '@vitest/eslint-plugin'
+      # The test stack moves together: the browser providers track both vitest
+      # and the playwright version they drive.
+      vitest:
+        patterns: ['vitest', '@vitest/*', 'playwright', '@stryker-mutator/*']
+      # Everything else dev, minor and patch only, so dev majors arrive alone
       dev-tooling:
         dependency-type: development
         update-types: ['minor', 'patch']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,10 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+    # Pinned, not inferred: once deps: commits exist in main, inference could
+    # put CI bumps in the consumer-facing Dependencies section.
+    commit-message:
+      prefix: chore(deps)
 
   # The composite action pins its own versions and needs its own entry
   - package-ecosystem: github-actions
@@ -70,3 +74,7 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+    # Pinned, not inferred: once deps: commits exist in main, inference could
+    # put CI bumps in the consumer-facing Dependencies section.
+    commit-message:
+      prefix: chore(deps)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,66 @@
       "bootstrap-sha": "f6fbb6bb8f892eb7fa300171255c84edc7f2aada"
     }
   },
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/resources/schema.json"
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/resources/schema.json",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "feature",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ]
 }


### PR DESCRIPTION
Splits the dev-tooling group into families so one stuck bump no longer holds up fifteen others, and gives runtime dependency bumps their own changelog section.

## Why

The first grouped run ([#1018](https://github.com/cashubtc/cashu-ts/pull/1018)) put 16 packages in one PR and collected two unrelated chores: prettier 3.9 reformats six files, and typescript-eslint 8.67 flags existing source. Neither can merge until both are fixed, and the eleven healthy bumps wait. [#1021](https://github.com/cashubtc/cashu-ts/pull/1021) then proposed `@eslint/js` 10 alone, which cannot install at all against eslint 9.

Separately, [#1017](https://github.com/cashubtc/cashu-ts/pull/1017) bumped `@noble/*` and `@scure/*`, which ship to consumers, under a `chore` prefix that is hidden from the changelog and starts no release. It left no trace.

## Changes

Groups now follow what you have to do when one breaks. A dependency joins the first group it matches, so families precede the `dependency-type` catch-all.

- `prettier`: its fix is always a `npm run format` commit.
- `eslint` family: peer-locked, and its fix is always rule fallout. Declared before `vitest` so `@vitest/eslint-plugin` lands here.
- `vitest` (with `playwright`, `@stryker-mutator/*`): the browser providers track both.
- `dev-tooling`: unchanged catch-all, minor and patch only.

Production bumps now use a `deps` prefix, development keeps `chore(deps-dev)`, and `release-please-config.json` gives `deps` a Dependencies section. That list replaces the preset wholesale, so it reproduces the current defaults and adds `deps`. It still starts no release on its own, which suits a bump already held seven days by cooldown.

## Impact

Dependency PRs and changelog grouping. No source changes.
