### PR TITLE
fix(utils): harden keyset ID handling in the binary token encoder

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -269,7 +269,8 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
 }
 
 function templateFromToken(token: Token): TokenV4Template {
-  const idMap: { [id: string]: Proof[] } = {};
+  // Keyed by token-supplied IDs, so a plain object would resolve `__proto__` etc. to inherited members.
+  const idMap = Object.create(null) as { [id: string]: Proof[] };
   const mint = token.mint;
   for (let i = 0; i < token.proofs.length; i++) {
     const proof = token.proofs[i];
@@ -964,6 +965,11 @@ export function getEncodedTokenBinary(token: Token): Uint8Array {
   const utf8Encoder = new TextEncoder();
   // Normalize amounts for untyped (JS) callers who may pass JSON.parse'd tokens directly.
   const proofs = normalizeProofAmounts(token.proofs);
+  if (hasNonHexId(proofs)) {
+    throw new CTSError(
+      'Proofs contain a legacy keyset ID and cannot be encoded. Swap them at the mint first.',
+    );
+  }
   const template = templateFromToken({ ...token, proofs });
   const binaryTemplate = encodeCBOR(template);
   const prefix = utf8Encoder.encode('craw');

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1221,6 +1221,15 @@ describe('test raw tokens', () => {
 
     expect(decodedToken).toEqual(token);
   });
+
+  test.each(['__proto__', 'constructor', 'toString', 'zzzz'])(
+    'getEncodedTokenBinary rejects non-hex keyset id %s',
+    (id) => {
+      const badToken = { ...token, proofs: token.proofs.map((p) => ({ ...p, id })) };
+
+      expect(() => utils.getEncodedTokenBinary(badToken)).toThrow(CTSError);
+    },
+  );
 });
 
 describe('test deprecated base64 keyset id derivation', () => {


### PR DESCRIPTION
`getEncodedTokenBinary` now validates keyset IDs the way the other two token
encoders already do, and the CBOR template builder's grouping map no longer
inherits from `Object.prototype`.

## Why

`getEncodedToken` and `getEncodedTokenV4` both call `hasNonHexId` and throw a
`CTSError` before building the template. The binary encoder skipped that check,
so a non-hex keyset ID got as far as `hexToBytes` and surfaced as a raw
`RangeError` from `@noble/hashes` instead. The encoders should behave the same
way on the same input.

Separately, `templateFromToken` groups proofs in a map keyed by token-supplied
strings. `KeyChain.keysets` and the `WalletEvents` proof map already use
`Object.create(null)` for exactly this reason; this was the remaining plain
object of that shape.

## Changes

- `getEncodedTokenBinary` rejects non-hex keyset IDs with the same `CTSError`
  message `getEncodedToken` uses.
- `templateFromToken`'s `idMap` is created with `Object.create(null)`.
- Tests covering both, parameterised over four IDs.

## Impact

No change for anything that encoded successfully before: a valid keyset ID is
hex by definition, and IDs that fail the new check already failed a few lines
later. The error type is now `CTSError` rather than a raw one. No public API
change.
