### PR TITLE
fix(wallet): unblind swap and mint outputs with the keyset the mint signed under [backport v4-dev]

### DIFF
--- a/docs-src/wallet_ops/send.md
+++ b/docs-src/wallet_ops/send.md
@@ -62,6 +62,8 @@ const mySendData: OutputData[] = [
 const { keep, send } = await wallet.ops.send(15, myProofs).asCustom(mySendData).run();
 ```
 
+Custom data may name any active keyset of the wallet unit, per output. The wallet checks each keyset before the swap and unblinds every output with the keyset the mint signed under.
+
 ## 6) Force pure offline (no mint calls)
 
 **Exact match only (throws on no exact match):**

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -189,6 +189,7 @@ export interface AuthProvider {
 
 // @public
 export interface BatchMintPreview<TQuote extends Pick<MintQuoteBaseResponse, 'quote' | 'pubkey'> = MintQuoteBaseResponse> {
+    // @deprecated
     keysetId: string;
     // @deprecated (undocumented)
     legacySignatures?: Array<string | null>;
@@ -825,6 +826,7 @@ export class MeltOnchainBuilder {
 // @public
 export interface MeltPreview<TQuote extends Pick<MeltQuoteBaseResponse, 'quote'> = MeltQuoteBaseResponse> {
     inputs: Proof[];
+    // @deprecated
     keysetId: string;
     // (undocumented)
     method: string;
@@ -1202,6 +1204,7 @@ export class MintOperationError extends HttpResponseError {
 
 // @public
 export interface MintPreview<TQuote extends Pick<MintQuoteBaseResponse, 'quote'> = MintQuoteBaseResponse> {
+    // @deprecated
     keysetId: string;
     // @deprecated (undocumented)
     legacySignature?: string;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -995,6 +995,10 @@ class Wallet {
         !customTotal.equals(newAmount),
         `Custom output data total (${customTotal.toString()}) does not match amount (${newAmount.toString()})`,
       );
+      // Custom data names its own keyset per output; check each is usable before anything is spent.
+      for (const d of outputType.data) {
+        this.getOutputKeyset(d.blindedMessage.id);
+      }
       return outputType;
     }
 
@@ -1653,9 +1657,12 @@ class Wallet {
     );
     this.validateReturnedSignatures(signatures, swapTransaction.outputData);
 
-    // Construct proofs
-    const keyset = this.getKeyset(swapPreview.keysetId);
-    const swapProofs = swapTransaction.outputData.map((d, i) => d.toProof(signatures[i], keyset));
+    // Construct proofs. Each signature names the keyset it was made under, which custom outputs
+    // may have chosen per output; unblinding must use that one.
+    await this._ensureKeysetsForSignatures(signatures);
+    const swapProofs = swapTransaction.outputData.map((d, i) =>
+      d.toProof(signatures[i], this.keysetForSignature(signatures[i].id)),
+    );
     const reorderedProofs = Array(swapProofs.length);
     const reorderedKeepVector = Array(swapTransaction.keepVector.length);
     swapTransaction.sortedIndices.forEach((s, i) => {
@@ -2011,12 +2018,7 @@ class Wallet {
     const { outputs, signatures } = await this.mint.restore({
       outputs: outputData.map((d) => d.blindedMessage),
     });
-    // NUT-09: each signature names the keyset to unblind with, which need not be the scanned
-    // one. Zero-value entries are dropped below and need no keys.
-    await this._ensureOperableKeysets(
-      signatures.map((s) => (s?.amount.isZero() ? undefined : s?.id)),
-      { implicit: true },
-    );
+    await this._ensureKeysetsForSignatures(signatures);
 
     const signatureMap: { [sig: string]: SerializedBlindedSignature } = {};
     outputs.forEach((o, i) => (signatureMap[o.B_] = signatures[i]));
@@ -2737,7 +2739,7 @@ class Wallet {
   async completeMint(
     mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
-    const { payload, outputData, keysetId, method, legacySignature } = mintPreview;
+    const { payload, outputData, method, legacySignature } = mintPreview;
     // TODO: Remove legacy message support
     const { signatures } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
@@ -2752,11 +2754,14 @@ class Wallet {
     );
     this.validateReturnedSignatures(signatures, outputData);
 
-    const keyset = this.getKeyset(keysetId);
+    // Unblind under the keyset each signature names, as custom outputs may pick their own.
+    await this._ensureKeysetsForSignatures(signatures);
     this._logger.debug('MINT COMPLETED', {
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
     });
-    return outputData.map((d, i) => d.toProof(signatures[i], keyset));
+    return outputData.map((d, i) =>
+      d.toProof(signatures[i], this.keysetForSignature(signatures[i].id)),
+    );
   }
 
   /**
@@ -2911,7 +2916,7 @@ class Wallet {
   async completeBatchMint(
     batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
-    const { method, payload, outputData, keysetId, legacySignatures } = batchPreview;
+    const { method, payload, outputData, legacySignatures } = batchPreview;
     // TODO: Remove legacy message support
     const { signatures: sigs } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
@@ -2926,12 +2931,13 @@ class Wallet {
     );
     this.validateReturnedSignatures(sigs, outputData);
 
-    const keyset = this.getKeyset(keysetId);
+    // Unblind under the keyset each signature names, as custom outputs may pick their own.
+    await this._ensureKeysetsForSignatures(sigs);
     this._logger.debug('BATCH MINT COMPLETED', {
       quotes: payload.quotes.length,
       amounts: outputData.map((o) => o.blindedMessage.amount.toString()),
     });
-    return outputData.map((d, i) => d.toProof(sigs[i], keyset));
+    return outputData.map((d, i) => d.toProof(sigs[i], this.keysetForSignature(sigs[i].id)));
   }
 
   // -----------------------------------------------------------------
@@ -3623,11 +3629,25 @@ class Wallet {
   }
 
   /**
-   * Keyset a blank's signature was issued under, for unblinding.
+   * Loads the keysets a mint response was signed under.
+   *
+   * @remarks
+   * Each signature names its own keyset, which need not be the one the preview or scan used.
+   * Zero-value entries are dropped by the caller and need no keys.
+   */
+  private _ensureKeysetsForSignatures(signatures: SerializedBlindedSignature[]): Promise<void> {
+    return this._ensureOperableKeysets(
+      signatures.map((s) => (s?.amount.isZero() ? undefined : s?.id)),
+      { implicit: true },
+    );
+  }
+
+  /**
+   * Keyset a signature was issued under, for unblinding.
    *
    * @remarks
    * Must already be loaded (see `_ensureOperableKeysets`); `getKeyset` also rejects a keyset from
-   * another unit, which a blank cannot vouch for itself.
+   * another unit, which the signature cannot vouch for itself.
    */
   private keysetForSignature(id: string): Keyset {
     try {

--- a/src/wallet/types/payloads.ts
+++ b/src/wallet/types/payloads.ts
@@ -28,7 +28,10 @@ export interface MintPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
+   *
+   * @deprecated Read `outputData[i].blindedMessage.id` instead. Removed in v5.
    */
   keysetId: string;
   /**
@@ -60,7 +63,10 @@ export interface BatchMintPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
+   *
+   * @deprecated Read `outputData[i].blindedMessage.id` instead. Removed in v5.
    */
   keysetId: string;
   /**
@@ -92,7 +98,10 @@ export interface MeltPreview<
    */
   outputData: OutputDataLike[];
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
+   *
+   * @deprecated Read `outputData[i].blindedMessage.id` instead. Removed in v5.
    */
   keysetId: string;
   /**
@@ -143,7 +152,10 @@ export type SwapPreview = {
    */
   fees: Amount;
   /**
-   * Keyset ID used to prepare the outputs.
+   * Keyset the wallet prepared generated outputs under. Custom outputs name their own keyset per
+   * output.
+   *
+   * @deprecated Read `outputData[i].blindedMessage.id` instead. Removed in v5.
    */
   keysetId: string;
   /**

--- a/test/wallet/bolt12.test.ts
+++ b/test/wallet/bolt12.test.ts
@@ -482,6 +482,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
+    vi.spyOn(wallet.keyChain, 'hasKeyset').mockReturnValue(true);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([]);
     const meltQuote = {
       quote: 'm1',
@@ -521,6 +522,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
+    vi.spyOn(wallet.keyChain, 'hasKeyset').mockReturnValue(true);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
         blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },
@@ -581,6 +583,7 @@ describe('Wallet (BOLT12) – wrappers', () => {
     wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
     const ks = makeKeysetFromCache(MINTCACHE.keys[0]);
     vi.spyOn(wallet.keyChain, 'getKeyset').mockReturnValue(ks);
+    vi.spyOn(wallet.keyChain, 'hasKeyset').mockReturnValue(true);
     vi.spyOn(wallet as any, 'createOutputData').mockReturnValue([
       {
         blindedMessage: { amount: Amount.from(16), B_: 'B1', id: '009a1f293253e41e' },

--- a/test/wallet/wallet-custom-outputs.node.test.ts
+++ b/test/wallet/wallet-custom-outputs.node.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  Amount,
+  KeyChain,
+  Mint,
+  OutputData,
+  Wallet,
+  createBlindSignature,
+  createNewMintKeys,
+  hashToCurve,
+  pointFromHex,
+  serializeMintKeys,
+  type KeysetPair,
+  type Proof,
+  type RequestArgs,
+  type SerializedBlindedMessage,
+} from '../../src';
+
+import { mintInfoResp } from './_setup';
+
+// Two active keysets on one synthetic mint: the wallet prefers the cheaper one, so custom
+// outputs built under the dearer one no longer match the wallet's own keyset choice.
+const mintUrl = 'https://mint.test';
+const unit = 'sat';
+const dear = createNewMintKeys(8, new Uint8Array(32).fill(2), { input_fee_ppk: 1000 });
+const cheap = createNewMintKeys(8, new Uint8Array(32).fill(3), { input_fee_ppk: 0 });
+const retired = createNewMintKeys(8, new Uint8Array(32).fill(4), { input_fee_ppk: 0 });
+const usd = createNewMintKeys(8, new Uint8Array(32).fill(5), { input_fee_ppk: 0, unit: 'usd' });
+const unknown = createNewMintKeys(8, new Uint8Array(32).fill(6), { input_fee_ppk: 0 });
+const pairs = [dear, cheap, retired, usd, unknown];
+const seed = new Uint8Array(64).fill(1);
+
+function keysFor(pair: KeysetPair, keysetUnit = unit) {
+  return { id: pair.keysetId, unit: keysetUnit, keys: serializeMintKeys(pair.pubKeys) };
+}
+
+function signatureFor(pair: KeysetPair, secret: string, amount: Amount): string {
+  const key = pair.privKeys[amount.toString()];
+  return createBlindSignature(
+    hashToCurve(new TextEncoder().encode(secret)),
+    key,
+    pair.keysetId,
+  ).C_.toHex(true);
+}
+
+function inputUnder(pair: KeysetPair, amount: number, secret: string): Proof {
+  return {
+    id: pair.keysetId,
+    secret,
+    amount: Amount.from(amount),
+    C: signatureFor(pair, secret, Amount.from(amount)),
+  };
+}
+
+function proofIsValid(p: Proof): boolean {
+  const pair = pairs.find((k) => k.keysetId === p.id);
+  return pair !== undefined && p.C === signatureFor(pair, p.secret, p.amount);
+}
+
+// A mint that signs every output under the keyset the output names.
+function makeWallet() {
+  const calls: string[] = [];
+  const mint = new Mint(mintUrl, {
+    customRequest: async <T>(args: RequestArgs): Promise<T> => {
+      calls.push(args.endpoint);
+      const body = args.requestBody as unknown as { outputs: SerializedBlindedMessage[] };
+      const signatures = body.outputs.map((o) => {
+        const pair = pairs.find((k) => k.keysetId === o.id);
+        if (!pair) throw new Error(`mint does not know keyset ${o.id}`);
+        const amount = Amount.from(o.amount);
+        const C_ = createBlindSignature(
+          pointFromHex(o.B_),
+          pair.privKeys[amount.toString()],
+          o.id,
+        ).C_.toHex(true);
+        return { id: o.id, amount: amount.toString(), C_ };
+      });
+      return { signatures } as T;
+    },
+  });
+  const wallet = new Wallet(mint, { unit });
+  const info = {
+    ...mintInfoResp,
+    nuts: { 4: { methods: [{ method: 'bolt11', unit }], disabled: false } },
+  };
+  wallet.loadMintFromCache(
+    info,
+    KeyChain.mintToCacheDTO(
+      mintUrl,
+      [
+        { id: dear.keysetId, unit, active: true, input_fee_ppk: 1000 },
+        { id: cheap.keysetId, unit, active: true, input_fee_ppk: 0 },
+        { id: retired.keysetId, unit, active: false, input_fee_ppk: 0 },
+        { id: usd.keysetId, unit: 'usd', active: true, input_fee_ppk: 0 },
+      ],
+      [keysFor(dear), keysFor(cheap), keysFor(retired), keysFor(usd, 'usd')],
+    ),
+  );
+  return { wallet, calls };
+}
+
+describe('custom outputs on a keyset other than the wallet default', () => {
+  test('send unblinds each output with the keyset that signed it', async () => {
+    const { wallet, calls } = makeWallet();
+    const keep = OutputData.createDeterministicData(Amount.from(7), seed, 0, keysFor(dear));
+    const send = OutputData.createDeterministicData(
+      Amount.from(8),
+      seed,
+      keep.length,
+      keysFor(dear),
+    );
+    const input = inputUnder(dear, 16, 'custom-send-input');
+
+    const result = await wallet.send(8, [input], undefined, {
+      keep: { type: 'custom', data: keep },
+      send: { type: 'custom', data: send },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect([...result.keep, ...result.send].every(proofIsValid)).toBe(true);
+    expect(result.send.map((p) => p.id)).toEqual([dear.keysetId]);
+  });
+
+  test('send accepts a plan that mixes active keysets', async () => {
+    const { wallet } = makeWallet();
+    const keep = OutputData.createDeterministicData(Amount.from(7), seed, 0, keysFor(cheap));
+    const send = OutputData.createDeterministicData(
+      Amount.from(8),
+      seed,
+      keep.length,
+      keysFor(dear),
+    );
+    const input = inputUnder(dear, 16, 'custom-mixed-input');
+
+    const result = await wallet.send(8, [input], undefined, {
+      keep: { type: 'custom', data: keep },
+      send: { type: 'custom', data: send },
+    });
+
+    expect([...result.keep, ...result.send].every(proofIsValid)).toBe(true);
+    expect(new Set(result.keep.map((p) => p.id))).toEqual(new Set([cheap.keysetId]));
+    expect(new Set(result.send.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
+  test('receive unblinds custom outputs with the keyset that signed them', async () => {
+    const { wallet } = makeWallet();
+    const input = inputUnder(dear, 16, 'custom-receive-input');
+    // The 16 sat input pays 1 sat in fees under the dearer keyset.
+    const data = OutputData.createDeterministicData(Amount.from(15), seed, 0, keysFor(dear));
+
+    const proofs = await wallet.receive([input], undefined, { type: 'custom', data });
+
+    expect(proofs.every(proofIsValid)).toBe(true);
+    expect(new Set(proofs.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
+  test('mint unblinds custom outputs with the keyset that signed them', async () => {
+    const { wallet } = makeWallet();
+    const data = OutputData.createDeterministicData(Amount.from(16), seed, 0, keysFor(dear));
+
+    const proofs = await wallet.mintProofsBolt11(16, 'quote-id', undefined, {
+      type: 'custom',
+      data,
+    });
+
+    expect(proofs.every(proofIsValid)).toBe(true);
+    expect(new Set(proofs.map((p) => p.id))).toEqual(new Set([dear.keysetId]));
+  });
+
+  test.each([
+    ['unknown', unknown, /Keyset '/],
+    ['inactive', retired, /Inactive keyset/],
+    ['other-unit', usd, /Keyset unit does not match wallet unit/],
+  ])('rejects a custom plan on an %s keyset before calling the mint', async (_, pair, msg) => {
+    const { wallet, calls } = makeWallet();
+    const keep = OutputData.createDeterministicData(Amount.from(7), seed, 0, keysFor(dear));
+    const send = OutputData.createDeterministicData(
+      Amount.from(8),
+      seed,
+      keep.length,
+      keysFor(pair),
+    );
+    const input = inputUnder(dear, 16, `custom-${pair.keysetId}`);
+
+    await expect(
+      wallet.send(8, [input], undefined, {
+        keep: { type: 'custom', data: keep },
+        send: { type: 'custom', data: send },
+      }),
+    ).rejects.toThrow(msg);
+    expect(calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Manual backport of #1095 (fixes #1094 on v4).

## Why

Custom output data names its own keyset per output, which need not be the keyset the preview was prepared under. When the wallet's default keyset moved, the preview carried one keyset and the outputs another; since #1083 that surfaced as a throw after the mint had already consumed the inputs.

## Changes

- `completeSwap`, `completeMint` and `completeBatchMint` unblind under the keyset each signature names, as `completeMelt` already does. Restore now shares the same helper.
- Custom plans are checked before the mint call: every output must name a known, active keyset in the wallet unit.
- `keysetId` on the four preview types is marked deprecated (v5 removes it); read the id from the outputs instead.
- The mint quote signing-rule change in #1095 is v5-only and is not ported.

## Impact

Forgiving change, no API change. Callers who pin `keysetId` keep working. A custom plan on an unknown or inactive keyset now fails at prepare time instead of at the mint.
