### PR TITLE
fix(wallet): unblind swap and mint outputs with the keyset the mint signed under

### DIFF
--- a/docs-src/usage/mint_token.md
+++ b/docs-src/usage/mint_token.md
@@ -4,6 +4,9 @@
 
 ## 1) One-step BOLT11 mint
 
+`mintProofsBolt11()` fetches the full quote when passed a quote ID, regardless of the output keyset.
+Pass a full quote response instead to avoid that extra request.
+
 ```ts
 import { Wallet, MintQuoteState } from '@cashu/cashu-ts';
 

--- a/docs-src/wallet_ops/send.md
+++ b/docs-src/wallet_ops/send.md
@@ -60,6 +60,8 @@ const mySendData: OutputData[] = [/* amounts must sum to 15 */];
 const { keep, send } = await wallet.ops.send(15, myProofs).asCustom(mySendData).run();
 ```
 
+Custom data may name any active keyset of the wallet unit, per output. The wallet checks each keyset before the swap and unblinds every output with the keyset the mint signed under.
+
 Normal sends swap v3 proofs that lack transferable bearer keys, even when the amounts match exactly. Supplying a script-path plan also forces a swap.
 
 ## 6) Force pure offline (no mint calls)

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -210,7 +210,6 @@ export interface AuthProvider {
 
 // @public
 export interface BatchMintPreview<TQuote extends Pick<MintQuoteBaseResponse, 'quote' | 'pubkey'> = MintQuoteBaseResponse> {
-    keysetId: string;
     // @deprecated (undocumented)
     legacySignatures?: Array<string | null>;
     // (undocumented)
@@ -1055,7 +1054,6 @@ export class MeltOnchainBuilder {
 // @public
 export interface MeltPreview<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse> {
     inputs: Proof[];
-    keysetId: string;
     // (undocumented)
     method: string;
     outputData: OutputDataLike[];
@@ -1456,7 +1454,6 @@ export class MintOperationError extends HttpResponseError {
 
 // @public
 export interface MintPreview<TQuote extends Pick<MintQuoteBaseResponse, 'quote'> = MintQuoteBaseResponse> {
-    keysetId: string;
     // @deprecated (undocumented)
     legacySignature?: string;
     // (undocumented)
@@ -2432,7 +2429,6 @@ export type SerializedProof = Omit<Proof, 'amount'> & {
 export type SerializedSwapPreview = {
     amount: string;
     fees: string;
-    keysetId: string;
     inputs: SerializedProof[];
     sendOutputs?: SerializedOutputData[];
     keepOutputs?: SerializedOutputData[];
@@ -2632,7 +2628,6 @@ export type SwapMethod = {
 export type SwapPreview = {
     amount: Amount;
     fees: Amount;
-    keysetId: string;
     inputs: Proof[];
     sendOutputs?: OutputDataLike[];
     keepOutputs?: OutputDataLike[];

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -41,6 +41,20 @@ No migration is needed unless you deliberately created outputs on inactive or le
 
 ---
 
+## `keysetId` removed from the preview types
+
+`SwapPreview`, `MintPreview`, `BatchMintPreview` and `MeltPreview` no longer carry `keysetId`. It
+named the wallet's keyset at prepare time, but custom output data names its own keyset per output
+and the wallet now unblinds each output with the keyset the mint signed under. Read the id from the
+outputs instead; a persisted `SerializedSwapPreview` that still has the field deserializes fine.
+
+```ts
+// Before
+const id = preview.keysetId;
+// After
+const id = preview.outputData[0].blindedMessage.id; // or sendOutputs / keepOutputs for a SwapPreview
+```
+
 ## Mint quotes now require a usable active keyset
 
 All mint-quote creation methods (`createMintQuote`, `createMintQuoteBolt11`, `createMintQuoteBolt12`, `createMintQuoteOnchain`) now throw `no active keyset for unit '…' — a paid mint quote could not be redeemed` if the mint has no usable (active, hex-id, keyed) keyset for the wallet's unit. This prevents paying an invoice for a quote that could never be redeemed for proofs — `loadMint` deliberately tolerates keyset-less mints (e.g. a mint unwinding liabilities) by leaving the wallet unbound, so without this check the failure only surfaced after payment, at minting time.

--- a/src/wallet/SwapPreview.ts
+++ b/src/wallet/SwapPreview.ts
@@ -17,7 +17,6 @@ export type SerializedProof = Omit<Proof, 'amount'> & { amount: string };
 export type SerializedSwapPreview = {
   amount: string;
   fees: string;
-  keysetId: string;
   inputs: SerializedProof[];
   sendOutputs?: SerializedOutputData[];
   keepOutputs?: SerializedOutputData[];
@@ -42,7 +41,6 @@ export function serializeSwapPreview(preview: SwapPreview): SerializedSwapPrevie
   return {
     amount: preview.amount.toString(),
     fees: preview.fees.toString(),
-    keysetId: preview.keysetId,
     inputs: preview.inputs.map(serializeProof),
     ...(preview.sendOutputs && {
       sendOutputs: preview.sendOutputs.map((o) => OutputData.serialize(o)),
@@ -64,7 +62,6 @@ export function deserializeSwapPreview(serialized: SerializedSwapPreview): SwapP
     return {
       amount: Amount.from(serialized.amount),
       fees: Amount.from(serialized.fees),
-      keysetId: serialized.keysetId,
       inputs: normalizeProofAmounts(serialized.inputs),
       ...(serialized.sendOutputs && {
         sendOutputs: serialized.sendOutputs.map((s) => OutputData.deserialize(s)),

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1463,7 +1463,6 @@ class Wallet {
     return {
       amount: receiveAmount,
       fees: swapFee,
-      keysetId: keyset.id,
       inputs: preimage === undefined ? proofs : attachHTLCPreimage(proofs, preimage),
       keepOutputs: outputs,
     };
@@ -1741,7 +1740,6 @@ class Wallet {
     return {
       amount: sendAmountTarget,
       fees: swapFee,
-      keysetId: keyset.id,
       inputs:
         preimage === undefined ? selectedProofs : attachHTLCPreimage(selectedProofs, preimage),
       sendOutputs,
@@ -3318,7 +3316,6 @@ class Wallet {
       method,
       payload: mintPayload,
       outputData: outputs,
-      keysetId: keyset.id,
       quote,
       legacySignature,
     };
@@ -3565,7 +3562,6 @@ class Wallet {
       method,
       payload: batchPayload,
       outputData: outputs,
-      keysetId: keyset.id,
       quotes: entries.map((e) => e.quote),
       ...(hasSignatures ? { legacySignatures } : {}),
     };
@@ -4149,7 +4145,6 @@ class Wallet {
       inputs:
         preimage === undefined ? normalizedProofs : attachHTLCPreimage(normalizedProofs, preimage),
       outputData,
-      keysetId: keyset.id,
       quote: meltQuote,
     };
 

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -71,7 +71,7 @@ import type {
   SpendInfo,
   SwapRequest,
 } from '../model/types';
-import type { SerializedBlindedSignature } from '../model/types/blinded';
+import type { SerializedBlindedMessage, SerializedBlindedSignature } from '../model/types/blinded';
 import type { KeyChainCache } from '../model/types/keyset';
 import { CheckStateEnum, type ProofState } from '../model/types/NUT07';
 import { type BatchMintRequest } from '../model/types/NUT29';
@@ -618,6 +618,22 @@ class Wallet {
       keyset: keyset.id,
     });
     return keyset;
+  }
+
+  /**
+   * Whether a mint request's outputs sit on a v3 keyset, which selects the quote signing rule.
+   *
+   * @remarks
+   * Chosen from the outputs, not the wallet keyset: custom data may name another. NUT-04 requires
+   * every output of a v3 mint request to share one keyset.
+   */
+  private mintsOntoV3(outputs: SerializedBlindedMessage[]): boolean {
+    const v3 = outputs.some((o) => isBlsKeyset(o.id));
+    this.failIf(
+      v3 && new Set(outputs.map((o) => o.id)).size > 1,
+      'Outputs on a v3 keyset must all share that keyset (NUT-04)',
+    );
+    return v3;
   }
 
   /**
@@ -3217,6 +3233,7 @@ class Wallet {
     // Create outputs and mint payload
     const outputs = this.createOutputData(mintAmount, keyset, mintOT);
     const blindedMessages = outputs.map((d) => d.blindedMessage);
+    const v3 = this.mintsOntoV3(blindedMessages);
     const mintPayload: MintRequest = {
       outputs: blindedMessages,
       quote: quote.quote,
@@ -3254,7 +3271,7 @@ class Wallet {
         quoteId: quote.quote,
         outputs: blindedMessages,
       };
-      if (isBlsKeyset(keyset.id)) {
+      if (v3) {
         // V3 (nutroot secrets): the quote is a transaction input; its lock key signs the
         // quote input digest (NUT-10). No legacy fallback on v3 keysets.
         // The transcript commits the quote's face amount, not this draw: the output
@@ -3282,7 +3299,7 @@ class Wallet {
         mintPayload.signature = schnorrSignDigest(request.digest, signingKey);
         // Keep a legacy (pre nuts#375) signature over the same outputs as a fallback for
         // not-yet-upgraded mints — see completeMint(). Never on v3 keysets.
-        if (!isBlsKeyset(keyset.id)) {
+        if (!v3) {
           legacySignature = signMintQuoteLegacy(signingKey, quote.quote, blindedMessages);
         }
       } else {
@@ -3475,6 +3492,7 @@ class Wallet {
     // Create consolidated output data
     const outputs = this.createOutputData(totalAmount, keyset, mintOT);
     const blindedMessages = outputs.map((d) => d.blindedMessage);
+    const v3 = this.mintsOntoV3(blindedMessages);
 
     // Sign each locked quote over ALL blinded messages (NUT-29).
     // Unlocked quotes get null. If no quotes are locked, omit signatures entirely.
@@ -3487,14 +3505,14 @@ class Wallet {
     // and all outputs (NUT-10).
     // Every quote in a v3 batch is a signing input, so an unlocked one has no witness and the
     // mint must reject the batch (NUT-29). Fail here, before any request is built.
-    if (isBlsKeyset(keyset.id)) {
+    if (v3) {
       const unlocked = entries.findIndex((e) => !('pubkey' in e.quote && e.quote.pubkey));
       this.failIf(
         unlocked >= 0,
         `prepareBatchMint: quote #${unlocked + 1} is unlocked; every quote minting onto a v3 keyset must be locked`,
       );
     }
-    const v3BatchDigests = isBlsKeyset(keyset.id)
+    const v3BatchDigests = v3
       ? inputsForPayload({
           mintQuotes: entries.map((e, i) => {
             // Face amount, as in prepareMint: the transcript never commits the draw,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -3077,7 +3077,8 @@ class Wallet {
    * @remarks
    * Convenience helper for the common BOLT11 flow. Internally this uses `prepareMint('bolt11',…)`
    * followed by `completeMint()`. Use `prepareMint()` directly when you need the generic method
-   * based API or want to persist a replay-safe preview before completion.
+   * based API or want to persist a replay-safe preview before completion. A quote ID is fetched
+   * before minting; pass a full quote object to avoid that request.
    * @param amount Amount to mint.
    * @param quote Mint quote ID or object (bolt11).
    * @param config Optional parameters (e.g. privkey for locked quotes).
@@ -3092,14 +3093,7 @@ class Wallet {
   ): Promise<Proof[]> {
     this.requireSupport('mint', 'bolt11');
     if (typeof quote === 'string') {
-      // A v3 quote is a signed transaction input whose transcript commits its face amount and
-      // whose lock key must be known (NUT-04), so the stub only serves a pre-v3 keyset. The
-      // legacy path skips the round-trip: an invalid quote surfaces in the minting step.
-      const quoteObj = isBlsKeyset(this.getOutputKeyset(config?.keysetId).id)
-        ? await this.checkMintQuoteBolt11(quote)
-        : { quote };
-      const preview = await this.prepareMint('bolt11', amount, quoteObj, config, outputType);
-      return this.completeMint(preview);
+      quote = await this.checkMintQuoteBolt11(quote);
     }
     this.validateMintQuote(quote);
     const preview = await this.prepareMint('bolt11', amount, quote, config, outputType);

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1050,6 +1050,10 @@ class Wallet {
         !customTotal.equals(newAmount),
         `Custom output data total (${customTotal.toString()}) does not match amount (${newAmount.toString()})`,
       );
+      // Custom data names its own keyset per output; check each is usable before anything is spent.
+      for (const d of outputType.data) {
+        this.getOutputKeyset(d.blindedMessage.id);
+      }
       return outputType;
     }
 
@@ -1797,10 +1801,12 @@ class Wallet {
     );
     this.validateReturnedSignatures(signatures, swapTransaction.outputData);
 
-    // Construct proofs
-    // Plain getKeyset: the mint has already signed
-    const keyset = this.getKeyset(swapPreview.keysetId);
-    const swapProofs = swapTransaction.outputData.map((d, i) => d.toProof(signatures[i], keyset));
+    // Construct proofs. Each signature names the keyset it was made under, which custom outputs
+    // may have chosen per output; unblinding must use that one.
+    await this._ensureKeysetsForSignatures(signatures);
+    const swapProofs = swapTransaction.outputData.map((d, i) =>
+      d.toProof(signatures[i], this.keysetForSignature(signatures[i].id)),
+    );
     const reorderedProofs = Array(swapProofs.length);
     const reorderedKeepVector = Array(swapTransaction.keepVector.length);
     swapTransaction.sortedIndices.forEach((s, i) => {
@@ -3341,7 +3347,7 @@ class Wallet {
   async completeMint(
     mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
-    const { payload, outputData, keysetId, method, legacySignature } = mintPreview;
+    const { payload, outputData, method, legacySignature } = mintPreview;
     // TODO: Remove legacy message support
     const { signatures } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
@@ -3356,12 +3362,14 @@ class Wallet {
     );
     this.validateReturnedSignatures(signatures, outputData);
 
-    // Plain getKeyset: the mint has already signed
-    const keyset = this.getKeyset(keysetId);
+    // Unblind under the keyset each signature names, as custom outputs may pick their own.
+    await this._ensureKeysetsForSignatures(signatures);
     this._logger.debug('MINT COMPLETED', {
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
     });
-    return outputData.map((d, i) => d.toProof(signatures[i], keyset));
+    return outputData.map((d, i) =>
+      d.toProof(signatures[i], this.keysetForSignature(signatures[i].id)),
+    );
   }
 
   /**
@@ -3558,7 +3566,7 @@ class Wallet {
   async completeBatchMint(
     batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
-    const { method, payload, outputData, keysetId, legacySignatures } = batchPreview;
+    const { method, payload, outputData, legacySignatures } = batchPreview;
     // TODO: Remove legacy message support
     const { signatures: sigs } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
@@ -3573,13 +3581,13 @@ class Wallet {
     );
     this.validateReturnedSignatures(sigs, outputData);
 
-    // Plain getKeyset: the mint has already signed
-    const keyset = this.getKeyset(keysetId);
+    // Unblind under the keyset each signature names, as custom outputs may pick their own.
+    await this._ensureKeysetsForSignatures(sigs);
     this._logger.debug('BATCH MINT COMPLETED', {
       quotes: payload.quotes.length,
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
     });
-    return outputData.map((d, i) => d.toProof(sigs[i], keyset));
+    return outputData.map((d, i) => d.toProof(sigs[i], this.keysetForSignature(sigs[i].id)));
   }
 
   // -----------------------------------------------------------------
@@ -4302,18 +4310,11 @@ class Wallet {
   }
 
   /**
-   * Keyset a blank's signature was issued under, for unblinding.
+   * Loads the keysets a mint response was signed under.
    *
    * @remarks
-   * Must already be loaded (see `_ensureOperableKeysets`); `getKeyset` also rejects a keyset from
-   * another unit, which a blank cannot vouch for itself.
-   */
-  /**
-   * Loads the keysets a NUT-09 restore response was signed under.
-   *
-   * @remarks
-   * Each signature names its own keyset, which need not be the scanned one. Zero-value entries are
-   * dropped by the caller and need no keys.
+   * Each signature names its own keyset, which need not be the one the preview or scan used.
+   * Zero-value entries are dropped by the caller and need no keys.
    */
   private _ensureKeysetsForSignatures(signatures: SerializedBlindedSignature[]): Promise<void> {
     return this._ensureOperableKeysets(
@@ -4322,6 +4323,13 @@ class Wallet {
     );
   }
 
+  /**
+   * Keyset a signature was issued under, for unblinding.
+   *
+   * @remarks
+   * Must already be loaded (see `_ensureOperableKeysets`); `getKeyset` also rejects a keyset from
+   * another unit, which the signature cannot vouch for itself.
+   */
   private keysetForSignature(id: string): Keyset {
     try {
       return this.getKeyset(id);

--- a/src/wallet/types/payloads.ts
+++ b/src/wallet/types/payloads.ts
@@ -28,7 +28,8 @@ export interface MintPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
    */
   keysetId: string;
   /**
@@ -60,7 +61,8 @@ export interface BatchMintPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
    */
   keysetId: string;
   /**
@@ -92,7 +94,8 @@ export interface MeltPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
    */
   keysetId: string;
   /**
@@ -143,7 +146,8 @@ export type SwapPreview = {
    */
   fees: Amount;
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
    */
   keysetId: string;
   /**

--- a/src/wallet/types/payloads.ts
+++ b/src/wallet/types/payloads.ts
@@ -28,11 +28,6 @@ export interface MintPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
-   * output.
-   */
-  keysetId: string;
-  /**
    * Mint Quote object.
    */
   quote: TQuote;
@@ -61,11 +56,6 @@ export interface BatchMintPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
-   * output.
-   */
-  keysetId: string;
-  /**
    * Mint Quote objects included in this batch.
    */
   quotes: TQuote[];
@@ -93,11 +83,6 @@ export interface MeltPreview<
    * Outputs (blinded messages) that can be filled by the mint to return overpaid fees.
    */
   outputData: OutputDataLike[];
-  /**
-   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
-   * output.
-   */
-  keysetId: string;
   /**
    * Melt Quote object.
    */
@@ -145,11 +130,6 @@ export type SwapPreview = {
    * Total fees for the swap (inc receiver's fees if applicable)
    */
   fees: Amount;
-  /**
-   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
-   * output.
-   */
-  keysetId: string;
   /**
    * Input Proofs for this transaction.
    */

--- a/test/model/ScriptPath.test.ts
+++ b/test/model/ScriptPath.test.ts
@@ -49,7 +49,6 @@ function fixture() {
   const preview: SwapPreview = {
     amount: Amount.from(1),
     fees: Amount.from(0),
-    keysetId,
     inputs: [proof],
     keepOutputs: [OutputData.createSingleRandomData(1, keysetId)],
   };
@@ -137,7 +136,6 @@ describe('ScriptPath signing packages', () => {
     const preview: SwapPreview = {
       amount: Amount.from(1),
       fees: Amount.from(0),
-      keysetId,
       inputs: [proof],
       keepOutputs: [OutputData.createSingleRandomData(1, keysetId)],
     };
@@ -168,7 +166,6 @@ describe('ScriptPath signing packages', () => {
     const preview: SwapPreview = {
       amount: Amount.from(1),
       fees: Amount.from(0),
-      keysetId,
       inputs: [proof],
       keepOutputs: [OutputData.createSingleRandomData(1, keysetId)],
     };
@@ -298,7 +295,6 @@ describe('ScriptPath signing packages', () => {
         method: 'bolt11',
         inputs: preview.inputs,
         outputData: [],
-        keysetId,
         quote: { quote: 'q1', amount: Amount.from(1) },
       }),
     ).toThrow(/Cannot merge a swap package into a melt/);
@@ -331,7 +327,6 @@ describe('ScriptPath melt packages', () => {
       method: 'bolt11',
       inputs: preview.inputs,
       outputData: [OutputData.createSingleRandomData(1, keysetId)],
-      keysetId,
       quote: { quote: 'quote-1', amount: Amount.from(1) },
     };
     return { alice, meltPreview, proof, swapPreview: preview };

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -958,7 +958,6 @@ describe('WalletOps builders', () => {
         method: 'bolt11',
         payload: { quote, outputs: [] },
         outputData: [],
-        keysetId: '123',
         quote: {
           quote,
           method: 'bolt11',
@@ -1027,7 +1026,6 @@ describe('WalletOps builders', () => {
         method: 'bolt12',
         payload: { quote: mint12.quote, outputs: [] },
         outputData: [],
-        keysetId: '123',
         quote: {
           quote: mint12.quote,
           method: 'bolt12',
@@ -1136,7 +1134,6 @@ describe('WalletOps builders', () => {
         method: 'onchain',
         payload: { quote: mintOnchain.quote, outputs: [] },
         outputData: [],
-        keysetId: '123',
         quote: mintOnchain,
       };
       wallet.prepareMint.mockResolvedValueOnce(preview);

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -489,6 +489,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
+    vi.spyOn(wallet.keyChain, 'hasKeyset').mockReturnValue(true);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([]);
     const meltQuote = {
       quote: 'm1',
@@ -528,6 +529,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
+    vi.spyOn(wallet.keyChain, 'hasKeyset').mockReturnValue(true);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
         blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },
@@ -588,6 +590,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
+    vi.spyOn(wallet.keyChain, 'hasKeyset').mockReturnValue(true);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
         blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },

--- a/test/wallet/wallet-custom-outputs.node.test.ts
+++ b/test/wallet/wallet-custom-outputs.node.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  Amount,
+  KeyChain,
+  Mint,
+  OutputData,
+  Wallet,
+  createBlindSignature,
+  createNewMintKeys,
+  hashToCurve,
+  pointFromHex,
+  serializeMintKeys,
+  type KeysetPair,
+  type Proof,
+  type RequestArgs,
+  type SerializedBlindedMessage,
+} from '../../src';
+
+import { mintInfoResp } from './_setup';
+
+// Two active keysets on one synthetic mint: the wallet prefers the cheaper one, so custom
+// outputs built under the dearer one no longer match the wallet's own keyset choice.
+const mintUrl = 'https://mint.test';
+const unit = 'sat';
+const dear = createNewMintKeys(8, new Uint8Array(32).fill(2), { input_fee_ppk: 1000 });
+const cheap = createNewMintKeys(8, new Uint8Array(32).fill(3), { input_fee_ppk: 0 });
+const retired = createNewMintKeys(8, new Uint8Array(32).fill(4), { input_fee_ppk: 0 });
+const usd = createNewMintKeys(8, new Uint8Array(32).fill(5), { input_fee_ppk: 0, unit: 'usd' });
+const unknown = createNewMintKeys(8, new Uint8Array(32).fill(6), { input_fee_ppk: 0 });
+const pairs = [dear, cheap, retired, usd, unknown];
+const seed = new Uint8Array(64).fill(1);
+
+function keysFor(pair: KeysetPair, keysetUnit = unit) {
+  return { id: pair.keysetId, unit: keysetUnit, keys: serializeMintKeys(pair.pubKeys) };
+}
+
+function signatureFor(pair: KeysetPair, secret: string, amount: Amount): string {
+  const key = pair.privKeys[amount.toString()];
+  return createBlindSignature(
+    hashToCurve(new TextEncoder().encode(secret)),
+    key,
+    pair.keysetId,
+  ).C_.toHex(true);
+}
+
+function inputUnder(pair: KeysetPair, amount: number, secret: string): Proof {
+  return {
+    id: pair.keysetId,
+    secret,
+    amount: Amount.from(amount),
+    C: signatureFor(pair, secret, Amount.from(amount)),
+  };
+}
+
+function proofIsValid(p: Proof): boolean {
+  const pair = pairs.find((k) => k.keysetId === p.id);
+  return pair !== undefined && p.C === signatureFor(pair, p.secret, p.amount);
+}
+
+// A mint that signs every output under the keyset the output names.
+function makeWallet() {
+  const calls: string[] = [];
+  const mint = new Mint(mintUrl, {
+    customRequest: async <T>(args: RequestArgs): Promise<T> => {
+      calls.push(args.endpoint);
+      // The transport serialises the body before handing it over.
+      const body = JSON.parse(args.requestBody as string) as {
+        outputs: SerializedBlindedMessage[];
+      };
+      const signatures = body.outputs.map((o) => {
+        const pair = pairs.find((k) => k.keysetId === o.id);
+        if (!pair) throw new Error(`mint does not know keyset ${o.id}`);
+        const amount = Amount.from(o.amount);
+        const C_ = createBlindSignature(
+          pointFromHex(o.B_),
+          pair.privKeys[amount.toString()],
+          o.id,
+        ).C_.toHex(true);
+        return { id: o.id, amount: amount.toString(), C_ };
+      });
+      return { signatures } as T;
+    },
+  });
+  const wallet = new Wallet(mint, { unit });
+  const info = {
+    ...mintInfoResp,
+    nuts: { 4: { methods: [{ method: 'bolt11', unit }], disabled: false } },
+  };
+  wallet.loadMintFromCache(
+    info,
+    KeyChain.mintToCacheDTO(
+      mintUrl,
+      [
+        { id: dear.keysetId, unit, active: true, input_fee_ppk: 1000 },
+        { id: cheap.keysetId, unit, active: true, input_fee_ppk: 0 },
+        { id: retired.keysetId, unit, active: false, input_fee_ppk: 0 },
+        { id: usd.keysetId, unit: 'usd', active: true, input_fee_ppk: 0 },
+      ],
+      [keysFor(dear), keysFor(cheap), keysFor(retired), keysFor(usd, 'usd')],
+    ),
+  );
+  return { wallet, calls };
+}
+
+describe('custom outputs on a keyset other than the wallet default', () => {
+  test('send unblinds each output with the keyset that signed it', async () => {
+    const { wallet, calls } = makeWallet();
+    const keep = OutputData.createDeterministicData(Amount.from(7), seed, 0, keysFor(dear));
+    const send = OutputData.createDeterministicData(
+      Amount.from(8),
+      seed,
+      keep.length,
+      keysFor(dear),
+    );
+    const input = inputUnder(dear, 16, 'custom-send-input');
+
+    const result = await wallet.send(8, [input], undefined, {
+      keep: { type: 'custom', data: keep },
+      send: { type: 'custom', data: send },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect([...result.keep, ...result.send].every(proofIsValid)).toBe(true);
+    expect(result.send.map((p) => p.id)).toEqual([dear.keysetId]);
+  });
+
+  test('send accepts a plan that mixes active keysets', async () => {
+    const { wallet } = makeWallet();
+    const keep = OutputData.createDeterministicData(Amount.from(7), seed, 0, keysFor(cheap));
+    const send = OutputData.createDeterministicData(
+      Amount.from(8),
+      seed,
+      keep.length,
+      keysFor(dear),
+    );
+    const input = inputUnder(dear, 16, 'custom-mixed-input');
+
+    const result = await wallet.send(8, [input], undefined, {
+      keep: { type: 'custom', data: keep },
+      send: { type: 'custom', data: send },
+    });
+
+    expect([...result.keep, ...result.send].every(proofIsValid)).toBe(true);
+    expect(new Set(result.keep.map((p) => p.id))).toEqual(new Set([cheap.keysetId]));
+    expect(new Set(result.send.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
+  test('receive unblinds custom outputs with the keyset that signed them', async () => {
+    const { wallet } = makeWallet();
+    const input = inputUnder(dear, 16, 'custom-receive-input');
+    // The 16 sat input pays 1 sat in fees under the dearer keyset.
+    const data = OutputData.createDeterministicData(Amount.from(15), seed, 0, keysFor(dear));
+
+    const proofs = await wallet.receive([input], undefined, { type: 'custom', data });
+
+    expect(proofs.every(proofIsValid)).toBe(true);
+    expect(new Set(proofs.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
+  test('mint unblinds custom outputs with the keyset that signed them', async () => {
+    const { wallet } = makeWallet();
+    const data = OutputData.createDeterministicData(Amount.from(16), seed, 0, keysFor(dear));
+
+    const proofs = await wallet.mintProofsBolt11(16, 'quote-id', undefined, {
+      type: 'custom',
+      data,
+    });
+
+    expect(proofs.every(proofIsValid)).toBe(true);
+    expect(new Set(proofs.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
+  test.each([
+    ['unknown', unknown, /Keyset '/],
+    ['inactive', retired, /Inactive keyset/],
+    ['other-unit', usd, /Keyset unit does not match wallet unit/],
+  ])('rejects a custom plan on an %s keyset before calling the mint', async (_, pair, msg) => {
+    const { wallet, calls } = makeWallet();
+    const keep = OutputData.createDeterministicData(Amount.from(7), seed, 0, keysFor(dear));
+    const send = OutputData.createDeterministicData(
+      Amount.from(8),
+      seed,
+      keep.length,
+      keysFor(pair),
+    );
+    const input = inputUnder(dear, 16, `custom-${pair.keysetId}`);
+
+    await expect(
+      wallet.send(8, [input], undefined, {
+        keep: { type: 'custom', data: keep },
+        send: { type: 'custom', data: send },
+      }),
+    ).rejects.toThrow(msg);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/test/wallet/wallet-custom-outputs.node.test.ts
+++ b/test/wallet/wallet-custom-outputs.node.test.ts
@@ -162,7 +162,7 @@ describe('custom outputs on a keyset other than the wallet default', () => {
     const { wallet } = makeWallet();
     const data = OutputData.createDeterministicData(Amount.from(16), seed, 0, keysFor(dear));
 
-    const proofs = await wallet.mintProofsBolt11(16, 'quote-id', undefined, {
+    const proofs = await wallet.mintProofs('bolt11', 16, { quote: 'quote-id' }, undefined, {
       type: 'custom',
       data,
     });

--- a/test/wallet/wallet-custom-outputs.node.test.ts
+++ b/test/wallet/wallet-custom-outputs.node.test.ts
@@ -171,6 +171,22 @@ describe('custom outputs on a keyset other than the wallet default', () => {
     expect(new Set(proofs.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
   });
 
+  test('batch mint unblinds custom outputs with the keyset that signed them', async () => {
+    const { wallet } = makeWallet();
+    const data = OutputData.createDeterministicData(Amount.from(16), seed, 0, keysFor(dear));
+
+    const preview = await wallet.prepareBatchMint(
+      'bolt11',
+      [{ amount: 16, quote: { quote: 'quote-id' } }],
+      undefined,
+      { type: 'custom', data },
+    );
+    const proofs = await wallet.completeBatchMint(preview);
+
+    expect(proofs.every(proofIsValid)).toBe(true);
+    expect(new Set(proofs.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
   test.each([
     ['unknown', unknown, /Keyset '/],
     ['inactive', retired, /Inactive keyset/],

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -87,7 +87,7 @@ describe('Legacy (pre-v1) keyset output gating', () => {
     await wallet.loadMint();
 
     const preview = await wallet.prepareMint('bolt11', 3, { quote: 'test-quote' });
-    expect(preview.keysetId).toBe(DUMMY_TEST_KEYSET.id);
+    expect(preview.outputData[0].blindedMessage.id).toBe(DUMMY_TEST_KEYSET.id);
   });
 
   test('prepareMint refuses to create proofs on an inactive keyset', async () => {

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -1061,7 +1061,6 @@ describe('async melt preference body', () => {
         },
       ],
       outputData: [],
-      keysetId: v3KeysetId,
       quote: { quote: 'q-slim' },
     };
     await expect(wallet.completeMelt(preview)).rejects.toThrow(/quote amount/);

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -681,6 +681,32 @@ describe('requestTokens', () => {
       );
     }
 
+    test.each([
+      [DUMMY_TEST_KEYSET.id, NUT02_V3_VECTOR1_KEYSET.id],
+      [NUT02_V3_VECTOR1_KEYSET.id, DUMMY_TEST_KEYSET.id],
+    ] as const)(
+      'fetches string quote IDs for custom outputs: wallet %s, output %s',
+      async (keysetId, outputId) => {
+        serveBothKeysets();
+        const wallet = new Wallet(mintUrl, { unit, keysetId });
+        await wallet.loadMint();
+        const quote = lockedQuote();
+        const fetchQuote = vi.spyOn(wallet, 'checkMintQuoteBolt11').mockResolvedValue(quote);
+        vi.spyOn(wallet, 'completeMint').mockResolvedValue([]);
+        const data = [OutputData.createSingleRandomData(1, outputId)];
+
+        await expect(
+          wallet.mintProofsBolt11(1, quote, { privkey }, { type: 'custom', data }),
+        ).resolves.toEqual([]);
+        expect(fetchQuote).not.toHaveBeenCalled();
+
+        await expect(
+          wallet.mintProofsBolt11(1, quote.quote, { privkey }, { type: 'custom', data }),
+        ).resolves.toEqual([]);
+        expect(fetchQuote).toHaveBeenCalledExactlyOnceWith(quote.quote);
+      },
+    );
+
     test('custom outputs on a v3 keyset sign the transaction digest whatever keyset the wallet holds', async () => {
       serveBothKeysets();
       const wallet = new Wallet(mintUrl, { unit });
@@ -803,6 +829,9 @@ describe('requestTokens', () => {
 
   test('test requestTokens bad response', async () => {
     server.use(
+      http.get(mintUrl + '/v1/mint/quote/bolt11/badquote', () => {
+        return HttpResponse.json({});
+      }),
       http.post(mintUrl + '/v1/mint/bolt11', () => {
         return HttpResponse.json({});
       }),

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -18,16 +18,22 @@ import {
   Amount,
   type AmountLike,
   Mint,
+  OutputData,
   MintOperationError,
   type RequestFn,
 } from '../../src';
-import { schnorrSignDigest, verifyMintQuoteSignature } from '../../src/crypto';
+import { schnorrSignDigest, schnorrVerifyDigest, verifyMintQuoteSignature } from '../../src/crypto';
 import { getPubKeyFromPrivKey } from '../../src/crypto/curve_secp';
 import { verifyMintQuoteSignatureLegacy } from '../../src/crypto/NUT20';
 import { inputsForPayload } from '../../src/crypto/transcript';
 import request from '../../src/transport';
 import { sumProofs } from '../../src/utils';
-import { NUT02_V3_VECTOR1_KEYS, NUT02_V3_VECTOR1_KEYSET } from '../consts';
+import {
+  DUMMY_TEST_KEYS,
+  DUMMY_TEST_KEYSET,
+  NUT02_V3_VECTOR1_KEYS,
+  NUT02_V3_VECTOR1_KEYSET,
+} from '../consts';
 
 import { useTestServer, mint, mintUrl, unit, logger, mintInfoResp, invoice } from './_setup';
 
@@ -657,6 +663,90 @@ describe('requestTokens', () => {
       expect(bytesToHex(seen!.digest)).toBe(bytesToHex(tx.quotes.get('callback-quote')!.digest));
       expect(bytesToHex(seen!.transactionMessage!)).toBe(bytesToHex(tx.transactionMessage));
       expect(preview.legacySignature).toBeUndefined();
+    });
+
+    // A pre-v3 keyset beside the v3 one, so custom outputs can name a keyset the wallet did not
+    // pick.
+    function serveBothKeysets() {
+      server.use(
+        http.get(mintUrl + '/v1/keysets', () =>
+          HttpResponse.json({ keysets: [DUMMY_TEST_KEYSET, NUT02_V3_VECTOR1_KEYSET] }),
+        ),
+        http.get(mintUrl + '/v1/keys', () =>
+          HttpResponse.json({ keysets: [DUMMY_TEST_KEYS, NUT02_V3_VECTOR1_KEYS] }),
+        ),
+        http.get(mintUrl + '/v1/keys/' + NUT02_V3_VECTOR1_KEYSET.id, () =>
+          HttpResponse.json({ keysets: [NUT02_V3_VECTOR1_KEYS] }),
+        ),
+      );
+    }
+
+    test('custom outputs on a v3 keyset sign the transaction digest whatever keyset the wallet holds', async () => {
+      serveBothKeysets();
+      const wallet = new Wallet(mintUrl, { unit });
+      await wallet.loadMint();
+      const data = [OutputData.createSingleRandomData(1, NUT02_V3_VECTOR1_KEYSET.id)];
+      const preview = await wallet.prepareMint(
+        'bolt11',
+        1,
+        lockedQuote(),
+        { privkey, keysetId: DUMMY_TEST_KEYSET.id },
+        { type: 'custom', data },
+      );
+      const tx = inputsForPayload({
+        mintQuotes: [{ quoteId: 'callback-quote', amount: 1 }],
+        outputs: preview.payload.outputs,
+      });
+      expect(
+        schnorrVerifyDigest(
+          preview.payload.signature!,
+          tx.quotes.get('callback-quote')!.digest,
+          pubkey,
+        ),
+      ).toBe(true);
+      expect(preview.legacySignature).toBeUndefined();
+    });
+
+    test('a mint plan mixing a v3 output with another keyset is rejected before the request is built', async () => {
+      serveBothKeysets();
+      const wallet = new Wallet(mintUrl, { unit });
+      await wallet.loadMint();
+      const quote = { ...lockedQuote(), amount: Amount.from(2), amount_paid: Amount.from(2) };
+      const data = [
+        OutputData.createSingleRandomData(1, NUT02_V3_VECTOR1_KEYSET.id),
+        OutputData.createSingleRandomData(1, DUMMY_TEST_KEYSET.id),
+      ];
+      await expect(
+        wallet.prepareMint('bolt11', 2, quote, { privkey }, { type: 'custom', data }),
+      ).rejects.toThrow(/share that keyset/);
+    });
+
+    test('a batch onto custom v3 outputs signs every quote over the transaction digest', async () => {
+      serveBothKeysets();
+      const wallet = new Wallet(mintUrl, { unit });
+      await wallet.loadMint();
+      const quotes = ['batch-a', 'batch-b'].map((q) => ({ ...lockedQuote(), quote: q }));
+      const data = [OutputData.createSingleRandomData(2, NUT02_V3_VECTOR1_KEYSET.id)];
+      const preview = await wallet.prepareBatchMint(
+        'bolt11',
+        quotes.map((quote) => ({ amount: 1, quote })),
+        { privkey, keysetId: DUMMY_TEST_KEYSET.id },
+        { type: 'custom', data },
+      );
+      const tx = inputsForPayload({
+        mintQuotes: quotes.map((q) => ({ quoteId: q.quote, amount: 1 })),
+        outputs: preview.payload.outputs,
+      });
+      quotes.forEach((q, i) => {
+        expect(
+          schnorrVerifyDigest(
+            preview.payload.signatures![i]!,
+            tx.quotes.get(q.quote)!.digest,
+            pubkey,
+          ),
+        ).toBe(true);
+      });
+      expect(preview.legacySignatures).toEqual([null, null]);
     });
   });
 

--- a/test/wallet/wallet-nutroot-edges.node.test.ts
+++ b/test/wallet/wallet-nutroot-edges.node.test.ts
@@ -220,13 +220,18 @@ describe('nutroot edge cases', () => {
       expect(w.keysetId).toBe(id);
       if (mode === 'prepare') {
         const preview = await builder.prepare();
-        expect(preview.keysetId).toBe(legacyId);
         expect(preview.sendOutputs?.[0].blindedMessage.id).toBe(legacyId);
       } else {
         const complete = vi.spyOn(w, 'completeSwap').mockResolvedValue({ send: [], keep: [] });
         await builder.run();
         expect(complete).toHaveBeenCalledWith(
-          expect.objectContaining({ keysetId: legacyId }),
+          expect.objectContaining({
+            sendOutputs: [
+              expect.objectContaining({
+                blindedMessage: expect.objectContaining({ id: legacyId }),
+              }),
+            ],
+          }),
           undefined,
           undefined,
         );

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -151,7 +151,7 @@ describe('receive across a rotation', () => {
     expect(counts().keysARequests).toBe(0); // baseline: loadMint alone doesn't fetch A's keys
 
     const preview = await wallet.prepareSwapToReceive([proofOnA]);
-    expect(preview.keysetId).toBe('009a1f293253e41e'); // outputs on the active keyset
+    expect(preview.keepOutputs?.[0].blindedMessage.id).toBe('009a1f293253e41e'); // outputs on the active keyset
     expect(counts().keysARequests).toBe(1); // one /v1/keys/A fetch, then cached
 
     await wallet.prepareSwapToReceive([proofOnA]);
@@ -167,7 +167,7 @@ describe('receive across a rotation', () => {
     wallet.on.keychainUpdated(({ cache }) => updates.push(cache));
 
     const preview = await wallet.prepareSwapToReceive([proofOnB]);
-    expect(preview.keysetId).toBe('009a1f293253e41e');
+    expect(preview.keepOutputs?.[0].blindedMessage.id).toBe('009a1f293253e41e');
     expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
     expect(updates).toHaveLength(1);
     expect(updates[0].keysets.map((k) => k.id)).toContain('009a1f293253e41e');
@@ -828,7 +828,7 @@ describe('strictCachedKeysets', () => {
     expect(counts().keysARequests).toBe(1);
 
     const preview = await wallet.prepareSwapToReceive([proofOnA]);
-    expect(preview.keysetId).toBe('009a1f293253e41e');
+    expect(preview.keepOutputs?.[0].blindedMessage.id).toBe('009a1f293253e41e');
     expect(counts().keysARequests).toBe(1); // no extra fetch from the op itself
   });
 
@@ -905,7 +905,7 @@ describe('send and melt inputs across a rotation', () => {
 
     const preview = await wallet.prepareSwapToSend(1, [proofOnB]);
     expect(preview.inputs[0].id).toBe('009a1f293253e41e');
-    expect(preview.keysetId).toBe('009a1f293253e41e'); // outputs on the repaired binding
+    expect(preview.sendOutputs?.[0].blindedMessage.id).toBe('009a1f293253e41e'); // outputs on the repaired binding
     expect(counts().keysetsRequests).toBe(1); // exactly one repair refresh
   });
 
@@ -928,7 +928,7 @@ describe('send and melt inputs across a rotation', () => {
 
     const preview = await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(keysetB.id));
     expect(preview.inputs).toHaveLength(2);
-    expect(preview.keysetId).toBe('009a1f293253e41e'); // NUT-08 blanks on the repaired binding
+    expect(preview.outputData[0].blindedMessage.id).toBe('009a1f293253e41e'); // NUT-08 blanks on the repaired binding
     expect(counts().keysetsRequests).toBe(1);
   });
 
@@ -945,7 +945,7 @@ describe('send and melt inputs across a rotation', () => {
     const warn = vi.spyOn(wallet.logger, 'warn');
     const preview = await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id));
     expect(preview.inputs).toHaveLength(2);
-    expect(preview.keysetId).toBe('009a1f293253e41e'); // change blanks on the active keyset
+    expect(preview.outputData[0].blindedMessage.id).toBe('009a1f293253e41e'); // change blanks on the active keyset
     expect(warn).toHaveBeenCalledWith(
       'Melt input keyset is not listed by the mint; proceeding anyway',
       { keyset: proofOnA.id },
@@ -1018,10 +1018,10 @@ describe('send and melt inputs across a rotation', () => {
     await wallet.loadMint(); // A known-but-keyless, bound to B
 
     const sendPreview = await wallet.prepareSwapToSend(1, [proofOnA]);
-    expect(sendPreview.keysetId).toBe('009a1f293253e41e');
+    expect(sendPreview.sendOutputs?.[0].blindedMessage.id).toBe('009a1f293253e41e');
 
     const meltPreview = await wallet.prepareMelt('bolt11', meltQuote, meltProofsOn(proofOnA.id));
-    expect(meltPreview.keysetId).toBe('009a1f293253e41e');
+    expect(meltPreview.outputData[0].blindedMessage.id).toBe('009a1f293253e41e');
 
     expect(counts().keysARequests).toBe(0); // never attempted
   });

--- a/test/wallet/wallet-send.node.test.ts
+++ b/test/wallet/wallet-send.node.test.ts
@@ -502,7 +502,6 @@ describe('send', () => {
     const serialized = serializeSwapPreview({
       amount: Amount.from(1),
       fees: Amount.from(0),
-      keysetId: '00bd033559de27d0',
       inputs: [proofs[0]],
       unselectedProofs: [{ ...proofs[0], secret: 'not-part-of-the-replay' }],
     });
@@ -515,7 +514,6 @@ describe('send', () => {
     const bad: SerializedSwapPreview = {
       amount: '1',
       fees: '0',
-      keysetId: '00bd033559de27d0',
       inputs: [],
       sendOutputs: [
         {
@@ -532,7 +530,6 @@ describe('send', () => {
     const bad: SerializedSwapPreview = {
       amount: '1',
       fees: '0',
-      keysetId: '00bd033559de27d0',
       get inputs(): SerializedProof[] {
         // eslint-disable-next-line @typescript-eslint/only-throw-error -- exercising the non-Error path
         throw 'not-an-error';


### PR DESCRIPTION
Fixes #1094

Custom outputs may now name any active keyset of the wallet unit, per output, and the wallet unblinds each one with the keyset the mint signed under.

## Why

Custom output data has always been an expert mode: the caller builds the OutputData and is expected to cover every angle. One of those angles, passing `keysetId` in the config so the preview matches the data, was a necessary but poorly documented assumption. When the wallet's default keyset moved (eg a cheaper active keyset appeared after the data was built), the preview carried one keyset and the outputs another. Since #1081 that surfaced as a throw after the mint had already consumed the inputs.

## Changes

- `completeSwap`, `completeMint` and `completeBatchMint` unblind under the keyset each signature names, as `completeMelt` already does. The signature id is bound to the output id beforehand, so the mint cannot move an output.
- Custom plans are checked before the mint call: every output must name a known, active keyset in the wallet unit. Mixed active keysets in one plan are allowed.
- `prepareMint` and `prepareBatchMint` pick the NUT-20 or NUT-10 quote signing rule from the outputs, not the wallet keyset. A v3 output beside any other keyset is refused (NUT-04).
- `keysetId` is removed from the four preview types and the serialized swap preview: it described the wallet's keyset, not the outputs. Read the id from the outputs instead; a persisted preview that still carries it deserializes unchanged. Migration guide updated.

## Impact

Callers who pin `keysetId` keep working. A custom plan on an unknown or inactive keyset now fails at prepare time instead of at the mint. Breaking for anyone reading `preview.keysetId` (v5 RC only). The v4 backport (#1096) is manual: the quote-rule change is v5-only, and the field is deprecated there rather than removed.

