### PR TITLE
fix(utils): index the reviver holder by its actual shape

### DIFF
--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -382,7 +382,7 @@ function walkReviver(
   key: string,
   reviver: ReviverFn,
 ): unknown {
-  const current = holder[key as keyof typeof holder];
+  const current: unknown = Array.isArray(holder) ? holder[Number(key)] : holder[key];
   if (Array.isArray(current)) {
     for (let i = 0; i < current.length; i += 1) {
       const v = walkReviver(current, String(i), reviver);


### PR DESCRIPTION
Indexes the reviver holder by its actual shape instead of casting the key through `keyof`.

## Why

`walkReviver` read `holder[key as keyof typeof holder]`, where `holder` is `Record<string, unknown> | unknown[]`. `keyof` that union includes the array method names, so `current` could be typed as an unbound `Array.prototype` method rather than a value. typescript-eslint 8.67 tightened `unbound-method` enough to flag it, which is how it surfaced ([#1018](https://github.com/cashubtc/cashu-ts/pull/1018) fails lint on this line with no source change of its own).

## Changes

- Branch on the shape: numeric index for arrays, string key for records. The cast goes away and `current` is plainly `unknown`.

No test: array recursion only ever passes `String(i)`, and the root holder is a record, so no input reaches the case the old typing allowed. This is a typing fix, not a behaviour change.

Verified against typescript-eslint 8.67 in a scratch checkout of #1018, where `check-lint` and `check-types` pass with this applied and the utils suite stays green (451 tests). `npm run prtasks` passes on main.

## Impact

None for consumers. Unblocks the eslint side of #1018.
