### PR TITLE
feat(nut14): preimage option for spending HTLC inputs

### DIFF
--- a/docs-src/wallet_ops/receive.md
+++ b/docs-src/wallet_ops/receive.md
@@ -94,3 +94,11 @@ The replay window has bounds:
   preview is what covers a process restart.
 - A preview and a seed protect different windows: the preview covers a restart inside the
   TTL; deterministic secrets plus NUT-09 restore cover loss after it.
+
+## Spending an HTLC
+
+An HTLC input needs the preimage as well as any signatures. Pass it in the receive, send or melt config, or through `.preimage()` on the builders: it goes on the witness of every input whose hashlock it opens, before signing, and `attachHTLCPreimage(proofs, preimage)` does the same for proofs you handle yourself.
+
+```ts
+const proofs = await wallet.receive(token, { privkey, preimage });
+```

--- a/docs-src/wallet_ops/receive.md
+++ b/docs-src/wallet_ops/receive.md
@@ -97,7 +97,7 @@ The replay window has bounds:
 
 ## Spending an HTLC
 
-An HTLC input needs the preimage as well as any signatures. Pass it in the receive, send or melt config, or through `.preimage()` on the builders: it goes on the witness of every input whose hashlock it opens, before signing, and `attachHTLCPreimage(proofs, preimage)` does the same for proofs you handle yourself.
+An HTLC input needs the preimage as well as any signatures. Pass it in the receive, send or melt config, or through `.preimage()` on the builders: it goes on the witness of every input whose hashlock it opens, before signing, and `attachHTLCPreimage(proofs, preimage)` does the same for proofs you handle yourself. A `send` with a preimage always swaps, so the receiver gets plain proofs rather than the locked one. A v3 hashlock is a leaf: plan it with `planScriptPaths(proofs, { privkeys, preimage })` and pass the plans as `scriptPath` (see [spending locked proofs](spend_locked.md)).
 
 ```ts
 const proofs = await wallet.receive(token, { privkey, preimage });

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -148,6 +148,9 @@ export function assertSecretKind(allowed: SecretKind | SecretKind[], secret: Sec
 export function assertV3PointSecret(secret: Uint8Array | string): void;
 
 // @public
+export function attachHTLCPreimage<T extends ProofLike>(proofs: T[], preimage: string): T[];
+
+// @public
 export function auditableLock(pubkey: string): LockOptions_2;
 
 // @public
@@ -1013,6 +1016,7 @@ export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | '
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
+    preimage(preimage: string): this;
     prepare(): Promise<MeltPreview<TQuote>>;
     privkey(k: string | string[]): this;
     run(): Promise<MeltProofsResponse<TQuote>>;
@@ -1033,6 +1037,7 @@ export class MeltOnchainBuilder {
     constructor(wallet: Wallet, quote: MeltQuoteOnchainResponse, proofs: ProofLike[]);
     feeIndex(index: number): this;
     keyset(id: string): this;
+    preimage(preimage: string): this;
     privkey(k: string | string[]): this;
     run(): Promise<MeltProofsResponse<MeltQuoteOnchainResponse>>;
     scriptPath(plans: ScriptPathPlan[]): this;
@@ -1053,6 +1058,7 @@ export type MeltProofsConfig = {
     keysetId?: string;
     privkey?: string | string[];
     scriptPath?: ScriptPathPlan[];
+    preimage?: string;
     onCountersReserved?: OnCountersReserved;
     nut08Change?: boolean;
 };
@@ -2145,6 +2151,7 @@ export class ReceiveBuilder {
     asRandom(denoms?: AmountLike[]): this;
     keyset(id: string): this;
     onCountersReserved(cb: OnCountersReserved): this;
+    preimage(preimage: string): this;
     prepare(): Promise<SwapPreview>;
     privkey(k: string | string[]): this;
     proofsWeHave(p: Array<Pick<ProofLike, 'amount'>>): this;
@@ -2158,6 +2165,7 @@ export type ReceiveConfig = {
     keysetId?: string;
     privkey?: string | string[];
     scriptPath?: ScriptPathPlan[];
+    preimage?: string;
     requireDleq?: boolean;
     proofsWeHave?: Array<Pick<ProofLike, 'amount'>>;
     onCountersReserved?: OnCountersReserved;
@@ -2320,6 +2328,7 @@ export class SendBuilder {
     offlineCloseMatch(requireDleq?: boolean): this;
     offlineExactOnly(requireDleq?: boolean): this;
     onCountersReserved(cb: OnCountersReserved): this;
+    preimage(preimage: string): this;
     prepare(): Promise<SwapPreview>;
     privkey(k: string | string[]): this;
     proofsWeHave(p: Array<Pick<ProofLike, 'amount'>>): this;
@@ -2332,6 +2341,7 @@ export type SendConfig = {
     keysetId?: string;
     privkey?: string | string[];
     scriptPath?: ScriptPathPlan[];
+    preimage?: string;
     includeFees?: boolean;
     proofsWeHave?: Array<Pick<ProofLike, 'amount'>>;
     onCountersReserved?: OnCountersReserved;

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -3,7 +3,7 @@ import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils.js';
 
 import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
-import { type HTLCWitness, type Proof } from '../model/types';
+import { type HTLCWitness, type Proof, type ProofLike } from '../model/types';
 
 import {
   assertSecretKind,
@@ -13,7 +13,11 @@ import {
   parseSecret,
   getSecretKind,
 } from './NUT10';
-import { type P2PKVerificationResult, verifyP2PKSpendingConditions } from './NUT11';
+import {
+  type P2PKVerificationResult,
+  parseWitnessData,
+  verifyP2PKSpendingConditions,
+} from './NUT11';
 
 // ------------------------------
 // NUT-14 Secrets
@@ -197,4 +201,35 @@ export function getHTLCWitnessPreimage(witness: Proof['witness']): string | unde
   // Check preimage is a non-empty string
   const preimage = parsed.preimage;
   return typeof preimage === 'string' && preimage.length > 0 ? preimage : undefined;
+}
+
+/**
+ * Puts `preimage` on the witness of every HTLC proof whose hashlock it opens.
+ *
+ * @remarks
+ * Other proofs pass through untouched. Existing signatures are kept, and signing keeps the
+ * preimage, so this composes with {@link signP2PKProofs} in either order.
+ * @param proofs Proofs to stamp.
+ * @param preimage 64 hex characters.
+ * @throws If `preimage` is malformed.
+ */
+export function attachHTLCPreimage<T extends ProofLike>(proofs: T[], preimage: string): T[] {
+  if (!/^[0-9a-f]{64}$/i.test(preimage)) {
+    throw new CTSError('Preimage must be a 64 character hexadecimal string (32 bytes).');
+  }
+  const hex = preimage.toLowerCase();
+  return proofs.map((proof) => {
+    let secret: Secret;
+    try {
+      secret = parseSecret(proof.secret);
+    } catch {
+      return proof;
+    }
+    if (getSecretKind(secret) !== 'HTLC' || !verifyHTLCHash(hex, getDataField(secret))) {
+      return proof;
+    }
+    const signatures = parseWitnessData(proof.witness)?.signatures ?? [];
+    const witness: HTLCWitness = { preimage: hex, ...(signatures.length && { signatures }) };
+    return { ...proof, witness };
+  });
 }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -19,6 +19,7 @@ import {
   buildP2PKSigAllMessageV0,
   assertSigAllInputs,
   parseSecret,
+  attachHTLCPreimage,
   isV3PointSecret,
 } from '../crypto';
 // Internal transitional fallback — not part of crypto/index.ts
@@ -1339,7 +1340,7 @@ class Wallet {
     config?: ReceiveConfig,
     outputType?: OutputType,
   ): Promise<SwapPreview> {
-    const { keysetId, requireDleq, proofsWeHave, onCountersReserved } = config || {};
+    const { keysetId, requireDleq, proofsWeHave, onCountersReserved, preimage } = config || {};
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
 
     // Extract proofs — either directly or by decoding the token
@@ -1424,7 +1425,7 @@ class Wallet {
       amount: receiveAmount,
       fees: swapFee,
       keysetId: keyset.id,
-      inputs: proofs,
+      inputs: preimage === undefined ? proofs : attachHTLCPreimage(proofs, preimage),
       keepOutputs: outputs,
     };
   }
@@ -1614,7 +1615,7 @@ class Wallet {
   ): Promise<SwapPreview> {
     const sendAmountTarget = this.parseAmount(amount, 'prepareSwapToSend');
     const normalizedProofs = normalizeProofAmounts(proofs);
-    const { keysetId, includeFees = false, onCountersReserved } = config || {};
+    const { keysetId, includeFees = false, onCountersReserved, preimage } = config || {};
 
     // Rotation evidence check: repair the snapshot before any assertion or fee math
     // relies on it. Inputs are priced from keyset metadata, so keys are not fetched.
@@ -1700,7 +1701,8 @@ class Wallet {
       amount: sendAmountTarget,
       fees: swapFee,
       keysetId: keyset.id,
-      inputs: selectedProofs,
+      inputs:
+        preimage === undefined ? selectedProofs : attachHTLCPreimage(selectedProofs, preimage),
       sendOutputs,
       keepOutputs,
       unselectedProofs,
@@ -3929,7 +3931,7 @@ class Wallet {
   ): Promise<MeltPreview<TQuote>> {
     this.validateMeltQuote(meltQuote);
     outputType = outputType ?? this.defaultOutputType(); // Fallback to policy
-    const { keysetId, onCountersReserved, nut08Change = true } = config || {};
+    const { keysetId, onCountersReserved, nut08Change = true, preimage } = config || {};
 
     // Rotation evidence check: repair the snapshot so the output binding is current.
     // bolt11/bolt12 melts never consult the input keyset (no keys, no fee metadata), so an
@@ -4015,7 +4017,8 @@ class Wallet {
     // Create melt preview
     const meltPreview: MeltPreview<TQuote> = {
       method,
-      inputs: normalizedProofs,
+      inputs:
+        preimage === undefined ? normalizedProofs : attachHTLCPreimage(normalizedProofs, preimage),
       outputData,
       keysetId: keyset.id,
       quote: meltQuote,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1534,6 +1534,7 @@ class Wallet {
       if (
         keysetId ||
         config?.scriptPath?.length ||
+        config?.preimage !== undefined ||
         wantsDeterministicByPolicy ||
         !isPlainRandom(outputConfig.send) ||
         (outputConfig.keep && !isPlainRandom(outputConfig.keep))
@@ -1542,6 +1543,7 @@ class Wallet {
         const reasons: string[] = [];
         if (keysetId) reasons.push('keysetId override');
         if (config?.scriptPath?.length) reasons.push('script-path spend');
+        if (config?.preimage !== undefined) reasons.push('HTLC preimage');
         if (wantsDeterministicByPolicy) reasons.push('wallet default is deterministic');
         if (!isPlainRandom(outputConfig.send)) reasons.push('non-default send output type');
         if (outputConfig.keep && !isPlainRandom(outputConfig.keep))

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -1,4 +1,4 @@
-import { isBlsKeyset } from '../crypto';
+import { attachHTLCPreimage, isBlsKeyset } from '../crypto';
 import { Amount, type AmountLike } from '../model/Amount';
 import { CTSError } from '../model/Errors';
 import { type OutputDataLike, type OutputDataFactory } from '../model/OutputData';
@@ -356,6 +356,16 @@ export class SendBuilder {
   }
 
   /**
+   * NUT-14: preimage for HTLC inputs, placed on their witness before signing.
+   *
+   * @param preimage 64 hex characters.
+   */
+  preimage(preimage: string) {
+    this.config.preimage = preimage;
+    return this;
+  }
+
+  /**
    * Provide existing proofs to help optimise denomination selection.
    *
    * @remarks
@@ -438,7 +448,10 @@ export class SendBuilder {
 
     // Strict offline, exact match only
     if (this.offlineExact) {
-      // Sign if needed
+      // Stamp and sign if needed
+      if (this.config.preimage !== undefined) {
+        this.proofs = attachHTLCPreimage(this.proofs, this.config.preimage);
+      }
       if (this.config.privkey) {
         this.proofs = this.wallet.signP2PKProofs(this.proofs, this.config.privkey);
       }
@@ -451,7 +464,10 @@ export class SendBuilder {
 
     // Offline close match, may overshoot
     if (this.offlineClose) {
-      // Sign if needed
+      // Stamp and sign if needed
+      if (this.config.preimage !== undefined) {
+        this.proofs = attachHTLCPreimage(this.proofs, this.config.preimage);
+      }
       if (this.config.privkey) {
         this.proofs = this.wallet.signP2PKProofs(this.proofs, this.config.privkey);
       }
@@ -590,6 +606,16 @@ export class ReceiveBuilder {
    */
   scriptPath(plans: ScriptPathPlan[]) {
     this.config.scriptPath = plans;
+    return this;
+  }
+
+  /**
+   * NUT-14: preimage for HTLC inputs, placed on their witness before signing.
+   *
+   * @param preimage 64 hex characters.
+   */
+  preimage(preimage: string) {
+    this.config.preimage = preimage;
     return this;
   }
 
@@ -990,6 +1016,16 @@ export class MeltBuilder<
   }
 
   /**
+   * NUT-14: preimage for HTLC inputs, placed on their witness before signing.
+   *
+   * @param preimage 64 hex characters.
+   */
+  preimage(preimage: string) {
+    this.config.preimage = preimage;
+    return this;
+  }
+
+  /**
    * Receive a callback once counters are atomically reserved for deterministic outputs.
    *
    * @param cb Called with OperationCounters when counters are reserved.
@@ -1097,6 +1133,16 @@ export class MeltOnchainBuilder {
    */
   scriptPath(plans: ScriptPathPlan[]) {
     this.config.scriptPath = plans;
+    return this;
+  }
+
+  /**
+   * NUT-14: preimage for HTLC inputs, placed on their witness before signing.
+   *
+   * @param preimage 64 hex characters.
+   */
+  preimage(preimage: string) {
+    this.config.preimage = preimage;
     return this;
   }
 

--- a/src/wallet/types/config.ts
+++ b/src/wallet/types/config.ts
@@ -207,6 +207,10 @@ export type SendConfig = {
   keysetId?: string;
   privkey?: string | string[];
   scriptPath?: ScriptPathPlan[];
+  /**
+   * NUT-14: placed on the witness of every HTLC input whose hashlock it opens, before signing.
+   */
+  preimage?: string;
   includeFees?: boolean;
   proofsWeHave?: Array<Pick<ProofLike, 'amount'>>;
   onCountersReserved?: OnCountersReserved;
@@ -228,6 +232,10 @@ export type ReceiveConfig = {
   keysetId?: string;
   privkey?: string | string[];
   scriptPath?: ScriptPathPlan[];
+  /**
+   * NUT-14: placed on the witness of every HTLC input whose hashlock it opens, before signing.
+   */
+  preimage?: string;
   requireDleq?: boolean;
   proofsWeHave?: Array<Pick<ProofLike, 'amount'>>;
   onCountersReserved?: OnCountersReserved;
@@ -273,6 +281,10 @@ export type MeltProofsConfig = {
   keysetId?: string;
   privkey?: string | string[];
   scriptPath?: ScriptPathPlan[];
+  /**
+   * NUT-14: placed on the witness of every HTLC input whose hashlock it opens, before signing.
+   */
+  preimage?: string;
   onCountersReserved?: OnCountersReserved;
   /**
    * Request NUT-08 blank outputs so the mint can return unspent fee reserve. Defaults to true. Set

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { Amount, type Logger, type Proof } from '../../src';
 import {
+  attachHTLCPreimage,
   createHTLCHash,
   createHTLCsecret,
   getHTLCWitnessPreimage,
@@ -298,5 +299,43 @@ describe('HTLC refund (sender) pathway', () => {
   test('unsigned refund proof does not spend', () => {
     // No refund signature and no preimage: nothing authorises the spend.
     expect(isHTLCSpendAuthorised(keyedRefundProof())).toBe(false);
+  });
+});
+
+describe('attachHTLCPreimage', () => {
+  const { hash, preimage } = createHTLCHash();
+  const proof = (secret: string, witness?: Proof['witness']): Proof => ({
+    id: '00bd033559de27d0',
+    amount: Amount.from(1),
+    secret,
+    C: '02' + 'ab'.repeat(32),
+    ...(witness !== undefined && { witness }),
+  });
+
+  test('stamps the HTLC proofs it opens and leaves the rest alone', () => {
+    const opens = proof(createHTLCsecret(hash));
+    const other = proof(createHTLCsecret(createHTLCHash().hash));
+    const p2pk = proof(JSON.stringify(['P2PK', { nonce: '00', data: PUBKEY }]));
+    const plain = proof('plain-secret');
+    const out = attachHTLCPreimage([opens, other, p2pk, plain], preimage.toUpperCase());
+    expect(out[0].witness).toEqual({ preimage });
+    expect(out.slice(1)).toEqual([other, p2pk, plain]);
+  });
+
+  test('keeps existing signatures, and signing keeps the preimage', () => {
+    const locked = proof(createHTLCsecret(hash, [['pubkeys', PUBKEY]]));
+    const signedFirst = attachHTLCPreimage(signP2PKProofs([locked], bytesToHex(PRIVKEY)), preimage);
+    const stampedFirst = signP2PKProofs(
+      attachHTLCPreimage([locked], preimage),
+      bytesToHex(PRIVKEY),
+    );
+    for (const [p] of [signedFirst, stampedFirst]) {
+      expect(getHTLCWitnessPreimage(p.witness)).toBe(preimage);
+      expect(verifyHTLCSpendingConditions(p).success).toBe(true);
+    }
+  });
+
+  test('rejects a malformed preimage', () => {
+    expect(() => attachHTLCPreimage([], 'nope')).toThrow(/64 character/);
   });
 });

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
-import { LockBuilder } from '../../src';
+import { LockBuilder, createHTLCHash, createHTLCsecret } from '../../src';
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import type { OutputData, OutputDataLike } from '../../src/model/OutputData';
 import { PaymentRequest } from '../../src/model/PaymentRequest';
@@ -690,6 +690,32 @@ describe('WalletOps builders', () => {
       expect(wallet.signP2PKProofs).toHaveBeenCalledWith(proofs, 'sk');
     });
 
+    it('passes the preimage in the config', async () => {
+      await ops.send(5, proofs).preimage('aa'.repeat(32)).run();
+      const [, , config] = wallet.send.mock.calls[0];
+      expect(config).toEqual({ preimage: 'aa'.repeat(32) });
+    });
+
+    it('offlineExactOnly stamps HTLC proofs with the preimage before signing', async () => {
+      const { hash, preimage } = createHTLCHash();
+      const locked: Proof[] = [{ ...proofs[0], secret: createHTLCsecret(hash) }, proofs[1]];
+      await ops.send(5, locked).offlineExactOnly().preimage(preimage).privkey('sk').run();
+
+      const [stamped] = wallet.signP2PKProofs.mock.calls[0];
+      expect(stamped[0].witness).toEqual({ preimage });
+      expect(stamped[1]).toBe(proofs[1]);
+    });
+
+    it('offlineCloseMatch stamps HTLC proofs with the preimage', async () => {
+      const { hash, preimage } = createHTLCHash();
+      const locked: Proof[] = [{ ...proofs[0], secret: createHTLCsecret(hash) }];
+      await ops.send(5, locked).offlineCloseMatch().preimage(preimage).run();
+
+      const [, sent] = wallet.sendOffline.mock.calls[0];
+      expect(sent[0].witness).toEqual({ preimage });
+      expect(wallet.signP2PKProofs).not.toHaveBeenCalled();
+    });
+
     it('offlineExactOnly does not sign when no privkey is set', async () => {
       await ops.send(5, proofs).offlineExactOnly().run();
 
@@ -713,6 +739,12 @@ describe('WalletOps builders', () => {
   // --------------------------- ReceiveBuilder --------------------------------
 
   describe('ReceiveBuilder', () => {
+    it('passes the preimage in the config', async () => {
+      await ops.receive(token).preimage('cc'.repeat(32)).run();
+      const [, config] = wallet.receive.mock.calls[0];
+      expect(config).toMatchObject({ preimage: 'cc'.repeat(32) });
+    });
+
     it('calls wallet.receive with config only when no OutputType was set', async () => {
       await ops.receive(token).requireDleq(true).keyset('kid').run();
 
@@ -1148,6 +1180,12 @@ describe('WalletOps builders', () => {
   // --------------------------- MeltBuilder -----------------------------------
 
   describe('MeltBuilder', () => {
+    it('passes the preimage in the config', async () => {
+      await ops.meltBolt11(melt11, proofs).preimage('bb'.repeat(32)).prepare();
+      const [, , , cfg] = wallet.prepareMelt.mock.calls[0];
+      expect(cfg).toMatchObject({ preimage: 'bb'.repeat(32) });
+    });
+
     it('supports wallet.prepareMelt', async () => {
       const cb = vi.fn();
       await ops
@@ -1314,6 +1352,12 @@ describe('WalletOps builders', () => {
   // --------------------------- MeltOnchainBuilder ----------------------------
 
   describe('MeltOnchainBuilder', () => {
+    it('passes the preimage in the config', async () => {
+      await ops.meltOnchain(meltOnchainSingle, proofs).preimage('dd'.repeat(32)).run();
+      const [, , , cfg] = wallet.meltProofsOnchain.mock.calls[0];
+      expect(cfg).toMatchObject({ preimage: 'dd'.repeat(32) });
+    });
+
     it('auto-selects the only fee option when no feeIndex is set', async () => {
       await ops.meltOnchain(meltOnchainSingle, proofs).privkey('sk').run();
 

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -18,6 +18,8 @@ import {
   type MintKeyset,
   type MeltPreview,
   Amount,
+  createHTLCHash,
+  createHTLCsecret,
 } from '../../src';
 import { DUMMY_TEST_KEYSET, MINTCACHE, PUBKEYS } from '../consts';
 
@@ -94,6 +96,47 @@ describe('melt proofs', () => {
     expect(response.change[1]).toMatchObject({ amount: Amount.from(2), id: '00bd033559de27d0' });
     expect(/[0-9a-f]{64}/.test(response.change[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(response.change[0].secret)).toBe(true);
+  });
+
+  test('melt with a preimage stamps the HTLC inputs', async () => {
+    let inputs: Array<{ witness?: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/melt/bolt11', async ({ request }) => {
+        ({ inputs } = (await request.json()) as { inputs: Array<{ witness?: string }> });
+        return HttpResponse.json({
+          quote: 'test_melt_quote',
+          amount: 10,
+          unit: 'sat',
+          fee_reserve: 3,
+          state: MeltQuoteState.PAID,
+          expiry: 1234567890,
+          payment_preimage: 'preimage',
+          request: 'bolt11request',
+          change: [],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit, logger });
+    await wallet.loadMint();
+    const { hash, preimage } = createHTLCHash();
+    const meltQuote: MeltQuoteBolt11Response = {
+      quote: 'test_melt_quote',
+      amount: Amount.from(10),
+      fee_reserve: Amount.from(3),
+      request: 'bolt11request',
+      state: MeltQuoteState.UNPAID,
+      expiry: 1234567890,
+      payment_preimage: null,
+      unit: 'sat',
+      method: 'bolt11',
+    };
+    const locked: Proof[] = [
+      { id: '00bd033559de27d0', amount: Amount.from(13), secret: createHTLCsecret(hash), C: 'C1' },
+    ];
+    const response = await wallet.meltProofsBolt11(meltQuote, locked, { preimage });
+
+    expect(response.quote.state).toBe(MeltQuoteState.PAID);
+    expect(JSON.parse(inputs[0].witness!)).toEqual({ preimage });
   });
 
   test('test melt proofs no change', async () => {

--- a/test/wallet/wallet-receive.node.test.ts
+++ b/test/wallet/wallet-receive.node.test.ts
@@ -11,6 +11,9 @@ import {
   type AmountLike,
   type HasKeysetKeys,
   type ProofLike,
+  createHTLCHash,
+  createHTLCsecret,
+  getPubKeyFromPrivKey,
 } from '../../src';
 import { getG2PubKeyFromPrivKey, hashToCurveBls } from '../../src/crypto/curve_bls';
 import { deriveKeysetId } from '../../src/utils';
@@ -738,6 +741,41 @@ describe('receive', () => {
     ]);
     expect(/[0-9a-f]{64}/.test(proofs[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(proofs[0].secret)).toBe(true);
+  });
+
+  test('test receive preimage stamps the HTLC witness before signing', async () => {
+    let inputs: Array<{ witness?: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        ({ inputs } = (await request.json()) as { inputs: Array<{ witness?: string }> });
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const privkey = bytesToHex(new Uint8Array(32).fill(7));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(hexToBytes(privkey)));
+    const { hash, preimage } = createHTLCHash();
+    const locked = {
+      id: '00bd033559de27d0',
+      amount: 1,
+      secret: createHTLCsecret(hash, [['pubkeys', pubkey]]),
+      C: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+    };
+
+    const proofs = await wallet.receive([locked], { privkey, preimage });
+    expect(proofs).toHaveLength(1);
+    const witness = JSON.parse(inputs[0].witness!);
+    expect(witness.preimage).toBe(preimage);
+    expect(witness.signatures).toHaveLength(1);
   });
 
   test('test receive keysetId', async () => {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -15,6 +15,8 @@ import {
   type Proof,
   type ProofLike,
   type OutputConfig,
+  createHTLCHash,
+  createHTLCsecret,
 } from '../../src';
 
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp } from './_setup';
@@ -382,6 +384,45 @@ describe('send', () => {
     expect(result.send[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
     expect(/[0-9a-f]{64}/.test(result.send[0].C)).toBe(true);
     expect(/[0-9a-f]{64}/.test(result.send[0].secret)).toBe(true);
+  });
+
+  test('send with a preimage stamps the HTLC inputs it swaps', async () => {
+    let inputs: Array<{ witness?: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        ({ inputs } = (await request.json()) as { inputs: Array<{ witness?: string }> });
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { hash, preimage } = createHTLCHash();
+    const locked: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(2),
+        secret: createHTLCsecret(hash),
+        C: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+    ];
+
+    // 1 of 2 sat cannot match offline, so the proof goes to the mint stamped
+    const result = await wallet.send(1, locked, { preimage });
+    expect(result.send).toHaveLength(1);
+    expect(JSON.parse(inputs[0].witness!)).toEqual({ preimage });
   });
 
   test('swap preview round trips through serialize/deserialize and replays identically', async () => {

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -425,6 +425,43 @@ describe('send', () => {
     expect(JSON.parse(inputs[0].witness!)).toEqual({ preimage });
   });
 
+  test('send with a preimage swaps an exact offline match instead of forwarding it locked', async () => {
+    let inputs: Array<{ witness?: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/swap', async ({ request }) => {
+        ({ inputs } = (await request.json()) as { inputs: Array<{ witness?: string }> });
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const { hash, preimage } = createHTLCHash();
+    const secret = createHTLCsecret(hash);
+    const locked: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(1),
+        secret,
+        C: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+    ];
+
+    // 1 of 1 sat matches offline, but the preimage means the sender is redeeming the HTLC
+    const result = await wallet.send(1, locked, { preimage });
+    expect(inputs).toHaveLength(1);
+    expect(JSON.parse(inputs[0].witness!)).toEqual({ preimage });
+    expect(result.send).toHaveLength(1);
+    expect(result.send[0].secret).not.toBe(secret);
+  });
+
   test('swap preview round trips through serialize/deserialize and replays identically', async () => {
     const bodies: string[] = [];
     server.use(


### PR DESCRIPTION
Spending an HTLC input needed the caller to assemble the NUT-14 witness by hand. This adds a `preimage` option to `SendConfig`, `ReceiveConfig` and `MeltProofsConfig`, plus `.preimage()` on the send, receive and melt builders. The preimage goes on the witness of every input whose hashlock it opens, before signing, so it composes with `privkey` in either order and a keyless HTLC spends on the preimage alone. `attachHTLCPreimage(proofs, preimage)` is exported for proofs handled outside the wallet flow.

## Why

Both the receiver of an HTLC and the counterparty in a hashlock swap end up doing this stamping in app code. The signer already preserves a preimage found on the witness; only the entry point was missing.

## Notes

- Inputs the preimage does not open are left untouched, so mixed tokens are safe.
- A malformed preimage throws before anything is sent.
- Tests: NUT-14 unit tests for the stamp in both stamp-then-sign orders, and a receive test that inspects the swap request's witness.
- Docs: short "Spending an HTLC" section in the P2PK builder page. API report updated.
