### PR TITLE
chore(scripts): report and verify the experimental build honestly

### DIFF
--- a/scripts/make-experimental.sh
+++ b/scripts/make-experimental.sh
@@ -85,17 +85,28 @@ BASE_SHA=$(git rev-parse --short HEAD)   # the $BASE commit this build sits on
 for pr in "${PRS[@]}"; do
   echo ">> merging PR #$pr"
   git fetch "$REMOTE" "pull/$pr/head:pr-$pr" --force
-  if ! git merge --no-edit "pr-$pr"; then
-    if [[ -n "$(git ls-files --unmerged)" ]]; then
-      echo "" >&2
-      echo "!! unresolved conflict merging PR #$pr — fix the files, then:" >&2
-      echo "     git add -A && git commit --no-edit --no-verify" >&2
-      echo "   then re-run; rerere replays the fix automatically next time." >&2
-      exit 1
-    fi
-    # rerere replayed a known resolution and staged it — just conclude the merge
-    git commit --no-edit --no-verify
+  # Captured, not streamed, because whether the merge hit a conflict is the only
+  # way to tell a replayed resolution from a hook that refused the auto-commit.
+  if merge_log=$(git merge --no-edit "pr-$pr" 2>&1); then
+    printf '%s\n' "$merge_log"
+    continue
+  fi
+  printf '%s\n' "$merge_log"
+  if [[ -n "$(git ls-files --unmerged)" ]]; then
+    echo "" >&2
+    echo "!! unresolved conflict merging PR #$pr — fix the files, then:" >&2
+    echo "     git add -A && git commit --no-edit --no-verify" >&2
+    echo "   then re-run; rerere replays the fix automatically next time." >&2
+    exit 1
+  fi
+  # Nothing left unmerged, so the tree is right and only the commit is missing.
+  git commit --no-edit --no-verify
+  if grep -q '^CONFLICT' <<<"$merge_log"; then
     echo ">> rerere auto-resolved PR #$pr"
+  else
+    # No conflict at all: a hook rejected the merge commit. Committed anyway,
+    # since this branch is throwaway, but a failing hook is worth knowing about.
+    echo "!! PR #$pr merged clean; a git hook blocked the commit (see above), committed with --no-verify" >&2
   fi
 done
 

--- a/scripts/make-experimental.sh
+++ b/scripts/make-experimental.sh
@@ -119,13 +119,18 @@ if [[ "${PUBLISH:-}" == "1" ]]; then
   # never picks it up (@latest unaffected). Unique per bundle (sha changes with
   # the PRs); re-publishing an identical bundle is a harmless no-op (npm rejects
   # the duplicate version).
-  # compile (nothing else triggers it on publish) + unit tests on the MERGED
-  # tree — each PR passed CI alone, but this catches breakage from combining
-  # them, which is the whole point of the experimental build. Not full `prtasks`: lint/format/
-  # api-report are repo hygiene that don't affect the published lib/, and
-  # api:update mutates files mid-publish. Skip tests with SKIP_TEST=1 to iterate.
-  echo ">> building + testing merged tree"
+  # compile + types + unit tests on the MERGED tree — each PR passed CI alone,
+  # but this catches breakage from combining them, which is the whole point of
+  # the experimental build. Not full `prtasks`: lint/format/api-report are repo
+  # hygiene that don't affect the published lib/, and api:update mutates files
+  # mid-publish. Skip tests with SKIP_TEST=1 to iterate.
+  echo ">> building + type-checking + testing merged tree"
   npm run compile
+  # Types get their own step because nothing else here checks them: esbuild
+  # (compile) and vitest both strip types without checking. A rerere replay that
+  # has gone stale against a moved base can produce a type-only break that
+  # compiles and passes tests, and would otherwise publish clean.
+  npm run check-types
   # node project only: fast, no Playwright browser dep, no coverage report —
   # enough to catch breakage from combining the PRs. SKIP_TEST=1 to skip.
   [[ "${SKIP_TEST:-}" == "1" ]] || npx vitest run --project node


### PR DESCRIPTION
Two faults in `make-experimental.sh`, both found by them actually misfiring during a rebuild.

## A blocked hook was reported as a resolved conflict

`git merge` returns non-zero when a hook rejects the merge commit, leaving nothing unmerged. The script took that path as a rerere replay and announced `>> rerere auto-resolved PR #N` for a merge that had no conflict at all.

That hid a `commit-msg` hook failing on a PATH without `npx`, and would hide a `pre-commit` failure the same way. The merge output is now captured rather than streamed, since the presence of a conflict is what separates the two cases. Both still conclude the merge with `--no-verify`, the branch being throwaway, but a blocked hook now says so on stderr.

## A type-only break could publish clean

The publish gate ran `compile` and the node tests, and neither checks types: esbuild and vitest both strip them, which is why `check-types` exists as its own script. A rerere replay that has gone stale against a moved base can therefore produce a type-only break that compiles, passes and publishes.

This is not hypothetical. A resolution banked before #950's `Bytes` migration replayed onto a moved base and reinstated a duplicate `bytesToHex` import. That one was caught, because esbuild rejects a duplicate identifier outright, but the same staleness producing a wrong type would have shipped.

Verified both directions: a wrong-typed export builds and tests without complaint, and is caught only by `check-types`.

Still not full `prtasks`, since `format` and `api:update` mutate files and would dirty the tree mid-build.