### PR TITLE
fix(wallet): omit unselected proofs from serialized swap previews [backport v4-dev]

### DIFF
--- a/docs-src/usage/nut19.md
+++ b/docs-src/usage/nut19.md
@@ -147,7 +147,8 @@ const receivePreview = await wallet.prepareSwapToReceive(token);
 const sendPreview = await wallet.prepareSwapToSend(21, proofs, { includeFees: true });
 
 // Swap previews have a serialize helper: persist the JSON-safe form, then
-// rehydrate it with deserializeSwapPreview to replay after a restart.
+// rehydrate it with deserializeSwapPreview to replay after a restart. The blob carries
+// spendable proofs, so protect it like the proof database.
 const stored = JSON.stringify(serializeSwapPreview(receivePreview));
 const { keep } = await wallet.completeSwap(deserializeSwapPreview(JSON.parse(stored)));
 ```

--- a/docs-src/wallet_ops/receive.md
+++ b/docs-src/wallet_ops/receive.md
@@ -81,6 +81,9 @@ const { keep } = await wallet.completeSwap(preview);
 const { keep: recovered } = await wallet.completeSwap(deserializeSwapPreview(JSON.parse(stored)));
 ```
 
+> The serialized preview contains `inputs` in the clear, so it is spendable bearer material.
+> Store it with the same protection as the proof database, and delete it once the swap settles.
+
 The replay window has bounds:
 
 - The mint must advertise `/v1/swap` in its NUT-19 `cached_endpoints`, and the replay must

--- a/docs-src/wallet_ops/send.md
+++ b/docs-src/wallet_ops/send.md
@@ -101,7 +101,8 @@ import { deserializeSwapPreview, serializeSwapPreview } from '@cashu/cashu-ts';
 
 const preview = await wallet.ops.send(21, myProofs).prepare();
 
-// Unselected proofs can go back to storage now; they are not part of the replay.
+// Unselected proofs are not part of the replay and are not serialized: return them to
+// storage yourself, and add them back to `keep` after a replayed completeSwap.
 const backToStorage = preview.unselectedProofs ?? [];
 
 // Persist before completing. Previews contain Amount, bigint and Uint8Array values,
@@ -115,6 +116,9 @@ const { keep: change, send: recovered } = await wallet.completeSwap(
   deserializeSwapPreview(JSON.parse(stored)),
 );
 ```
+
+> The serialized preview contains `inputs` in the clear, so it is spendable bearer material.
+> Store it with the same protection as the proof database, and delete it once the swap settles.
 
 The replay window has bounds:
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1921,7 +1921,6 @@ export type SerializedSwapPreview = {
     inputs: SerializedProof[];
     sendOutputs?: SerializedOutputData[];
     keepOutputs?: SerializedOutputData[];
-    unselectedProofs?: SerializedProof[];
 };
 
 // @public (undocumented)

--- a/src/wallet/SwapPreview.ts
+++ b/src/wallet/SwapPreview.ts
@@ -21,7 +21,6 @@ export type SerializedSwapPreview = {
   inputs: SerializedProof[];
   sendOutputs?: SerializedOutputData[];
   keepOutputs?: SerializedOutputData[];
-  unselectedProofs?: SerializedProof[];
 };
 
 function serializeProof(proof: Proof): SerializedProof {
@@ -34,6 +33,10 @@ function serializeProof(proof: Proof): SerializedProof {
  * @remarks
  * Persist the result before `completeSwap` to support NUT-19 replay safety: a preview rehydrated
  * with {@link deserializeSwapPreview} replays a byte-identical swap request.
+ *
+ * The result holds `inputs` in the clear, so it is spendable bearer material: store it as carefully
+ * as the proof database. `unselectedProofs` take no part in the replay and are not included; return
+ * them to storage separately.
  */
 export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPreview {
   return {
@@ -46,9 +49,6 @@ export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPrevie
     }),
     ...(preview.keepOutputs && {
       keepOutputs: preview.keepOutputs.map((o) => OutputData.serialize(o)),
-    }),
-    ...(preview.unselectedProofs && {
-      unselectedProofs: preview.unselectedProofs.map(serializeProof),
     }),
   };
 }
@@ -71,9 +71,6 @@ export function deserializeSwapPreview(serialized: SerializedSwapPreview): SwapP
       }),
       ...(serialized.keepOutputs && {
         keepOutputs: serialized.keepOutputs.map((s) => OutputData.deserialize(s)),
-      }),
-      ...(serialized.unselectedProofs && {
-        unselectedProofs: normalizeProofAmounts(serialized.unselectedProofs),
       }),
     };
   } catch (e) {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -321,6 +321,19 @@ describe('send', () => {
     expect(first.send[0].secret).toBe(replayed.send[0].secret);
   });
 
+  test('serializeSwapPreview omits unselected proofs', () => {
+    const serialized = serializeSwapPreview({
+      amount: Amount.from(1),
+      fees: Amount.from(0),
+      keysetId: '00bd033559de27d0',
+      inputs: [proofs[0]],
+      unselectedProofs: [{ ...proofs[0], secret: 'not-part-of-the-replay' }],
+    });
+
+    expect(serialized).not.toHaveProperty('unselectedProofs');
+    expect(JSON.stringify(serialized)).not.toContain('not-part-of-the-replay');
+  });
+
   test('deserializeSwapPreview rejects malformed output data', () => {
     const bad: SerializedSwapPreview = {
       amount: '1',


### PR DESCRIPTION
# Description
Backport of #1040 to `v4-dev`.