### PR TITLE
chore(scripts): deprecate the superseded snapshot on experimental publish

### DIFF
--- a/scripts/make-experimental.sh
+++ b/scripts/make-experimental.sh
@@ -154,10 +154,22 @@ if [[ "${PUBLISH:-}" == "1" ]]; then
   prs_csv=$(IFS=,; echo "${PRS[*]}")
   node -e "const fs=require('fs'),p=require('./package.json');p.experimentalBundle={base:'$BASE@$BASE_SHA',prs:[$prs_csv]};fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
+  # Read before publishing, since publish moves the tag.
+  pkg=$(node -p "require('./package.json').name")
+  prev=$(npm view "$pkg@experimental" version 2>/dev/null || true)
+
   echo ">> publishing $expver @experimental"
   npm version "$expver" --no-git-tag-version --allow-same-version
   git commit -aqm "chore(experimental): $expver" --no-verify   # throwaway; skip husky/commitlint
   npm publish --tag experimental
+
+  # Snapshots are throwaway, so nudge anyone pinned to the one this replaces.
+  # Never fail the publish over it: npm deprecate exits non-zero on a 422 it
+  # actually applied.
+  if [[ -n "$prev" && "$prev" != "$expver" ]]; then
+    echo ">> deprecating superseded $prev"
+    npm deprecate "$pkg@$prev" "Superseded snapshot build. Use @cashu/cashu-ts@experimental or @next." || true
+  fi
 
   printf '\n=== announce ===\nnpm i @cashu/cashu-ts@%s   (tag: experimental)\nbundled on %s@%s:\n%s\n' "$expver" "$BASE" "$BASE_SHA" "$summary"
 fi


### PR DESCRIPTION
The experimental publish script now deprecates the snapshot build it replaces, instead of that being a manual step after every publish.

## Why

Snapshot builds accumulate on npm. Anyone pinned to an exact `5.0.0-experimental.<sha>` gets no signal that a newer bundle exists, and deprecating each superseded build by hand is easy to forget.

## Changes

A `PUBLISH=1` run reads the `experimental` dist-tag before publishing, since publishing moves it, then deprecates the version it replaced with the same wording used manually so far. A failure there is ignored: `npm deprecate` exits non-zero on a 422 it has actually applied, and bookkeeping should not fail a publish that succeeded.

## Impact

None for `latest` consumers. It only touches `@experimental` snapshots: the currently tagged build is never deprecated, and re-publishing an identical bundle is a no-op.
