### PR TITLE
fix(nut20): match quote lock keys by x coordinate [backport v4-dev]

### DIFF
--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -269,16 +269,25 @@ function toXOnlyPubkey(pubkey: string): string {
 /**
  * Find the private key that can sign for a given compressed public key.
  *
+ * @remarks
+ * Matches on the x coordinate: a key imported from an x-only context (any nostr key) is published
+ * as `02 || x` but its scalar derives the odd-y twin half the time. That twin is `n - d`, and it is
+ * what gets returned, so the caller signs for the point the quote actually names.
  * @param pubkey Compressed SEC1 public key (33 bytes, hex-encoded) to match against.
  * @param privkeys One or more candidate private keys (hex-encoded).
- * @returns The matching private key hex string.
+ * @returns The private key hex string that signs for `pubkey`.
  * @throws If no candidate key derives to the expected pubkey.
  */
 export function findSigningKey(pubkey: string, privkeys: string | string[]): string {
   const keys = Array.isArray(privkeys) ? privkeys : [privkeys];
+  const wanted = pubkey.toLowerCase();
   for (const key of keys) {
     const derived = bytesToHex(secp256k1.getPublicKey(hexToBytes(key), true));
-    if (derived.toLowerCase() === pubkey.toLowerCase()) return key;
+    if (derived === wanted) return key;
+    if (derived.slice(2) === wanted.slice(2)) {
+      const d = secp256k1.Point.Fn.fromBytes(hexToBytes(key));
+      return bytesToHex(secp256k1.Point.Fn.toBytes(secp256k1.Point.Fn.neg(d)));
+    }
   }
   throw new CTSError(`No private key matches quote pubkey ${pubkey}`);
 }

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -19,7 +19,11 @@ import {
   schnorrSignDigest,
   schnorrSignMessage,
   schnorrVerifyDigest,
+<<<<<<< HEAD
   pointFromBytes,
+=======
+  findSigningKey,
+>>>>>>> 0f4d025 (fix(nut20): match quote lock keys by x coordinate (#1044))
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 
@@ -192,5 +196,33 @@ describe('getValidSigners / meetsSignerThreshold', () => {
   test('non-string pubkey entries fail closed without throwing', () => {
     const pubkeys = [42 as unknown as string, compressed];
     expect(getValidSigners([signature], message, pubkeys)).toEqual([compressed]);
+  });
+});
+
+describe('findSigningKey', () => {
+  const priv = (n: number) => n.toString(16).padStart(64, '0');
+  const pub = (key: string) => bytesToHex(secp256k1.getPublicKey(hexToBytes(key), true));
+  const flip = (pubkey: string) => (pubkey.startsWith('02') ? '03' : '02') + pubkey.slice(2);
+
+  test('returns the candidate that derives the pubkey, case-insensitively', () => {
+    expect(findSigningKey(pub(priv(2)), [priv(1), priv(2)])).toBe(priv(2));
+    expect(findSigningKey(pub(priv(2)).toUpperCase(), priv(2))).toBe(priv(2));
+  });
+
+  test('an x-only import signs for the published parity through the negated scalar', () => {
+    // A nostr key is published as 02||x whatever its y; the wallet may hold the scalar of the
+    // other twin. The returned key must derive exactly the pubkey the quote names.
+    for (const key of [priv(1), priv(2), priv(3), priv(0x1234)]) {
+      const twin = flip(pub(key));
+      const signing = findSigningKey(twin, key);
+      expect(signing).not.toBe(key);
+      expect(pub(signing)).toBe(twin);
+    }
+  });
+
+  test('throws when no candidate matches on x', () => {
+    expect(() => findSigningKey(pub(priv(9)), [priv(1), priv(2)])).toThrow(
+      /No private key matches/,
+    );
   });
 });

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -19,11 +19,8 @@ import {
   schnorrSignDigest,
   schnorrSignMessage,
   schnorrVerifyDigest,
-<<<<<<< HEAD
   pointFromBytes,
-=======
   findSigningKey,
->>>>>>> 0f4d025 (fix(nut20): match quote lock keys by x coordinate (#1044))
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 


### PR DESCRIPTION
# Description
Backport of #1044 to `v4-dev`.