### PR TITLE
fix(deps): move noble and scure to 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "4.10.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^2.2.0",
-        "@noble/hashes": "^2.2.0",
-        "@scure/base": "^2.2.0",
-        "@scure/bip32": "^2.2.0"
+        "@noble/curves": "^2.4.0",
+        "@noble/hashes": "^2.4.0",
+        "@scure/base": "^2.4.0",
+        "@scure/bip32": "^2.4.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
@@ -1966,50 +1966,23 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
-      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.4.0.tgz",
+      "integrity": "sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.3.0.tgz",
-      "integrity": "sha512-mMPjNcXxJsvNveIgRIXrnwd4omu0wdXo4JowAUZO7/82+/bpAwVltclx6MG6nv2M3dA6IbfVv4xwWxaREm3OcA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.4.0.tgz",
+      "integrity": "sha512-i3DS0CptAocyvqE4n3SUkpzeQK4vJMFwWLofTwRiiKo2aWojBOfyMCgfKw9HVpO6fSY5AK86sHS/Uzn8kK9Few==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "2.3.0",
-        "@noble/hashes": "2.3.0",
-        "@scure/base": "2.3.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
-      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "2.3.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
-      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
+        "@noble/curves": "2.4.0",
+        "@noble/hashes": "2.4.0",
+        "@scure/base": "2.4.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "ws": "^8.20.0"
   },
   "dependencies": {
-    "@noble/curves": "^2.2.0",
-    "@noble/hashes": "^2.2.0",
-    "@scure/base": "^2.2.0",
-    "@scure/bip32": "^2.2.0"
+    "@noble/curves": "^2.4.0",
+    "@noble/hashes": "^2.4.0",
+    "@scure/base": "^2.4.0",
+    "@scure/bip32": "^2.4.0"
   }
 }


### PR DESCRIPTION
Moves `@noble/curves`, `@noble/hashes`, `@scure/base` and `@scure/bip32` to `^2.4.0` and collapses a duplicate copy of noble in the tree.

## Why

The declared floors sat at `^2.2.0` while the lockfile had moved on, and `@scure/bip32` pins its noble versions exactly. So the tree held two copies:

```
node_modules/@noble/curves                            2.4.0
node_modules/@scure/bip32/node_modules/@noble/curves  OLD
```

Key derivation ran the older copy whatever the top level said, and the standalone IIFE bundle carries dependencies inline, so it shipped both.

## Changes

All four floors to `^2.4.0`. `@scure/bip32@2.4.0` pins base, curves and hashes at 2.4.0, so the tree dedupes and consumers resolve what the tests actually run against.

## Impact

Consumers on a lockfile below 2.4.0 will resolve up on their next install. One copy of noble in the dependency tree and in the standalone bundle.
