### PR TITLE
test: import LockBuilder and the BLS helpers statically

### DIFF
--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -12,6 +12,9 @@ import {
   getPubKeyFromPrivKey,
   getG2PubKeyFromPrivKey,
   hashToCurveBls,
+  blindMessageBls,
+  createBlindSignatureBls,
+  unblindSignatureBls,
 } from '../../src/crypto';
 import { buildNutrootSecret, NUTROOT_NUMS_KEY } from '../../src/crypto/nutroot';
 import { CTSError } from '../../src/model/Errors';
@@ -1082,16 +1085,15 @@ describe('test zero-knowledge utilities', () => {
         expect(() => utils.verifyProofsForReceive([v3Proof], () => v3Keyset)).not.toThrow();
       });
 
-      test('mixed-denomination v3 batch verifies in one pairing', async () => {
-        const bls = await import('../../src/crypto');
+      test('mixed-denomination v3 batch verifies in one pairing', () => {
         // Same mint key (a=2), different secrets + amounts → realistic mixed-denomination receive.
         const aBytes = hexToBytes('0'.repeat(63) + '2');
         const K2hex = bytesToHex(getG2PubKeyFromPrivKey(aBytes));
         const makeProof = (amount: bigint, secret: string, r: bigint): Proof => {
           const s = new TextEncoder().encode(secret);
-          const { B_ } = bls.blindMessageBls(s, r);
-          const { C_ } = bls.createBlindSignatureBls(B_, aBytes, v3Id);
-          const C = bls.unblindSignatureBls(C_, r);
+          const { B_ } = blindMessageBls(s, r);
+          const { C_ } = createBlindSignatureBls(B_, aBytes, v3Id);
+          const C = unblindSignatureBls(C_, r);
           return {
             amount: Amount.from(amount),
             id: v3Id,
@@ -1114,15 +1116,14 @@ describe('test zero-knowledge utilities', () => {
         expect(() => utils.verifyProofsForReceive(proofs, () => keyset)).not.toThrow();
       });
 
-      test('tampered C in a 5-proof v3 batch is rejected and offender named', async () => {
-        const bls = await import('../../src/crypto');
+      test('tampered C in a 5-proof v3 batch is rejected and offender named', () => {
         const aBytes = hexToBytes('0'.repeat(63) + '2');
         const K2hex = bytesToHex(getG2PubKeyFromPrivKey(aBytes));
         const makeProof = (amount: bigint, secret: string, r: bigint): Proof => {
           const s = new TextEncoder().encode(secret);
-          const { B_ } = bls.blindMessageBls(s, r);
-          const { C_ } = bls.createBlindSignatureBls(B_, aBytes, v3Id);
-          const C = bls.unblindSignatureBls(C_, r);
+          const { B_ } = blindMessageBls(s, r);
+          const { C_ } = createBlindSignatureBls(B_, aBytes, v3Id);
+          const C = unblindSignatureBls(C_, r);
           return {
             amount: Amount.from(amount),
             id: v3Id,

--- a/test/wallet/lock.node.test.ts
+++ b/test/wallet/lock.node.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { Wallet } from '../../src';
+import { LockBuilder, Wallet } from '../../src';
 import { getPubKeyFromPrivKey } from '../../src/crypto/curve_secp';
 import { NUTROOT_NUMS_KEY, parseNutrootLeaf, serializeNutrootLeaf } from '../../src/crypto/nutroot';
 import { Amount } from '../../src/model/Amount';
@@ -471,8 +471,7 @@ describe('Wallet.createOutputData lock chokepoint', () => {
 });
 
 describe('LockBuilder', () => {
-  test('emits semantic LockOptions', async () => {
-    const { LockBuilder } = await import('../../src');
+  test('emits semantic LockOptions', () => {
     const options = new LockBuilder()
       .addMainPubkey([PUB_A, PUB_B])
       .requireMainSignatures(2)
@@ -487,8 +486,7 @@ describe('LockBuilder', () => {
     });
   });
 
-  test('addLeaf makes trees NUT-11 cannot express', async () => {
-    const { LockBuilder } = await import('../../src');
+  test('addLeaf makes trees NUT-11 cannot express', () => {
     const options = new LockBuilder()
       .addMainPubkey(PUB_A)
       .addLeaf({ type: 'after', n: 1, time: TIME, keys: [PUB_R] })
@@ -499,8 +497,7 @@ describe('LockBuilder', () => {
     expect(lockToNutrootOptions(options).leaves).toHaveLength(2);
   });
 
-  test('round-trips through fromOptions', async () => {
-    const { LockBuilder } = await import('../../src');
+  test('round-trips through fromOptions', () => {
     const options = new LockBuilder()
       .addHashlock(HASH)
       .addMainPubkey(PUB_A)


### PR DESCRIPTION
Removes five needless dynamic imports from the test tree; no production code changes.

## Why

A tidy-up spotted while reviewing the module mocking in #964. Both files already import the same module statically at the top, so the `await import(...)` calls only added an async wrapper to tests that otherwise await nothing.

## Changes

- `test/wallet/lock.node.test.ts`: `LockBuilder` joins the static import, three dynamic imports go. The whole-namespace import that asserts `P2PKBuilder` is absent stays, since it exists to inspect the export surface.
- `test/utils/core.test.ts`: the three BLS helpers join the static crypto import, two dynamic imports go.
- The five affected callbacks drop `async`.

The `AuthManager` test's `import * as wallet` looked dead at first but is the handle for its mocked `KeyChain`, so it is untouched.
