### PR TITLE
fix(wallet): omit unselected proofs from serialized swap previews

### DIFF
--- a/docs-src/usage/nut19.md
+++ b/docs-src/usage/nut19.md
@@ -149,7 +149,8 @@ const receivePreview = await wallet.prepareSwapToReceive(token);
 const sendPreview = await wallet.prepareSwapToSend(21, proofs, { includeFees: true });
 
 // Swap previews have a serialize helper: persist the JSON-safe form, then
-// rehydrate it with deserializeSwapPreview to replay after a restart.
+// rehydrate it with deserializeSwapPreview to replay after a restart. The blob carries
+// spendable proofs, so protect it like the proof database.
 const stored = JSON.stringify(serializeSwapPreview(receivePreview));
 const { keep } = await wallet.completeSwap(deserializeSwapPreview(JSON.parse(stored)));
 ```

--- a/docs-src/wallet_ops/receive.md
+++ b/docs-src/wallet_ops/receive.md
@@ -81,6 +81,9 @@ const { keep } = await wallet.completeSwap(preview);
 const { keep: recovered } = await wallet.completeSwap(deserializeSwapPreview(JSON.parse(stored)));
 ```
 
+> The serialized preview contains `inputs` in the clear, so it is spendable bearer material.
+> Store it with the same protection as the proof database, and delete it once the swap settles.
+
 The replay window has bounds:
 
 - The mint must advertise `/v1/swap` in its NUT-19 `cached_endpoints`, and the replay must

--- a/docs-src/wallet_ops/send.md
+++ b/docs-src/wallet_ops/send.md
@@ -99,7 +99,8 @@ import { deserializeSwapPreview, serializeSwapPreview } from '@cashu/cashu-ts';
 
 const preview = await wallet.ops.send(21, myProofs).prepare();
 
-// Unselected proofs can go back to storage now; they are not part of the replay.
+// Unselected proofs are not part of the replay and are not serialized: return them to
+// storage yourself, and add them back to `keep` after a replayed completeSwap.
 const backToStorage = preview.unselectedProofs ?? [];
 
 // Persist before completing. Previews contain Amount, bigint and Uint8Array values,
@@ -113,6 +114,9 @@ const { keep: change, send: recovered } = await wallet.completeSwap(
   deserializeSwapPreview(JSON.parse(stored)),
 );
 ```
+
+> The serialized preview contains `inputs` in the clear, so it is spendable bearer material.
+> Store it with the same protection as the proof database, and delete it once the swap settles.
 
 The replay window has bounds:
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2140,7 +2140,6 @@ export type SerializedSwapPreview = {
     inputs: SerializedProof[];
     sendOutputs?: SerializedOutputData[];
     keepOutputs?: SerializedOutputData[];
-    unselectedProofs?: SerializedProof[];
 };
 
 // @public (undocumented)

--- a/src/wallet/SwapPreview.ts
+++ b/src/wallet/SwapPreview.ts
@@ -21,7 +21,6 @@ export type SerializedSwapPreview = {
   inputs: SerializedProof[];
   sendOutputs?: SerializedOutputData[];
   keepOutputs?: SerializedOutputData[];
-  unselectedProofs?: SerializedProof[];
 };
 
 function serializeProof(proof: Proof): SerializedProof {
@@ -34,6 +33,10 @@ function serializeProof(proof: Proof): SerializedProof {
  * @remarks
  * Persist the result before `completeSwap` to support NUT-19 replay safety: a preview rehydrated
  * with {@link deserializeSwapPreview} replays a byte-identical swap request.
+ *
+ * The result holds `inputs` in the clear, so it is spendable bearer material: store it as carefully
+ * as the proof database. `unselectedProofs` take no part in the replay and are not included; return
+ * them to storage separately.
  */
 export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPreview {
   return {
@@ -46,9 +49,6 @@ export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPrevie
     }),
     ...(preview.keepOutputs && {
       keepOutputs: preview.keepOutputs.map((o) => OutputData.serialize(o)),
-    }),
-    ...(preview.unselectedProofs && {
-      unselectedProofs: preview.unselectedProofs.map(serializeProof),
     }),
   };
 }
@@ -71,9 +71,6 @@ export function deserializeSwapPreview(serialized: SerializedSwapPreview): SwapP
       }),
       ...(serialized.keepOutputs && {
         keepOutputs: serialized.keepOutputs.map((s) => OutputData.deserialize(s)),
-      }),
-      ...(serialized.unselectedProofs && {
-        unselectedProofs: normalizeProofAmounts(serialized.unselectedProofs),
       }),
     };
   } catch (e) {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -385,6 +385,19 @@ describe('send', () => {
     expect(first.send[0].secret).toBe(replayed.send[0].secret);
   });
 
+  test('serializeSwapPreview omits unselected proofs', () => {
+    const serialized = serializeSwapPreview({
+      amount: Amount.from(1),
+      fees: Amount.from(0),
+      keysetId: '00bd033559de27d0',
+      inputs: [proofs[0]],
+      unselectedProofs: [{ ...proofs[0], secret: 'not-part-of-the-replay' }],
+    });
+
+    expect(serialized).not.toHaveProperty('unselectedProofs');
+    expect(JSON.stringify(serialized)).not.toContain('not-part-of-the-replay');
+  });
+
   test('deserializeSwapPreview rejects malformed output data', () => {
     const bad: SerializedSwapPreview = {
       amount: '1',


### PR DESCRIPTION
A serialized swap preview no longer carries the proofs that were not selected for the swap.

## Why

`unselectedProofs` take no part in the NUT-19 replay: `completeSwap` passes them straight through to the returned `keep` array without touching them. Persisting them writes spendable proofs to a second location for no benefit, and nothing in the docs said the serialized blob was sensitive at all.

## Changes

- `unselectedProofs` removed from `SerializedSwapPreview`, in both `serializeSwapPreview` and `deserializeSwapPreview`.
- The serializer docblock and the send, receive and NUT-19 recipes now say a serialized preview holds `inputs` in the clear and needs the same protection as the proof database.
- The send recipe already returned unselected proofs to storage before serializing; that comment now explains why it matters.

## Impact

`SerializedSwapPreview` loses one optional field. Previews stored by 4.10.0 still deserialize, as the extra key is ignored. Callers who replay a persisted preview get `keep` without the unselected proofs and should return those to storage themselves, which is what the send recipe already showed.
