### PR TITLE
fix(wallet): unblind melt change and restore with the keyset the mint signed under [backport v4-dev]

### DIFF
--- a/docs-src/usage/melt_token.md
+++ b/docs-src/usage/melt_token.md
@@ -73,8 +73,8 @@ await wallet.completeMelt(preview, undefined, { preferAsync: true });
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-const sigs = paidQuote.change ?? [];
-// the change may sit on a keyset rotated in while the melt was pending
+// zero-value entries carry no ecash (NUT-08); the rest may sit on a keyset rotated in meanwhile
+const sigs = (paidQuote.change ?? []).filter((s) => !s.amount.isZero());
 await wallet.ensureOperableKeysets(sigs.map((s) => s.id));
 const change = wallet.createMeltChangeProofs(restored, sigs);
 ```

--- a/docs-src/usage/melt_token.md
+++ b/docs-src/usage/melt_token.md
@@ -73,7 +73,10 @@ await wallet.completeMelt(preview, undefined, { preferAsync: true });
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
+const sigs = paidQuote.change ?? [];
+// the change may sit on a keyset rotated in while the melt was pending
+await wallet.ensureOperableKeysets(sigs.map((s) => s.id));
+const change = wallet.createMeltChangeProofs(restored, sigs);
 ```
 
 - `OutputData.serialize` / `OutputData.deserialize` are the JSON-safe round-trip primitives

--- a/docs-src/usage/melt_token.md
+++ b/docs-src/usage/melt_token.md
@@ -73,8 +73,9 @@ await wallet.completeMelt(preview, undefined, { preferAsync: true });
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-// zero-value entries carry no ecash (NUT-08); the rest may sit on a keyset rotated in meanwhile
-const sigs = (paidQuote.change ?? []).filter((s) => !s.amount.isZero());
+// zero-value entries carry no ecash (NUT-08); the rest may sit on a keyset rotated in meanwhile.
+// Amount.from also covers a paid quote that arrived over WebSocket or was rehydrated from JSON.
+const sigs = (paidQuote.change ?? []).filter((s) => !Amount.from(s.amount).isZero());
 await wallet.ensureOperableKeysets(sigs.map((s) => s.id));
 const change = wallet.createMeltChangeProofs(restored, sigs);
 ```

--- a/docs-src/wallet_ops/melt.md
+++ b/docs-src/wallet_ops/melt.md
@@ -59,8 +59,9 @@ await wallet.completeMelt(preview, undefined, { preferAsync: true });
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-// zero-value entries carry no ecash (NUT-08); the rest may sit on a keyset rotated in meanwhile
-const sigs = (paidQuote.change ?? []).filter((s) => !s.amount.isZero());
+// zero-value entries carry no ecash (NUT-08); the rest may sit on a keyset rotated in meanwhile.
+// Amount.from also covers a paid quote that arrived over WebSocket or was rehydrated from JSON.
+const sigs = (paidQuote.change ?? []).filter((s) => !Amount.from(s.amount).isZero());
 await wallet.ensureOperableKeysets(sigs.map((s) => s.id));
 const change = wallet.createMeltChangeProofs(restored, sigs);
 ```

--- a/docs-src/wallet_ops/melt.md
+++ b/docs-src/wallet_ops/melt.md
@@ -59,8 +59,8 @@ await wallet.completeMelt(preview, undefined, { preferAsync: true });
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-const sigs = paidQuote.change ?? [];
-// the change may sit on a keyset rotated in while the melt was pending
+// zero-value entries carry no ecash (NUT-08); the rest may sit on a keyset rotated in meanwhile
+const sigs = (paidQuote.change ?? []).filter((s) => !s.amount.isZero());
 await wallet.ensureOperableKeysets(sigs.map((s) => s.id));
 const change = wallet.createMeltChangeProofs(restored, sigs);
 ```

--- a/docs-src/wallet_ops/melt.md
+++ b/docs-src/wallet_ops/melt.md
@@ -59,7 +59,10 @@ await wallet.completeMelt(preview, undefined, { preferAsync: true });
 const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
   OutputData.deserialize(s),
 );
-const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
+const sigs = paidQuote.change ?? [];
+// the change may sit on a keyset rotated in while the melt was pending
+await wallet.ensureOperableKeysets(sigs.map((s) => s.id));
+const change = wallet.createMeltChangeProofs(restored, sigs);
 ```
 
 - See [Melt Token § 3 — Async melt with later change recovery](../usage/melt_token.md) for the

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -379,7 +379,9 @@ export class OutputData implements OutputDataLike {
    * const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
    *   OutputData.deserialize(s),
    * );
