### PR TITLE
fix(wallet): normalise quote amounts in WebSocket updates

### DIFF
--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -1,6 +1,7 @@
 import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type JsonRpcMessage, type JsonRpcReqParams, type RpcSubId } from '../model/types';
+import { JSONInt } from '../utils/JSONInt';
 import { generateUuidV7 } from '../utils/uuid.js';
 
 import { getWebSocketImpl } from './ws';
@@ -314,7 +315,8 @@ export class WSConnection {
     const message = this.messageQueue.dequeue() as string;
 
     try {
-      const parsed = JSON.parse(message) as JsonRpcMessage;
+      // Same bigint-safe parse as the HTTP transport, so a u64 amount is not rounded on the way in
+      const parsed = JSONInt.parse(message) as JsonRpcMessage;
 
       if ('result' in parsed && parsed.id != undefined) {
         if (this.rpcListeners[parsed.id]) {

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -1,5 +1,6 @@
 import { hashToCurve, hashToCurveBls, isBlsKeyset } from '../crypto';
 import { safeCallback } from '../logger';
+import { Amount } from '../model/Amount';
 import { CTSError } from '../model/Errors';
 import { MintQuoteState, MeltQuoteState } from '../model/types';
 import type {
@@ -33,6 +34,25 @@ function safeStringify(obj: unknown): string {
   } catch {
     return Object.prototype.toString.call(obj);
   }
+}
+
+// NUT-17 payloads are raw JSON, so give callbacks the Amount fields the HTTP responses carry.
+function normalizeMintQuoteUpdate(p: MintQuoteBolt11Response): MintQuoteBolt11Response {
+  return {
+    ...p,
+    ...(p.amount != null && { amount: Amount.from(p.amount) }),
+    ...(p.amount_paid != null && { amount_paid: Amount.from(p.amount_paid) }),
+    ...(p.amount_issued != null && { amount_issued: Amount.from(p.amount_issued) }),
+  };
+}
+
+function normalizeMeltQuoteUpdate(p: MeltQuoteBolt11Response): MeltQuoteBolt11Response {
+  return {
+    ...p,
+    ...(p.amount != null && { amount: Amount.from(p.amount) }),
+    ...(p.fee_reserve != null && { fee_reserve: Amount.from(p.fee_reserve) }),
+    ...(p.change && { change: p.change.map((s) => ({ ...s, amount: Amount.from(s.amount) })) }),
+  };
 }
 
 function normalizeError(err: unknown): Error {
@@ -245,8 +265,19 @@ export class WalletEvents {
     if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const uniq = Array.from(new Set(ids));
-    const subId = ws.createSubscription({ kind: 'bolt11_mint_quote', filters: uniq }, cb, err);
-    const cancel = () => ws.cancelSubscription(subId, cb);
+    // A malformed payload reports through err rather than reaching cb with the wrong types
+    const handler = (p: MintQuoteBolt11Response) => {
+      let quote: MintQuoteBolt11Response;
+      try {
+        quote = normalizeMintQuoteUpdate(p);
+      } catch (e) {
+        err(normalizeError(e));
+        return;
+      }
+      cb(quote);
+    };
+    const subId = ws.createSubscription({ kind: 'bolt11_mint_quote', filters: uniq }, handler, err);
+    const cancel = () => ws.cancelSubscription(subId, handler);
     return this.withAbort(opts?.signal, cancel);
   }
 
@@ -293,8 +324,18 @@ export class WalletEvents {
     if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
 
     const uniq = Array.from(new Set(ids));
-    const subId = ws.createSubscription({ kind: 'bolt11_melt_quote', filters: uniq }, cb, err);
-    const cancel = () => ws.cancelSubscription(subId, cb);
+    const handler = (p: MeltQuoteBolt11Response) => {
+      let quote: MeltQuoteBolt11Response;
+      try {
+        quote = normalizeMeltQuoteUpdate(p);
+      } catch (e) {
+        err(normalizeError(e));
+        return;
+      }
+      cb(quote);
+    };
+    const subId = ws.createSubscription({ kind: 'bolt11_melt_quote', filters: uniq }, handler, err);
+    const cancel = () => ws.cancelSubscription(subId, handler);
     return this.withAbort(opts?.signal, cancel);
   }
 

--- a/test/transport/WSConnection.test.ts
+++ b/test/transport/WSConnection.test.ts
@@ -159,6 +159,38 @@ describe('testing WSConnection', () => {
     });
     expect(payload).toMatchObject({ quote: '123', request: '456', paid: true, expiry: 123 });
   });
+  test('a notification carrying a u64 amount arrives without rounding', async () => {
+    server.on('connection', (socket) => {
+      socket.on('message', (m) => {
+        try {
+          const parsed = JSON.parse(m.toString());
+          if (parsed.method === 'subscribe') {
+            socket.send(
+              `{"jsonrpc": "2.0", "result": {"status": "OK", "subId": "${parsed.params.subId}"}, "id": ${parsed.id}}`,
+            );
+            setTimeout(() => {
+              socket.send(
+                `{"jsonrpc": "2.0", "method": "subscribe", "params": {"subId": "${parsed.params.subId}", "payload": {"quote": "u64", "amount": 18446744073709551615}}}`,
+              );
+            }, 100);
+          }
+        } catch {
+          console.log('Server parsing failed...');
+        }
+      });
+    });
+    const conn = new WSConnection(fakeUrl);
+    await conn.connect();
+
+    const payload = await new Promise<{ amount: unknown }>((res) => {
+      conn.createSubscription(
+        { kind: 'bolt11_mint_quote', filters: ['u64'] },
+        (p: { amount: unknown }) => res(p),
+        vi.fn(),
+      );
+    });
+    expect(payload.amount).toBe(18446744073709551615n);
+  });
 });
 
 describe('WSConnection – socket-not-open paths', () => {

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -184,6 +184,49 @@ describe('WalletEvents', () => {
       expect(cb).toHaveBeenCalledWith(expect.objectContaining({ quote: 'm2' }));
     });
 
+    it('mintQuoteUpdates normalises amounts the way the HTTP path does', async () => {
+      const cb = vi.fn();
+      await events.mintQuoteUpdates(['n1'], cb, vi.fn());
+      mock.mint.webSocketConnection!.emit('bolt11_mint_quote', {
+        quote: 'n1',
+        state: 'PAID',
+        amount: 5,
+        amount_paid: 5,
+        amount_issued: 0,
+      });
+      const p = cb.mock.calls[0][0];
+      expect(p.amount).toBeInstanceOf(Amount);
+      expect(p.amount_paid.equals(Amount.from(5))).toBe(true);
+      expect(p.amount_issued.isZero()).toBe(true);
+    });
+
+    it('meltQuoteUpdates normalises amount, fee reserve and change signatures', async () => {
+      const cb = vi.fn();
+      await events.meltQuoteUpdates(['n2'], cb, vi.fn());
+      mock.mint.webSocketConnection!.emit('bolt11_melt_quote', {
+        quote: 'n2',
+        state: 'PAID',
+        amount: 10,
+        fee_reserve: 2,
+        change: [{ id: '00bd033559de27d0', amount: 1, C_: '02' + 'ab'.repeat(32) }],
+      });
+      const p = cb.mock.calls[0][0];
+      expect(p.amount.equals(Amount.from(10))).toBe(true);
+      expect(p.fee_reserve.equals(Amount.from(2))).toBe(true);
+      expect(p.change[0].amount).toBeInstanceOf(Amount);
+      expect(p.change[0].amount.isZero()).toBe(false);
+    });
+
+    it('a quote update with a malformed amount goes to the error callback', async () => {
+      const cb = vi.fn();
+      const err = vi.fn();
+      await events.meltQuoteUpdates(['n3'], cb, err);
+      mock.mint.webSocketConnection!.emit('bolt11_melt_quote', { quote: 'n3', amount: 'ten' });
+      expect(cb).not.toHaveBeenCalled();
+      expect(err).toHaveBeenCalledTimes(1);
+      expect(err.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+
     it('proofStateUpdates subscribes and forwards payloads with proof attached', async () => {
       const cb = vi.fn();
       const err = vi.fn();
@@ -279,7 +322,7 @@ describe('WalletEvents', () => {
       const ws = mock.mint.webSocketConnection!;
       ws.emit('bolt11_mint_quote', { quote: 'q1', state: 'PAID', amount: 123 });
       const res = await p;
-      expect(res).toMatchObject({ quote: 'q1', amount: 123 });
+      expect(res).toMatchObject({ quote: 'q1', amount: Amount.from(123) });
       await flushMicrotasks();
       expect(ws.cancelSubscription).toHaveBeenCalled();
     });
@@ -323,7 +366,10 @@ describe('WalletEvents', () => {
       const ws = mock.mint.webSocketConnection!;
       ws.emit('bolt11_mint_quote', { quote: 'b', state: 'PAID', amount: 42 });
       const res = await p;
-      expect(res).toMatchObject({ id: 'b', quote: expect.objectContaining({ amount: 42 }) });
+      expect(res).toMatchObject({
+        id: 'b',
+        quote: expect.objectContaining({ amount: Amount.from(42) }),
+      });
       await flushMicrotasks();
       expect(ws.cancelSubscription.mock.calls.length).toBeGreaterThanOrEqual(3);
     });
@@ -414,7 +460,7 @@ describe('WalletEvents', () => {
       const ws = mock.mint.webSocketConnection!;
       ws.emit('bolt11_melt_quote', { quote: 'm1', state: 'PAID', amount: 7 });
       const res = await p;
-      expect(res).toMatchObject({ quote: 'm1', amount: 7 });
+      expect(res).toMatchObject({ quote: 'm1', amount: Amount.from(7) });
       await flushMicrotasks();
       expect(ws.cancelSubscription).toHaveBeenCalled();
     });

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -218,13 +218,17 @@ describe('WalletEvents', () => {
     });
 
     it('a quote update with a malformed amount goes to the error callback', async () => {
-      const cb = vi.fn();
-      const err = vi.fn();
-      await events.meltQuoteUpdates(['n3'], cb, err);
-      mock.mint.webSocketConnection!.emit('bolt11_melt_quote', { quote: 'n3', amount: 'ten' });
-      expect(cb).not.toHaveBeenCalled();
-      expect(err).toHaveBeenCalledTimes(1);
-      expect(err.mock.calls[0][0]).toBeInstanceOf(Error);
+      for (const kind of ['bolt11_mint_quote', 'bolt11_melt_quote'] as const) {
+        const cb = vi.fn();
+        const err = vi.fn();
+        const subscribe =
+          kind === 'bolt11_mint_quote' ? events.mintQuoteUpdates : events.meltQuoteUpdates;
+        await subscribe.call(events, ['n3'], cb, err);
+        mock.mint.webSocketConnection!.emit(kind, { quote: 'n3', amount: 'ten' });
+        expect(cb).not.toHaveBeenCalled();
+        expect(err).toHaveBeenCalledTimes(1);
+        expect(err.mock.calls[0][0]).toBeInstanceOf(Error);
+      }
     });
 
     it('proofStateUpdates subscribes and forwards payloads with proof attached', async () => {


### PR DESCRIPTION
WebSocket quote updates now match the HTTP path: frames are parsed bigint-safe, and mint and melt quote callbacks receive `Amount` fields.

## Why

`WSConnection` parsed NUT-17 frames with plain `JSON.parse`, which rounds any integer above 2^53 before the payload is seen, so a u64 amount arrived truncated. The HTTP transport has used `JSONInt.parse` since the bigint work in #519; the socket was never switched over.

`WalletEvents` then forwarded that payload unchanged. A consumer calling `.equals` or `.isZero` on `amount`, `fee_reserve`, `amount_paid`, `amount_issued` or a change signature amount from `onceMeltPaid`, `onceMintPaid` or the update subscriptions got a `TypeError`, because the value was a number despite the type. The async-melt recovery recipe in the docs runs into exactly that.

## Changes

- `WSConnection` parses frames with `JSONInt.parse`, the same bigint-safe parser as the HTTP transport. Safe integers still arrive as numbers; larger ones arrive as bigint.
- `mintQuoteUpdates` and `meltQuoteUpdates` wrap the callback so present amount fields are converted with `Amount.from`. Absent fields stay absent.
- A payload whose amount cannot be parsed reports through the error callback rather than reaching the consumer with the wrong shape.
- Tests: a u64 maximum sent through a real mock socket arrives exact; both quote kinds are normalised; the malformed case reports on both; the existing once-paid tests now assert `Amount` values.

## Impact

Consumers that treated WebSocket amounts as plain numbers (arithmetic, `===`) will now see `Amount` objects, as the type always declared. No API signature changes.