### PR TITLE
ci: recognise deps commits when releasing v3-dev

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,66 @@
       "bootstrap-sha": "f6fbb6bb8f892eb7fa300171255c84edc7f2aada"
     }
   },
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/resources/schema.json"
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/resources/schema.json",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "feature",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ]
 }


### PR DESCRIPTION
release-please skips runtime dependency bumps on v3-dev, so they reach consumers with no changelog entry.

## Why

Dependabot writes runtime bumps with a `deps` prefix (`prefix-development` keeps dev bumps on `chore`, which release-please ignores). The `changelog-sections` block that maps `deps` to a Dependencies section was only added to main, so on v3-dev the prefix is an unknown type and the commit counts as not user facing.

Today's run on v3-dev shows it: `Considering: 2 commits` then `No user facing commits found - skipping`, with the noble bump among those two. On v4-dev the release PR refreshed after the bump merged and still has no Dependencies section.

## Changes

Copied `changelog-sections` from main verbatim. Specifying the block replaces release-please's defaults, so it has to be the full list rather than a `deps` entry on its own.

## Impact

Runtime dependency bumps now open a release PR and appear under Dependencies. No change to what any other prefix does.