### PR TITLE
fix(utils): tighten UTF-8, CBOR and TLV decoding [backport v4-dev]

### DIFF
--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -1,6 +1,7 @@
 import { bytesToHex, randomBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
+import { hasLoneSurrogate } from '../utils/bytes';
 
 export type SecretKind = 'P2PK' | 'HTLC' | (string & {}); // union with any string
 
@@ -44,6 +45,10 @@ export function createSecret(kind: SecretKind, data: string, tags?: string[][]):
  */
 export function parseSecret(secret: string | Secret): Secret {
   let parsed: unknown;
+  // Ill-formed UTF-16 would alias this secret with the one spelling its U+FFFD replacement.
+  if (typeof secret === 'string' && hasLoneSurrogate(secret)) {
+    throw new CTSError('Invalid NUT-10 secret Unicode');
+  }
   try {
     if (typeof secret === 'string') {
       parsed = JSON.parse(secret) as Secret;

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -12,6 +12,7 @@ import {
 
 import { CTSError } from '../model/Errors';
 import { hexToNumber, decodeBase64AnyToUint8 } from '../utils';
+import { hasLoneSurrogate } from '../utils/bytes';
 
 /**
  * Private key type - can be hex string or Uint8Array.
@@ -165,6 +166,10 @@ export function computeMessageDigest(message: string): Uint8Array;
 export function computeMessageDigest(message: string, asHex: false): Uint8Array;
 export function computeMessageDigest(message: string, asHex: true): string;
 export function computeMessageDigest(message: string, asHex = false): string | Uint8Array {
+  // Ill-formed UTF-16 would hash as its U+FFFD replacement, aliasing distinct messages.
+  if (hasLoneSurrogate(message)) {
+    throw new CTSError('Message must be well-formed UTF-16');
+  }
   const hashBytes = sha256(new TextEncoder().encode(message));
   return asHex ? bytesToHex(hashBytes) : hashBytes;
 }
@@ -220,7 +225,14 @@ export const schnorrVerifyMessage = (
   pubkey: string,
   throws: boolean = false,
 ): boolean => {
-  return schnorrVerifyDigest(signature, computeMessageDigest(message), pubkey, throws);
+  try {
+    return schnorrVerifyDigest(signature, computeMessageDigest(message), pubkey, throws);
+  } catch (e) {
+    if (throws) {
+      throw e;
+    }
+  }
+  return false;
 };
 
 /**

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -3,6 +3,7 @@ import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { computeMessageDigest, buildP2PKSigAllMessageV0, schnorrSignDigest } from '../crypto';
 import { parseWitnessData } from '../crypto/NUT11';
 import { JSONInt, decodeBase64UrlToUint8, encodeUint8ToBase64Url } from '../utils';
+import { decodeUtf8Document } from '../utils/bytes';
 import type { MeltPreview, SwapPreview } from '../wallet/types';
 
 import { Amount } from './Amount';
@@ -100,7 +101,7 @@ function deserializePackage(input: string): SigAllSigningPackage {
   let json: string;
 
   try {
-    json = new TextDecoder('utf-8').decode(decodeBase64UrlToUint8(base64url));
+    json = decodeUtf8Document(decodeBase64UrlToUint8(base64url));
   } catch (e) {
     throw new CTSError(
       `Failed to parse signing package: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -3,6 +3,7 @@ import { base64, base64nopad, base64url, base64urlnopad } from '@scure/base';
 
 import { CTSError } from '../model/Errors';
 
+import { decodeUtf8Document } from './bytes';
 import { JSONInt } from './JSONInt';
 
 /**
@@ -103,7 +104,7 @@ function encodeJsonToBase64Url(jsonObj: unknown): string {
  * {@link encodeJsonToBase64Url}.
  */
 function decodeBase64UrlToJson<T extends object>(base64String: string): T {
-  const jsonString = new TextDecoder('utf-8').decode(decodeBase64UrlToUint8(base64String));
+  const jsonString = decodeUtf8Document(decodeBase64UrlToUint8(base64String));
   return JSONInt.parse(jsonString) as T;
 }
 
@@ -114,7 +115,7 @@ function decodeBase64UrlToJson<T extends object>(base64String: string): T {
  * The deprecated cashuA format predates the base64url convention, so tokens in the wild use both.
  */
 function decodeBase64AnyToJson<T extends object>(base64String: string): T {
-  const jsonString = new TextDecoder('utf-8').decode(decodeBase64AnyToUint8(base64String));
+  const jsonString = decodeUtf8Document(decodeBase64AnyToUint8(base64String));
   return JSONInt.parse(jsonString) as T;
 }
 

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,54 @@
+import { CTSError } from '../model/Errors';
+
+const fieldUtf8Decoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+/**
+ * Decodes bytes as UTF-8 for a length-delimited wire field.
+ *
+ * @remarks
+ * A leading BOM is kept as content rather than stripped (the field's length already frames it) and
+ * malformed sequences are rejected rather than replaced.
+ * @throws CTSError If the bytes are not valid UTF-8.
+ */
+export function decodeUtf8Field(bytes: Uint8Array): string {
+  try {
+    return fieldUtf8Decoder.decode(bytes);
+  } catch (cause) {
+    throw new CTSError('Malformed UTF-8 sequence', { cause });
+  }
+}
+
+const documentUtf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+/**
+ * Decodes bytes as UTF-8 for a whole serialized document (eg a JSON payload).
+ *
+ * @remarks
+ * Unlike {@link decodeUtf8Field}, a leading BOM is envelope framing here, not content, so it is
+ * stripped; malformed sequences are still rejected rather than replaced.
+ * @throws CTSError If the bytes are not valid UTF-8.
+ */
+export function decodeUtf8Document(bytes: Uint8Array): string {
+  let text: string;
+  try {
+    text = documentUtf8Decoder.decode(bytes);
+  } catch (cause) {
+    throw new CTSError('Malformed UTF-8 sequence', { cause });
+  }
+  // Strip the BOM ourselves: a reused decoder does not do it consistently across engines.
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+const LONE_SURROGATE_RE = /[\uD800-\uDFFF]/u;
+
+/**
+ * Reports whether a string contains an unpaired UTF-16 surrogate.
+ *
+ * @remarks
+ * With the `u` flag a valid surrogate pair combines into one code point and no longer falls in the
+ * surrogate range, so only an ill-formed one matches. Such a string has no UTF-8 representation:
+ * encoding it replaces the surrogate with U+FFFD, which aliases it with other strings.
+ */
+export function hasLoneSurrogate(text: string): boolean {
+  return LONE_SURROGATE_RE.test(text);
+}

--- a/src/utils/cbor.ts
+++ b/src/utils/cbor.ts
@@ -1,4 +1,7 @@
 import { CTSError } from '../model/Errors';
+
+import { decodeUtf8Field } from './bytes';
+import { MAX_CBOR_NODES } from './limits';
 /*
  * Lightweight CBOR encoder/decoder (purpose and limitations)
  *
@@ -318,7 +321,16 @@ export function decodeCBOR(data: Uint8Array): ResultValue {
 // overflowing the stack. Real tokens and payment requests nest only a few levels.
 const MAX_CBOR_DEPTH = 64;
 
-function decodeItem(view: DataView, offset: number, depth = 0): DecodeResult<ResultValue> {
+// Running total of array items + map entries across one recursive decode, so a wide (not deep)
+// payload is bounded like a deep one.
+type DecodeBudget = { nodes: number };
+
+function decodeItem(
+  view: DataView,
+  offset: number,
+  depth = 0,
+  budget: DecodeBudget = { nodes: 0 },
+): DecodeResult<ResultValue> {
   if (depth > MAX_CBOR_DEPTH) {
     throw new CTSError('CBOR nesting exceeds the maximum depth');
   }
@@ -339,9 +351,9 @@ function decodeItem(view: DataView, offset: number, depth = 0): DecodeResult<Res
     case 3:
       return decodeString(view, offset, additionalInfo);
     case 4:
-      return decodeArray(view, offset, additionalInfo, depth);
+      return decodeArray(view, offset, additionalInfo, depth, budget);
     case 5:
-      return decodeMap(view, offset, additionalInfo, depth);
+      return decodeMap(view, offset, additionalInfo, depth, budget);
     case 7:
       return decodeSimpleAndFloat(view, offset, additionalInfo);
     default:
@@ -441,8 +453,15 @@ function decodeString(
     throw new CTSError('String length exceeds data length');
   }
   const bytes = new Uint8Array(view.buffer, view.byteOffset + newOffset, len);
-  const value = new TextDecoder().decode(bytes);
+  const value = decodeUtf8Field(bytes);
   return { value, offset: newOffset + len };
+}
+
+function checkNodeBudget(budget: DecodeBudget) {
+  budget.nodes++;
+  if (budget.nodes > MAX_CBOR_NODES) {
+    throw new CTSError('CBOR payload exceeds the maximum item/entry budget');
+  }
 }
 
 function decodeArray(
@@ -450,13 +469,15 @@ function decodeArray(
   offset: number,
   additionalInfo: number,
   depth: number,
+  budget: DecodeBudget,
 ): DecodeResult<ResultValue[]> {
   const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
   const len = Number(length);
   const array = [];
   let currentOffset = newOffset;
   for (let i = 0; i < len; i++) {
-    const result = decodeItem(view, currentOffset, depth + 1);
+    checkNodeBudget(budget);
+    const result = decodeItem(view, currentOffset, depth + 1, budget);
     array.push(result.value);
     currentOffset = result.offset;
   }
@@ -468,20 +489,26 @@ function decodeMap(
   offset: number,
   additionalInfo: number,
   depth: number,
+  budget: DecodeBudget,
 ): DecodeResult<Record<string, ResultValue>> {
   const { value: length, offset: newOffset } = decodeLength(view, offset, additionalInfo);
   const len = Number(length);
   const map: { [key: string]: ResultValue } = {};
   let currentOffset = newOffset;
   for (let i = 0; i < len; i++) {
-    const keyResult = decodeItem(view, currentOffset, depth + 1);
+    checkNodeBudget(budget);
+    const keyResult = decodeItem(view, currentOffset, depth + 1, budget);
     if (!isResultKeyType(keyResult.value)) {
       throw new CTSError('Invalid key type');
     }
-    const valueResult = decodeItem(view, keyResult.offset, depth + 1);
+    const key = String(keyResult.value);
+    if (Object.prototype.hasOwnProperty.call(map, key)) {
+      throw new CTSError(`Duplicate map key "${key}"`);
+    }
+    const valueResult = decodeItem(view, keyResult.offset, depth + 1, budget);
     // Define explicitly so a "__proto__" key becomes an own data property instead of
     // hitting the prototype setter and reparenting the decoded map (see JSONInt.parseObject).
-    Object.defineProperty(map, String(keyResult.value), {
+    Object.defineProperty(map, key, {
       value: valueResult.value,
       writable: true,
       enumerable: true,
@@ -526,7 +553,13 @@ function decodeSimpleAndFloat(
   }
   if (additionalInfo === 24) {
     ensureAvailable(view, offset, 1);
-    return { value: view.getUint8(offset++), offset };
+    const simpleValue = view.getUint8(offset++);
+    // Values below 32 have a short-form encoding (20-23 are false/true/null/undefined), so the
+    // extended form is non-minimal and would decode them as plain numbers.
+    if (simpleValue < 32) {
+      throw new CTSError(`Invalid extended simple value: ${simpleValue}`);
+    }
+    return { value: simpleValue, offset };
   }
   if (additionalInfo === 25) {
     ensureAvailable(view, offset, 2);

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -62,3 +62,13 @@ export const MAX_MINT_INFO_LIST = 1_024;
  * only construct the divided-down result.
  */
 export const U64_MAX = 2n ** 64n - 1n;
+
+/**
+ * Total array items + map entries `decodeCBOR` accepts from one payload.
+ *
+ * @remarks
+ * A v4 proof with both a DLEQ and a witness costs about 9 nodes (1 array slot, the 5-entry proof
+ * map, the 3-entry nested DLEQ map), so `ABSOLUTE_MAX_ARRAY_LENGTH` proofs of that shape need about
+ * 90,000; this leaves headroom above that on top of the usual one-allocation-per-input-byte bound.
+ */
+export const MAX_CBOR_NODES = 262_144;

--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -4,6 +4,8 @@ import { CTSError } from '../model/Errors';
 import { PaymentRequestTransportType } from '../wallet/types/payment-requests';
 import type { PaymentRequestTransport } from '../wallet/types/payment-requests';
 
+import { decodeUtf8Field } from './bytes';
+
 /**
  * NUT-10 Spending Condition structure.
  */
@@ -192,7 +194,7 @@ function decodeNextPart(data: Uint8Array): TLVPart {
 }
 
 function parseString(value: Uint8Array): string {
-  return new TextDecoder().decode(value);
+  return decodeUtf8Field(value);
 }
 
 function parseU64(value: Uint8Array): bigint {
@@ -666,7 +668,7 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
       pubkey = value;
     } else if (tag === 0x01) {
       // Relay URL
-      relays.push(new TextDecoder().decode(value));
+      relays.push(decodeUtf8Field(value));
     }
     // Ignore unknown tags
   }

--- a/test/crypto/NUT10.test.ts
+++ b/test/crypto/NUT10.test.ts
@@ -197,6 +197,15 @@ describe('NUT10 parseSecret shape validation', () => {
     expect(() => parseSecret(`["P2PK",{"nonce":"${NONCE}","data":123}]`)).toThrow(/nonce \/ data/);
   });
 
+  test('rejects lone surrogates that alias another secret under UTF-8', () => {
+    const illFormed = `["P2PK",{"nonce":"\ud800","data":"${DATA}"}]`;
+    const replacement = `["P2PK",{"nonce":"\uFFFD","data":"${DATA}"}]`;
+
+    expect(illFormed).not.toBe(replacement);
+    expect(new TextEncoder().encode(illFormed)).toEqual(new TextEncoder().encode(replacement));
+    expect(() => parseSecret(illFormed)).toThrow(/unicode|surrogate/i);
+  });
+
   test('rejects a falsy non-array tags value', () => {
     // A truthiness check let 0/false/"" slip past array validation and surface a
     // raw TypeError in downstream tag readers; they must be rejected here instead.

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -9,6 +9,7 @@ import {
   pointFromHex,
   blindMessage,
   unblindSignature,
+  computeMessageDigest,
   createBlindSignature,
   constructUnblindedSignature,
   createRandomRawBlindedMessage,
@@ -19,6 +20,7 @@ import {
   schnorrSignDigest,
   schnorrSignMessage,
   schnorrVerifyDigest,
+  schnorrVerifyMessage,
   pointFromBytes,
   findSigningKey,
 } from '../../src/crypto';
@@ -166,6 +168,28 @@ describe('schnorrVerifyDigest', () => {
 
   test('rejects a 33-byte pubkey with a non-02/03 prefix', () => {
     expect(schnorrVerifyDigest(signature, digest, 'ff' + pubkey.slice(2))).toBe(false);
+  });
+});
+
+describe('computeMessageDigest', () => {
+  test('rejects unpaired UTF-16 surrogates instead of hashing colliding strings', () => {
+    // Both strings encode to the same U+FFFD replacement bytes under a lenient TextEncoder.
+    expect(() => computeMessageDigest('\ud800')).toThrow();
+    expect(() => computeMessageDigest('\ud801')).toThrow();
+  });
+
+  test('still digests well-formed strings, surrogate pairs included', () => {
+    expect(() => computeMessageDigest('hello')).not.toThrow();
+    expect(() => computeMessageDigest('\u{1F95C}')).not.toThrow(); // a valid surrogate pair
+  });
+});
+
+describe('schnorrVerifyMessage', () => {
+  test('fails closed rather than throwing when the message is ill-formed', () => {
+    const privkey = '0000000000000000000000000000000000000000000000000000000000000001';
+    const pubkey = bytesToHex(secp256k1.getPublicKey(hexToBytes(privkey), true));
+    expect(schnorrVerifyMessage('00'.repeat(64), '\ud800', pubkey)).toBe(false);
+    expect(() => schnorrVerifyMessage('00'.repeat(64), '\ud800', pubkey, true)).toThrow();
   });
 });
 

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -17,6 +17,7 @@ import {
   type MeltPreview,
   type SwapPreview,
 } from '../../src';
+import { encodeUint8ToBase64Url } from '../../src/utils/base64';
 
 const dummyProof: Proof = {
   id: 'testid',
@@ -242,6 +243,36 @@ describe('SigAll — serializePackage / deserializePackage', () => {
 
   test('throws on invalid JSON', () => {
     const encoded = 'sigallA' + btoa('{not valid json}').replace(/=+$/, '');
+    expect(() => SigAll.deserializePackage(encoded)).toThrow('Failed to parse signing package');
+  });
+
+  test('tolerates a leading BOM in the JSON document', () => {
+    // An editor-saved package can pick up a BOM; it is envelope framing, not JSON content.
+    const json = JSON.stringify({
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: 'testsecret', C: '02' + '1'.repeat(64) }],
+      outputs: [{ amount: 32, id: 'bm1', B_: 'dummyB' }],
+    });
+    const bytes = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(json)]);
+    const encoded = 'sigallA' + encodeUint8ToBase64Url(bytes);
+
+    const parsed = SigAll.deserializePackage(encoded);
+    expect(parsed.type).toBe('swap');
+  });
+
+  test('rejects a package whose secret bytes are not valid UTF-8, rather than replacing them', () => {
+    // The malformed byte sits inside an otherwise well-formed string field: a lenient decoder
+    // would replace it with U+FFFD and parse this as valid JSON with a different secret.
+    const prefix = new TextEncoder().encode(
+      '{"version":"sigallA","type":"swap","inputs":[{"secret":"',
+    );
+    const suffix = new TextEncoder().encode(
+      `","C":"02${'1'.repeat(64)}"}],"outputs":[{"amount":32,"id":"bm1","B_":"dummyB"}]}`,
+    );
+    const bytes = new Uint8Array([...prefix, 0xff, ...suffix]);
+    const encoded = 'sigallA' + encodeUint8ToBase64Url(bytes);
+
     expect(() => SigAll.deserializePackage(encoded)).toThrow('Failed to parse signing package');
   });
 

--- a/test/utils/base64.test.ts
+++ b/test/utils/base64.test.ts
@@ -6,7 +6,9 @@ import {
   decodeBase64UrlToUint8,
   encodeJsonToBase64Url,
   encodeUint8ToBase64,
+  encodeUint8ToBase64Url,
   isBase64String,
+  decodeBase64AnyToJson,
   decodeBase64AnyToUint8,
   decodeBase64ToUint8Legacy,
 } from '../../src/utils';
@@ -125,6 +127,33 @@ describe('testing uint8 encoding', () => {
     expect(encodeJsonToBase64Url(obj)).toStrictEqual(base64url);
   });
 });
+describe('base64 JSON decoders and UTF-8', () => {
+  const malformedJson = new Uint8Array([
+    ...new TextEncoder().encode('{"secret":"'),
+    0xff,
+    ...new TextEncoder().encode('"}'),
+  ]);
+  const bomJson = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode('{"a":1}')]);
+
+  test('base64url JSON rejects malformed UTF-8 instead of replacing bytes', () => {
+    expect(() => decodeBase64UrlToJson(encodeUint8ToBase64Url(malformedJson))).toThrow();
+  });
+
+  test('base64url JSON still decodes a document with a leading BOM', () => {
+    // A v3 token authored or re-saved by an editor that adds a BOM must still round-trip: the
+    // BOM is envelope framing here, not JSON content, unlike a length-framed CBOR/TLV field.
+    expect(decodeBase64UrlToJson(encodeUint8ToBase64Url(bomJson))).toEqual({ a: 1 });
+  });
+
+  test('the deprecated cashuA path rejects malformed UTF-8 too', () => {
+    expect(() => decodeBase64AnyToJson(encodeUint8ToBase64(malformedJson))).toThrow();
+  });
+
+  test('the deprecated cashuA path still decodes a document with a leading BOM', () => {
+    expect(decodeBase64AnyToJson(encodeUint8ToBase64(bomJson))).toEqual({ a: 1 });
+  });
+});
+
 describe('isBase64String', () => {
   // standard base64 with padding
   test('valid: standard base64 with padding', () => {

--- a/test/utils/bytes.test.ts
+++ b/test/utils/bytes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+
+import { decodeUtf8Document, decodeUtf8Field } from '../../src/utils/bytes';
+
+describe('decodeUtf8Field', () => {
+  test('keeps a leading BOM as content instead of stripping it', () => {
+    // ef bb bf is the UTF-8 BOM, followed by 'a'.
+    const bytes = Uint8Array.of(0xef, 0xbb, 0xbf, 0x61);
+    expect(decodeUtf8Field(bytes)).toBe('﻿a');
+  });
+
+  test('rejects a byte sequence that is not valid UTF-8', () => {
+    expect(() => decodeUtf8Field(Uint8Array.of(0xff))).toThrow();
+  });
+});
+
+describe('decodeUtf8Document', () => {
+  test('strips a leading BOM instead of keeping it as content', () => {
+    // ef bb bf is the UTF-8 BOM, followed by '{"a":1}'.
+    const bytes = Uint8Array.of(0xef, 0xbb, 0xbf, ...new TextEncoder().encode('{"a":1}'));
+    expect(decodeUtf8Document(bytes)).toBe('{"a":1}');
+  });
+
+  test('rejects a byte sequence that is not valid UTF-8', () => {
+    expect(() => decodeUtf8Document(Uint8Array.of(0xff))).toThrow();
+  });
+});

--- a/test/utils/cbor.test.ts
+++ b/test/utils/cbor.test.ts
@@ -6,6 +6,7 @@ import {
   encodeCBOR,
   decodeBase64UrlToUint8,
   encodeUint8ToBase64Url,
+  MAX_CBOR_NODES,
 } from '../../src/utils';
 // Note: do NOT import 'fs' or 'path' at top-level — the browser test runner
 // will attempt to import them and Vite externalizes those modules which causes
@@ -86,10 +87,100 @@ describe('cbor decoder', () => {
   // per-vector harness further below. Keep focused decoder unit tests here.
 
   test('decode simple value in next byte (additionalInfo 24) returns next byte', () => {
-    // 0xf8 <next byte> -> simple/extended simple
-    const buf = new Uint8Array([0xf8, 0x10]);
+    // 0xf8 <next byte>, byte >= 32 -> unassigned simple value, decoded as a plain number
+    const buf = new Uint8Array([0xf8, 0x20]);
     const v = decodeCBOR(buf) as number;
-    expect(v).toBe(0x10);
+    expect(v).toBe(0x20);
+  });
+
+  test('rejects an extended simple value below 32 instead of decoding it as a number', () => {
+    // 0xf8 0x14 is a non-minimal encoding of simple value 20 (false). Treating it as the
+    // number 20 lets a boolean consumer read a false-carrying byte as truthy.
+    const extendedFalse = new Uint8Array([0xf8, 0x14]);
+    expect(() => decodeCBOR(extendedFalse)).toThrow(/simple/i);
+  });
+
+  test('preserves a leading U+FEFF in a decoded map key instead of stripping it as a BOM', () => {
+    // CBOR map { "<BOM>a": 1000 }. The three UTF-8 BOM bytes are part of the declared
+    // four-byte text key and must not be consumed as framing.
+    const buf = new Uint8Array([0xa1, 0x64, 0xef, 0xbb, 0xbf, 0x61, 0x19, 0x03, 0xe8]);
+    const result = decodeCBOR(buf) as Record<string, unknown>;
+    const key = '﻿a';
+
+    expect(Object.prototype.hasOwnProperty.call(result, 'a')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(result, key)).toBe(true);
+    expect(result[key]).toBe(1000);
+  });
+
+  test('rejects a map key that is not valid UTF-8', () => {
+    // 0x61 0xff: a one-byte text string whose sole byte is not valid UTF-8.
+    const buf = new Uint8Array([0xa1, 0x61, 0xff, 0x01]);
+    expect(() => decodeCBOR(buf)).toThrow();
+  });
+
+  test('rejects a map containing a duplicate key', () => {
+    // CBOR map { a: 1, a: 1000 }. Last-wins would silently pick 1000.
+    const buf = new Uint8Array([0xa2, 0x61, 0x61, 0x01, 0x61, 0x61, 0x19, 0x03, 0xe8]);
+    expect(() => decodeCBOR(buf)).toThrow(/duplicate/i);
+  });
+
+  test('rejects arrays large enough to amplify per-item allocation cost', () => {
+    // The encoder itself never emits an array this long. Hand-written CBOR can still declare
+    // the count and encode each empty map in one byte, forcing the decoder to allocate an
+    // object and array slot per byte of input.
+    const itemCount = MAX_CBOR_NODES + 40_000;
+    const buf = new Uint8Array(5 + itemCount);
+    buf[0] = 0x9a;
+    buf[1] = (itemCount >>> 24) & 0xff;
+    buf[2] = (itemCount >>> 16) & 0xff;
+    buf[3] = (itemCount >>> 8) & 0xff;
+    buf[4] = itemCount & 0xff;
+    buf.fill(0xa0, 5);
+
+    expect(() => decodeCBOR(buf)).toThrow(/budget|too many|limit/i);
+  });
+
+  test('rejects maps large enough to amplify per-entry allocation cost', () => {
+    const entryCount = MAX_CBOR_NODES + 40_000;
+    // Definite-length map followed by unique uint32 keys and null values.
+    const encoded: number[] = [
+      0xba,
+      (entryCount >>> 24) & 0xff,
+      (entryCount >>> 16) & 0xff,
+      (entryCount >>> 8) & 0xff,
+      entryCount & 0xff,
+    ];
+    for (let i = 0; i < entryCount; i++) {
+      encoded.push(0x1a, (i >>> 24) & 0xff, (i >>> 16) & 0xff, (i >>> 8) & 0xff, i & 0xff, 0xf6);
+    }
+
+    expect(() => decodeCBOR(Uint8Array.from(encoded))).toThrow(/budget|too many|limit/i);
+  });
+
+  test('accepts an array right at the node budget', () => {
+    const itemCount = MAX_CBOR_NODES;
+    const buf = new Uint8Array(5 + itemCount);
+    buf[0] = 0x9a;
+    buf[1] = (itemCount >>> 24) & 0xff;
+    buf[2] = (itemCount >>> 16) & 0xff;
+    buf[3] = (itemCount >>> 8) & 0xff;
+    buf[4] = itemCount & 0xff;
+    // The rest of the buffer is left zeroed: each 0x00 byte is a valid one-byte item (unsigned 0).
+
+    const result = decodeCBOR(buf) as number[];
+    expect(result.length).toBe(itemCount);
+  });
+
+  test('rejects an array one item past the node budget', () => {
+    const itemCount = MAX_CBOR_NODES + 1;
+    const buf = new Uint8Array(5 + itemCount);
+    buf[0] = 0x9a;
+    buf[1] = (itemCount >>> 24) & 0xff;
+    buf[2] = (itemCount >>> 16) & 0xff;
+    buf[3] = (itemCount >>> 8) & 0xff;
+    buf[4] = itemCount & 0xff;
+
+    expect(() => decodeCBOR(buf)).toThrow(/budget|too many|limit/i);
   });
 
   test('decodeMap does not let a __proto__ key reparent or pollute the result', () => {
@@ -705,6 +796,11 @@ describe('CBOR Test Vectors', () => {
       // skip the entire vector to avoid a decode-time throw.
       if (majorType === 7) {
         if (additionalInfo < 24 && !(additionalInfo >= 20 && additionalInfo <= 23)) {
+          return;
+        }
+        // Extended simple values below 32 (eg "f818" simple(24)) are reserved: our decoder
+        // rejects them rather than aliasing them with the boolean/null/undefined domain.
+        if (additionalInfo === 24 && parseInt((hex as string).slice(2, 4), 16) < 32) {
           return;
         }
         // For float16/32/64 (additionalInfo 25,26,27) and the 1-byte simple

--- a/test/utils/tlv-malformed.test.ts
+++ b/test/utils/tlv-malformed.test.ts
@@ -1,0 +1,44 @@
+/**
+ * UTF-8 handling of the NUT-26 TLV codec's length-framed string fields. Payment requests arrive
+ * from the wild, so a field must decode to exactly its bytes or fail with a CTSError.
+ */
+
+import { bech32 } from '@scure/base';
+import { describe, expect, test } from 'vitest';
+
+import { decodeTLV, encodeTLV } from '../../src/utils/tlv';
+import { PaymentRequestTransportType } from '../../src/wallet/types/payment-requests';
+
+// One TLV record: tag (1 byte) || length (2 bytes BE) || value.
+const rec = (tag: number, value: number[]): number[] => [
+  tag,
+  (value.length >> 8) & 0xff,
+  value.length & 0xff,
+  ...value,
+];
+const bytes = (...parts: number[][]): Uint8Array => new Uint8Array(parts.flat());
+
+describe('TLV string fields decode to exactly their bytes', () => {
+  test('a leading BOM in a string field is kept as content, not stripped as framing', () => {
+    // 'ef bb bf 61 62' is the UTF-8 BOM followed by 'ab'; the TLV length already frames it.
+    const decoded = decodeTLV(bytes(rec(0x01, [0xef, 0xbb, 0xbf, 0x61, 0x62])));
+    expect(decoded.id).toBe('﻿ab');
+  });
+
+  test('a string field that is not valid UTF-8 is rejected', () => {
+    expect(() => decodeTLV(bytes(rec(0x01, [0xff])))).toThrow();
+  });
+
+  test('an nprofile relay URL that is not valid UTF-8 is rejected', () => {
+    // A relay URL is a length-framed string field: same UTF-8 rules as every other one.
+    const nprofile = (payload: number[]) =>
+      bech32.encode('nprofile', bech32.toWords(new Uint8Array(payload)), 1024);
+    const nostr = (target: string) => ({
+      transports: [{ type: PaymentRequestTransportType.NOSTR, target }],
+    });
+
+    expect(() =>
+      encodeTLV(nostr(nprofile([0x00, 0x20, ...new Array(32).fill(0xaa), 0x01, 0x01, 0xff]))),
+    ).toThrow(/Malformed UTF-8/);
+  });
+});

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -7,6 +7,7 @@ import {
   PaymentRequestTransportType,
   type NUT10Option,
 } from '../../src/index';
+import { encodeUint8ToBase64Url } from '../../src/utils/base64';
 import { encodeBech32m } from '../../src/utils/bech32m';
 import { encodeTLV } from '../../src/utils/tlv';
 
@@ -111,6 +112,17 @@ describe('payment requests', () => {
       'unsupported pr: invalid prefix',
     );
     expect(() => decodePaymentRequest(prWithInvalidVersion)).toThrow('unsupported pr version');
+  });
+
+  test('rejects a creqA request containing duplicate amount keys', () => {
+    // CBOR map: { a: 1, a: 1000, u: 'sat' }. A first-wins display and a last-wins decoder
+    // would otherwise disagree about the amount the wallet sends.
+    const ambiguous = new Uint8Array([
+      0xa3, 0x61, 0x61, 0x01, 0x61, 0x61, 0x19, 0x03, 0xe8, 0x61, 0x75, 0x63, 0x73, 0x61, 0x74,
+    ]);
+    const encoded = 'creqA' + encodeUint8ToBase64Url(ambiguous);
+
+    expect(() => decodePaymentRequest(encoded)).toThrow(/duplicate/i);
   });
 
   describe('toRawRequest', () => {
@@ -399,6 +411,20 @@ describe('payment requests', () => {
       // would produce a lock weaker than the payee requested, so it must throw.
       const nut10: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [['locktime', '']] };
       expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(/Invalid NUT-10 tag/);
+    });
+
+    test('does not promote a BOM-prefixed extension tag into an authorised signer', () => {
+      // A leading U+FEFF makes 'pubkeys' an unrecognised extension tag key; round-tripping
+      // through the wire encoding must not let TextDecoder's BOM handling turn it into the
+      // real 'pubkeys' tag.
+      const tag = '\uFEFFpubkeys';
+      const request = prWithNut10({ kind: 'P2PK', data: PUBKEY, tags: [[tag, PUBKEY_2]] });
+      const decoded = PaymentRequest.fromEncodedRequest(request.toEncodedCreqB());
+
+      expect(decoded.toP2PKOptions()).toEqual({
+        pubkey: PUBKEY,
+        additionalTags: [[tag, PUBKEY_2]],
+      });
     });
 
     test('rejects duplicate tag keys (NUT-11 unspendable lock)', () => {


### PR DESCRIPTION
Backport of #1097. Decoding of wire payloads is now exact on the LTS line too: bytes that are not valid UTF-8 are rejected rather than replaced with U+FFFD, and a leading BOM is treated as content or as framing depending on which one it is.

## Why

`TextDecoder` defaults are lenient. A malformed byte inside a CBOR string, a TLV field, a base64url JSON document or a SIG_ALL signing package became U+FFFD, so two distinct byte sequences decoded to the same string. Those same defaults strip a leading BOM, which in a length-framed field is content, not framing. Every rejection added here applies to malformed input only, so no legitimate caller changes behaviour.

## Changes

Ported by hand rather than by the backport bot, because v4 has no `src/utils/bytes.ts` for the two helpers to land in. The new file carries only `decodeUtf8Field` and `decodeUtf8Document`, imported by relative path, so `src/utils/index.ts` is untouched and `etc/cashu-ts.api.md` is unchanged.

`MAX_CBOR_NODES` was re-derived against v4's own `V4ProofTemplate` rather than copied: still 9 nodes for a proof carrying DLEQ and witness, and v4 has the same `ABSOLUTE_MAX_ARRAY_LENGTH`, so 262,144 stands unchanged.

Two v4-only differences from #1097: `decodeBase64AnyToJson` (the deprecated cashuA path main does not have) gets the same treatment, and an existing CBOR test that asserted the old lenient handling of extended simple values was updated to match main.

## Impact

`computeMessageDigest` is public and now throws on ill-formed UTF-16; `schnorrVerifyMessage` still returns `false` rather than throwing. No API surface change.
