### PR TITLE
feat(wallet): accept a custom hash-to-curve for proof state checks

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -125,3 +125,19 @@ const wallet = new Wallet('http://localhost:3338', {
 });
 await wallet.loadMint();
 ```
+
+The `hashToCurve` option is the same escape hatch for `Y = hash_to_curve(secret)`, used by
+`checkProofsStates` and NUT-17 subscriptions. A restore scan hashes every counter it visits, and on
+BLS keysets the pure JS hash dominates that cost, so a WASM or native implementation is worth
+plugging in there. The keyset id selects the curve: v3 (`02...`) ids are BLS12-381 G1, all others
+secp256k1. Hash the secret string as UTF-8 and return the compressed point as hex; `hashToCurveHex`
+is the default and can serve the curve you are not replacing.
+
+```typescript
+const wallet = new Wallet('http://localhost:3338', {
+  hashToCurve: (secret, keysetId) =>
+    isBlsKeyset(keysetId)
+      ? fastBlsHashToCurveHex(new TextEncoder().encode(secret))
+      : hashToCurveHex(secret, keysetId),
+});
+```

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -766,6 +766,9 @@ export function hashToCurve(secret: Uint8Array): WeierstrassPoint<bigint>;
 export function hashToCurveBls(secret: Uint8Array): G1Point;
 
 // @public
+export function hashToCurveHex(secret: string, keysetId: string): string;
+
+// @public
 export type HasKeysetId = {
     id: string;
 };
@@ -2757,6 +2760,7 @@ export class Wallet {
         denominationTarget?: number;
         selectProofs?: SelectProofs;
         outputDataCreator?: OutputDataCreator;
+        hashToCurve?: (secret: string, keysetId: string) => string;
         requireSigDleq?: boolean;
         strictCachedKeysets?: boolean;
         customRequest?: RequestFn;

--- a/src/crypto/curves.ts
+++ b/src/crypto/curves.ts
@@ -5,7 +5,8 @@ import { bytesToNumberBE } from '@noble/curves/utils.js';
 import { CTSError } from '../model/Errors';
 import { decodeBase64ToUint8Legacy, hexToNumber, isValidHex } from '../utils';
 
-import { type G1Point, pointFromHexG1 } from './curve_bls';
+import { type G1Point, hashToCurveBls, pointFromHexG1 } from './curve_bls';
+import { hashToCurve } from './curve_secp';
 
 /**
  * Tagged-union point covering both keyset curves on the wallet output / proof path.
@@ -51,6 +52,17 @@ export function isBlsKeyset(keysetId: string): boolean {
   if (keysetId.length !== 16 && keysetId.length !== 66) return false;
   if (!isValidHex(keysetId)) return false;
   return keysetId.startsWith('02');
+}
+
+/**
+ * `Y = hash_to_curve(secret)` as compressed hex, on the curve the keyset id selects.
+ *
+ * @remarks
+ * The secret string is hashed as UTF-8, hex secrets included.
+ */
+export function hashToCurveHex(secret: string, keysetId: string): string {
+  const msg = new TextEncoder().encode(secret);
+  return (isBlsKeyset(keysetId) ? hashToCurveBls(msg) : hashToCurve(msg)).toHex(true);
 }
 
 export const getKeysetIdInt = (keysetId: string): bigint => {

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -230,10 +230,7 @@ class Wallet {
   private _explicitBind: boolean = false;
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
-  /**
-   * @internal
-   */
-  readonly computeY: (secret: string, keysetId: string) => string;
+  private _hashToCurve: (secret: string, keysetId: string) => string;
   private _requireSigDleq = false;
   private _strictCachedKeysets: boolean = false;
   private _logger: Logger;
@@ -317,7 +314,7 @@ class Wallet {
     this._logger = options?.logger ?? NULL_LOGGER; // init early (seed can throw)
     this._selectProofs = options?.selectProofs ?? selectProofsRotating; // vital
     this._outputDataCreator = options?.outputDataCreator ?? new DefaultOutputDataCreator();
-    this.computeY = options?.hashToCurve ?? hashToCurveHex;
+    this._hashToCurve = options?.hashToCurve ?? hashToCurveHex;
     this.mint =
       typeof mint === 'string'
         ? new Mint(mint, {
@@ -2998,6 +2995,13 @@ class Wallet {
         requestedAmount: requestedAmount.toString(),
       },
     );
+  }
+
+  /**
+   * @internal
+   */
+  computeY(secret: string, keysetId: string): string {
+    return this._hashToCurve(secret, keysetId);
   }
 
   /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -12,8 +12,7 @@ import {
   signMintQuote,
   findSigningKey,
   signP2PKProofs as cryptoSignP2PKProofs,
-  hashToCurve,
-  hashToCurveBls,
+  hashToCurveHex,
   isBlsKeyset,
   isP2PKSigAll,
   buildP2PKSigAllMessageV0,
@@ -231,6 +230,10 @@ class Wallet {
   private _explicitBind: boolean = false;
   private _selectProofs: SelectProofs;
   private _outputDataCreator: OutputDataCreator;
+  /**
+   * @internal
+   */
+  readonly computeY: (secret: string, keysetId: string) => string;
   private _requireSigDleq = false;
   private _strictCachedKeysets: boolean = false;
   private _logger: Logger;
@@ -268,6 +271,11 @@ class Wallet {
    *   maintained implementation is the default Noble Curves based behavior exposed by
    *   `OutputData.create*()`. Custom creators are an escape hatch for runtime-specific needs, and
    *   compatibility and maintenance are the integrator's responsibility.
+   * @param options.hashToCurve Custom `Y = hash_to_curve(secret)` returning compressed hex; hash
+   *   the secret string as UTF-8, as `hashToCurveHex` does. The keyset id selects the curve (v3
+   *   `02…` ids are BLS12-381 G1, all others secp256k1). Use it to plug a WASM or native
+   *   implementation: a restore scan hashes every counter it visits, and the pure JS BLS hash
+   *   dominates that cost. Same support terms as `outputDataCreator`.
    * @param options.requireSigDleq Fail mint/swap/melt responses when the mint advertises NUT-12
    *   support but omits DLEQ proofs on returned blinded signatures. This is a fail-fast consistency
    *   check, not protection against a malicious mint already consuming inputs or payments.
@@ -296,6 +304,7 @@ class Wallet {
       denominationTarget?: number;
       selectProofs?: SelectProofs; // optional override
       outputDataCreator?: OutputDataCreator;
+      hashToCurve?: (secret: string, keysetId: string) => string;
       requireSigDleq?: boolean;
       strictCachedKeysets?: boolean;
       customRequest?: RequestFn;
@@ -308,6 +317,7 @@ class Wallet {
     this._logger = options?.logger ?? NULL_LOGGER; // init early (seed can throw)
     this._selectProofs = options?.selectProofs ?? selectProofsRotating; // vital
     this._outputDataCreator = options?.outputDataCreator ?? new DefaultOutputDataCreator();
+    this.computeY = options?.hashToCurve ?? hashToCurveHex;
     this.mint =
       typeof mint === 'string'
         ? new Mint(mint, {
@@ -4331,12 +4341,7 @@ class Wallet {
    * @returns NUT-07 state for each proof, in same order.
    */
   async checkProofsStates(proofs: Array<Pick<ProofLike, 'secret' | 'id'>>): Promise<ProofState[]> {
-    const enc = new TextEncoder();
-    const Ys = proofs.map((p) =>
-      isBlsKeyset(p.id)
-        ? hashToCurveBls(enc.encode(p.secret)).toHex(true)
-        : hashToCurve(enc.encode(p.secret)).toHex(true),
-    );
+    const Ys = proofs.map((p) => this.computeY(p.secret, p.id));
     // Shuffle the wire order to reduce linkability with B_'s (eg when coupled with a restore scan).
     // Indices travel with the request, so callers still get their original order back.
     const order = Ys.map((_, i) => i);

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -1,4 +1,3 @@
-import { hashToCurve, hashToCurveBls, isBlsKeyset } from '../crypto';
 import { safeCallback } from '../logger';
 import { Amount } from '../model/Amount';
 import { CTSError, HttpResponseError } from '../model/Errors';
@@ -659,15 +658,12 @@ export class WalletEvents {
     err: (e: Error) => void,
     opts?: WatchOpts,
   ): Promise<SubscriptionCanceller> {
-    const enc = new TextEncoder();
     // Object.create(null) avoids prototype-key collisions: a mint sending
     // payload.Y === '__proto__' (or 'constructor', etc.) would otherwise
     // resolve to an inherited property and bypass the unknown-Y guard below.
     const proofMap = Object.create(null) as Record<string, T>;
     for (const p of proofs) {
-      const y = isBlsKeyset(p.id)
-        ? hashToCurveBls(enc.encode(p.secret)).toHex(true)
-        : hashToCurve(enc.encode(p.secret)).toHex(true);
+      const y = this.wallet.computeY(p.secret, p.id);
       if (proofMap[y]) {
         throw new CTSError('Duplicate proof secret in proofStateUpdates input');
       }

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { Amount, CheckStateEnum, HttpResponseError } from '../../src';
-import { hashToCurve, hashToCurveBls } from '../../src/crypto';
+import { hashToCurve, hashToCurveBls, hashToCurveHex } from '../../src/crypto';
 import type { Proof } from '../../src/model/types';
 import type { KeyChainCache } from '../../src/model/types/keyset';
 import { type OperationCounters } from '../../src/wallet';
@@ -113,11 +113,15 @@ class MockMint {
   });
 }
 
+// Wallet.computeY stand-in: the default hash, since no test overrides the hook here.
+const computeY = hashToCurveHex;
+
 /**
  * Only what WalletEvents touches.
  */
 class MockWallet {
   public mint = new MockMint();
+  public computeY = computeY;
   public unit = 'sat';
   public getMintInfo = vi.fn((): { isSupported: (n: number) => any } => {
     throw new Error('Mint info not initialized');
@@ -1202,6 +1206,7 @@ describe('WalletEvents', () => {
   // A wallet whose connectWebSocket resolves but never populates webSocketConnection.
   const makeNullWsWallet = () => ({
     mint: { connectWebSocket: vi.fn(async () => {}), webSocketConnection: undefined },
+    computeY,
   });
 
   // A fully controllable mint WS: deliver a PAID to one quote id, or error one id in isolation.
@@ -1236,7 +1241,10 @@ describe('WalletEvents', () => {
         for (const s of subs.values()) if (s.filters.includes(quote)) s.err(error);
       },
     };
-    const wallet = { mint: { connectWebSocket: vi.fn(async () => {}), webSocketConnection: ws } };
+    const wallet = {
+      mint: { connectWebSocket: vi.fn(async () => {}), webSocketConnection: ws },
+      computeY,
+    };
     return { wallet, ws };
   };
 

--- a/test/wallet/wallet-state.node.test.ts
+++ b/test/wallet/wallet-state.node.test.ts
@@ -40,6 +40,33 @@ describe('checkProofsStates', () => {
     });
   });
 
+  test('checkProofsStates uses a custom hashToCurve for Y', async () => {
+    const fakeY = '02' + 'ab'.repeat(32);
+    const seen: string[][] = [];
+    server.use(
+      http.post(mintUrl + '/v1/checkstate', async ({ request }) => {
+        const body = (await request.json()) as { Ys: string[] };
+        seen.push(body.Ys);
+        return HttpResponse.json({
+          states: body.Ys.map((Y) => ({ Y, state: 'SPENT', witness: null })),
+        });
+      }),
+    );
+    const calls: Array<[string, string]> = [];
+    const wallet = new Wallet(mint, {
+      unit,
+      hashToCurve: (secret, keysetId) => {
+        calls.push([secret, keysetId]);
+        return fakeY;
+      },
+    });
+    await wallet.loadMint();
+
+    const result = await wallet.checkProofsStates(proofs);
+    expect(calls).toEqual([[proofs[0].secret, proofs[0].id]]);
+    expect(seen).toEqual([[fakeY]]);
+    expect(result[0].state).toEqual(CheckStateEnum.SPENT);
+  });
   test('checkProofsStates with omitted witness coerces undefined → null', async () => {
     server.use(
       http.post(mintUrl + '/v1/checkstate', () => {


### PR DESCRIPTION
Stacked on #964. Adds a `hashToCurve` wallet option so integrators can plug a WASM or native `Y = hash_to_curve(secret)` implementation.

## Why

With #964 a restore scan state-checks every counter it visits, so it hashes each one to `Y`. On BLS keysets the pure JS hash is about 1.6ms per counter and dominates the scan on a long history. There is no protocol route round this (the mint only knows `B_` and `Y`, and both cost a curve op), so the fix is to let the consumer own the hash and choose a faster backend without cashu-ts taking a dependency.

## Changes

- `hashToCurve?: (secret: string, keysetId: string) => string` on the `Wallet` constructor, on the same support terms as `outputDataCreator`. The secret string is hashed as UTF-8, hex secrets included; the keyset id selects the curve.
- `hashToCurveHex(secret, keysetId)` in `crypto/curves` is the default and is exported, so a custom hook can delegate the curve it is not replacing.
- `checkProofsStates` and `proofStateUpdates` both use the wallet's chosen function, replacing two inline copies of the same ternary.
- Docs: a short note under the custom output generation section.
- Test: the custom hook is called with secret and keyset id, its `Y` goes on the wire, and states map back.
