### PR TITLE
feat(utils): export strict hex byte codecs

### DIFF
--- a/docs-src/usage/helpers.md
+++ b/docs-src/usage/helpers.md
@@ -43,3 +43,23 @@ if (found?.kind === 'token') {
   const pr = decodePaymentRequest(found.payload);
 }
 ```
+
+## `hexToBytes` and `bytesToHex`
+
+Most of the API speaks hex strings, but the crypto entry points take and return `Uint8Array`:
+`bip39seed`, the `seed` passed to `deriveKeyPair`, and the digests from `computeMessageDigest`.
+These two convert between the forms, so a seed you keep as hex in storage does not need a byte
+library of its own.
+
+Both are strict: input is not trimmed, and prefixes, whitespace, odd lengths and non-hex
+characters all throw `CTSError`. Uppercase hex is accepted and output is always lowercase.
+
+```ts
+import { hexToBytes, bytesToHex, Wallet } from '@cashu/cashu-ts';
+
+const seed = hexToBytes(storedSeedHex); // Uint8Array, ready for the Wallet
+const wallet = new Wallet(mintUrl, { bip39seed: seed });
+
+bytesToHex(seed); // back to lowercase hex for storage
+hexToBytes('0x00'); // throws CTSError: prefixes are not stripped
+```

--- a/docs-src/usage/usage_index.md
+++ b/docs-src/usage/usage_index.md
@@ -39,7 +39,7 @@ If you are building a wallet integration from scratch, read these in order:
 | [Logging](./logging.md)                             | Enable and route library logs while debugging wallet or mint behavior.          |
 | [Amounts](./amounts.md)                             | Work with the `Amount` and `AmountWithUnit` value objects.                      |
 | [Fees](./fees.md)                                   | Pick the right fee helper: input fees, sender-pays-fees, send-max, NUT-18.      |
-| [Helpers](./helpers.md)                             | Standalone helpers: normalize mint URLs, find tokens and payment requests.      |
+| [Helpers](./helpers.md)                             | Standalone helpers: normalize mint URLs, find tokens, convert hex and bytes.    |
 
 ## Related docs
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -258,6 +258,9 @@ export const BLS_HASH_TO_CURVE_DST = "CASHU_BLS12_381_G1_XMD:SHA-256_SSWU_RO_";
 // @public
 export function buildMintBackupPayload(mints: string[], timestamp: number): string;
 
+// @public
+export function bytesToHex(bytes: Uint8Array): string;
+
 // @public (undocumented)
 export type CancellerLike = SubscriptionCanceller | Promise<SubscriptionCanceller>;
 
@@ -697,6 +700,9 @@ export function hasTag(secret: Secret | string, key: string): boolean;
 export function hasValidDleq(proof: Proof, keyset: HasKeysetKeys, opts?: {
     require?: boolean;
 }): boolean;
+
+// @public
+export function hexToBytes(hex: string): Uint8Array;
 
 // @public
 export type HTLCWitness = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export * from './crypto';
 // Core Utils
 export * from './utils/core';
 export { JSONInt, type JSONIntApi } from './utils/JSONInt';
-// Export only the strict public codecs; Bytes remains an internal, lenient helper.
+// Public byte conversion is intentionally limited to strict hex codecs.
 export { bytesToHex, hexToBytes } from './utils/hex';
 
 // Payment request facade (tests rely on these at top level)

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,8 @@ export * from './crypto';
 // Core Utils
 export * from './utils/core';
 export { JSONInt, type JSONIntApi } from './utils/JSONInt';
+// Export only the strict public codecs; Bytes remains an internal, lenient helper.
+export { bytesToHex, hexToBytes } from './utils/hex';
 
 // Payment request facade (tests rely on these at top level)
 export {

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,0 +1,38 @@
+import {
+  bytesToHex as nobleBytesToHex,
+  hexToBytes as nobleHexToBytes,
+} from '@noble/hashes/utils.js';
+
+import { CTSError } from '../model/Errors';
+
+/**
+ * Converts bytes to a lowercase hex string.
+ *
+ * @param bytes Bytes to encode.
+ * @returns The unprefixed hex encoding.
+ * @throws CTSError If `bytes` is not a `Uint8Array`.
+ */
+export function bytesToHex(bytes: Uint8Array): string {
+  try {
+    return nobleBytesToHex(bytes);
+  } catch (cause) {
+    throw new CTSError('bytesToHex: expected bytes to be a Uint8Array', { cause });
+  }
+}
+
+/**
+ * Converts an unprefixed, even-length hex string to bytes.
+ *
+ * @remarks
+ * Input is not trimmed; prefixes, whitespace, odd lengths, and non-hex characters are rejected.
+ * @param hex Hex string to decode.
+ * @returns The decoded bytes.
+ * @throws CTSError If `hex` is not an unprefixed, even-length hex string.
+ */
+export function hexToBytes(hex: string): Uint8Array {
+  try {
+    return nobleHexToBytes(hex);
+  } catch (cause) {
+    throw new CTSError('hexToBytes: expected an unprefixed, even-length hex string', { cause });
+  }
+}

--- a/test/utils/hex.test.ts
+++ b/test/utils/hex.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import { bytesToHex, CTSError, hexToBytes } from '../../src';
+
+describe('hex byte codecs', () => {
+  test('round trips bytes through lowercase hex', () => {
+    const bytes = new Uint8Array([0, 1, 127, 128, 255]);
+
+    expect(bytesToHex(bytes)).toBe('00017f80ff');
+    expect(hexToBytes(bytesToHex(bytes))).toEqual(bytes);
+  });
+
+  test('accepts empty and uppercase hex', () => {
+    expect(hexToBytes('')).toEqual(new Uint8Array());
+    expect(hexToBytes('ABCD')).toEqual(new Uint8Array([0xab, 0xcd]));
+  });
+
+  test.each(['0', 'gg', '0x00', ' 00 '])('rejects non-strict input %j', (hex) => {
+    expect(() => hexToBytes(hex)).toThrow(CTSError);
+  });
+
+  test('rejects invalid argument types', () => {
+    expect(() => hexToBytes(123 as never)).toThrow(CTSError);
+    expect(() => bytesToHex('ab' as never)).toThrow(CTSError);
+  });
+});


### PR DESCRIPTION
Export package-owned `bytesToHex` and `hexToBytes` helpers so consumers can bridge hex strings and Cashu-TS byte-valued APIs without importing Noble directly.

## Why

Cashu-TS accepts and returns `Uint8Array` across its public crypto API, but it does not currently provide the common hex/byte conversion boundary. Consumers that only need this bridge must implement it themselves or add a direct byte-library dependency.

## Changes

- Add standalone `bytesToHex` and `hexToBytes` functions backed by Noble internally.
- Export them explicitly from the package root.
- Document the strict contract: unprefixed, even-length hex with no trimming.
- Translate validation failures to `CTSError` with a package-owned message while preserving the underlying error as `cause`.
- Cover empty input, uppercase hex, round trips, malformed hex, and wrong runtime argument types.
- Update the generated API report.

The internal `Bytes` helper remains unexported. Consolidating existing internal hex implementations is left to a follow-up so this PR stays focused on the public API.

## Impact

This is an additive public API change with no existing behavior changes.

## Testing

- `npm run prtasks`
- 7,523 tests passed across Node, Chromium, Firefox, and WebKit; 3 skipped.
