### PR TITLE
refactor(utils): remove obsolete byte helpers

### DIFF
--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { randomBytes } from '@noble/hashes/utils.js';
 
 import { type Logger, NULL_LOGGER, safeCallback } from '../logger';
 import { CTSError } from '../model/Errors';

--- a/src/crypto/NUT01.ts
+++ b/src/crypto/NUT01.ts
@@ -1,8 +1,8 @@
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass.js';
 import { bls12_381 } from '@noble/curves/bls12-381.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { HDKey } from '@scure/bip32';
 
 import { CTSError } from '../model/Errors';

--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, randomBytes } from '@noble/curves/utils.js';
+import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -1,5 +1,5 @@
 import { schnorr } from '@noble/curves/secp256k1.js';
-import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
 import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -1,6 +1,7 @@
-import { bytesToHex, numberToBytesBE } from '@noble/curves/utils.js';
+import { numberToBytesBE } from '@noble/curves/utils.js';
 import { hmac } from '@noble/hashes/hmac.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { HDKey, HARDENED_OFFSET } from '@scure/bip32';
 
 import { CTSError } from '../model/Errors';
@@ -162,6 +163,10 @@ export function createSecretAndBlindingFactorDeriver(
 
 function getDerivationKind(keysetId: string): DerivationKind {
   const isValidHex = /^[a-fA-F0-9]+$/.test(keysetId);
+  const isHmacHexVersion = keysetId.startsWith('01') || keysetId.startsWith('02');
+  if (isValidHex && isHmacHexVersion && keysetId.length % 2 !== 0) {
+    throw new CTSError('Invalid hex string: odd length.');
+  }
   if (!isValidHex && isBase64String(keysetId)) {
     return DerivationKind.DEPRECATED_BIP32;
   }
@@ -169,7 +174,7 @@ function getDerivationKind(keysetId: string): DerivationKind {
     return DerivationKind.DEPRECATED_BIP32;
   }
   // Strict version gate: does not assume future keyset versions are BLS.
-  if (isValidHex && (keysetId.startsWith('01') || keysetId.startsWith('02'))) {
+  if (isValidHex && isHmacHexVersion) {
     return DerivationKind.HMAC_SHA256;
   }
   throw new CTSError(`Unrecognized keyset ID version ${keysetId.slice(0, 2)}`);
@@ -206,13 +211,13 @@ function deriveHmacSecretAndBlindingFactor(
   }
   const base = Bytes.concat(
     Bytes.fromString('Cashu_KDF_HMAC_SHA256'),
-    Bytes.fromHex(keysetId),
+    hexToBytes(keysetId),
     // numberToBytesBE throws rather than wrapping, so an out-of-range counter can never
     // be silently encoded as a different one even if the guard above is ever moved.
     numberToBytesBE(counter, 8),
   );
   return {
-    secret: hmac(sha256, seed, Bytes.concat(base, Bytes.fromHex('00'))),
+    secret: hmac(sha256, seed, Bytes.concat(base, hexToBytes('00'))),
     blindingFactor: computeBlindingFactor(seed, base, keysetId),
   };
 }
@@ -224,7 +229,7 @@ function computeBlindingFactor(seed: Uint8Array, base: Uint8Array, keysetId: str
     // BLS_FR_ORDER ~ 0.45·2^256; rejection sampling yields a uniform sample over Fr*. Match the
     // NUT-00 batch-weight pattern. Loop cap is defensive; expected attempts ≈ 2.2.
     for (let attempt = 0; attempt < 1 << 16; attempt++) {
-      const msg = Bytes.concat(base, Bytes.fromHex('01'), numberToBytesBE(attempt, 4));
+      const msg = Bytes.concat(base, hexToBytes('01'), numberToBytesBE(attempt, 4));
       const digest = hmac(sha256, seed, msg);
       const x = Bytes.toBigInt(digest);
       if (x === 0n || x >= BLS_FR_ORDER) continue;
@@ -235,7 +240,7 @@ function computeBlindingFactor(seed: Uint8Array, base: Uint8Array, keysetId: str
   }
   // V2 (secp256k1): single HMAC, single-subtraction modular reduction. SECP256K1_N is ~2^256 so
   // at most one subtraction is needed; bias is ~2^-128 (negligible).
-  const digest = hmac(sha256, seed, Bytes.concat(base, Bytes.fromHex('01')));
+  const digest = hmac(sha256, seed, Bytes.concat(base, hexToBytes('01')));
   const x = Bytes.toBigInt(digest);
   const reduced = x >= SECP256K1_N ? x - SECP256K1_N : x;
   /* c8 ignore next */

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -1,5 +1,5 @@
-import { bytesToHex, hexToBytes, randomBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils.js';
 
 import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -1,7 +1,7 @@
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass.js';
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
-import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 

--- a/src/crypto/curve_bls.ts
+++ b/src/crypto/curve_bls.ts
@@ -1,15 +1,15 @@
 import { type Fp2 } from '@noble/curves/abstract/tower.js';
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass.js';
 import { bls12_381 } from '@noble/curves/bls12-381.js';
-import {
-  randomBytes,
-  bytesToHex,
-  bytesToNumberBE,
-  hexToBytes,
-  numberToBytesBE,
-} from '@noble/curves/utils.js';
+import { bytesToNumberBE, numberToBytesBE } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
+import {
+  bytesToHex,
+  concatBytes,
+  hexToBytes,
+  randomBytes,
+  utf8ToBytes,
+} from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 

--- a/src/crypto/curve_secp.ts
+++ b/src/crypto/curve_secp.ts
@@ -1,8 +1,7 @@
 import { type WeierstrassPoint } from '@noble/curves/abstract/weierstrass.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { randomBytes, bytesToHex } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { utf8ToBytes } from '@noble/hashes/utils.js';
+import { bytesToHex, randomBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 import { Bytes } from '../utils';

--- a/src/utils/Bytes.ts
+++ b/src/utils/Bytes.ts
@@ -15,32 +15,6 @@ function getBufferConstructor(): BufferConstructorLike | undefined {
 }
 
 export class Bytes {
-  static fromHex(hex: string): Uint8Array {
-    hex = hex.trim();
-    if (hex.length === 0) {
-      return new Uint8Array(0);
-    }
-    if (hex.length < 2 || hex.length & 1) {
-      throw new CTSError('Invalid hex string: odd length.');
-    }
-    if (hex.startsWith('0x') || hex.startsWith('0X')) {
-      hex = hex.slice(2);
-    }
-    const match = hex.match(/^[0-9a-fA-F]*$/);
-    if (!match) {
-      throw new CTSError('Invalid hex string: contains non-hex characters');
-    }
-    const matches = hex.match(/.{1,2}/g);
-    if (!matches) {
-      throw new CTSError('Invalid hex string');
-    }
-    return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
-  }
-
-  static toHex(bytes: Uint8Array): string {
-    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
-  }
-
   static fromString(str: string): Uint8Array {
     str = str.trim();
     return new TextEncoder().encode(str);
@@ -59,10 +33,6 @@ export class Bytes {
       offset += arr.length;
     }
     return result;
-  }
-
-  static alloc(size: number): Uint8Array {
-    return new Uint8Array(size);
   }
 
   static toBase64(bytes: Uint8Array): string {
@@ -116,44 +86,11 @@ export class Bytes {
     return result === 0;
   }
 
-  static compare(a: Uint8Array, b: Uint8Array): number {
-    const minLength = Math.min(a.length, b.length);
-    for (let i = 0; i < minLength; i++) {
-      if (a[i] < b[i]) return -1;
-      if (a[i] > b[i]) return 1;
-    }
-    return a.length - b.length;
-  }
-
   static toBigInt(bytes: Uint8Array): bigint {
     let result = 0n;
     for (const byte of bytes) {
       result = (result << 8n) | BigInt(byte);
     }
     return result;
-  }
-
-  static fromBigInt(value: bigint): Uint8Array {
-    if (value < 0n) {
-      throw new RangeError('value must be non-negative');
-    }
-    if (value === 0n) {
-      return new Uint8Array([0]);
-    }
-    // Calculate Uint8Array length
-    let temp = value;
-    let length = 0;
-    while (temp > 0n) {
-      length++;
-      temp >>= 8n;
-    }
-    // Fill it from the end (big endian)
-    const out = new Uint8Array(length);
-    temp = value;
-    for (let i = length - 1; i >= 0; i--) {
-      out[i] = Number(temp & 0xffn);
-      temp >>= 8n;
-    }
-    return out;
   }
 }

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1,5 +1,5 @@
-import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
 import {
   type DLEQ,
@@ -549,7 +549,7 @@ export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): str
           .map(([, pubKey]) => hexToBytes(pubKey)),
       );
       const hash = sha256(pubkeysConcat);
-      const hashHex = Bytes.toHex(hash).slice(0, 14);
+      const hashHex = bytesToHex(hash).slice(0, 14);
       return '00' + hashHex;
     }
     case 1:
@@ -573,7 +573,7 @@ export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): str
         preimage += `|final_expiry:${expiry}`;
       }
       const hash = sha256(Bytes.fromString(preimage));
-      const hashHex = Bytes.toHex(hash);
+      const hashHex = bytesToHex(hash);
       return (versionByte === 2 ? '02' : '01') + hashHex;
     }
     default:

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -1,4 +1,4 @@
-import { hexToBytes } from '@noble/curves/utils.js';
+import { hexToBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 import { type MintKeyset, type MintKeys } from '../model/types';

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -1,142 +1,9 @@
+import { hexToBytes } from '@noble/hashes/utils.js';
 import { describe, test, expect } from 'vitest';
 
 import { Bytes } from '../src/utils/Bytes';
 
 describe('Bytes utility class', () => {
-  describe('fromHex', () => {
-    test('should convert valid hex string to Uint8Array', () => {
-      const hex = 'deadbeef';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle hex string with 0x prefix', () => {
-      const hex = '0xdeadbeef';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle hex string with 0X prefix', () => {
-      const hex = '0Xdeadbeef';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle uppercase hex characters', () => {
-      const hex = 'DEADBEEF';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle mixed case hex characters', () => {
-      const hex = 'DeAdBeEf';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle empty string', () => {
-      const hex = '';
-      const result = Bytes.fromHex(hex);
-      expect(result).toEqual(new Uint8Array(0));
-    });
-
-    test('should handle whitespace-only string', () => {
-      const hex = '   ';
-      const result = Bytes.fromHex(hex);
-      expect(result).toEqual(new Uint8Array(0));
-    });
-
-    test('should handle hex string with leading/trailing whitespace', () => {
-      const hex = '  deadbeef  ';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle single byte hex', () => {
-      const hex = 'ff';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0xff]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should handle zero bytes', () => {
-      const hex = '0000';
-      const result = Bytes.fromHex(hex);
-      const expected = new Uint8Array([0x00, 0x00]);
-      expect(result).toEqual(expected);
-    });
-
-    test('should throw error for odd length hex string', () => {
-      const hex = 'deadbee';
-      expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
-    });
-
-    test('should throw error for single character', () => {
-      const hex = 'f';
-      expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
-    });
-
-    test('should throw error for non-hex characters', () => {
-      const hex = 'deadbeeg';
-      expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: contains non-hex characters');
-    });
-
-    test('should throw error for hex with special characters', () => {
-      const hex = 'dead-beef';
-      expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
-    });
-
-    test('should throw error for hex with spaces in middle', () => {
-      const hex = 'dead beef';
-      expect(() => Bytes.fromHex(hex)).toThrow('Invalid hex string: odd length.');
-    });
-  });
-
-  describe('toHex', () => {
-    test('should convert Uint8Array to hex string', () => {
-      const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      const result = Bytes.toHex(bytes);
-      expect(result).toBe('deadbeef');
-    });
-
-    test('should handle empty Uint8Array', () => {
-      const bytes = new Uint8Array(0);
-      const result = Bytes.toHex(bytes);
-      expect(result).toBe('');
-    });
-
-    test('should handle single byte', () => {
-      const bytes = new Uint8Array([0xff]);
-      const result = Bytes.toHex(bytes);
-      expect(result).toBe('ff');
-    });
-
-    test('should handle zero bytes', () => {
-      const bytes = new Uint8Array([0x00, 0x00]);
-      const result = Bytes.toHex(bytes);
-      expect(result).toBe('0000');
-    });
-
-    test('should pad single digit hex values', () => {
-      const bytes = new Uint8Array([0x01, 0x0a, 0x10]);
-      const result = Bytes.toHex(bytes);
-      expect(result).toBe('010a10');
-    });
-
-    test('should be consistent with fromHex', () => {
-      const originalHex = 'deadbeef01234567';
-      const bytes = Bytes.fromHex(originalHex);
-      const resultHex = Bytes.toHex(bytes);
-      expect(resultHex).toBe(originalHex);
-    });
-  });
-
   describe('fromString', () => {
     test('should convert string to Uint8Array', () => {
       const str = 'hello';
@@ -258,27 +125,6 @@ describe('Bytes utility class', () => {
       const arr2 = new Uint8Array(0);
       const result = Bytes.concat(arr1, arr2);
       expect(result).toEqual(new Uint8Array(0));
-    });
-  });
-
-  describe('alloc', () => {
-    test('should allocate Uint8Array of specified size', () => {
-      const size = 10;
-      const result = Bytes.alloc(size);
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(size);
-      expect(result).toEqual(new Uint8Array(size));
-    });
-
-    test('should allocate zero-length array', () => {
-      const result = Bytes.alloc(0);
-      expect(result).toEqual(new Uint8Array(0));
-    });
-
-    test('should initialize with zeros', () => {
-      const result = Bytes.alloc(5);
-      const expected = new Uint8Array([0, 0, 0, 0, 0]);
-      expect(result).toEqual(expected);
     });
   });
 
@@ -425,87 +271,7 @@ describe('Bytes utility class', () => {
     });
   });
 
-  describe('compare', () => {
-    test('should return 0 for identical arrays', () => {
-      const a = new Uint8Array([0x01, 0x02, 0x03]);
-      const b = new Uint8Array([0x01, 0x02, 0x03]);
-      expect(Bytes.compare(a, b)).toBe(0);
-    });
-
-    test('should return 0 for empty arrays', () => {
-      const a = new Uint8Array(0);
-      const b = new Uint8Array(0);
-      expect(Bytes.compare(a, b)).toBe(0);
-    });
-
-    test('should return negative for lexicographically smaller first array', () => {
-      const a = new Uint8Array([0x01, 0x02, 0x03]);
-      const b = new Uint8Array([0x01, 0x02, 0x04]);
-      expect(Bytes.compare(a, b)).toBe(-1);
-    });
-
-    test('should return positive for lexicographically larger first array', () => {
-      const a = new Uint8Array([0x01, 0x02, 0x04]);
-      const b = new Uint8Array([0x01, 0x02, 0x03]);
-      expect(Bytes.compare(a, b)).toBe(1);
-    });
-
-    test('should compare by length when one is prefix of another', () => {
-      const a = new Uint8Array([0x01, 0x02]);
-      const b = new Uint8Array([0x01, 0x02, 0x03]);
-      expect(Bytes.compare(a, b)).toBe(-1);
-      expect(Bytes.compare(b, a)).toBe(1);
-    });
-
-    test('should handle empty vs non-empty', () => {
-      const a = new Uint8Array(0);
-      const b = new Uint8Array([0x01]);
-      expect(Bytes.compare(a, b)).toBe(-1);
-      expect(Bytes.compare(b, a)).toBe(1);
-    });
-
-    test('should handle first byte difference', () => {
-      const a = new Uint8Array([0x00, 0xff, 0xff]);
-      const b = new Uint8Array([0x01, 0x00, 0x00]);
-      expect(Bytes.compare(a, b)).toBe(-1);
-    });
-
-    test('should be anti-symmetric', () => {
-      const a = new Uint8Array([0x01, 0x02, 0x03]);
-      const b = new Uint8Array([0x04, 0x05, 0x06]);
-      expect(Bytes.compare(a, b)).toBe(-Bytes.compare(b, a));
-    });
-
-    test('should be transitive', () => {
-      const a = new Uint8Array([0x01]);
-      const b = new Uint8Array([0x02]);
-      const c = new Uint8Array([0x03]);
-      expect(Bytes.compare(a, b)).toBeLessThan(0);
-      expect(Bytes.compare(b, c)).toBeLessThan(0);
-      expect(Bytes.compare(a, c)).toBeLessThan(0);
-    });
-
-    test('should handle single byte arrays', () => {
-      const a = new Uint8Array([0x42]);
-      const b = new Uint8Array([0x43]);
-      expect(Bytes.compare(a, b)).toBe(-1);
-      expect(Bytes.compare(b, a)).toBe(1);
-    });
-  });
-
   describe('integration tests', () => {
-    test('hex roundtrip with various data', () => {
-      const testCases = ['', '00', 'ff', 'deadbeef', '0123456789abcdef', 'a0b1c2d3e4f5'];
-
-      testCases.forEach((hex) => {
-        if (hex.length > 0) {
-          const bytes = Bytes.fromHex(hex);
-          const result = Bytes.toHex(bytes);
-          expect(result).toBe(hex);
-        }
-      });
-    });
-
     test('string roundtrip with various encodings', () => {
       const testCases = [
         '',
@@ -545,7 +311,7 @@ describe('Bytes utility class', () => {
     test('concat and split operations', () => {
       const part1 = Bytes.fromString('Hello, ');
       const part2 = Bytes.fromString('World!');
-      const part3 = Bytes.fromHex('deadbeef');
+      const part3 = hexToBytes('deadbeef');
 
       const combined = Bytes.concat(part1, part2, part3);
 
@@ -557,33 +323,6 @@ describe('Bytes utility class', () => {
       expect(extractedPart1).toEqual(part1);
       expect(extractedPart2).toEqual(part2);
       expect(extractedPart3).toEqual(part3);
-    });
-
-    test('comparison and equality consistency', () => {
-      const arrays = [
-        new Uint8Array([]),
-        new Uint8Array([0x00]),
-        new Uint8Array([0x01]),
-        new Uint8Array([0x00, 0x00]),
-        new Uint8Array([0x00, 0x01]),
-        new Uint8Array([0x01, 0x00]),
-        new Uint8Array([0xff, 0xff]),
-      ];
-
-      for (let i = 0; i < arrays.length; i++) {
-        for (let j = 0; j < arrays.length; j++) {
-          const a = arrays[i];
-          const b = arrays[j];
-          const isEqual = Bytes.equals(a, b);
-          const comparison = Bytes.compare(a, b);
-
-          if (isEqual) {
-            expect(comparison).toBe(0);
-          } else {
-            expect(comparison).not.toBe(0);
-          }
-        }
-      }
     });
   });
 });

--- a/test/crypto/NUT09.test.ts
+++ b/test/crypto/NUT09.test.ts
@@ -1,16 +1,15 @@
-import { bytesToHex } from '@noble/curves/utils.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
 
 import { deriveSecretAndBlindingFactor, getKeysetIdInt } from '../../src/crypto';
-import { Bytes } from '../../src/utils';
 
 // The standalone deriveSecret() helper was removed in v5; derive it locally for these tests.
 const deriveSecret = (seed: Uint8Array, keysetId: string, counter: number): Uint8Array =>
   deriveSecretAndBlindingFactor(seed, keysetId, counter).secret;
 
 const seed = Uint8Array.from(
-  Bytes.fromHex(
+  hexToBytes(
     'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
   ),
 );
@@ -28,7 +27,7 @@ describe('testing hdkey from seed', () => {
 
     const seed_expected =
       'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8';
-    const seed_uint8_array_expected = Bytes.fromHex(seed_expected);
+    const seed_uint8_array_expected = hexToBytes(seed_expected);
     expect(seed).toEqual(seed_uint8_array_expected);
   });
 });
@@ -118,7 +117,7 @@ describe('testing deterministic blindedMessage', () => {
 describe('test private key derivation from derivation path -- deprecated', () => {
   const seed =
     'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8';
-  const seed_uint8_array = Bytes.fromHex(seed);
+  const seed_uint8_array = hexToBytes(seed);
   const hdkey = HDKey.fromMasterSeed(seed_uint8_array);
   const expected_privatekey = '9d32fc57e6fa2942d05ee475d28ba6a56839b8cb8a3f174b05ed0ed9d3a420f6';
   const derivation_path = "m/129372'/0'/2004500376'/0'/0";

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -1,8 +1,9 @@
-import { bytesToHex } from '@noble/hashes/utils.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
 
 import { BLS_FR_ORDER, deriveSecretAndBlindingFactor, getKeysetIdInt } from '../../src/crypto';
+import { CTSError } from '../../src/model/Errors';
 import { Bytes } from '../../src/utils';
 
 // The standalone deriveBlindingFactor() helper was removed in v5; derive it locally for these tests.
@@ -63,7 +64,7 @@ describe('v2 derivation spec vectors', () => {
   // Lock-in for nuts/tests/13-tests.md "Version 2: Secret derivation". cashu-ts works in seed
   // space, so the spec's mnemonic ("half depart obvious quality work element tank gorilla view
   // sugar picture humble") is pre-derived to its BIP39 seed here.
-  const seed = Bytes.fromHex(
+  const seed = hexToBytes(
     'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25' +
       '780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
   );
@@ -123,7 +124,7 @@ describe('HMAC counter range', () => {
 
 describe('derivation kind selection', () => {
   // Known BIP-32 seed (NUT-13 spec / NUT-09 fixtures).
-  const seed = Bytes.fromHex(
+  const seed = hexToBytes(
     'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
   );
 
@@ -160,5 +161,9 @@ describe('derivation kind selection', () => {
     expect(() => deriveSecretAndBlindingFactor(seed, '03ff', 0)).toThrow(
       /^Unrecognized keyset ID version 03$/,
     );
+  });
+
+  test('rejects an odd-length known-version keyset id as a CTSError', () => {
+    expect(() => deriveSecretAndBlindingFactor(seed, '01f', 0)).toThrow(CTSError);
   });
 });

--- a/test/crypto/bls_random_scalar.test.ts
+++ b/test/crypto/bls_random_scalar.test.ts
@@ -9,9 +9,9 @@ import { BLS_FR_ORDER, blindMessageBls } from '../../src/crypto';
 // which biases scalars small; this guards against a regression back to that.
 const { randomBytesMock } = vi.hoisted(() => ({ randomBytesMock: vi.fn() }));
 
-vi.mock('@noble/curves/utils.js', async (importActual) => {
+vi.mock('@noble/hashes/utils.js', async (importActual) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest importActual generic
-  const actual = await importActual<typeof import('@noble/curves/utils.js')>();
+  const actual = await importActual<typeof import('@noble/hashes/utils.js')>();
   return { ...actual, randomBytes: randomBytesMock };
 });
 

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -1,3 +1,4 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test, vi } from 'vitest';
 
 import { getPubKeyFromPrivKey, type P2PKOptions } from '../../src/crypto';
@@ -6,7 +7,6 @@ import { OutputData, isOutputDataFactory } from '../../src/model/OutputData';
 import type { OutputDataFactory, OutputDataLike } from '../../src/model/OutputData';
 import { DefaultOutputDataCreator } from '../../src/model/OutputDataCreator';
 import type { HasKeysetKeys, SerializedBlindedSignature, Proof } from '../../src/model/types';
-import { Bytes } from '../../src/utils';
 
 describe('DefaultOutputDataCreator', () => {
   test('delegates single deterministic output creation to OutputData', () => {
@@ -37,8 +37,8 @@ describe('DefaultOutputDataCreator', () => {
   });
 
   test('default P2PK batch shares one ephemeral key for a blinded SIG_ALL split', () => {
-    const privkey = Bytes.fromHex('01'.repeat(32));
-    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
     const keyset: HasKeysetKeys = {
       id: '009a1f293253e41e',
       keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
@@ -55,8 +55,8 @@ describe('DefaultOutputDataCreator', () => {
   });
 
   test('a subclassed single-output P2PK hook is still called once per split amount', () => {
-    const privkey = Bytes.fromHex('01'.repeat(32));
-    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
     const keyset: HasKeysetKeys = {
       id: '009a1f293253e41e',
       keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
@@ -170,8 +170,8 @@ describe('OutputData helpers', () => {
   });
 
   test('preserves ephemeral P2PK blinding data when serializing output data', () => {
-    const privkey = Bytes.fromHex('01'.repeat(32));
-    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
     const output = OutputData.createSingleP2PKData(
       {
         kind: 'P2PK',
@@ -188,8 +188,8 @@ describe('OutputData helpers', () => {
   });
 
   test('keeps blinded HTLC lock keys in pubkeys tags', () => {
-    const privkey = Bytes.fromHex('01'.repeat(32));
-    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
     const output = OutputData.createSingleP2PKData(
       {
         kind: 'HTLC',
@@ -215,8 +215,8 @@ describe('OutputData helpers', () => {
   });
 
   test('a blinded SIG_ALL batch shares one ephemeral key across all outputs', () => {
-    const privkey = Bytes.fromHex('01'.repeat(32));
-    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
     const keyset: HasKeysetKeys = {
       id: '009a1f293253e41e',
       keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
@@ -248,8 +248,8 @@ describe('OutputData helpers', () => {
   });
 
   test('a blinded SIG_INPUTS batch blinds each output with its own ephemeral key', () => {
-    const privkey = Bytes.fromHex('01'.repeat(32));
-    const pubkey = Bytes.toHex(getPubKeyFromPrivKey(privkey));
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
     const keyset: HasKeysetKeys = {
       id: '009a1f293253e41e',
       keys: { '1': 'unused', '2': 'unused', '4': 'unused' },

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -1,3 +1,4 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { test, describe, expect } from 'vitest';
 
 import {
@@ -16,7 +17,6 @@ import {
   type MeltPreview,
   type SwapPreview,
 } from '../../src';
-import { Bytes } from '../../src/utils';
 
 const dummyProof: Proof = {
   id: 'testid',
@@ -666,7 +666,7 @@ describe('SigAll — mergeSignatures edge cases', () => {
 });
 
 describe('SigAll — signing binds to package contents', () => {
-  const signerPubkey = () => Bytes.toHex(getPubKeyFromPrivKey(Bytes.fromHex(dummyPrivkey)));
+  const signerPubkey = () => bytesToHex(getPubKeyFromPrivKey(hexToBytes(dummyPrivkey)));
 
   test('signPackage emits one signature, verifiable over the recomputed v0 digest', () => {
     const pkg = SigAll.extractSwapPackage(makeSwapPreview());

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -1,4 +1,4 @@
-import { hexToBytes } from '@noble/curves/utils.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
@@ -23,7 +23,7 @@ import {
 import { verifyMintQuoteSignature } from '../../src/crypto';
 import { verifyMintQuoteSignatureLegacy } from '../../src/crypto/NUT20';
 import request from '../../src/transport';
-import { Bytes, sumProofs } from '../../src/utils';
+import { sumProofs } from '../../src/utils';
 
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp, invoice } from './_setup';
 
@@ -672,7 +672,7 @@ describe('requestTokens', () => {
     });
 
     expect(preview.outputData.length).toBeGreaterThan(0);
-    const secrets = preview.outputData.map((p) => Bytes.toHex(p.secret));
+    const secrets = preview.outputData.map((p) => bytesToHex(p.secret));
     expect(new Set(secrets).size).toBe(secrets.length);
     expect(await wallet.counters.peekNext(keysetId)).toBe(preview.outputData.length);
   });


### PR DESCRIPTION
## Summary

- remove unused and duplicated hex, allocation, comparison, and bigint encoding methods from the internal Bytes class
- use @noble/hashes/utils.js as the production source for generic byte helpers, retaining curves utilities only for number conversion
- preserve CTSError validation for odd-length HMAC keyset IDs and migrate affected tests

No public API change.

## Testing

- npm run prtasks