### PR TITLE
Authenticate protected websockets in-band

### DIFF
--- a/docs-src/wallet_events/wallet_events.md
+++ b/docs-src/wallet_events/wallet_events.md
@@ -14,6 +14,8 @@
 
 > **Note:** For the 'Updates' subscriptions, the first call auto-establishes a mint WebSocket and errors surface via the onErr callback.
 
+> **Note:** When the mint protects `GET /v1/ws` (NUT-21/NUT-22), the connection is authenticated in-band before the first subscription, since a browser WebSocket cannot send an auth header. That costs one blind auth token per connection, not per subscription, and a connection that never subscribes spends nothing. Repeated rejections stop the wallet from retrying rather than draining the token pool; the resulting `WsAuthError` carries `terminal: true`.
+
 **One-shot helpers:**
 
 - `wallet.on.onceMintPaid(id, { signal, timeoutMs })` – resolve once quote paid

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2584,9 +2584,22 @@ export type WebSocketSupport = {
     commands: string[];
 };
 
+// @public
+export class WsAuthError extends CTSError {
+    constructor(message: string, options?: {
+        code?: number;
+        terminal?: boolean;
+        cause?: unknown;
+    });
+    // (undocumented)
+    readonly code?: number;
+    // (undocumented)
+    readonly terminal: boolean;
+}
+
 // @public (undocumented)
 export class WSConnection {
-    constructor(url: string, logger?: Logger);
+    constructor(url: string, logger?: Logger, getAuthToken?: () => Promise<string | undefined>);
     // (undocumented)
     get activeSubscriptions(): string[];
     // (undocumented)
@@ -2598,6 +2611,7 @@ export class WSConnection {
     connect(timeoutMs?: number): Promise<void>;
     // (undocumented)
     createSubscription<TPayload = unknown>(params: Omit<JsonRpcReqParams, 'subId'>, callback: (payload: TPayload) => void, errorCallback: (e: Error) => void): string;
+    ensureAuthenticated(timeoutMs?: number): Promise<void>;
     // (undocumented)
     ensureConnection(timeoutMs?: number): Promise<void>;
     // (undocumented)
@@ -2612,6 +2626,15 @@ export class WSConnection {
     setLogger(logger: Logger): void;
     // (undocumented)
     readonly url: URL;
+}
+
+// @public
+export class WsRpcError extends CTSError {
+    constructor(code: number, message: string, options?: {
+        cause?: unknown;
+    });
+    // (undocumented)
+    readonly code: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,8 @@ export {
   RateLimitError,
   StaleKeysetError,
   UnknownKeysetError,
+  WsAuthError,
+  WsRpcError,
 } from './model/Errors';
 
 // Low-level helpers/types that appear in public surfaces

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -1074,7 +1074,11 @@ class Mint {
       const wsUrl = mintUrl.toString();
 
       if (!this.ws) {
-        this.ws = new WSConnection(wsUrl, this._logger);
+        this.ws = new WSConnection(
+          wsUrl,
+          this._logger,
+          this._authProvider ? () => this.getWsAuthToken() : undefined,
+        );
       }
 
       await this.ws.ensureConnection();
@@ -1147,6 +1151,23 @@ class Mint {
     if (!info.requiresBlindAuthToken(method, path)) return undefined;
     const bat = await this._authProvider.getBlindAuthToken({ method, path });
     return bat;
+  }
+
+  /**
+   * Returns the token for the in-band NUT-17 WebSocket `authenticate` command, or undefined when
+   * the mint does not protect `/v1/ws`.
+   *
+   * @remarks
+   * A blind auth token is preferred because the command carries exactly one credential and the mint
+   * recognises a BAT by its `authA` prefix. The clear auth branch is forward looking: mints today
+   * expect a CAT in the upgrade header and refuse a header-less upgrade outright, which fails
+   * before any frame can be sent, so it only engages on a mint that accepts one.
+   */
+  private async getWsAuthToken(): Promise<string | undefined> {
+    const info = await this.getLazyMintInfo();
+    const bat = await this.handleBlindAuth('GET', '/v1/ws', info);
+    if (bat) return bat;
+    return this.handleClearAuth('GET', '/v1/ws', info);
   }
 
   private async requestWithAuth<T>(

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -182,3 +182,46 @@ export function isMintOperationError(e: unknown): e is MintOperationError {
     (e instanceof Error && e.name === 'MintOperationError' && 'code' in e)
   );
 }
+
+/**
+ * A JSON-RPC error frame received over the NUT-17 WebSocket.
+ *
+ * @remarks
+ * Carries the protocol error code, which the subscription callbacks cannot receive otherwise: they
+ * are typed `(e: Error) => void`. Relevant codes are 30001 (clear auth required), 30002 (clear auth
+ * failed), 31001 (blind auth required) and 31002 (blind auth failed). A 31001 on a subscribe means
+ * the connection was never authenticated. See [error
+ * codes](https://github.com/cashubtc/nuts/blob/main/error_codes.md).
+ */
+export class WsRpcError extends CTSError {
+  readonly code: number;
+
+  constructor(code: number, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.code = code;
+    this.name = 'WsRpcError';
+    Object.setPrototypeOf(this, WsRpcError.prototype);
+  }
+}
+
+/**
+ * Thrown when authenticating a NUT-17 WebSocket connection fails.
+ *
+ * @remarks
+ * `terminal` means this connection has failed to authenticate too many times in a row and will no
+ * longer try: further `ensureAuthenticated()` calls reject immediately without spending another
+ * token. That bound exists because a blind auth token is spent the moment it leaves the pool, so an
+ * unbounded reconnect loop would drain the pool. Recovery requires a new connection.
+ */
+export class WsAuthError extends CTSError {
+  readonly code?: number;
+  readonly terminal: boolean;
+
+  constructor(message: string, options?: { code?: number; terminal?: boolean; cause?: unknown }) {
+    super(message, options);
+    this.code = options?.code;
+    this.terminal = options?.terminal ?? false;
+    this.name = 'WsAuthError';
+    Object.setPrototypeOf(this, WsAuthError.prototype);
+  }
+}

--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -1,5 +1,5 @@
 import { type Logger, NULL_LOGGER } from '../logger';
-import { CTSError } from '../model/Errors';
+import { CTSError, WsAuthError, WsRpcError } from '../model/Errors';
 import { type JsonRpcMessage, type JsonRpcReqParams, type RpcSubId } from '../model/types';
 import { generateUuidV7 } from '../utils/uuid.js';
 
@@ -45,12 +45,21 @@ export class MessageQueue {
 
 // Internal interface for RPC listeners
 interface RpcListener {
-  callback: () => void;
+  callback: (result: unknown) => void;
   errorCallback: (e: Error) => void;
 }
 
 type OnOpenSuccess = () => void;
 type OnOpenError = (err: Error) => void;
+
+/**
+ * Consecutive failed `authenticate` attempts tolerated before a connection stops trying.
+ *
+ * @remarks
+ * A blind auth token is spent the moment it leaves the pool, so a mint that keeps rejecting would
+ * drain the wallet one reconnect at a time without this bound.
+ */
+const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
 
 export class WSConnection {
   public readonly url: URL;
@@ -64,12 +73,33 @@ export class WSConnection {
   private rpcId = 0;
   private _logger: Logger;
   private onCloseCallbacks: Array<(e: CloseEvent) => void> = [];
+  private readonly getAuthToken?: () => Promise<string | undefined>;
+  /**
+   * Keyed on the socket so a reconnect re-authenticates with no teardown bookkeeping: a new socket
+   * is a different object, so the cache misses.
+   */
+  private authState?: { socket: WebSocket; promise: Promise<void> };
+  private consecutiveAuthFailures = 0;
+  /**
+   * Fails an in-flight `authenticate` when the socket closes.
+   *
+   * @remarks
+   * A clean close clears the pending RPC listeners without failing them, so without this the
+   * attempt would wait out its whole timeout instead of failing at once.
+   */
+  private abortPendingAuth?: (e: Error) => void;
 
-  constructor(url: string, logger?: Logger) {
+  /**
+   * @param getAuthToken Supplies the NUT-21/22 token for the in-band `authenticate` command. It
+   *   must return `undefined` when the mint does not protect `/v1/ws`, decided from mint info
+   *   without consuming a token, so a connection that never subscribes spends nothing.
+   */
+  constructor(url: string, logger?: Logger, getAuthToken?: () => Promise<string | undefined>) {
     this._WS = getWebSocketImpl();
     this.url = new URL(url);
     this.messageQueue = new MessageQueue();
     this._logger = logger ?? NULL_LOGGER;
+    this.getAuthToken = getAuthToken;
   }
 
   setLogger(logger: Logger) {
@@ -186,6 +216,10 @@ export class WSConnection {
           this.rpcListeners = {};
         }
 
+        this.abortPendingAuth?.(
+          new CTSError(`WebSocket closed while authenticating (code ${code}${reason})`),
+        );
+
         this.onCloseCallbacks.forEach((cb) => cb(e));
       };
     });
@@ -239,8 +273,8 @@ export class WSConnection {
   }
 
   private sendRpcMessage(
-    method: 'subscribe' | 'unsubscribe',
-    params: Partial<JsonRpcReqParams>,
+    method: 'subscribe' | 'unsubscribe' | 'authenticate',
+    params: Partial<JsonRpcReqParams> | { token: string },
     id: number,
   ): void {
     if (this.ws?.readyState !== this._WS.OPEN) {
@@ -272,7 +306,7 @@ export class WSConnection {
   }
 
   private addRpcListener(
-    callback: () => void,
+    callback: (result: unknown) => void,
     errorCallback: (e: Error) => void,
     id: Exclude<RpcSubId, null>,
   ) {
@@ -302,6 +336,133 @@ export class WSConnection {
     }
   }
 
+  /**
+   * Authenticates this connection in-band (NUT-22) when the mint protects `/v1/ws`, once per
+   * socket.
+   *
+   * @remarks
+   * Call after {@link WSConnection.ensureConnection} and before the first subscription: the mint
+   * answers a subscribe on an unauthenticated connection with error 31001, and this waits for the
+   * mint's reply so a rejected token fails here rather than later, once it is already spent.
+   * Concurrent callers share one attempt, and a rejection stays cached for the socket, so a single
+   * token covers the connection for its lifetime. A no-op when no token supplier was given.
+   * @param timeoutMs How long to wait for the mint's reply.
+   */
+  async ensureAuthenticated(timeoutMs = 10_000): Promise<void> {
+    if (!this.getAuthToken) return;
+
+    const timeout = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 10_000;
+
+    const socket = this.ws;
+    if (socket?.readyState !== this._WS.OPEN) {
+      this._logger.error('Attempted ensureAuthenticated, but socket was not open');
+      throw new CTSError('Socket not open');
+    }
+
+    if (this.authState?.socket === socket) return this.authState.promise;
+
+    const promise = this.authenticate(timeout);
+    this.authState = { socket, promise };
+    return promise;
+  }
+
+  /**
+   * Fetches a token and authenticates, counting the attempt against the failure bound.
+   *
+   * @remarks
+   * A supplier failure is not counted: it throws before a token leaves the pool, so nothing was
+   * spent and retrying cannot drain it. Everything after that is counted once, in a single place,
+   * because `sendRpcMessage` already fails pending RPCs before rethrowing and a narrower catch
+   * would count a send failure twice.
+   */
+  private async authenticate(timeoutMs: number): Promise<void> {
+    if (this.consecutiveAuthFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+      throw new WsAuthError(
+        `WebSocket authentication gave up after ${MAX_CONSECUTIVE_AUTH_FAILURES} consecutive failures`,
+        { terminal: true },
+      );
+    }
+
+    let token: string | undefined;
+    try {
+      token = await this.getAuthToken!();
+    } catch (e) {
+      throw new WsAuthError('Could not obtain a WebSocket auth token', { cause: e });
+    }
+
+    if (!token) return;
+
+    try {
+      await this.sendAuthenticate(token, timeoutMs);
+    } catch (e) {
+      this.consecutiveAuthFailures++;
+      throw new WsAuthError('WebSocket authentication failed', {
+        code: e instanceof WsRpcError ? e.code : undefined,
+        terminal: this.consecutiveAuthFailures >= MAX_CONSECUTIVE_AUTH_FAILURES,
+        cause: e,
+      });
+    }
+
+    this.consecutiveAuthFailures = 0;
+    this._logger.debug('WebSocket connection authenticated');
+  }
+
+  /**
+   * Sends the `authenticate` command and resolves on the mint's answer.
+   *
+   * @remarks
+   * The timeout is required for correctness, not just latency: a clean close mid-authenticate
+   * clears the pending RPCs without failing them, which would leave this pending forever.
+   */
+  private sendAuthenticate(token: string, timeoutMs: number): Promise<void> {
+    const id = this.rpcId;
+    this.rpcId++;
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        this.abortPendingAuth = undefined;
+        fn();
+      };
+
+      timer = setTimeout(() => {
+        this.removeRpcListener(id);
+        settle(() => reject(new CTSError(`WebSocket authenticate timeout after ${timeoutMs}ms`)));
+      }, timeoutMs);
+
+      this.abortPendingAuth = (e: Error) => {
+        this.removeRpcListener(id);
+        settle(() => reject(e));
+      };
+
+      this.addRpcListener(
+        (result) => {
+          if (isAuthenticateResult(result)) {
+            settle(resolve);
+            return;
+          }
+          settle(() =>
+            reject(new CTSError('Mint answered authenticate with an unexpected result')),
+          );
+        },
+        (e: Error) => settle(() => reject(e)),
+        id,
+      );
+
+      try {
+        this.sendRpcMessage('authenticate', { token }, id);
+      } catch (e) {
+        this.removeRpcListener(id);
+        settle(() => reject(e instanceof Error ? e : new CTSError(String(e), { cause: e })));
+      }
+    });
+  }
+
   private handleNextMessage() {
     if (this.messageQueue.size === 0) {
       if (this.handlingInterval) {
@@ -318,12 +479,14 @@ export class WSConnection {
 
       if ('result' in parsed && parsed.id != undefined) {
         if (this.rpcListeners[parsed.id]) {
-          this.rpcListeners[parsed.id].callback();
+          this.rpcListeners[parsed.id].callback(parsed.result);
           this.removeRpcListener(parsed.id);
         }
       } else if ('error' in parsed && parsed.id != undefined) {
         if (this.rpcListeners[parsed.id]) {
-          this.rpcListeners[parsed.id].errorCallback(new CTSError(parsed.error.message));
+          this.rpcListeners[parsed.id].errorCallback(
+            new WsRpcError(parsed.error.code, parsed.error.message),
+          );
           this.removeRpcListener(parsed.id);
         }
       } else if ('method' in parsed) {
@@ -440,4 +603,17 @@ export class WSConnection {
   onClose(callback: (e: CloseEvent) => void) {
     this.onCloseCallbacks.push(callback);
   }
+}
+
+/**
+ * True for a NUT-22 `authenticate` result.
+ *
+ * @remarks
+ * A subscribe result also carries `status: "OK"`, so the absence of `subId` is what tells the two
+ * apart. Seeing one on an authenticate id means the mint answered the wrong request.
+ */
+function isAuthenticateResult(result: unknown): boolean {
+  if (typeof result !== 'object' || result === null) return false;
+  if ('subId' in result) return false;
+  return (result as { status?: unknown }).status === 'OK';
 }

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -10,6 +10,7 @@ import type {
   MintQuoteBolt11Response,
 } from '../model/types';
 import type { KeyChainCache } from '../model/types/keyset';
+import type { WSConnection } from '../transport';
 
 import { type OperationCounters } from './CounterSource';
 import type { Wallet } from './Wallet';
@@ -71,6 +72,21 @@ export class WalletEvents {
 
   // Callbacks registered for Keychain Updated events
   private keychainUpdatedHandlers = new Set<(payload: { cache: KeyChainCache }) => void>();
+
+  /**
+   * Returns the mint's WebSocket, connected and authenticated, ready to subscribe on.
+   *
+   * @remarks
+   * Authentication is awaited here rather than at connect time so a connection that never
+   * subscribes does not spend a blind auth token.
+   */
+  private async connectedSocket(): Promise<WSConnection> {
+    await this.wallet.mint.connectWebSocket();
+    const ws = this.wallet.mint.webSocketConnection;
+    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
+    await ws.ensureAuthenticated();
+    return ws;
+  }
 
   // Binds an abort signal to each subscription canceller
   private withAbort(
@@ -240,9 +256,7 @@ export class WalletEvents {
     err: (e: Error) => void,
     opts?: SubscribeOpts,
   ): Promise<SubscriptionCanceller> {
-    await this.wallet.mint.connectWebSocket();
-    const ws = this.wallet.mint.webSocketConnection;
-    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
+    const ws = await this.connectedSocket();
 
     const uniq = Array.from(new Set(ids));
     const subId = ws.createSubscription({ kind: 'bolt11_mint_quote', filters: uniq }, cb, err);
@@ -288,9 +302,7 @@ export class WalletEvents {
     err: (e: Error) => void,
     opts?: SubscribeOpts,
   ): Promise<SubscriptionCanceller> {
-    await this.wallet.mint.connectWebSocket();
-    const ws = this.wallet.mint.webSocketConnection;
-    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
+    const ws = await this.connectedSocket();
 
     const uniq = Array.from(new Set(ids));
     const subId = ws.createSubscription({ kind: 'bolt11_melt_quote', filters: uniq }, cb, err);
@@ -341,9 +353,7 @@ export class WalletEvents {
     err: (e: Error) => void,
     opts?: SubscribeOpts,
   ): Promise<SubscriptionCanceller> {
-    await this.wallet.mint.connectWebSocket();
-    const ws = this.wallet.mint.webSocketConnection;
-    if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
+    const ws = await this.connectedSocket();
 
     const enc = new TextEncoder();
     // Object.create(null) avoids prototype-key collisions: a mint sending

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -1514,6 +1514,134 @@ describe('Mint normalization', () => {
     }
   });
 
+  const wsAuthMintInfo = (protectedEndpoints: {
+    nut21?: Array<{ method: 'GET' | 'POST'; path: string }>;
+    nut22?: Array<{ method: 'GET' | 'POST'; path: string }>;
+  }) => ({
+    name: 'mint',
+    pubkey: '02abcd',
+    version: 'test',
+    contact: [],
+    nuts: {
+      '4': { disabled: false, methods: [] },
+      '5': { disabled: false, methods: [] },
+      '21': {
+        openid_discovery: 'https://auth.example/.well-known/openid-configuration',
+        client_id: 'cashu-client',
+        protected_endpoints: protectedEndpoints.nut21 ?? [],
+      },
+      '22': {
+        bat_max_mint: 5,
+        protected_endpoints: protectedEndpoints.nut22 ?? [],
+      },
+    },
+  });
+
+  const wsAuthProvider = () => ({
+    getBlindAuthToken: vi.fn(async () => 'authAbat'),
+    getCAT: vi.fn(() => 'cat-fallback'),
+    setCAT: vi.fn(),
+    ensureCAT: vi.fn(async () => 'cat123'),
+  });
+
+  /**
+   * Connects a mint to a mock-socket server and hands back the frames the wallet sent.
+   */
+  const connectForAuth = async (mint: Mint, wsUrl: string) => {
+    injectWebSocketImpl(WebSocket);
+    const server = new Server(wsUrl, { mock: false });
+    const frames: string[] = [];
+
+    await new Promise<void>((res) => {
+      server.on('connection', (socket) => {
+        socket.on('message', (m) => frames.push(m.toString()));
+        res();
+      });
+      void mint.connectWebSocket();
+    });
+
+    return { server, frames };
+  };
+
+  it('connectWebSocket does not spend an auth token', async () => {
+    const authProvider: AuthProvider = wsAuthProvider();
+    const mint = new Mint('https://mint.example/cashu', { authProvider });
+    mint.setMintInfo(wsAuthMintInfo({ nut22: [{ method: 'GET', path: '/v1/ws' }] }));
+
+    const { server } = await connectForAuth(mint, fakeWsUrl);
+    try {
+      expect(authProvider.getBlindAuthToken).not.toHaveBeenCalled();
+    } finally {
+      mint.disconnectWebSocket();
+      server.close();
+    }
+  });
+
+  it('ensureAuthenticated sends the blind auth token for a NUT-22 protected /v1/ws', async () => {
+    const authProvider: AuthProvider = wsAuthProvider();
+    const mint = new Mint('https://mint.example/cashu', { authProvider });
+    mint.setMintInfo(wsAuthMintInfo({ nut22: [{ method: 'GET', path: '/v1/ws' }] }));
+
+    const { server, frames } = await connectForAuth(mint, fakeWsUrl);
+    const pending = mint.webSocketConnection?.ensureAuthenticated(50).catch(() => {});
+    try {
+      await new Promise((res) => setTimeout(res, 20));
+
+      expect(authProvider.getBlindAuthToken).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v1/ws',
+      });
+      expect(JSON.parse(frames[0])).toMatchObject({
+        method: 'authenticate',
+        params: { token: 'authAbat' },
+      });
+    } finally {
+      mint.disconnectWebSocket();
+      await pending;
+      server.close();
+    }
+  });
+
+  it('ensureAuthenticated falls back to the clear auth token when only NUT-21 protects /v1/ws', async () => {
+    const authProvider: AuthProvider = wsAuthProvider();
+    const mint = new Mint('https://mint.example/cashu', { authProvider });
+    mint.setMintInfo(wsAuthMintInfo({ nut21: [{ method: 'GET', path: '/v1/ws' }] }));
+
+    const { server, frames } = await connectForAuth(mint, fakeWsUrl);
+    const pending = mint.webSocketConnection?.ensureAuthenticated(50).catch(() => {});
+    try {
+      await new Promise((res) => setTimeout(res, 20));
+
+      expect(authProvider.getBlindAuthToken).not.toHaveBeenCalled();
+      expect(JSON.parse(frames[0])).toMatchObject({
+        method: 'authenticate',
+        params: { token: 'cat123' },
+      });
+    } finally {
+      mint.disconnectWebSocket();
+      await pending;
+      server.close();
+    }
+  });
+
+  it('ensureAuthenticated sends nothing when /v1/ws is unprotected', async () => {
+    const authProvider: AuthProvider = wsAuthProvider();
+    const mint = new Mint('https://mint.example/cashu', { authProvider });
+    mint.setMintInfo(wsAuthMintInfo({ nut22: [{ method: 'POST', path: '/v1/swap' }] }));
+
+    const { server, frames } = await connectForAuth(mint, fakeWsUrl);
+    try {
+      await mint.webSocketConnection?.ensureAuthenticated(50);
+
+      expect(authProvider.getBlindAuthToken).not.toHaveBeenCalled();
+      expect(authProvider.ensureCAT).not.toHaveBeenCalled();
+      expect(frames).toHaveLength(0);
+    } finally {
+      mint.disconnectWebSocket();
+      server.close();
+    }
+  });
+
   it('connectWebSocket resets the connection when ensureConnection fails', async () => {
     injectWebSocketImpl(WebSocket);
     const ensureSpy = vi

--- a/test/transport/WSConnection.test.ts
+++ b/test/transport/WSConnection.test.ts
@@ -1,7 +1,7 @@
 import { type Client, Server, WebSocket } from 'mock-socket';
-import { vi, test, describe, expect, afterAll } from 'vitest';
+import { vi, test, describe, expect, afterAll, beforeEach, afterEach } from 'vitest';
 
-import { WSConnection, injectWebSocketImpl } from '../../src';
+import { WSConnection, injectWebSocketImpl, WsAuthError, WsRpcError } from '../../src';
 import type { Logger } from '../../src';
 
 injectWebSocketImpl(WebSocket);
@@ -1062,5 +1062,381 @@ describe('WSConnection – listener management', () => {
     } finally {
       injectWebSocketImpl(WebSocket);
     }
+  });
+});
+
+/**
+ * Deterministic socket for the authentication tests: nothing is sent over a real transport, so a
+ * test drives the mint's side frame by frame.
+ */
+class ScriptedWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static readonly instances: ScriptedWebSocket[] = [];
+  static failSend = false;
+
+  readyState = ScriptedWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  readonly sent: string[] = [];
+
+  constructor() {
+    ScriptedWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = ScriptedWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  send(message: string) {
+    if (ScriptedWebSocket.failSend) throw new Error('send boom');
+    this.sent.push(message);
+  }
+
+  close() {
+    this.readyState = ScriptedWebSocket.CLOSING;
+  }
+
+  emitMessage(message: string) {
+    this.onmessage?.({ data: message } as MessageEvent);
+  }
+
+  emitClose(code = 1000, wasClean = true) {
+    this.readyState = ScriptedWebSocket.CLOSED;
+    this.onclose?.({ code, reason: '', wasClean } as CloseEvent);
+  }
+
+  get frames(): Array<{ method?: string; params?: Record<string, unknown>; id: number }> {
+    return this.sent.map((m) => JSON.parse(m));
+  }
+
+  /**
+   * Answers the pending request with a NUT-22 authenticate ack.
+   */
+  ackAuth(index = 0) {
+    this.emitMessage(
+      JSON.stringify({ jsonrpc: '2.0', result: { status: 'OK' }, id: this.frames[index].id }),
+    );
+  }
+
+  rejectAuth(code = 31002, message = 'Blind authentication failed', index = 0) {
+    this.emitMessage(
+      JSON.stringify({ jsonrpc: '2.0', error: { code, message }, id: this.frames[index].id }),
+    );
+  }
+}
+
+/**
+ * Opens a connection on a scripted socket, ready to authenticate.
+ */
+async function openScripted(getAuthToken?: () => Promise<string | undefined>) {
+  const conn = new WSConnection(fakeUrl, undefined, getAuthToken);
+  const connecting = conn.connect();
+  const socket = ScriptedWebSocket.instances[ScriptedWebSocket.instances.length - 1];
+  socket.open();
+  await connecting;
+  return { conn, socket };
+}
+
+// The message pump runs on a zero-delay interval, so a macrotask hop lets a queued frame land.
+const drain = () => new Promise((resolve) => setTimeout(resolve, 5));
+
+describe('WSConnection – in-band authentication', () => {
+  beforeEach(() => {
+    ScriptedWebSocket.instances.length = 0;
+    ScriptedWebSocket.failSend = false;
+    injectWebSocketImpl(ScriptedWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    injectWebSocketImpl(WebSocket);
+  });
+
+  test('sends the NUT-22 authenticate frame and resolves on the mint ack', async () => {
+    const { conn, socket } = await openScripted(async () => 'authAtoken');
+
+    const authenticated = conn.ensureAuthenticated();
+    await drain();
+
+    expect(socket.frames[0]).toEqual({
+      jsonrpc: '2.0',
+      method: 'authenticate',
+      params: { token: 'authAtoken' },
+      id: 0,
+    });
+
+    socket.ackAuth();
+    await expect(authenticated).resolves.toBeUndefined();
+
+    conn.createSubscription({ kind: 'bolt11_mint_quote', filters: [] }, vi.fn(), vi.fn());
+    expect(socket.frames[1].id).toBe(1);
+  });
+
+  test('is a no-op when no token supplier was given', async () => {
+    const { conn, socket } = await openScripted();
+
+    await expect(conn.ensureAuthenticated()).resolves.toBeUndefined();
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  test('sends nothing when the mint does not protect the endpoint', async () => {
+    const getAuthToken = vi.fn(async () => undefined);
+    const { conn, socket } = await openScripted(getAuthToken);
+
+    await expect(conn.ensureAuthenticated()).resolves.toBeUndefined();
+    expect(socket.sent).toHaveLength(0);
+    expect(getAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws when the socket is not open', async () => {
+    const conn = new WSConnection(fakeUrl, undefined, async () => 'authAtoken');
+
+    await expect(conn.ensureAuthenticated()).rejects.toThrow('Socket not open');
+  });
+
+  test('rejects with the mint error code when the token is refused', async () => {
+    const { conn, socket } = await openScripted(async () => 'authAtoken');
+
+    const authenticated = conn.ensureAuthenticated();
+    await drain();
+    socket.rejectAuth();
+
+    const err = await authenticated.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WsAuthError);
+    expect(err).toMatchObject({ code: 31002, terminal: false });
+  });
+
+  test('rejects when the mint never answers', async () => {
+    const { conn } = await openScripted(async () => 'authAtoken');
+
+    const err = await conn.ensureAuthenticated(20).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WsAuthError);
+    expect((err as WsAuthError).cause).toMatchObject({
+      message: 'WebSocket authenticate timeout after 20ms',
+    });
+  });
+
+  test('concurrent callers share one attempt and spend one token', async () => {
+    const getAuthToken = vi.fn(async () => 'authAtoken');
+    const { conn, socket } = await openScripted(getAuthToken);
+
+    const both = Promise.all([conn.ensureAuthenticated(), conn.ensureAuthenticated()]);
+    await drain();
+    socket.ackAuth();
+
+    await expect(both).resolves.toEqual([undefined, undefined]);
+    expect(getAuthToken).toHaveBeenCalledTimes(1);
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  test('a rejection is cached for the socket, so a retry spends no second token', async () => {
+    const getAuthToken = vi.fn(async () => 'authAtoken');
+    const { conn, socket } = await openScripted(getAuthToken);
+
+    const first = conn.ensureAuthenticated();
+    await drain();
+    socket.rejectAuth();
+    await expect(first).rejects.toThrow(WsAuthError);
+
+    await expect(conn.ensureAuthenticated()).rejects.toThrow(WsAuthError);
+    expect(getAuthToken).toHaveBeenCalledTimes(1);
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  test('gives up after three consecutive failures instead of draining the pool', async () => {
+    const getAuthToken = vi.fn(async () => 'authAtoken');
+    const conn = new WSConnection(fakeUrl, undefined, getAuthToken);
+
+    const attempt = async () => {
+      const connecting = conn.connect();
+      const socket = ScriptedWebSocket.instances[ScriptedWebSocket.instances.length - 1];
+      socket.open();
+      await connecting;
+      const authenticated = conn.ensureAuthenticated();
+      await drain();
+      socket.rejectAuth();
+      const err = await authenticated.catch((e: unknown) => e);
+      conn.close();
+      return err as WsAuthError;
+    };
+
+    expect((await attempt()).terminal).toBe(false);
+    expect((await attempt()).terminal).toBe(false);
+    expect((await attempt()).terminal).toBe(true);
+    expect(getAuthToken).toHaveBeenCalledTimes(3);
+
+    const connecting = conn.connect();
+    const socket = ScriptedWebSocket.instances[ScriptedWebSocket.instances.length - 1];
+    socket.open();
+    await connecting;
+
+    const err = await conn.ensureAuthenticated().catch((e: unknown) => e);
+    expect(err).toMatchObject({ terminal: true });
+    expect(getAuthToken).toHaveBeenCalledTimes(3);
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  test('a success resets the failure count', async () => {
+    const conn = new WSConnection(fakeUrl, undefined, async () => 'authAtoken');
+
+    const attempt = async (ack: boolean) => {
+      const connecting = conn.connect();
+      const socket = ScriptedWebSocket.instances[ScriptedWebSocket.instances.length - 1];
+      socket.open();
+      await connecting;
+      const authenticated = conn.ensureAuthenticated();
+      await drain();
+      if (ack) socket.ackAuth();
+      else socket.rejectAuth();
+      const outcome = await authenticated.then(
+        () => null,
+        (e: unknown) => e as WsAuthError,
+      );
+      conn.close();
+      return outcome;
+    };
+
+    await attempt(false);
+    await attempt(false);
+    expect(await attempt(true)).toBeNull();
+
+    expect((await attempt(false))?.terminal).toBe(false);
+  });
+
+  test('a reconnect authenticates the new socket', async () => {
+    const getAuthToken = vi.fn(async () => 'authAtoken');
+    const conn = new WSConnection(fakeUrl, undefined, getAuthToken);
+
+    const first = conn.connect();
+    const firstSocket = ScriptedWebSocket.instances[0];
+    firstSocket.open();
+    await first;
+    const firstAuth = conn.ensureAuthenticated();
+    await drain();
+    firstSocket.ackAuth();
+    await firstAuth;
+
+    conn.close();
+
+    const second = conn.connect();
+    const secondSocket = ScriptedWebSocket.instances[1];
+    secondSocket.open();
+    await second;
+    const secondAuth = conn.ensureAuthenticated();
+    await drain();
+    secondSocket.ackAuth();
+    await secondAuth;
+
+    expect(getAuthToken).toHaveBeenCalledTimes(2);
+    expect(firstSocket.sent).toHaveLength(1);
+    expect(secondSocket.sent).toHaveLength(1);
+  });
+
+  test('counts a send failure exactly once', async () => {
+    const getAuthToken = vi.fn(async () => 'authAtoken');
+    const { conn } = await openScripted(getAuthToken);
+    ScriptedWebSocket.failSend = true;
+
+    const err = await conn.ensureAuthenticated().catch((e: unknown) => e);
+    expect(err).toMatchObject({ terminal: false });
+  });
+
+  test('rejects when an abnormal close interrupts authenticating', async () => {
+    const { conn, socket } = await openScripted(async () => 'authAtoken');
+
+    const authenticated = conn.ensureAuthenticated(50);
+    await drain();
+    socket.emitClose(1008, false);
+
+    await expect(authenticated).rejects.toThrow(WsAuthError);
+  });
+
+  test('rejects at once when a clean close interrupts authenticating', async () => {
+    const { conn, socket } = await openScripted(async () => 'authAtoken');
+
+    const authenticated = conn.ensureAuthenticated(30_000);
+    await drain();
+    socket.emitClose(1000, true);
+
+    const err = await authenticated.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WsAuthError);
+    expect((err as WsAuthError).cause).toMatchObject({
+      message: expect.stringContaining('closed while authenticating'),
+    });
+  });
+
+  test('a clean close while authenticating counts toward the bound', async () => {
+    const getAuthToken = vi.fn(async () => 'authAtoken');
+    const conn = new WSConnection(fakeUrl, undefined, getAuthToken);
+
+    const attempt = async () => {
+      const connecting = conn.connect();
+      const socket = ScriptedWebSocket.instances[ScriptedWebSocket.instances.length - 1];
+      socket.open();
+      await connecting;
+      const authenticated = conn.ensureAuthenticated(30_000);
+      await drain();
+      socket.emitClose(1000, true);
+      return (await authenticated.catch((e: unknown) => e)) as WsAuthError;
+    };
+
+    expect((await attempt()).terminal).toBe(false);
+    expect((await attempt()).terminal).toBe(false);
+    expect((await attempt()).terminal).toBe(true);
+    expect(getAuthToken).toHaveBeenCalledTimes(3);
+  });
+
+  test('does not accept a subscription result as an authenticate ack', async () => {
+    const { conn, socket } = await openScripted(async () => 'authAtoken');
+
+    const authenticated = conn.ensureAuthenticated();
+    await drain();
+    socket.emitMessage(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        result: { status: 'OK', subId: 'sub-1' },
+        id: socket.frames[0].id,
+      }),
+    );
+
+    const err = await authenticated.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WsAuthError);
+    expect((err as WsAuthError).cause).toMatchObject({
+      message: 'Mint answered authenticate with an unexpected result',
+    });
+  });
+
+  test('does not count a token supplier failure against the bound', async () => {
+    const { conn } = await openScripted(async () => {
+      throw new Error('pool empty');
+    });
+
+    const err = await conn.ensureAuthenticated().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WsAuthError);
+    expect(err).toMatchObject({ terminal: false });
+    expect((err as WsAuthError).cause).toMatchObject({ message: 'pool empty' });
+  });
+
+  test('surfaces the mint error code when a subscribe is refused as unauthenticated', async () => {
+    const { conn, socket } = await openScripted();
+
+    const errorCallback = vi.fn();
+    conn.createSubscription({ kind: 'bolt11_mint_quote', filters: [] }, vi.fn(), errorCallback);
+    socket.emitMessage(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: 31001, message: 'Endpoint requires blind auth' },
+        id: socket.frames[0].id,
+      }),
+    );
+    await drain();
+
+    expect(errorCallback).toHaveBeenCalledWith(expect.any(WsRpcError));
+    expect(errorCallback.mock.calls[0][0]).toMatchObject({ code: 31001 });
   });
 });

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { Amount } from '../../src';
+import { Amount, WsAuthError } from '../../src';
 import { hashToCurve, hashToCurveBls } from '../../src/crypto';
 import type { Proof } from '../../src/model/types';
 import type { KeyChainCache } from '../../src/model/types/keyset';
@@ -16,6 +16,8 @@ const flushMicrotasks = async (n = 2) => {
  * Mock WS that WalletEvents talks to.
  */
 class MockWS {
+  public ensureAuthenticated = vi.fn(async () => {});
+
   public createSubscription = vi.fn(
     (
       { kind, filters }: { kind: string; filters: string[] },
@@ -133,6 +135,47 @@ describe('WalletEvents', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  describe('websocket authentication', () => {
+    const subscribers = [
+      ['mintQuoteUpdates', () => events.mintQuoteUpdates(['a'], vi.fn(), vi.fn())],
+      ['meltQuoteUpdates', () => events.meltQuoteUpdates(['m1'], vi.fn(), vi.fn())],
+      [
+        'proofStateUpdates',
+        () =>
+          events.proofStateUpdates(
+            [{ amount: Amount.from(2), id: '00bd033559de27d0', secret: 's1', C: 'test' }],
+            vi.fn(),
+            vi.fn(),
+          ),
+      ],
+    ] as const;
+
+    it.each(subscribers)('%s authenticates before subscribing', async (_name, subscribe) => {
+      await subscribe();
+
+      const ws = mock.mint.webSocketConnection!;
+      expect(ws.ensureAuthenticated).toHaveBeenCalled();
+      expect(ws.ensureAuthenticated.mock.invocationCallOrder[0]).toBeLessThan(
+        ws.createSubscription.mock.invocationCallOrder[0],
+      );
+    });
+
+    it.each(subscribers)(
+      '%s surfaces an auth failure and creates no subscription',
+      async (_name, subscribe) => {
+        await events.mintQuoteUpdates(['seed'], vi.fn(), vi.fn());
+        const ws = mock.mint.webSocketConnection!;
+        const before = ws.createSubscription.mock.calls.length;
+        ws.ensureAuthenticated.mockRejectedValueOnce(
+          new WsAuthError('WebSocket authentication failed', { code: 31002 }),
+        );
+
+        await expect(subscribe()).rejects.toThrow(WsAuthError);
+        expect(ws.createSubscription.mock.calls.length).toBe(before);
+      },
+    );
   });
 
   describe('basic subscriptions', () => {
@@ -855,6 +898,7 @@ describe('WalletEvents', () => {
       subs.delete(id);
     });
     const ws = {
+      ensureAuthenticated: vi.fn(async () => {}),
       createSubscription,
       cancelSubscription,
       emitPaid: (quote: string) => {

--- a/test/wallet/wallet-websocket.node.test.ts
+++ b/test/wallet/wallet-websocket.node.test.ts
@@ -1,17 +1,20 @@
 import { Server } from 'mock-socket';
-import { test, describe, expect } from 'vitest';
+import { HttpResponse, http } from 'msw';
+import { test, describe, expect, vi } from 'vitest';
 
 import {
+  Mint,
   Wallet,
   MeltQuoteState,
   MintQuoteState,
+  type AuthProvider,
   type MeltQuoteBolt11Response,
   type MintQuoteBolt11Response,
 } from '../../src';
 
-import { mint, useTestServer } from './_setup';
+import { mint, mintInfoResp, mintUrl, useTestServer } from './_setup';
 
-useTestServer();
+const server = useTestServer();
 
 describe('WebSocket Updates', () => {
   test('mint update', async () => {
@@ -94,5 +97,81 @@ describe('WebSocket Updates', () => {
     });
     expect(state).toMatchObject({ quote: '123' });
     server.close();
+  });
+
+  test('authenticates before subscribing on a protected mint', async () => {
+    const authInfo = {
+      ...mintInfoResp,
+      nuts: {
+        ...mintInfoResp.nuts,
+        22: { bat_max_mint: 10, protected_endpoints: [{ method: 'GET', path: '/v1/ws' }] },
+      },
+    };
+    server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(authInfo)));
+
+    const fakeUrl = 'ws://localhost:3338/v1/ws';
+    const wsServer = new Server(fakeUrl, { mock: false });
+    const methods: string[] = [];
+    wsServer.on('connection', (socket) => {
+      socket.on('message', (m) => {
+        const parsed = JSON.parse(m.toString());
+        methods.push(parsed.method);
+        if (parsed.method === 'authenticate') {
+          socket.send(JSON.stringify({ jsonrpc: '2.0', result: { status: 'OK' }, id: parsed.id }));
+          return;
+        }
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              result: { status: 'OK', subId: parsed.params.subId },
+              id: parsed.id,
+            }),
+          );
+          setTimeout(() => {
+            socket.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'subscribe',
+                params: {
+                  subId: parsed.params.subId,
+                  payload: { quote: '123', request: '456', state: 'PAID', expiry: 123 },
+                },
+              }),
+            );
+          }, 20);
+        }
+      });
+    });
+
+    const authProvider: AuthProvider = {
+      getBlindAuthToken: vi.fn(async () => 'authAbat'),
+      getCAT: vi.fn(() => undefined),
+      setCAT: vi.fn(),
+    };
+    const authMint = new Mint(mintUrl, { authProvider });
+    const wallet = new Wallet(authMint);
+    await wallet.loadMint();
+
+    try {
+      const state = await new Promise((res, rej) => {
+        wallet.on
+          .mintQuoteUpdates(
+            ['123'],
+            (p: MintQuoteBolt11Response) => {
+              if (p.state === MintQuoteState.PAID) res(p);
+            },
+            rej,
+          )
+          .catch(rej);
+      });
+
+      expect(state).toMatchObject({ quote: '123' });
+      expect(authProvider.getBlindAuthToken).toHaveBeenCalledTimes(1);
+      expect(methods).toEqual(['authenticate', 'subscribe']);
+    } finally {
+      authMint.disconnectWebSocket();
+      wsServer.close();
+    }
   });
 });


### PR DESCRIPTION


<!-- Implementing NUTs? Open with a NUTS: tracking header. The "# " heading and bare refs
     make GitHub render each one with its PR title:

     # NUTS:

     - cashubtc/nuts#xxx

     Add "Fixes #xxx" to auto-close an issue. In the prose below, cite the NUT the change
     lands in, e.g. [NUT-29](https://github.com/cashubtc/nuts/blob/main/29.md), rather than
     the PR number: PRs get squashed and renumbered, the NUT is the stable home. -->

<!-- Open with a TL;DR: one or two lines of prose, no heading. The outcome, for
     someone reading nothing else. -->

## Why

Cash-TS implementation of the NUT improvement https://github.com/cashubtc/nuts/pull/413

A mint can protect GET /v1/ws under NUT-21 or NUT-22, but the WebSocket path sent no credentials, so every NUT-17 subscription failed against an auth-enabled mint. Headers are not an option: browsers cannot set them and the library injects a standard WebSocket constructor, so no target can. Send the NUT-22 authenticate command on the open socket instead.

The token is fetched lazily, just before the first subscribe, because it is spent the moment it leaves the pool: a connection that never subscribes costs nothing. The mint's reply is awaited so a rejected token fails where it happens rather than as a 31001 on the subscribe that follows. Consecutive failures are bounded so a mint that keeps rejecting cannot drain the pool one reconnect at a time.

Clear auth travels in the same command as the raw access token. That is forward looking: mints today expect a CAT in the upgrade header and refuse a header-less upgrade outright.

## Changes

<!-- Key changes, plus any non-obvious decision or trade-off. Skip what the diff makes obvious. -->

## Impact

<!-- What this means for consumers: breaking changes, compatibility, performance, security.
     Delete this section if there genuinely is none. -->
