### PR TITLE
fix(nut26): reject repeated singular TLV tags and untyped policy flags

### DIFF
--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -43,6 +43,21 @@ import { CTSError } from './Errors';
 import type { Proof } from './types/proof';
 
 /**
+ * Normalizes a wire boolean flag, admitting true/false, the numeric 0/1 form, and null.
+ *
+ * @remarks
+ * `null` is treated the same as an absent key: some encoders (eg cdk) serialize an unset optional
+ * field as CBOR null rather than omitting it.
+ * @throws If `value` is present, non-null, and not one of those four values.
+ */
+function normalizePaymentRequestFlag(value: unknown, field: 's' | 'mp'): boolean | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (value === true || value === 1) return true;
+  if (value === false || value === 0) return false;
+  throw new CTSError(`invalid payment request: ${field} must be a boolean (or 0/1)`);
+}
+
+/**
  * Constructor options for {@link PaymentRequest}. Keys mirror the class properties; `amount` and
  * method `fee` values accept flexible input and are normalized on construction.
  */
@@ -86,12 +101,8 @@ export class PaymentRequest {
       method: m.method,
       fee: m.fee !== undefined ? Amount.from(m.fee) : undefined,
     }));
-    // Coerce the optional flags to real booleans (preserving `undefined` for the
-    // absent/tri-state case) so an untyped CBOR value (`0`/`1`/`null`) can't leak a
-    // non-boolean into the getter or get re-serialized verbatim over the wire.
-    this.singleUse = options.singleUse === undefined ? undefined : Boolean(options.singleUse);
-    this.mintsPreferred =
-      options.mintsPreferred === undefined ? undefined : Boolean(options.mintsPreferred);
+    this.singleUse = normalizePaymentRequestFlag(options.singleUse, 's');
+    this.mintsPreferred = normalizePaymentRequestFlag(options.mintsPreferred, 'mp');
   }
 
   /**

--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -137,12 +137,23 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
   for (const part of parts) {
     switch (part.tag) {
       case TAG_ID:
+        // Singular tags reject a repeat (as the sub-TLV parsers do) rather than
+        // let the last value silently win.
+        if (result.id !== undefined) {
+          throw new CTSError('invalid pr: multiple id fields');
+        }
         result.id = parseString(part.value);
         break;
       case TAG_AMOUNT:
+        if (result.amount !== undefined) {
+          throw new CTSError('invalid pr: multiple amount fields');
+        }
         result.amount = parseU64(part.value);
         break;
       case TAG_UNIT:
+        if (result.unit !== undefined) {
+          throw new CTSError('invalid pr: multiple unit fields');
+        }
         if (part.value.length === 1 && part.value[0] === 0) {
           result.unit = 'sat';
         } else {
@@ -150,6 +161,9 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         }
         break;
       case TAG_SINGLE_USE:
+        if (result.singleUse !== undefined) {
+          throw new CTSError('invalid pr: multiple single_use fields');
+        }
         result.singleUse = parseU8(part.value) === 1;
         break;
       case TAG_MINT:
@@ -159,6 +173,9 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         result.mints.push(parseString(part.value));
         break;
       case TAG_DESCRIPTION:
+        if (result.description !== undefined) {
+          throw new CTSError('invalid pr: multiple description fields');
+        }
         result.description = parseString(part.value);
         break;
       case TAG_TRANSPORT:
@@ -176,6 +193,9 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         result.nut10 = parseNut10(part.value);
         break;
       case TAG_MINT_PREFERRED:
+        if (result.mintsPreferred !== undefined) {
+          throw new CTSError('invalid pr: multiple mint_preferred fields');
+        }
         result.mintsPreferred = parseU8(part.value) === 1;
         break;
       case TAG_NUTROOT:
@@ -295,9 +315,16 @@ function parseTransport(value: Uint8Array): PaymentRequestTransport {
   for (const part of parts) {
     switch (part.tag) {
       case TRANSPORT_TAG_KIND:
+        // kind/target are singular; a repeat makes the destination ambiguous.
+        if (kind !== undefined) {
+          throw new CTSError('invalid pr: multiple transport kind fields');
+        }
         kind = parseU8(part.value);
         break;
       case TRANSPORT_TAG_TARGET:
+        if (targetBytes !== undefined) {
+          throw new CTSError('invalid pr: multiple transport target fields');
+        }
         targetBytes = part.value;
         break;
       case TRANSPORT_TAG_TAG_TUPLE:
@@ -539,7 +566,12 @@ export function encodeTLV(request: DecodedTLVPaymentRequest): Uint8Array {
     if (request.unit === 'sat') {
       parts.push(encodeTLVPart(TAG_UNIT, new Uint8Array([0x00])));
     } else {
-      parts.push(encodeTLVPart(TAG_UNIT, encodeString(request.unit)));
+      // The single byte 0x00 is the wire form of 'sat', so no other unit may encode to it.
+      const encodedUnit = encodeString(request.unit);
+      if (encodedUnit.length === 1 && encodedUnit[0] === 0) {
+        throw new CTSError('invalid pr: unit encoding is reserved for sat');
+      }
+      parts.push(encodeTLVPart(TAG_UNIT, encodedUnit));
     }
   }
 
@@ -879,7 +911,10 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
     offset += length;
 
     if (tag === 0x00) {
-      // Pubkey
+      // Pubkey: exactly one per nprofile (relays are the repeatable record).
+      if (pubkey !== undefined) {
+        throw new CTSError('Nprofile contains multiple pubkeys');
+      }
       if (value.length !== 32) {
         throw new CTSError(`Invalid pubkey length: expected 32 bytes, got ${value.length}`);
       }

--- a/test/utils/tlv-malformed.test.ts
+++ b/test/utils/tlv-malformed.test.ts
@@ -38,6 +38,27 @@ describe('decodeTLV fails closed on malformed streams', () => {
     expect(decoded.id).toBe('id1');
   });
 
+  test('singular top-level tags reject a repeat', () => {
+    const u64 = (n: number): number[] => [0, 0, 0, 0, 0, 0, 0, n];
+    expect(() => decodeTLV(bytes(rec(0x01, utf8('a')), rec(0x01, utf8('b'))))).toThrow(
+      /multiple id/,
+    );
+    expect(() => decodeTLV(bytes(rec(0x02, u64(1)), rec(0x02, u64(9))))).toThrow(/multiple amount/);
+    expect(() => decodeTLV(bytes(rec(0x03, [0]), rec(0x03, utf8('usd'))))).toThrow(/multiple unit/);
+    expect(() => decodeTLV(bytes(rec(0x04, [0]), rec(0x04, [1])))).toThrow(/multiple single_use/);
+    expect(() => decodeTLV(bytes(rec(0x06, utf8('a')), rec(0x06, utf8('b'))))).toThrow(
+      /multiple description/,
+    );
+    expect(() => decodeTLV(bytes(rec(0x09, [0]), rec(0x09, [1])))).toThrow(
+      /multiple mint_preferred/,
+    );
+    // Repeatable tags still accumulate.
+    const mints = decodeTLV(
+      bytes(rec(0x05, utf8('https://a')), rec(0x05, utf8('https://b'))),
+    ).mints;
+    expect(mints).toEqual(['https://a', 'https://b']);
+  });
+
   test('transport structural violations', () => {
     const target = rec(0x02, utf8('https://x'));
     expect(() => decodeTLV(bytes(rec(0x07, [...rec(0x01, [2]), ...target])))).toThrow(
@@ -45,6 +66,14 @@ describe('decodeTLV fails closed on malformed streams', () => {
     );
     expect(() => decodeTLV(bytes(rec(0x07, target)))).toThrow(/missing required kind/);
     expect(() => decodeTLV(bytes(rec(0x07, rec(0x01, [1]))))).toThrow(/missing required target/);
+    // kind and target are singular within one transport.
+    const kind = rec(0x01, [1]);
+    expect(() => decodeTLV(bytes(rec(0x07, [...kind, ...kind, ...target])))).toThrow(
+      /multiple transport kind/,
+    );
+    expect(() => decodeTLV(bytes(rec(0x07, [...kind, ...target, ...target])))).toThrow(
+      /multiple transport target/,
+    );
     // A nostr target is a raw 32-byte pubkey; anything else cannot become an nprofile.
     expect(() => decodeTLV(bytes(rec(0x07, [...rec(0x01, [0]), ...rec(0x02, [0xaa])])))).toThrow(
       /expected 32 bytes/,
@@ -108,6 +137,13 @@ describe('encodeTLV refuses unencodable requests', () => {
     );
   });
 
+  test('a unit whose encoding is the sat sentinel byte', () => {
+    expect(() => encodeTLV({ unit: '\0' })).toThrow(/unit/);
+    // sat itself and ordinary units still encode.
+    expect(decodeTLV(encodeTLV({ unit: 'sat' })).unit).toBe('sat');
+    expect(decodeTLV(encodeTLV({ unit: 'usd' })).unit).toBe('usd');
+  });
+
   test('nutroot keys must be 33-byte points', () => {
     expect(() => encodeTLV({ nutroot: { receiverKey: 'aabb' } })).toThrow(/33 bytes/);
     expect(() =>
@@ -139,6 +175,10 @@ describe('encodeTLV refuses unencodable requests', () => {
     expect(() =>
       encodeTLV(nostr(nprofile([0x00, 0x20, ...new Array(32).fill(0xaa), 0x01, 0x01, 0xff]))),
     ).toThrow(/Malformed UTF-8/);
+    const key = (fill: number): number[] => [0x00, 0x20, ...Array.from({ length: 32 }, () => fill)];
+    expect(() => encodeTLV(nostr(nprofile([...key(0x11), ...key(0x22)])))).toThrow(
+      /multiple pubkeys/,
+    );
   });
 
   test('a leading BOM in a string field is kept as content, not stripped as framing', () => {

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -8,6 +8,7 @@ import {
   PaymentRequestTransportType,
   type NUT10Option,
 } from '../../src/index';
+import { encodeCBOR, encodeUint8ToBase64UrlPadded } from '../../src/utils';
 import { encodeUint8ToBase64Url } from '../../src/utils/base64';
 import { encodeBech32m } from '../../src/utils/bech32m';
 import { encodeTLV } from '../../src/utils/tlv';
@@ -300,12 +301,9 @@ describe('payment requests', () => {
       expect(fromWire.isMintListStrict).toBe(true);
     });
 
-    test('non-boolean truthy mp is coerced (no cross-format type confusion)', () => {
-      // An untyped CBOR producer might emit `mp: 1` to mean "preferred".
-      // Coercion must normalize it to a genuine boolean so the getter
-      // (`mintsPreferred !== true`) and TLV serialization agree rather than
-      // diverging — a raw `1` would read strict via the getter yet serialize
-      // preferred over TLV.
+    test('mp accepts the numeric 0/1 form', () => {
+      // An untyped CBOR producer might emit `mp: 1` to mean "preferred"; it must read as a
+      // genuine boolean so the getter and the TLV encoding agree.
       const fromOne = PaymentRequest.fromRawRequest({
         i: 'one',
         a: 100,
@@ -328,6 +326,73 @@ describe('payment requests', () => {
       });
       expect(fromZero.mintsPreferred).toBe(false);
       expect(fromZero.isMintListStrict).toBe(true);
+    });
+
+    test('rejects a policy flag that is not a boolean or 0/1', () => {
+      // A whitelist keeps a truthy string from reading as `mp: true`.
+      expect(() =>
+        PaymentRequest.fromRawRequest({
+          i: 'bad_mp',
+          a: 100,
+          u: 'sat',
+          m: ['https://mint.example.com'],
+          mp: 'false' as unknown as boolean,
+        }),
+      ).toThrow(/mp/);
+      expect(
+        () =>
+          new PaymentRequest({
+            id: 'bad_s',
+            singleUse: 'true' as unknown as boolean,
+          }),
+      ).toThrow(/s/);
+    });
+
+    test('rejects a string-valued mp flag encoded over creqA', () => {
+      const data = encodeCBOR({
+        a: 100,
+        u: 'sat',
+        m: ['https://listed.example'],
+        mp: 'false',
+      });
+      const encoded = 'creqA' + encodeUint8ToBase64UrlPadded(data);
+      expect(() => decodePaymentRequest(encoded)).toThrow(/mp/);
+    });
+
+    test('decodes a creqA with s/mp explicitly null as absent', () => {
+      // Some encoders serialize an unset Option field as CBOR null rather than omitting
+      // the key; treat null the same as absent instead of rejecting it.
+      const data = encodeCBOR({
+        i: 'null_flags',
+        a: 100,
+        u: 'sat',
+        s: null,
+        m: ['https://listed.example'],
+        mp: null,
+      });
+      const encoded = 'creqA' + encodeUint8ToBase64UrlPadded(data);
+      const decoded = decodePaymentRequest(encoded);
+      expect(decoded.singleUse).toBeUndefined();
+      expect(decoded.mintsPreferred).toBeUndefined();
+      expect(decoded.isMintListStrict).toBe(true);
+    });
+
+    test('decodes the cdk canonical NUT-18 vector', () => {
+      // cdk's own round-trip vector (crates/cashu/src/nuts/nut18/payment_request.rs): its
+      // Option fields serialize unset as CBOR null, so `s` and `d` arrive as null here.
+      const CDK_VECTOR =
+        'creqAp2FpaGI3YTkwMTc2YWEKYXVjc2F0YXP2YW2BeCJodHRwczovL25vZmVlcy50ZXN0bnV0LmNhc2h1LnNwYWNlYWT2YXSBo2F0ZW5vc3RyYWF4qW5wcm9maWxlMXFxc2dtNnFmYTNjOGR0ejJmdnpodmZxZWFjbXdtMGU1MHBlM2s1dGZtdnBqam1uMHZqN20ydGdwejNtaHh1ZTY5dWhoeWV0dnY5dWp1ZXJwZDQ2aHh0bmZkdXEzd2Ftbnd2YXo3dG1qdjRreHo3Znc4cWVueHZld3dkY3h6Y205OXVxczZhbW53dmF6N3Rtd2RhZWp1bXIwZHM0bGpoN25hZ4GCYW5iMTc=';
+      const decoded = decodePaymentRequest(CDK_VECTOR);
+      expect(decoded.id).toBe('b7a90176');
+      expect(decoded.amount?.toString()).toBe('10');
+      expect(decoded.unit).toBe('sat');
+      expect(decoded.singleUse).toBeUndefined();
+      expect(decoded.mints).toEqual(['https://nofees.testnut.cashu.space']);
+      expect(decoded.isMintListStrict).toBe(true);
+      expect(decoded.transport?.[0]?.type).toBe(PaymentRequestTransportType.NOSTR);
+      expect(decoded.transport?.[0]?.tags).toEqual([['n', '17']]);
+      // The nprofile target carries relays, so this also exercises the creqB nprofile path.
+      expect(decodePaymentRequest(decoded.toEncodedCreqB()).id).toBe('b7a90176');
     });
 
     test('mp/sm absent by default (no serialization, no defaults injected)', () => {


### PR DESCRIPTION
A creqB carrying a repeated field, or a payment request whose policy flags are not booleans, is now rejected rather than read differently by different decoders.

## Why

`decodeTLV` kept the last value of a repeated singular tag, so two readers of one creqB could disagree on its id, amount, unit or transport target. [NUT-26](https://github.com/cashubtc/nuts/blob/main/26.md) marks only `mint`, `transport`, `supported_method` and tag tuples as repeatable, and cdk's decoder already rejects a repeat of anything else. The `s` and `mp` flags went through `Boolean()`, so a string such as `'false'` read as `true`.

## Changes

A repeated singular tag, a repeated transport `kind`/`target` and a second nprofile identity pubkey now throw. `encodeTLV` refuses a non-`sat` unit whose encoding is the single `0x00` byte NUT-26 reserves for `sat`; decoding is unchanged, since `0x00` already maps to `sat`.

The flags accept `true`/`false`/`0`/`1`. CBOR `null` reads as absent, which is how cdk serialises an unset `Option` field: its canonical NUT-18 vector carries `s: null` and `d: null`, and is added as a fixture.

## Impact

Inputs that were previously misread now throw a `CTSError` from `decodePaymentRequest` and `PaymentRequest.fromRawRequest`. No API surface change.
