### PR TITLE
fix(utils): guard the keysetIds argument of getDecodedToken

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -362,6 +362,12 @@ function tokenFromTemplate(template: TokenV4Template): Token {
  * @returns Cashu token object.
  */
 export function getDecodedToken(tokenString: string, keysetIds: readonly string[]): Token {
+  // Plain JS callers on the pre-v4 signature otherwise fail deep inside on keysetIds.map
+  if (!Array.isArray(keysetIds)) {
+    throw new CTSError(
+      'getDecodedToken requires keysetIds (the wallet keyset id list) as its second argument; see the v4 migration guide, or use wallet.decodeToken()',
+    );
+  }
   const tokenStr = removePrefix(tokenString);
   const token: Token = handleTokens(tokenStr);
   token.proofs = mapShortKeysetIds(token.proofs, keysetIds);

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -204,6 +204,11 @@ test('exact custom split preserves order', () => {
 });
 
 describe('test decode token', () => {
+  test('rejects a missing keysetIds argument with a pointer to the new signature', () => {
+    const decode = utils.getDecodedToken as unknown as (t: string) => Token;
+    expect(() => decode(V3_TOKEN)).toThrow(/requires keysetIds/);
+  });
+
   test('testing v3 Token', async () => {
     const obj = {
       proofs: [


### PR DESCRIPTION
`getDecodedToken` now fails with a message naming its required `keysetIds` argument instead of a `TypeError` from inside the keyset id mapping. Refs #1079 (secondary report).

## Why

The second argument has been required since v4 and the migration guide covers it, but plain JS callers on the old single-argument form get `Cannot read properties of undefined (reading 'map')` with no hint at the cause. Public functions are called from JS as well as TS, so the boundary should say what is missing.

## Changes

One `Array.isArray` check at the top of `getDecodedToken`, throwing a `CTSError` that names the argument and points at the migration guide and `wallet.decodeToken()`. Correct callers are unaffected.

## Impact

None for callers passing an array. Callers already broken get a readable error.
