### PR TITLE
fix(transport): fail rather than follow redirects on requests with a body

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -1177,8 +1177,9 @@ class Mint {
       endpoint: joinUrls(this._mintUrl, path),
       method,
       headers,
-      // A CAT/BAT must never be replayed to a redirect target: fail rather than follow.
-      ...(bat || cat ? { redirect: 'error' as const } : {}),
+      // A redirect target must never receive a replay of the request: bodies carry
+      // proofs and headers carry CAT/BAT tokens. Fail rather than follow.
+      ...(bat || cat || init.requestBody ? { redirect: 'error' as const } : {}),
       ...(nut19?.supported && nut19.params ? nut19.params : {}),
       onResponseMeta: this._captureResponseMetadata,
     });

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -374,7 +374,8 @@ let requestLogger = NULL_LOGGER;
  * `RequestInit` fields (`cache`, `credentials`, `mode` etc) override the per-call value: they are
  * process-wide transport policy. Library options (`requestTimeout`, `fetch`, `maxResponseBytes`,
  * `idempotent`, NUT-19 policy) are defaults a per-call value overrides. `headers` merge, per-call
- * wins per key; `redirect` is always `error` on requests carrying auth headers.
+ * wins per key; `redirect` defaults to `error` on requests with a body, and is forced to `error` on
+ * requests carrying auth headers.
  * @param options See possible options here:
  *   https://developer.mozilla.org/en-US/docs/Web/API/fetch#options.
  */
@@ -645,6 +646,9 @@ async function _request(options: RequestOptions): Promise<unknown> {
         credentials: 'omit', // prevent cookie-based tracking
         referrer: '', // prevent leaking the embedding page URL
         referrerPolicy: 'no-referrer', // belt-and-braces for referrer across all contexts
+        // A 307/308 re-sends the body to the redirect target, so any request carrying one fails
+        // rather than follows. Overridable for deployments that legitimately redirect.
+        ...(body !== undefined ? { redirect: 'error' as const } : undefined),
         ...fetchOptions, // allows override of above options
         ...(carriesAuth ? { redirect: 'error' as const } : undefined), // not overridable on auth requests
         signal, // not overridable (includes caller signal)

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -225,6 +225,40 @@ describe('requests', { timeout: 7500 }, () => {
     expect(init?.redirect).toBe('error');
   });
 
+  test('redirect defaults to error on requests carrying a body, and stays overridable', async () => {
+    let init: Parameters<RequestFetch>[1];
+    const captureFetch = (async (
+      _input: Parameters<RequestFetch>[0],
+      requestInit?: Parameters<RequestFetch>[1],
+    ) => {
+      init = requestInit;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    await request({
+      endpoint: `${mintUrl}/v1/swap`,
+      method: 'POST',
+      requestBody: { inputs: [] },
+      fetch: captureFetch,
+    });
+    expect(init?.redirect).toBe('error');
+
+    await request({
+      endpoint: `${mintUrl}/v1/swap`,
+      method: 'POST',
+      requestBody: { inputs: [] },
+      redirect: 'follow',
+      fetch: captureFetch,
+    });
+    expect(init?.redirect).toBe('follow');
+
+    await request({ endpoint: `${mintUrl}/v1/info`, fetch: captureFetch });
+    expect(init?.redirect).toBeUndefined();
+  });
+
   test('per-request library options override the global default', async () => {
     const endpoint = mintUrl + '/v1/keys';
     server.use(

--- a/test/wallet/wallet-auth.node.test.ts
+++ b/test/wallet/wallet-auth.node.test.ts
@@ -100,7 +100,7 @@ describe('Auth header redirect handling', () => {
     };
   }
 
-  test('protected requests refuse redirects; unprotected requests are unchanged', async () => {
+  test('requests carrying a token or a body refuse redirects; bodiless ones are unchanged', async () => {
     server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(protectedSwapInfo)));
 
     const authedSpy = vi.fn((args: { endpoint: string }) =>
@@ -111,9 +111,18 @@ describe('Auth header redirect handling', () => {
     const authedArgs = authedSpy.mock.calls.find((c) => c[0].endpoint.includes('/v1/swap'))![0];
     expect(authedArgs).toMatchObject({ redirect: 'error' });
 
+    // No auth token, but the body carries proofs.
     const plainSpy = vi.fn().mockResolvedValue({ signatures: [] });
     const plainMint = new Mint(mintUrl);
     await plainMint.swap({ inputs: [], outputs: [] }, plainSpy);
-    expect(plainSpy.mock.calls[0][0]).not.toHaveProperty('redirect');
+    expect(plainSpy.mock.calls[0][0]).toMatchObject({ redirect: 'error' });
+
+    const getSpy = vi
+      .fn()
+      .mockResolvedValue({ quote: 'q', request: 'lnbc', unit: 'sat', amount: 1, state: 'UNPAID' });
+    await plainMint.checkMintQuote('bolt11', 'q', {
+      customRequest: getSpy as unknown as RequestFn,
+    });
+    expect(getSpy.mock.calls[0][0]).not.toHaveProperty('redirect');
   });
 });


### PR DESCRIPTION
A mint request that carries a body now fails on an HTTP redirect instead of following it, matching what already happened for requests carrying an auth token.

## Why

A 307 or 308 preserves the method and the body, so following one re-sends the whole request to the redirect target. `redirect: 'error'` was enforced only for requests carrying NUT-21/22 `Blind-auth` / `Clear-auth` headers; every other request used the fetch default of `follow`. The body is the more consequential half of a mint request, and it had no such guard.

## Changes

- `redirect: 'error'` is now the default whenever a request has a body. It sits before the caller's fetch options, so a deployment that legitimately redirects can still override it. The auth-header guard sits after and stays absolute.
- `Mint.requestWithAuth` mirrors the same predicate, so consumers passing a custom `RequestFn` inherit the invariant.
- Bodiless GETs are untouched and still follow redirects, so http to https upgrades and trailing-slash normalisation on `/v1/info` and `/v1/keys` keep working.

## Impact

No behaviour change for a mint reached through a reverse proxy, which passes requests through rather than redirecting. A mint origin answering 307/308 to a POST now fails immediately instead of silently completing elsewhere. A 301/302/303 already broke POSTs, since fetch rewrites those to GET and drops the body, so nothing that worked before stops working. Consumers who need the old behaviour can pass `redirect: 'follow'` per call or globally.