### PR TITLE
fix(nut26): reject repeated singular TLV tags and untyped policy flags [backport v4-dev]

### DIFF
--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -103,12 +103,23 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
   for (const part of parts) {
     switch (part.tag) {
       case TAG_ID:
+        // Singular tags reject a repeat (as the sub-TLV parsers do) rather than
+        // let the last value silently win.
+        if (result.id !== undefined) {
+          throw new CTSError('invalid pr: multiple id fields');
+        }
         result.id = parseString(part.value);
         break;
       case TAG_AMOUNT:
+        if (result.amount !== undefined) {
+          throw new CTSError('invalid pr: multiple amount fields');
+        }
         result.amount = parseU64(part.value);
         break;
       case TAG_UNIT:
+        if (result.unit !== undefined) {
+          throw new CTSError('invalid pr: multiple unit fields');
+        }
         if (part.value.length === 1 && part.value[0] === 0) {
           result.unit = 'sat';
         } else {
@@ -116,6 +127,9 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         }
         break;
       case TAG_SINGLE_USE:
+        if (result.singleUse !== undefined) {
+          throw new CTSError('invalid pr: multiple single_use fields');
+        }
         result.singleUse = parseU8(part.value) === 1;
         break;
       case TAG_MINT:
@@ -125,6 +139,9 @@ export function decodeTLV(data: Uint8Array): DecodedTLVPaymentRequest {
         result.mints.push(parseString(part.value));
         break;
       case TAG_DESCRIPTION:
+        if (result.description !== undefined) {
+          throw new CTSError('invalid pr: multiple description fields');
+        }
         result.description = parseString(part.value);
         break;
       case TAG_TRANSPORT:
@@ -243,9 +260,16 @@ function parseTransport(value: Uint8Array): PaymentRequestTransport {
   for (const part of parts) {
     switch (part.tag) {
       case TRANSPORT_TAG_KIND:
+        // kind/target are singular; a repeat makes the destination ambiguous.
+        if (kind !== undefined) {
+          throw new CTSError('invalid pr: multiple transport kind fields');
+        }
         kind = parseU8(part.value);
         break;
       case TRANSPORT_TAG_TARGET:
+        if (targetBytes !== undefined) {
+          throw new CTSError('invalid pr: multiple transport target fields');
+        }
         targetBytes = part.value;
         break;
       case TRANSPORT_TAG_TAG_TUPLE:
@@ -401,7 +425,12 @@ export function encodeTLV(request: DecodedTLVPaymentRequest): Uint8Array {
     if (request.unit === 'sat') {
       parts.push(encodeTLVPart(TAG_UNIT, new Uint8Array([0x00])));
     } else {
-      parts.push(encodeTLVPart(TAG_UNIT, encodeString(request.unit)));
+      // The single byte 0x00 is the wire form of 'sat', so no other unit may encode to it.
+      const encodedUnit = encodeString(request.unit);
+      if (encodedUnit.length === 1 && encodedUnit[0] === 0) {
+        throw new CTSError('invalid pr: unit encoding is reserved for sat');
+      }
+      parts.push(encodeTLVPart(TAG_UNIT, encodedUnit));
     }
   }
 
@@ -661,7 +690,10 @@ export function decodeNprofile(nprofile: string): { pubkey: Uint8Array; relays: 
     offset += length;
 
     if (tag === 0x00) {
-      // Pubkey
+      // Pubkey: exactly one per nprofile (relays are the repeatable record).
+      if (pubkey !== undefined) {
+        throw new CTSError('Nprofile contains multiple pubkeys');
+      }
       if (value.length !== 32) {
         throw new CTSError(`Invalid pubkey length: expected 32 bytes, got ${value.length}`);
       }

--- a/test/utils/tlv-malformed.test.ts
+++ b/test/utils/tlv-malformed.test.ts
@@ -17,6 +17,59 @@ const rec = (tag: number, value: number[]): number[] => [
   ...value,
 ];
 const bytes = (...parts: number[][]): Uint8Array => new Uint8Array(parts.flat());
+const utf8 = (text: string): number[] => [...new TextEncoder().encode(text)];
+
+describe('decodeTLV rejects a repeat of a singular tag', () => {
+  test('singular top-level tags reject a repeat', () => {
+    const u64 = (n: number): number[] => [0, 0, 0, 0, 0, 0, 0, n];
+    expect(() => decodeTLV(bytes(rec(0x01, utf8('a')), rec(0x01, utf8('b'))))).toThrow(
+      /multiple id/,
+    );
+    expect(() => decodeTLV(bytes(rec(0x02, u64(1)), rec(0x02, u64(9))))).toThrow(/multiple amount/);
+    expect(() => decodeTLV(bytes(rec(0x03, [0]), rec(0x03, utf8('usd'))))).toThrow(/multiple unit/);
+    expect(() => decodeTLV(bytes(rec(0x04, [0]), rec(0x04, [1])))).toThrow(/multiple single_use/);
+    expect(() => decodeTLV(bytes(rec(0x06, utf8('a')), rec(0x06, utf8('b'))))).toThrow(
+      /multiple description/,
+    );
+    // Repeatable tags still accumulate.
+    const mints = decodeTLV(
+      bytes(rec(0x05, utf8('https://a')), rec(0x05, utf8('https://b'))),
+    ).mints;
+    expect(mints).toEqual(['https://a', 'https://b']);
+  });
+
+  test('transport kind and target are singular within one transport', () => {
+    const kind = rec(0x01, [1]);
+    const target = rec(0x02, utf8('https://x'));
+    expect(() => decodeTLV(bytes(rec(0x07, [...kind, ...kind, ...target])))).toThrow(
+      /multiple transport kind/,
+    );
+    expect(() => decodeTLV(bytes(rec(0x07, [...kind, ...target, ...target])))).toThrow(
+      /multiple transport target/,
+    );
+  });
+});
+
+describe('encodeTLV refuses unencodable requests', () => {
+  test('a unit whose encoding is the sat sentinel byte', () => {
+    expect(() => encodeTLV({ unit: '\0' })).toThrow(/unit/);
+    // sat itself and ordinary units still encode.
+    expect(decodeTLV(encodeTLV({ unit: 'sat' })).unit).toBe('sat');
+    expect(decodeTLV(encodeTLV({ unit: 'usd' })).unit).toBe('usd');
+  });
+
+  test('an nprofile with two identity pubkeys is rejected', () => {
+    const nostr = (target: string) => ({
+      transports: [{ type: PaymentRequestTransportType.NOSTR, target }],
+    });
+    const nprofile = (payload: number[]) =>
+      bech32.encode('nprofile', bech32.toWords(new Uint8Array(payload)), 1024);
+    const key = (fill: number): number[] => [0x00, 0x20, ...Array.from({ length: 32 }, () => fill)];
+    expect(() => encodeTLV(nostr(nprofile([...key(0x11), ...key(0x22)])))).toThrow(
+      /multiple pubkeys/,
+    );
+  });
+});
 
 describe('TLV string fields decode to exactly their bytes', () => {
   test('a leading BOM in a string field is kept as content, not stripped as framing', () => {


### PR DESCRIPTION
# Description
Backport of #1099 to `v4-dev`.