### PR TITLE
fix(transport): fail rather than follow redirects on requests with a body [backport v4-dev]

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -1162,8 +1162,9 @@ class Mint {
       endpoint: joinUrls(this._mintUrl, path),
       method,
       headers,
-      // A CAT/BAT must never be replayed to a redirect target: fail rather than follow.
-      ...(bat || cat ? { redirect: 'error' as const } : {}),
+      // A redirect target must never receive a replay of the request: bodies carry
+      // proofs and headers carry CAT/BAT tokens. Fail rather than follow.
+      ...(bat || cat || init.requestBody ? { redirect: 'error' as const } : {}),
       ...(nut19?.supported && nut19.params ? nut19.params : {}),
       onResponseMeta: this._captureResponseMetadata,
     });

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -273,15 +273,9 @@ let requestLogger = NULL_LOGGER;
  *
  * @remarks
  * `RequestInit` fields (`cache`, `credentials`, `mode` etc) override the per-call value: they are
-<<<<<<< HEAD
  * process-wide transport policy. Library options (`requestTimeout`, NUT-19 policy) are defaults a
- * per-call value overrides. `headers` merge, per-call wins per key; `redirect` is always `error` on
-=======
- * process-wide transport policy. Library options (`requestTimeout`, `fetch`, `maxResponseBytes`,
- * `idempotent`, NUT-19 policy) are defaults a per-call value overrides. `headers` merge, per-call
- * wins per key; `redirect` defaults to `error` on requests with a body, and is forced to `error` on
->>>>>>> 8bc3383 (fix(transport): fail rather than follow redirects on requests with a body (#1039))
- * requests carrying auth headers.
+ * per-call value overrides. `headers` merge, per-call wins per key; `redirect` defaults to `error`
+ * on requests with a body, and is forced to `error` on requests carrying auth headers.
  * @param options See possible options here:
  *   https://developer.mozilla.org/en-US/docs/Web/API/fetch#options.
  */

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -273,8 +273,14 @@ let requestLogger = NULL_LOGGER;
  *
  * @remarks
  * `RequestInit` fields (`cache`, `credentials`, `mode` etc) override the per-call value: they are
+<<<<<<< HEAD
  * process-wide transport policy. Library options (`requestTimeout`, NUT-19 policy) are defaults a
  * per-call value overrides. `headers` merge, per-call wins per key; `redirect` is always `error` on
+=======
+ * process-wide transport policy. Library options (`requestTimeout`, `fetch`, `maxResponseBytes`,
+ * `idempotent`, NUT-19 policy) are defaults a per-call value overrides. `headers` merge, per-call
+ * wins per key; `redirect` defaults to `error` on requests with a body, and is forced to `error` on
+>>>>>>> 8bc3383 (fix(transport): fail rather than follow redirects on requests with a body (#1039))
  * requests carrying auth headers.
  * @param options See possible options here:
  *   https://developer.mozilla.org/en-US/docs/Web/API/fetch#options.
@@ -514,6 +520,9 @@ async function _request(options: RequestOptions): Promise<unknown> {
         credentials: 'omit', // prevent cookie-based tracking
         referrer: '', // prevent leaking the embedding page URL
         referrerPolicy: 'no-referrer', // belt-and-braces for referrer across all contexts
+        // A 307/308 re-sends the body to the redirect target, so any request carrying one fails
+        // rather than follows. Overridable for deployments that legitimately redirect.
+        ...(body !== undefined ? { redirect: 'error' as const } : undefined),
         ...fetchOptions, // allows override of above options
         ...(carriesAuth ? { redirect: 'error' as const } : undefined), // not overridable on auth requests
         signal, // not overridable (includes caller signal)

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -159,6 +159,40 @@ describe('requests', { timeout: 7500 }, () => {
     }
   });
 
+  test('redirect defaults to error on requests carrying a body, and stays overridable', async () => {
+    let init: Parameters<RequestFetch>[1];
+    const captureFetch = (async (
+      _input: Parameters<RequestFetch>[0],
+      requestInit?: Parameters<RequestFetch>[1],
+    ) => {
+      init = requestInit;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    await request({
+      endpoint: `${mintUrl}/v1/swap`,
+      method: 'POST',
+      requestBody: { inputs: [] },
+      fetch: captureFetch,
+    });
+    expect(init?.redirect).toBe('error');
+
+    await request({
+      endpoint: `${mintUrl}/v1/swap`,
+      method: 'POST',
+      requestBody: { inputs: [] },
+      redirect: 'follow',
+      fetch: captureFetch,
+    });
+    expect(init?.redirect).toBe('follow');
+
+    await request({ endpoint: `${mintUrl}/v1/info`, fetch: captureFetch });
+    expect(init?.redirect).toBeUndefined();
+  });
+
   test('per-request library options override the global default', async () => {
     const endpoint = mintUrl + '/v1/keys';
     server.use(

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -160,37 +160,37 @@ describe('requests', { timeout: 7500 }, () => {
   });
 
   test('redirect defaults to error on requests carrying a body, and stays overridable', async () => {
-    let init: Parameters<RequestFetch>[1];
-    const captureFetch = (async (
-      _input: Parameters<RequestFetch>[0],
-      requestInit?: Parameters<RequestFetch>[1],
-    ) => {
+    let init: RequestInit | undefined;
+    const captureFetch: typeof fetch = async (_input, requestInit) => {
       init = requestInit;
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
-    }) as RequestFetch;
+    };
+    vi.stubGlobal('fetch', captureFetch);
 
-    await request({
-      endpoint: `${mintUrl}/v1/swap`,
-      method: 'POST',
-      requestBody: { inputs: [] },
-      fetch: captureFetch,
-    });
-    expect(init?.redirect).toBe('error');
+    try {
+      await request({
+        endpoint: `${mintUrl}/v1/swap`,
+        method: 'POST',
+        requestBody: { inputs: [] },
+      });
+      expect(init?.redirect).toBe('error');
 
-    await request({
-      endpoint: `${mintUrl}/v1/swap`,
-      method: 'POST',
-      requestBody: { inputs: [] },
-      redirect: 'follow',
-      fetch: captureFetch,
-    });
-    expect(init?.redirect).toBe('follow');
+      await request({
+        endpoint: `${mintUrl}/v1/swap`,
+        method: 'POST',
+        requestBody: { inputs: [] },
+        redirect: 'follow',
+      });
+      expect(init?.redirect).toBe('follow');
 
-    await request({ endpoint: `${mintUrl}/v1/info`, fetch: captureFetch });
-    expect(init?.redirect).toBeUndefined();
+      await request({ endpoint: `${mintUrl}/v1/info` });
+      expect(init?.redirect).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   test('per-request library options override the global default', async () => {

--- a/test/wallet/wallet-auth.node.test.ts
+++ b/test/wallet/wallet-auth.node.test.ts
@@ -100,7 +100,7 @@ describe('Auth header redirect handling', () => {
     };
   }
 
-  test('protected requests refuse redirects; unprotected requests are unchanged', async () => {
+  test('requests carrying a token or a body refuse redirects; bodiless ones are unchanged', async () => {
     server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(protectedSwapInfo)));
 
     const authedSpy = vi.fn((args: { endpoint: string }) =>
@@ -111,9 +111,18 @@ describe('Auth header redirect handling', () => {
     const authedArgs = authedSpy.mock.calls.find((c) => c[0].endpoint.includes('/v1/swap'))![0];
     expect(authedArgs).toMatchObject({ redirect: 'error' });
 
+    // No auth token, but the body carries proofs.
     const plainSpy = vi.fn().mockResolvedValue({ signatures: [] });
     const plainMint = new Mint(mintUrl);
     await plainMint.swap({ inputs: [], outputs: [] }, plainSpy);
-    expect(plainSpy.mock.calls[0][0]).not.toHaveProperty('redirect');
+    expect(plainSpy.mock.calls[0][0]).toMatchObject({ redirect: 'error' });
+
+    const getSpy = vi
+      .fn()
+      .mockResolvedValue({ quote: 'q', request: 'lnbc', unit: 'sat', amount: 1, state: 'UNPAID' });
+    await plainMint.checkMintQuote('bolt11', 'q', {
+      customRequest: getSpy as unknown as RequestFn,
+    });
+    expect(getSpy.mock.calls[0][0]).not.toHaveProperty('redirect');
   });
 });


### PR DESCRIPTION
# Description
Backport of #1039 to `v4-dev`.