### PR TITLE
fix(nut20): match quote lock keys by x coordinate

### DIFF
--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -152,16 +152,25 @@ function toXOnlyPubkey(pubkey: string): string {
 /**
  * Find the private key that can sign for a given compressed public key.
  *
+ * @remarks
+ * Matches on the x coordinate: a key imported from an x-only context (any nostr key) is published
+ * as `02 || x` but its scalar derives the odd-y twin half the time. That twin is `n - d`, and it is
+ * what gets returned, so the caller signs for the point the quote actually names.
  * @param pubkey Compressed SEC1 public key (33 bytes, hex-encoded) to match against.
  * @param privkeys One or more candidate private keys (hex-encoded).
- * @returns The matching private key hex string.
+ * @returns The private key hex string that signs for `pubkey`.
  * @throws If no candidate key derives to the expected pubkey.
  */
 export function findSigningKey(pubkey: string, privkeys: string | string[]): string {
   const keys = Array.isArray(privkeys) ? privkeys : [privkeys];
+  const wanted = pubkey.toLowerCase();
   for (const key of keys) {
     const derived = bytesToHex(secp256k1.getPublicKey(hexToBytes(key), true));
-    if (derived.toLowerCase() === pubkey.toLowerCase()) return key;
+    if (derived === wanted) return key;
+    if (derived.slice(2) === wanted.slice(2)) {
+      const d = secp256k1.Point.Fn.fromBytes(hexToBytes(key));
+      return bytesToHex(secp256k1.Point.Fn.toBytes(secp256k1.Point.Fn.neg(d)));
+    }
   }
   throw new CTSError(`No private key matches quote pubkey ${pubkey}`);
 }

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -26,6 +26,7 @@ import {
   schnorrSignDigest,
   schnorrSignMessage,
   schnorrVerifyDigest,
+  findSigningKey,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 
@@ -277,5 +278,33 @@ describe('getValidSigners / meetsSignerThreshold', () => {
   test('non-string pubkey entries fail closed without throwing', () => {
     const pubkeys = [42 as unknown as string, compressed];
     expect(getValidSigners([signature], message, pubkeys)).toEqual([compressed]);
+  });
+});
+
+describe('findSigningKey', () => {
+  const priv = (n: number) => n.toString(16).padStart(64, '0');
+  const pub = (key: string) => bytesToHex(secp256k1.getPublicKey(hexToBytes(key), true));
+  const flip = (pubkey: string) => (pubkey.startsWith('02') ? '03' : '02') + pubkey.slice(2);
+
+  test('returns the candidate that derives the pubkey, case-insensitively', () => {
+    expect(findSigningKey(pub(priv(2)), [priv(1), priv(2)])).toBe(priv(2));
+    expect(findSigningKey(pub(priv(2)).toUpperCase(), priv(2))).toBe(priv(2));
+  });
+
+  test('an x-only import signs for the published parity through the negated scalar', () => {
+    // A nostr key is published as 02||x whatever its y; the wallet may hold the scalar of the
+    // other twin. The returned key must derive exactly the pubkey the quote names.
+    for (const key of [priv(1), priv(2), priv(3), priv(0x1234)]) {
+      const twin = flip(pub(key));
+      const signing = findSigningKey(twin, key);
+      expect(signing).not.toBe(key);
+      expect(pub(signing)).toBe(twin);
+    }
+  });
+
+  test('throws when no candidate matches on x', () => {
+    expect(() => findSigningKey(pub(priv(9)), [priv(1), priv(2)])).toThrow(
+      /No private key matches/,
+    );
   });
 });


### PR DESCRIPTION
`findSigningKey` compared compressed pubkeys byte for byte. A key imported from an x-only context (any nostr key, including NIP-61 nutzap keys) is published as `02 || x`, but its scalar derives the odd-y twin half the time, so minting a locked quote failed with "No private key matches quote pubkey" for half of all such users.

The fix matches on the x coordinate and returns the scalar for the published parity (`n - d` when the derived point is the other twin), so the NUT-20 signature verifies against the pubkey the quote names. Exact matches behave as before.

Tests cover the exact match, the negated-scalar path across several keys, and the no-match error.
