### PR TITLE
fix(transport): never retry a request carrying a Blind-auth header

### DIFF
--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -482,6 +482,14 @@ function endpointPathMatchesCachedPath(endpointPath: string, cachedPath: string)
  */
 async function requestWithRetry(options: RequestOptions): Promise<unknown> {
   const { ttl, cached_endpoints, endpoint } = options;
+  // A BAT is single-use (NUT-22): if the first attempt reached the mint, a retry replays a spent
+  // token and fails auth, hiding the original result. The auth layer issues a fresh one per call.
+  const carriesBat = Object.keys(options.headers ?? {}).some(
+    (name) => name.toLowerCase() === 'blind-auth',
+  );
+  if (carriesBat) {
+    return await _request(options);
+  }
   const endpointPathname = getEndpointPathnameSafe(endpoint);
   const requestMethod = options.method?.toUpperCase() ?? 'GET';
 

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -1245,6 +1245,32 @@ describe('idempotent single retry (non-cached endpoints)', () => {
     expect(requestCount).toBe(2);
   });
 
+  test('a request carrying a Blind-auth header is never retried', async () => {
+    // The BAT is single-use: a replay would fail auth and hide the first attempt's outcome.
+    const endpoint = mintUrl + '/v1/keys';
+    let requestCount = 0;
+    server.use(
+      http.get(endpoint, () => {
+        requestCount++;
+        return Response.error();
+      }),
+    );
+    await expect(request({ endpoint, headers: { 'Blind-auth': 'batoken' } })).rejects.toThrow(
+      NetworkError,
+    );
+    expect(requestCount).toBe(1);
+    // The NUT-19 backoff loop is skipped the same way.
+    await expect(
+      request({
+        endpoint,
+        headers: { 'blind-auth': 'batoken' },
+        ttl: 1000,
+        cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
+      }),
+    ).rejects.toThrow(NetworkError);
+    expect(requestCount).toBe(2);
+  });
+
   test('HTTP errors are not retried, even when idempotent', async () => {
     const endpoint = mintUrl + '/v1/keys';
     let requestCount = 0;


### PR DESCRIPTION
`requestWithRetry` sends a request once when its headers carry `Blind-auth`, skipping both the single idempotent retry and the NUT-19 backoff loop. Everything else retries as before.

## Why

A BAT is single-use (NUT-22). When the first attempt reached the mint and only the response was lost, a retry replayed the spent token and the caller saw an auth failure in place of the original outcome, with one BAT consumed for nothing. `requestWithAuth` builds the headers once per call, so the fix belongs below it: the auth layer already issues a fresh BAT on the next call.

## Also

- Test: a `Blind-auth` GET fails after one attempt on a network error, on both the plain and the NUT-19 cached path.
