### PR TITLE
fix(transport): never retry a request carrying a Blind-auth header (v4)

### DIFF
--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -381,6 +381,14 @@ function endpointPathMatchesCachedPath(endpointPath: string, cachedPath: string)
  */
 async function requestWithRetry(options: RequestOptions): Promise<unknown> {
   const { ttl, cached_endpoints, endpoint } = options;
+  // A BAT is single-use (NUT-22): if the first attempt reached the mint, a retry replays a spent
+  // token and fails auth, hiding the original result. The auth layer issues a fresh one per call.
+  const carriesBat = Object.keys(options.headers ?? {}).some(
+    (name) => name.toLowerCase() === 'blind-auth',
+  );
+  if (carriesBat) {
+    return await _request(options);
+  }
   const endpointPathname = getEndpointPathnameSafe(endpoint);
   const requestMethod = options.method?.toUpperCase() ?? 'GET';
 

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -553,6 +553,27 @@ describe('requests', { timeout: 7500 }, () => {
       expect(requestCount).toBeGreaterThan(1); // should retry multiple times (exponential backoff)
     }, 10000);
 
+    test('a cached request carrying a Blind-auth header is never retried', async () => {
+      // The BAT is single-use (NUT-22): a replay would fail auth and hide the first outcome.
+      const endpoint = mintUrl + '/v1/keys';
+      let requestCount = 0;
+      server.use(
+        http.get(endpoint, () => {
+          requestCount++;
+          return Response.error();
+        }),
+      );
+      await expect(
+        request({
+          endpoint,
+          headers: { 'blind-auth': 'batoken' },
+          ttl: 10000,
+          cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
+        }),
+      ).rejects.toThrow(NetworkError);
+      expect(requestCount).toBe(1);
+    });
+
     test('includes concrete delay value in retry log message', async () => {
       const endpoint = mintUrl + '/v1/keys';
       const retryPolicy: Nut19Policy = {


### PR DESCRIPTION
Backport of #1090 to `v4-dev`.

## What

`requestWithRetry` sends a request once when its headers carry `Blind-auth`, skipping the NUT-19 backoff loop. Everything else retries as before.

## Why

A BAT is single-use (NUT-22). When the first attempt reached the mint and only the response was lost, a retry replayed the spent token and the caller saw an auth failure in place of the original outcome, with one BAT consumed for nothing. `requestWithAuth` builds the headers once per call, so the fix belongs below it: the auth layer already issues a fresh BAT on the next call.

## Also

- Test: a `Blind-auth` GET on a cached endpoint fails after one attempt on a network error. v4 has no idempotent retry-once, so only the cached path applies here.
