### PR TITLE
ci: label runtime dependency bumps as fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,12 +12,12 @@ updates:
     # ranges, which would let a noble major claim support for two incompatible
     # majors at once
     versioning-strategy: increase-if-necessary
-    # Runtime deps ship to consumers, so their bumps go in the changelog under
-    # Dependencies (see changelog-sections in release-please-config.json).
-    # Dev bumps keep the chore prefix release-please ignores.
+    # Runtime deps ship to consumers, so a bump changes the published package
+    # and earns a patch. fix is the type release-please acts on; dev bumps keep
+    # the chore prefix it ignores.
     commit-message:
-      prefix: deps
-      prefix-development: chore(deps-dev)
+      prefix: fix(deps)
+      prefix-development: chore(deps)
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -61,8 +61,8 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
-    # Pinned, not inferred: once deps: commits exist in main, inference could
-    # put CI bumps in the consumer-facing Dependencies section.
+    # Pinned, not inferred: inference could promote a CI bump into a releasable
+    # fix(deps) commit.
     commit-message:
       prefix: chore(deps)
 
@@ -74,7 +74,7 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
-    # Pinned, not inferred: once deps: commits exist in main, inference could
-    # put CI bumps in the consumer-facing Dependencies section.
+    # Pinned, not inferred: inference could promote a CI bump into a releasable
+    # fix(deps) commit.
     commit-message:
       prefix: chore(deps)


### PR DESCRIPTION
Dependabot's runtime dependency bumps have never cut a release. Retyping them as `fix(deps)` makes them do so.

## Why

Runtime bumps carried the `deps` prefix, which release-please only recognises when it runs in manifest mode reading `release-please-config.json`. This repo passes `release-type` to the action instead, so that file is never read and `deps` is an unknown type. The v3-dev release-please run says it plainly:

```
✔ Considering: 3 commits
✔ No user facing commits found since 2716ff76 - skipping
```

A noble bump changes what consumers install, so the published package changed and it earns a patch. `fix(deps)` is the conventional spelling for that, and matches Renovate's default for production dependencies.

## Changes

- `prefix: deps` -> `prefix: fix(deps)` for the npm ecosystem.
- Dev bumps move from `chore(deps-dev)` to `chore(deps)`, sharing the prefix already used for action bumps. Both are invisible to consumers and the scope is obvious from the PR.
- Comments updated: they justified the old scheme by pointing at `release-please-config.json`.

## Impact

Runtime dependency bumps now appear under Bug Fixes and cut a patch release. Dev and CI bumps stay unreleasable. The seven day cooldown still applies, so this does not add churn.

This file exists only on main, so the LTS branches are unaffected; their bumps arrive by backport and inherit the new subject.