-   * const change = wallet.createMeltChangeProofs(restored, paidQuote.change ?? []);
+   * const sigs = (paidQuote.change ?? []).filter((s) => !s.amount.isZero());
+   * await wallet.ensureOperableKeysets(sigs.map((s) => s.id)); // change may be on a rotated-in keyset
+   * const change = wallet.createMeltChangeProofs(restored, sigs);
    * ```
    */
   static serialize(output: OutputDataLike): SerializedOutputData {

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -133,6 +133,13 @@ export class OutputData implements OutputDataLike {
         'Mint response is missing a signature for one of the outputs. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',
       );
     }
+    // Blanks (amount=0: NUT-08 change, NUT-09 restore) leave the keyset to the mint, which may
+    // have rotated meanwhile. Any other output must come back on the keyset it asked for.
+    if (!this.blindedMessage.amount.isZero() && sig.id !== this.blindedMessage.id) {
+      throw new CTSError(
+        `Mint signature keyset id ${sig.id} does not match output ${this.blindedMessage.id}`,
+      );
+    }
     let dleq: DLEQ | undefined;
     if (sig.dleq) {
       dleq = {

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -386,7 +386,8 @@ export class OutputData implements OutputDataLike {
    * const restored = (JSON.parse(stored) as SerializedOutputData[]).map((s) =>
    *   OutputData.deserialize(s),
    * );
-   * const sigs = (paidQuote.change ?? []).filter((s) => !s.amount.isZero());
+   * // zero-value entries carry no ecash (NUT-08); Amount.from also covers a quote rehydrated from JSON
+   * const sigs = (paidQuote.change ?? []).filter((s) => !Amount.from(s.amount).isZero());
    * await wallet.ensureOperableKeysets(sigs.map((s) => s.id)); // change may be on a rotated-in keyset
    * const change = wallet.createMeltChangeProofs(restored, sigs);
    * ```

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3597,9 +3597,12 @@ class Wallet {
       changeSigs.length > outputData.length,
       `Mint returned ${changeSigs.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
-    this.validateReturnedSignatures(changeSigs, outputData);
+    // A paid quote from a WebSocket update or rehydrated from storage carries raw JSON amounts,
+    // so normalise here rather than trust the type at this public boundary.
+    const sigs = changeSigs.map((s) => (s ? { ...s, amount: Amount.from(s.amount) } : s));
+    this.validateReturnedSignatures(sigs, outputData);
     const change: Proof[] = [];
-    changeSigs.forEach((s, i) => {
+    sigs.forEach((s, i) => {
       // NUT-08 pairs signatures to blanks by index; a zero-value one carries no ecash.
       if (s.amount.isZero()) return;
       change.push(outputData[i].toProof(s, this.keysetForSignature(s.id)));

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2006,6 +2006,11 @@ class Wallet {
     const { outputs, signatures } = await this.mint.restore({
       outputs: outputData.map((d) => d.blindedMessage),
     });
+    // NUT-09: each signature names the keyset to unblind with, which need not be the scanned one
+    await this._ensureOperableKeysets(
+      signatures.map((s) => s?.id),
+      { implicit: true },
+    );
 
     const signatureMap: { [sig: string]: SerializedBlindedSignature } = {};
     outputs.forEach((o, i) => (signatureMap[o.B_] = signatures[i]));
@@ -2015,11 +2020,14 @@ class Wallet {
 
     for (let i = 0; i < outputData.length; i++) {
       const matchingSig = signatureMap[outputData[i].blindedMessage.B_];
-      if (matchingSig) {
-        lastCounterWithSignature = start + i;
-        outputData[i].blindedMessage.amount = matchingSig.amount;
-        restoredProofs.push(outputData[i].toProof(matchingSig, keyset));
-      }
+      if (!matchingSig) continue; // counter was never issued into
+      lastCounterWithSignature = start + i;
+      // Signed at zero (a NUT-08 blank the mint did not omit): used counter, but no ecash
+      if (matchingSig.amount.isZero()) continue;
+      outputData[i].blindedMessage.amount = matchingSig.amount;
+      restoredProofs.push(
+        outputData[i].toProof(matchingSig, this.keysetForSignature(matchingSig.id)),
+      );
     }
 
     return {
@@ -2380,25 +2388,27 @@ class Wallet {
   private validateReturnedSignatures(
     signatures: SerializedBlindedSignature[],
     outputData: OutputDataLike[],
-    options?: { checkAmounts?: boolean },
   ): void {
     // With DLEQ we can verify the returned blinded signature is paired to the original B_.
     // Without DLEQ, equal-denomination reordering is a protocol trust assumption.
     const requiresDleq =
       this._requireSigDleq && (this._mintInfo?.isSupported(12).supported ?? false);
-    const checkAmounts = options?.checkAmounts ?? true;
 
     for (let i = 0; i < signatures.length; i++) {
       this.failIf(
         signatures[i] == undefined,
         `Mint response is missing a signature at index ${i}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
+      // amount=0 marks a blank (NUT-08 fee change, NUT-09 restore): the mint chooses the amount
+      // and, after a rotation, the keyset. Otherwise the mint must return exactly what was asked,
+      // or it's a downgrade attack.
+      const blank = outputData[i].blindedMessage.amount.isZero();
       this.failIf(
-        signatures[i].id !== outputData[i].blindedMessage.id,
+        !blank && signatures[i].id !== outputData[i].blindedMessage.id,
         `Mint signature keyset id at index ${i} does not match output: expected ${outputData[i].blindedMessage.id}, got ${signatures[i].id}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
       this.failIf(
-        checkAmounts && !signatures[i].amount.equals(outputData[i].blindedMessage.amount),
+        !blank && !signatures[i].amount.equals(outputData[i].blindedMessage.amount),
         `Mint returned signature with wrong amount at index ${i}: expected ${outputData[i].blindedMessage.amount.toString()}, got ${signatures[i].amount.toString()}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
       );
       this.failIf(
@@ -3522,15 +3532,15 @@ class Wallet {
     // Merge preview quote with response to protect against incomplete response.
     const mergedQuote = { ...meltPreview.quote, ...meltResponse };
 
-    // Create any change Proofs. Change may arrive on a rotated-out keyset, and a
-    // permissive mint may sign change on a keyset other than the blanks' (NUT-08).
-    // The inputs are spent by now, so a failure here must hand back what recovery needs.
+    // Create any change Proofs. The spec is silent on which keyset settles change after a
+    // rotation, so take the keyset each signature names. The inputs are spent by now, so a
+    // failure here must hand back what recovery needs.
     const changeSigs = meltResponse.change ?? [];
     let change: Proof[];
     try {
       if (changeSigs.length > 0) {
         await this._ensureOperableKeysets(
-          changeSigs.map((s) => s.id),
+          changeSigs.filter((s) => !s.amount.isZero()).map((s) => s.id),
           { implicit: true },
         );
       }
@@ -3564,8 +3574,8 @@ class Wallet {
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted OutputData.
    * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).
-   * @throws {@link CTSError} If signature count exceeds output count, any signature's keyset id
-   *   does not match its paired output, or signatures cannot be verified.
+   * @throws {@link CTSError} If signature count exceeds output count, a signature names a keyset
+   *   that is not loaded or not in the wallet's unit, or signatures cannot be verified.
    * @see {@link OutputData.serialize} for the persist/restore lifecycle example.
    */
   createMeltChangeProofs(
@@ -3577,21 +3587,32 @@ class Wallet {
       changeSigs.length > outputData.length,
       `Mint returned ${changeSigs.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
-    this.validateReturnedSignatures(changeSigs, outputData, {
-      checkAmounts: false, // change outputs are blank
+    this.validateReturnedSignatures(changeSigs, outputData);
+    const change: Proof[] = [];
+    changeSigs.forEach((s, i) => {
+      // NUT-08 pairs signatures to blanks by index; a zero-value one carries no ecash.
+      if (s.amount.isZero()) return;
+      change.push(outputData[i].toProof(s, this.keysetForSignature(s.id)));
     });
-    return changeSigs.map((s, i) => {
-      let keyset: Keyset;
-      try {
-        keyset = this.getKeyset(s.id);
-      } catch (e) {
-        throw new CTSError(
-          `Cannot reconstruct melt change: keyset ${s.id} is not loaded in this wallet (may be inactive after rotation). If the wallet is seeded, try restoring (NUT-09) to recover.`,
-          { cause: e },
-        );
-      }
-      return outputData[i].toProof(s, keyset);
-    });
+    return change;
+  }
+
+  /**
+   * Keyset a blank's signature was issued under, for unblinding.
+   *
+   * @remarks
+   * Must already be loaded (see `_ensureOperableKeysets`); `getKeyset` also rejects a keyset from
+   * another unit, which a blank cannot vouch for itself.
+   */
+  private keysetForSignature(id: string): Keyset {
+    try {
+      return this.getKeyset(id);
+    } catch (e) {
+      throw new CTSError(
+        `Cannot reconstruct proof: keyset ${id} is not loaded in this wallet (may be inactive after rotation). If the wallet is seeded, try restoring (NUT-09) to recover.`,
+        { cause: e },
+      );
+    }
   }
 
   // -----------------------------------------------------------------

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1951,14 +1951,17 @@ class Wallet {
   ): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> {
     const size = batchSize ?? this.maxArrayLength;
     const requiredEmptyBatches = Math.ceil(gapLimit / size);
+    // Pin the scan: a keychain repair mid-scan can rebind an auto-bound wallet
+    const scanKeyset = keysetId ?? this.keysetId;
     const restoredProofs: Proof[] = [];
 
     let lastCounterWithSignature: undefined | number;
     let emptyBatchesFound = 0;
 
     while (emptyBatchesFound < requiredEmptyBatches) {
-      const restoreRes = await this.restore(counter, size, { keysetId });
-      if (restoreRes.proofs.length > 0) {
+      const restoreRes = await this.restore(counter, size, { keysetId: scanKeyset });
+      // A batch of zero-value signatures yields no proofs but its counters are used
+      if (restoreRes.proofs.length > 0 || restoreRes.lastCounterWithSignature !== undefined) {
         emptyBatchesFound = 0;
         restoredProofs.push(...restoreRes.proofs);
         lastCounterWithSignature = restoreRes.lastCounterWithSignature;
@@ -2006,9 +2009,10 @@ class Wallet {
     const { outputs, signatures } = await this.mint.restore({
       outputs: outputData.map((d) => d.blindedMessage),
     });
-    // NUT-09: each signature names the keyset to unblind with, which need not be the scanned one
+    // NUT-09: each signature names the keyset to unblind with, which need not be the scanned
+    // one. Zero-value entries are dropped below and need no keys.
     await this._ensureOperableKeysets(
-      signatures.map((s) => s?.id),
+      signatures.map((s) => (s?.amount.isZero() ? undefined : s?.id)),
       { implicit: true },
     );
 
@@ -3587,14 +3591,16 @@ class Wallet {
       changeSigs.length > outputData.length,
       `Mint returned ${changeSigs.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
-    this.validateReturnedSignatures(changeSigs, outputData);
-    const change: Proof[] = [];
-    changeSigs.forEach((s, i) => {
-      // NUT-08 pairs signatures to blanks by index; a zero-value one carries no ecash.
-      if (s.amount.isZero()) return;
-      change.push(outputData[i].toProof(s, this.keysetForSignature(s.id)));
-    });
-    return change;
+    // NUT-08 pairs signatures to blanks by index. A zero-value one carries no ecash and is
+    // dropped before validation, so a junk entry cannot fail the DLEQ or key checks.
+    const pairs = changeSigs
+      .map((sig, i) => ({ sig, blank: outputData[i] }))
+      .filter(({ sig }) => !sig?.amount.isZero());
+    this.validateReturnedSignatures(
+      pairs.map((p) => p.sig),
+      pairs.map((p) => p.blank),
+    );
+    return pairs.map(({ sig, blank }) => blank.toProof(sig, this.keysetForSignature(sig.id)));
   }
 
   /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1990,10 +1990,12 @@ class Wallet {
 
     // Ensure we have keys - wallet only loads active keysets by default.
     // Under strictCachedKeysets, skip the fetch: getKeyset below reports a keyless keyset.
+    // Resolve once: an auto-bound wallet can rebind during the awaits below
+    const scanId = keysetId ?? this.keysetId;
     if (!this._strictCachedKeysets) {
-      await this._keyChain.ensureKeysetKeys(keysetId ?? this.keysetId);
+      await this._keyChain.ensureKeysetKeys(scanId);
     }
-    const keyset = this.getKeyset(keysetId); // specified or wallet keyset
+    const keyset = this.getKeyset(scanId);
 
     // create deterministic blank outputs for unknown restore amounts
     // Note: zero amount + zero denomination passes splitAmount validation
@@ -2407,6 +2409,9 @@ class Wallet {
       // and, after a rotation, the keyset. Otherwise the mint must return exactly what was asked,
       // or it's a downgrade attack.
       const blank = outputData[i].blindedMessage.amount.isZero();
+      // A zero-value signature on a blank carries no ecash and is dropped by the caller (NUT-08),
+      // so nothing here applies to it, the DLEQ requirement included.
+      if (blank && signatures[i].amount.isZero()) continue;
       this.failIf(
         !blank && signatures[i].id !== outputData[i].blindedMessage.id,
         `Mint signature keyset id at index ${i} does not match output: expected ${outputData[i].blindedMessage.id}, got ${signatures[i].id}. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
@@ -3574,7 +3579,8 @@ class Wallet {
    * @remarks
    * Synchronous by design and called internally by `completeMelt` (which ensures keys first);
    * direct callers deferring change construction (NUT-06 async melts, crash recovery) should `await
-   * wallet.keyChain.ensureKeysetKeys(id)` per signature keyset first.
+   * wallet.ensureOperableKeysets(changeSigs.map((s) => s.id))` first, which also picks up a keyset
+   * rotated in while the melt was pending.
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted OutputData.
    * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).
@@ -3591,16 +3597,14 @@ class Wallet {
       changeSigs.length > outputData.length,
       `Mint returned ${changeSigs.length} signatures, but only ${outputData.length} blanks were provided. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.`,
     );
-    // NUT-08 pairs signatures to blanks by index. A zero-value one carries no ecash and is
-    // dropped before validation, so a junk entry cannot fail the DLEQ or key checks.
-    const pairs = changeSigs
-      .map((sig, i) => ({ sig, blank: outputData[i] }))
-      .filter(({ sig }) => !sig?.amount.isZero());
-    this.validateReturnedSignatures(
-      pairs.map((p) => p.sig),
-      pairs.map((p) => p.blank),
-    );
-    return pairs.map(({ sig, blank }) => blank.toProof(sig, this.keysetForSignature(sig.id)));
+    this.validateReturnedSignatures(changeSigs, outputData);
+    const change: Proof[] = [];
+    changeSigs.forEach((s, i) => {
+      // NUT-08 pairs signatures to blanks by index; a zero-value one carries no ecash.
+      if (s.amount.isZero()) return;
+      change.push(outputData[i].toProof(s, this.keysetForSignature(s.id)));
+    });
+    return change;
   }
 
   /**

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3579,8 +3579,8 @@ class Wallet {
    * @remarks
    * Synchronous by design and called internally by `completeMelt` (which ensures keys first);
    * direct callers deferring change construction (NUT-06 async melts, crash recovery) should `await
-   * wallet.ensureOperableKeysets(changeSigs.map((s) => s.id))` first, which also picks up a keyset
-   * rotated in while the melt was pending.
+   * wallet.ensureOperableKeysets(ids)` first for the ids of the value-bearing signatures, which
+   * also picks up a keyset rotated in while the melt was pending.
    * @param outputData Outputs from `prepareMelt()`, or deserialised persisted OutputData.
    * @param changeSigs The optional `change` signatures from the melt response or paid quote.
    * @returns Spendable change proofs (possibly empty).

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2030,7 +2030,7 @@ class Wallet {
       lastCounterWithSignature = start + i;
       // Signed at zero (a NUT-08 blank the mint did not omit): used counter, but no ecash
       if (matchingSig.amount.isZero()) continue;
-      outputData[i].blindedMessage.amount = matchingSig.amount;
+      // The output stays a blank: toProof takes the amount and keyset from the signature
       restoredProofs.push(
         outputData[i].toProof(matchingSig, this.keysetForSignature(matchingSig.id)),
       );

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3601,9 +3601,21 @@ class Wallet {
     // so normalise here rather than trust the type at this public boundary.
     const sigs = changeSigs.map((s) => (s ? { ...s, amount: Amount.from(s.amount) } : s));
     this.validateReturnedSignatures(sigs, outputData);
+    // NUT-08 requires the mint to omit zero-value signatures; they carry no ecash, so drop them
+    // rather than fail a settled melt, but make the conformance slip visible.
+    const zeroSigs = sigs.filter((s) => s.amount.isZero()).length;
+    if (zeroSigs > 0) {
+      this._logger.warn(
+        'Mint returned zero-value change signatures, which NUT-08 requires it to omit',
+        {
+          mintUrl: this.mint.mintUrl,
+          count: zeroSigs,
+        },
+      );
+    }
     const change: Proof[] = [];
     sigs.forEach((s, i) => {
-      // NUT-08 pairs signatures to blanks by index; a zero-value one carries no ecash.
+      // NUT-08 pairs signatures to blanks by index
       if (s.amount.isZero()) return;
       change.push(outputData[i].toProof(s, this.keysetForSignature(s.id)));
     });

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -302,6 +302,14 @@ describe('OutputData helpers', () => {
 });
 
 describe('OutputData.toProof across a keyset rotation', () => {
+  test('a non-blank output rejects a signature from another keyset even with matching keys', () => {
+    const G = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+    const output = OutputData.createSingleRandomData(1, '009a1f293253e41e');
+    const keysetB: HasKeysetKeys = { id: '00ad268c4d1f5826', keys: { 1: G } };
+    const sig: SerializedBlindedSignature = { id: keysetB.id, amount: Amount.from(1), C_: G };
+    expect(() => output.toProof(sig, keysetB)).toThrow(/does not match output/);
+  });
+
   test('a real signature under another keyset unblinds to a proof the mint would accept', () => {
     // Mint side: the blank names keyset A, but the mint signs it with keyset B's key for amount 1
     const mintPrivKey = secp256k1.utils.randomSecretKey();

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -4,7 +4,15 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, concatBytes, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test, vi } from 'vitest';
 
-import { getPubKeyFromPrivKey, P2BK_DST, pointFromHex, type P2PKOptions } from '../../src/crypto';
+import {
+  createBlindSignature,
+  createDLEQProof,
+  getPubKeyFromPrivKey,
+  hashToCurve,
+  P2BK_DST,
+  pointFromHex,
+  type P2PKOptions,
+} from '../../src/crypto';
 import { Amount, type AmountLike } from '../../src/model/Amount';
 import { OutputData, isOutputDataFactory } from '../../src/model/OutputData';
 import type { OutputDataFactory, OutputDataLike } from '../../src/model/OutputData';
@@ -290,5 +298,34 @@ describe('OutputData helpers', () => {
     );
     expect(new Set(data).size).toBe(outputs.length);
     expect(new Set(outputs.map((o) => o.ephemeralE)).size).toBe(outputs.length);
+  });
+});
+
+describe('OutputData.toProof across a keyset rotation', () => {
+  test('a real signature under another keyset unblinds to a proof the mint would accept', () => {
+    // Mint side: the blank names keyset A, but the mint signs it with keyset B's key for amount 1
+    const mintPrivKey = secp256k1.utils.randomSecretKey();
+    const keysetB: HasKeysetKeys = {
+      id: '00ad268c4d1f5826',
+      keys: { '1': bytesToHex(getPubKeyFromPrivKey(mintPrivKey)) },
+    };
+    const output = OutputData.createSingleRandomData(0, '009a1f293253e41e');
+    const B_ = pointFromHex(output.blindedMessage.B_);
+    const blindSig = createBlindSignature(B_, mintPrivKey, keysetB.id);
+    const dleq = createDLEQProof(B_, mintPrivKey);
+    const sig: SerializedBlindedSignature = {
+      id: keysetB.id,
+      amount: Amount.from(1),
+      C_: blindSig.C_.toHex(true),
+      dleq: { s: bytesToHex(dleq.s), e: bytesToHex(dleq.e) },
+    };
+
+    // toProof verifies the DLEQ against keyset B; a mismatched key would throw here
+    const proof = output.toProof(sig, keysetB);
+    expect(proof.id).toBe(keysetB.id);
+    // and the unblinded C is k * hash_to_curve(secret), which is what the mint checks on redeem
+    const Y = hashToCurve(new TextEncoder().encode(proof.secret));
+    const expectedC = Y.multiply(secp256k1.Point.Fn.fromBytes(mintPrivKey));
+    expect(pointFromHex(proof.C).equals(expectedC)).toBe(true);
   });
 });

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -523,15 +523,15 @@ describe('Wallet (BOLT12) – wrappers', () => {
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
-        blindedMessage: { amount: 16n, B_: 'B1', id: '009a1f293253e41e' },
+        blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 16, secret: 'secret1', C: 'C1' }),
       },
       {
-        blindedMessage: { amount: 4n, B_: 'B2', id: '009a1f293253e41e' },
+        blindedMessage: { amount: Amount.from(4), B_: 'B2', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 4, secret: 'secret2', C: 'C2' }),
       },
       {
-        blindedMessage: { amount: 1n, B_: 'B3', id: '009a1f293253e41e' },
+        blindedMessage: { amount: Amount.from(1), B_: 'B3', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 1, secret: 'secret3', C: 'C3' }),
       },
     ]);
@@ -583,15 +583,15 @@ describe('Wallet (BOLT12) – wrappers', () => {
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
-        blindedMessage: { amount: 16n, B_: 'B1', id: '009a1f293253e41e' },
+        blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 16, secret: 'secret1', C: 'C1' }),
       },
       {
-        blindedMessage: { amount: 4n, B_: 'B2', id: '009a1f293253e41e' },
+        blindedMessage: { amount: Amount.from(4), B_: 'B2', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 4, secret: 'secret2', C: 'C2' }),
       },
       {
-        blindedMessage: { amount: 1n, B_: 'B3', id: '009a1f293253e41e' },
+        blindedMessage: { amount: Amount.from(1), B_: 'B3', id: '009a1f293253e41e' },
         toProof: () => ({ amount: 1, secret: 'secret3', C: 'C3' }),
       },
     ]);

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -895,6 +895,21 @@ describe('async melt preference body', () => {
     });
   });
 
+  test('createMeltChangeProofs drops a zero-value signature before the DLEQ requirement applies', async () => {
+    server.use(http.get(mintUrl + '/v1/info', () => HttpResponse.json(mintInfoRespWithNut12)));
+    const wallet = new Wallet(mint, { unit, requireSigDleq: true, logger });
+    await wallet.loadMint();
+
+    const blank = OutputData.createSingleRandomData(0, '00bd033559de27d0');
+    const zeroSig: SerializedBlindedSignature = {
+      id: '00bd033559de27d0',
+      amount: Amount.from(0),
+      C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+    };
+
+    expect(wallet.createMeltChangeProofs([blank], [zeroSig])).toEqual([]);
+  });
+
   test('createMeltChangeProofs pairs by index and drops zero-value signatures', async () => {
     const wallet = new Wallet(mint, { unit, logger });
     await wallet.loadMint();

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -910,6 +910,31 @@ describe('async melt preference body', () => {
     expect(wallet.createMeltChangeProofs([blank], [zeroSig])).toEqual([]);
   });
 
+  test('createMeltChangeProofs accepts raw JSON amounts from a stored or WebSocket quote', async () => {
+    const wallet = new Wallet(mint, { unit, logger });
+    await wallet.loadMint();
+
+    const blanks = [0, 0].map((a) => OutputData.createSingleRandomData(a, '00bd033559de27d0'));
+    // what JSON.parse yields: plain numbers where the type says Amount
+    const raw = [
+      {
+        id: '00bd033559de27d0',
+        amount: 0,
+        C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+      {
+        id: '00bd033559de27d0',
+        amount: 2,
+        C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+    ] as unknown as SerializedBlindedSignature[];
+
+    const change = wallet.createMeltChangeProofs(blanks, raw);
+    expect(change).toHaveLength(1);
+    expect(change[0].amount).toBeInstanceOf(Amount);
+    expect(change[0].amount.equals(Amount.from(2))).toBe(true);
+  });
+
   test('createMeltChangeProofs pairs by index and drops zero-value signatures', async () => {
     const wallet = new Wallet(mint, { unit, logger });
     await wallet.loadMint();

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -15,8 +15,10 @@ import {
   type MeltQuoteBolt12Response,
   type AuthProvider,
   type OutputType,
+  type MintKeyset,
   Amount,
 } from '../../src';
+import { DUMMY_TEST_KEYSET, MINTCACHE, PUBKEYS } from '../consts';
 
 import { useTestServer, mint, mintUrl, unit, invoice, logger, mintInfoResp } from './_setup';
 
@@ -832,20 +834,90 @@ describe('async melt preference body', () => {
     expect(/[0-9a-f]{64}/.test(change[0].secret)).toBe(true);
   });
 
-  test('createMeltChangeProofs rejects signature/output keyset id mismatch', async () => {
+  // Mint rotated while the melt was pending: A inactive, B (sat) and a usd keyset active.
+  const keysetB: MintKeyset = {
+    id: '009a1f293253e41e',
+    unit: 'sat',
+    active: true,
+    input_fee_ppk: 0,
+  };
+  const keysetUsd = MINTCACHE.keysets[1];
+  function useRotatedKeysets() {
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({
+          keysets: [{ ...DUMMY_TEST_KEYSET, active: false }, keysetB, keysetUsd],
+        }),
+      ),
+      http.get(mintUrl + '/v1/keys', () =>
+        HttpResponse.json({ keysets: [{ ...keysetB, keys: PUBKEYS }, MINTCACHE.keys[1]] }),
+      ),
+    );
+  }
+
+  test('createMeltChangeProofs unblinds change with the keyset the signature names', async () => {
+    useRotatedKeysets();
     const wallet = new Wallet(mint, { unit, logger });
     await wallet.loadMint();
 
-    const output = OutputData.createSingleRandomData(0, '00bd033559de27d0');
-    const mismatchedSig: SerializedBlindedSignature = {
-      id: '009a1f293253e41e', // different keyset id from the output
+    const blank = OutputData.createSingleRandomData(0, '00bd033559de27d0');
+    const sig: SerializedBlindedSignature = {
+      id: '009a1f293253e41e', // signed under the new keyset, not the blank's
       amount: Amount.from(1),
       C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
     };
 
-    expect(() => wallet.createMeltChangeProofs([output], [mismatchedSig])).toThrow(
-      /signature keyset id at index 0 does not match output/i,
-    );
+    const [proof] = wallet.createMeltChangeProofs([blank], [sig]);
+    expect(proof).toMatchObject({ id: '009a1f293253e41e', amount: Amount.from(1) });
+  });
+
+  test('createMeltChangeProofs rejects change signed under a keyset of another unit', () => {
+    // Keys for every unit are loaded here (a cache restore), so only the unit check stands in the way
+    const wallet = new Wallet(mint, { unit, logger });
+    wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
+
+    const blank = OutputData.createSingleRandomData(0, '00bd033559de27d0');
+    const sig: SerializedBlindedSignature = {
+      id: keysetUsd.id,
+      amount: Amount.from(1),
+      C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+    };
+
+    let err: unknown;
+    try {
+      wallet.createMeltChangeProofs([blank], [sig]);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toMatchObject({
+      message: expect.stringMatching(/is not loaded in this wallet/),
+      cause: { message: expect.stringMatching(/unit does not match/) },
+    });
+  });
+
+  test('createMeltChangeProofs pairs by index and drops zero-value signatures', async () => {
+    const wallet = new Wallet(mint, { unit, logger });
+    await wallet.loadMint();
+
+    const blanks = [0, 0].map((a) => OutputData.createSingleRandomData(a, '00bd033559de27d0'));
+    const sigs: SerializedBlindedSignature[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(0),
+        C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(2),
+        C_: '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422',
+      },
+    ];
+
+    const change = wallet.createMeltChangeProofs(blanks, sigs);
+    expect(change).toHaveLength(1);
+    expect(change[0]).toMatchObject({ amount: Amount.from(2) });
+    // the surviving signature was paired with the second blank, not compacted onto the first
+    expect(change[0].secret).toBe(new TextDecoder().decode(blanks[1].secret));
   });
 
   test('createMeltChangeProofs surfaces NUT-09 recovery hint when keyset is unknown', async () => {

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -936,7 +936,11 @@ describe('async melt preference body', () => {
   });
 
   test('createMeltChangeProofs pairs by index and drops zero-value signatures', async () => {
-    const wallet = new Wallet(mint, { unit, logger });
+    const warn = vi.fn();
+    const wallet = new Wallet(mint, {
+      unit,
+      logger: { error: vi.fn(), warn, info: vi.fn(), debug: vi.fn(), trace: vi.fn(), log: vi.fn() },
+    });
     await wallet.loadMint();
 
     const blanks = [0, 0].map((a) => OutputData.createSingleRandomData(a, '00bd033559de27d0'));
@@ -958,6 +962,11 @@ describe('async melt preference body', () => {
     expect(change[0]).toMatchObject({ amount: Amount.from(2) });
     // the surviving signature was paired with the second blank, not compacted onto the first
     expect(change[0].secret).toBe(new TextDecoder().decode(blanks[1].secret));
+    // tolerated, but the mint's NUT-08 slip is reported
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('NUT-08'),
+      expect.objectContaining({ count: 1 }),
+    );
   });
 
   test('createMeltChangeProofs surfaces NUT-09 recovery hint when keyset is unknown', async () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -18,6 +18,41 @@ import {
 const server = useTestServer();
 
 describe('Restoring deterministic proofs', () => {
+  test('Batch restore treats a batch of zero-value signatures as occupied', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    const mockRestore = vi
+      .spyOn(wallet, 'restore')
+      .mockImplementation(
+        async (start): Promise<{ proofs: Proof[]; lastCounterWithSignature?: number }> => {
+          // first batch: signed, but every signature is zero-value
+          if (start === 0) return { proofs: [], lastCounterWithSignature: 5 };
+          if (start === 50)
+            return { proofs: Array(3).fill(1) as Proof[], lastCounterWithSignature: 52 };
+          return { proofs: [] };
+        },
+      );
+    const res = await wallet.batchRestore(100, 50);
+    expect(res.proofs).toHaveLength(3);
+    expect(res.lastCounterWithSignature).toBe(52);
+    mockRestore.mockClear();
+  });
+
+  test('Batch restore keeps scanning the keyset it started on', async () => {
+    const wallet = new Wallet(mint);
+    await wallet.loadMint();
+    const bound = wallet.keysetId;
+    const mockRestore = vi.spyOn(wallet, 'restore').mockImplementation(async () => {
+      // a keychain repair inside restore() can rebind an auto-bound wallet mid-scan
+      (wallet as unknown as { _boundKeysetId: string })._boundKeysetId = '009a1f293253e41e';
+      return { proofs: [] };
+    });
+    await wallet.batchRestore(100, 50);
+    expect(mockRestore.mock.calls.length).toBeGreaterThan(1);
+    expect(mockRestore.mock.calls.every((c) => c[2]?.keysetId === bound)).toBe(true);
+    mockRestore.mockClear();
+  });
+
   test('Batch restore', async () => {
     const wallet = new Wallet(mint);
     await wallet.loadMint();
@@ -120,11 +155,12 @@ describe('restore', () => {
       ),
       http.post(mintUrl + '/v1/restore', async ({ request }) => {
         const body = (await request.json()) as { outputs: unknown[] };
-        // counter 0 on the scanned keyset, counter 1 signed at zero, counter 2 on keyset B
+        // counter 0 on the scanned keyset, counter 1 signed at zero under a keyset the wallet
+        // has never heard of (no keys are needed for it), counter 2 on keyset B
         return HttpResponse.json({
           outputs: body.outputs,
           signatures: body.outputs.map((_, i) => ({
-            id: i === 2 ? keysetB.id : dummyKeysResp.keysets[0].id,
+            id: i === 2 ? keysetB.id : i === 1 ? 'aaaaaaaaaaaaaaaa' : dummyKeysResp.keysets[0].id,
             amount: i === 1 ? 0 : 1,
             C_: VALID_POINT,
           })),

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -3,8 +3,17 @@ import { HttpResponse, http } from 'msw';
 import { test, describe, expect, vi } from 'vitest';
 
 import { Wallet, Amount, type Proof } from '../../src';
+import { PUBKEYS } from '../consts';
 
-import { useTestServer, mint, unit, dummyKeysResp, mintUrl, logger } from './_setup';
+import {
+  useTestServer,
+  mint,
+  unit,
+  dummyKeysResp,
+  dummyKeysetResp,
+  mintUrl,
+  logger,
+} from './_setup';
 
 const server = useTestServer();
 
@@ -97,5 +106,37 @@ describe('restore', () => {
     expect(res.proofs.length).toBeGreaterThan(0);
     // proofs should be of amount 1 because we overprinted 1 in the signatures
     expect(res.proofs.every((p) => p.amount.equals(Amount.from(1)))).toBe(true);
+  });
+
+  test('unblinds restore signatures with the keyset they name and skips zero-value ones', async () => {
+    const VALID_POINT = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
+    const keysetB = { id: '009a1f293253e41e', unit: 'sat', active: true, input_fee_ppk: 0 };
+    server.use(
+      http.get(mintUrl + '/v1/keysets', () =>
+        HttpResponse.json({ keysets: [...dummyKeysetResp.keysets, keysetB] }),
+      ),
+      http.get(mintUrl + '/v1/keys/009a1f293253e41e', () =>
+        HttpResponse.json({ keysets: [{ ...keysetB, keys: PUBKEYS }] }),
+      ),
+      http.post(mintUrl + '/v1/restore', async ({ request }) => {
+        const body = (await request.json()) as { outputs: unknown[] };
+        // counter 0 on the scanned keyset, counter 1 signed at zero, counter 2 on keyset B
+        return HttpResponse.json({
+          outputs: body.outputs,
+          signatures: body.outputs.map((_, i) => ({
+            id: i === 2 ? keysetB.id : dummyKeysResp.keysets[0].id,
+            amount: i === 1 ? 0 : 1,
+            C_: VALID_POINT,
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32), logger });
+    await wallet.loadMint();
+
+    const res = await wallet.restore(0, 3);
+
+    expect(res.proofs.map((p) => p.id)).toEqual([dummyKeysResp.keysets[0].id, keysetB.id]);
+    expect(res.lastCounterWithSignature).toBe(2);
   });
 });


### PR DESCRIPTION
Backport of #1081 to v4. Melt change and restore now unblind with whichever keyset the mint's signature names, and zero-value change signatures are ignored instead of failing the melt after payment. Fixes #1079.

## Why

The melt is irreversible by the time change arrives, so refusing a valid signature only loses funds. Two cases did that:

- A mint that returns zero-value change signatures (allowed by [NUT-08](https://github.com/cashubtc/nuts/blob/main/08.md), which only says the mint *should* omit them) hit a missing key for amount 0 and threw `MeltChangeError` on a paid melt.
- A mint that rotates keysets while a melt is pending has no spec-sanctioned keyset to sign the change under. Whichever it picks, a wallet that insists on the blank's keyset burns the change. `createMeltChangeProofs` already looked keys up by the signature's id, but the shared validator rejected the mismatch first.

## Changes

- The shared validator skips the keyset id check for blanks and derives that from the blank's zero amount, replacing the `checkAmounts` flag. Swap and mint outputs keep both checks.
- Melt change is paired to blanks by index, then zero-value signatures are dropped, so both omission styles map correctly.
- Restore ([NUT-09](https://github.com/cashubtc/nuts/blob/main/09.md)) unblinds each signature with the keyset it names, which makes change signed on a rotated keyset recoverable by a scan of the keyset the blanks were derived from.
- The `toProof` key-id check from #1081 is not ported: v4's `toProof` has no such check today, and the callers above now always hand it the signature's keyset.

## Impact

No public API change. Cross-unit keysets are still rejected by `getKeyset`. Melts that previously failed with `MeltChangeError` in these two cases now return the change.
