### PR TITLE
chore: group the commitlint and vite bumps with their families

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,10 +42,15 @@ updates:
           - 'typescript-eslint'
           - '@typescript-eslint/*'
           - '@vitest/eslint-plugin'
+      # cli and config-conventional share @commitlint/types, so bumping one
+      # alone nests the other major inside the tree.
+      commitlint:
+        patterns: ['@commitlint/*']
       # The test stack moves together: the browser providers track both vitest
-      # and the playwright version they drive.
+      # and the playwright version they drive, and vitest both depends on and
+      # peers on vite, so a vite major on its own cannot install.
       vitest:
-        patterns: ['vitest', '@vitest/*', 'playwright', '@stryker-mutator/*']
+        patterns: ['vitest', '@vitest/*', 'playwright', '@stryker-mutator/*', 'vite']
       # Everything else dev, minor and patch only, so dev majors arrive alone
       dev-tooling:
         dependency-type: development


### PR DESCRIPTION
Two more Dependabot families that need to move as one PR.

## Why

#1063 bumped `@commitlint/cli` to 21 on its own. The lockfile went green with `@commitlint/config-conventional` and `@commitlint/types` still on 20.x at the top level and 21.x copies nested under every other commitlint package. The same split is waiting for `vite`: vitest both depends on and peers on it (`^6 || ^7 || ^8`), so a vite major arriving alone cannot install.

## Changes

- New `commitlint` group (`@commitlint/*`).
- `vite` added to the `vitest` group. `vite-plugin-dts` stays out on purpose so its blocked v5 keeps arriving alone.

Considered a `typescript` group (typedoc peers on an enumerated major list, api-extractor pins one exactly) and left it out: a TS major fails loudly at install rather than going green, and #1050 showed a solo TS 7 PR is easy to close by hand.

## Impact

Config only. Dependabot reads this file from `main`, so the LTS branches need nothing.
