### PR TITLE
fix(nut11): reject malformed P2PK tag values and bound key lists

### DIFF
--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -211,32 +211,42 @@ export function getTag(secret: Secret | string, key: string): string[] | undefin
 }
 
 /**
- * Get the first scalar value of a tag as a string, or undefined if missing.
+ * Get the single value of a scalar tag as a string, or undefined if missing.
  *
  * @param secret - The Proof secret.
  * @param key - Tag key to lookup.
  * @returns - Tag value or undefined if not present.
+ * @throws If the tag carries more than one value.
  */
 export function getTagScalar(secret: Secret | string, key: string): string | undefined {
   const vals = getTag(secret, key);
-  return vals && vals.length > 0 ? vals[0] : undefined;
+  if (vals === undefined) return undefined;
+  if (vals.length !== 1) {
+    throw new CTSError(`Invalid NUT-10 tag "${key}": must carry a single value`);
+  }
+  return vals[0];
 }
 
 /**
- * Get the first scalar value of a tag parsed as a base-10 integer, or undefined.
+ * Get the single value of a scalar tag parsed as a base-10 integer, or undefined if missing.
  *
+ * @remarks
+ * A present value that is not a safe base-10 integer throws rather than reading as absent, so a
+ * caller's default never replaces a malformed condition.
  * @param secret - The Proof secret.
  * @param key - Tag key to lookup.
- * @returns - Tag value as an integer, undefined if not present or invalid.
+ * @returns - Tag value as an integer, undefined if not present.
+ * @throws If the tag carries more than one value, or a value that is not a safe integer.
  */
 export function getTagInt(secret: Secret | string, key: string): number | undefined {
   const v = getTagScalar(secret, key);
   if (v === undefined) return undefined;
   // Strict integer parse: reject the partial parses ("1700000000abc" -> 1700000000)
   // and hex/exponent/float forms Number.parseInt would accept. The sign is kept so a
-  // caller's semantic check (assertPositiveInteger, getLocktime's `<= 0`) still fails
-  // closed on an out-of-range value instead of it being silently dropped to undefined.
-  if (!/^-?\d+$/.test(v)) return undefined;
-  const n = Number(v);
-  return Number.isSafeInteger(n) ? n : undefined;
+  // caller's semantic check (assertPositiveInteger, getLocktime's `<= 0`) applies.
+  const n = /^-?\d+$/.test(v) ? Number(v) : NaN;
+  if (!Number.isSafeInteger(n)) {
+    throw new CTSError(`Invalid NUT-10 tag "${key}": must be an integer`);
+  }
+  return n;
 }

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -5,6 +5,7 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
+import { MAX_P2PK_PUBKEYS, MAX_P2PK_SIGNATURES } from '../utils/limits';
 import { type NUT10Option } from '../wallet/types/payment-requests';
 
 import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
@@ -31,14 +32,6 @@ export const SigFlags = {
 } as const;
 export type SigFlag = (typeof SigFlags)[keyof typeof SigFlags];
 const VALID_SIG_FLAGS: ReadonlySet<SigFlag> = new Set(Object.values(SigFlags));
-
-// Upper bounds on untrusted P2PK/HTLC secret and witness sizes, applied on the verify/sign path so
-// per-key and per-signature work stays bounded rather than scaling with input. NUT-28 caps a lock
-// at 11 slots (data + pubkeys + refund); SIG_ALL adds a signature per message variant per signer,
-// so signatures need more headroom than keys. These are work bounds, not the exact NUT-28 rule
-// (still enforced at build).
-const MAX_P2PK_PUBKEYS = 16;
-const MAX_P2PK_SIGNATURES = 64;
 
 export type LockState = 'PERMANENT' | 'ACTIVE' | 'EXPIRED';
 
@@ -998,11 +991,11 @@ function getP2PKWitnessRefundkeys(secret: Secret): string[] {
 }
 
 function getLocktime(secret: Secret): number {
-  const ts = getTagInt(secret, 'locktime');
-  if (ts === undefined || !Number.isFinite(ts) || ts <= 0) {
-    return Infinity;
-  }
-  return ts;
+  // NUT-11: a locktime that is not a valid unix time makes the lock permanent, so a malformed
+  // value is passed through for the mint to judge rather than rejected here. Arity still throws.
+  const v = getTagScalar(secret, 'locktime');
+  const ts = v !== undefined && /^\d+$/.test(v) ? Number(v) : NaN;
+  return Number.isSafeInteger(ts) && ts > 0 ? ts : Infinity;
 }
 
 function deriveLockState(

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -23,6 +23,7 @@ import {
 } from '../utils';
 import { decodeBech32m, encodeBech32m } from '../utils/bech32m';
 import { JSONInt } from '../utils/JSONInt';
+import { MAX_P2PK_PUBKEYS } from '../utils/limits';
 import { decodeTLV, encodeTLV } from '../utils/tlv';
 import type { DecodedTLVPaymentRequest } from '../utils/tlv';
 import { lockToNutrootOptions, lockToP2PKOptions, type LockOptions } from '../wallet/lock';
@@ -472,8 +473,14 @@ export class PaymentRequest {
       }
       return leaf;
     });
-    const blindKeys = (nutroot.blindKeys ?? []).map((key) => normalizeSecpPubkey(key));
+    // Every blind-me key must be a leaf key, so the tree's own key count (at most
+    // NUTROOT_MAX_SLOTS) bounds the list before any EC decompression.
     const leafKeys = new Set(leaves.flatMap((leaf) => leaf.keys));
+    const requestedBlindKeys = nutroot.blindKeys ?? [];
+    if (requestedBlindKeys.length > leafKeys.size) {
+      throw new CTSError(`Too many blind-me keys: ${requestedBlindKeys.length}`);
+    }
+    const blindKeys = requestedBlindKeys.map((key) => normalizeSecpPubkey(key));
     for (const key of blindKeys) {
       if (!leafKeys.has(key)) {
         throw new CTSError(`blind-me key is not in the requested tree: ${key}`);
@@ -928,19 +935,30 @@ export function nut10ToP2PKOptions(nut10: NUT10Option | undefined): P2PKOptions 
     nut10.kind,
     { nonce: '', data: nut10.data, tags: nut10.tags ?? [] },
   ]);
+  // Bound EC decompression before mapping over the request's keys; the exact NUT-28 slot
+  // rule is enforced by the builder.
+  const pubkeys = getTag(secret, 'pubkeys') ?? [];
+  if (pubkeys.length > MAX_P2PK_PUBKEYS) {
+    throw new CTSError(`Too many pubkeys: ${pubkeys.length}`);
+  }
+  const refundKeys = getTag(secret, 'refund') ?? [];
+  if (refundKeys.length > MAX_P2PK_PUBKEYS) {
+    throw new CTSError(`Too many refund pubkeys: ${refundKeys.length}`);
+  }
   // `data` is the NUT-10 data slot (hashlock for HTLC, primary pubkey for P2PK);
   // the `pubkeys` tag carries the optional additional / receiver keys for either kind.
-  const taggedPubkeys = (getTag(secret, 'pubkeys') ?? []).map(normalizeSecpPubkey);
+  const taggedPubkeys = pubkeys.map(normalizeSecpPubkey);
   const options: P2PKOptions = {
     kind: isHTLC ? 'HTLC' : 'P2PK',
     data: isHTLC ? nut10.data : normalizeSecpPubkey(nut10.data),
     ...(taggedPubkeys.length ? { pubkeys: taggedPubkeys } : {}),
   };
 
-  // Optional fields pass straight through: the accessors return undefined when
-  // absent, and the builder ignores undefined options. getTag never yields [].
+  // Optional fields pass straight through: the accessors return undefined when absent
+  // and throw when malformed, and the builder ignores undefined options.
   options.locktime = getTagInt(secret, 'locktime');
-  options.refundKeys = getTag(secret, 'refund')?.map(normalizeSecpPubkey);
+  // `getTag` yields undefined, never [], so a key-only tag reads as absent.
+  options.refundKeys = refundKeys.length ? refundKeys.map(normalizeSecpPubkey) : undefined;
   options.requiredSignatures = getTagInt(secret, 'n_sigs');
   options.requiredRefundSignatures = getTagInt(secret, 'n_sigs_refund');
   if (getTagScalar(secret, 'sigflag') === 'SIG_ALL') {

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -97,3 +97,17 @@ export const MAX_PAYLOAD_DECODE_ATTEMPTS = 16;
  * bounded quantifier recursively, so a match of a few million characters overflows the stack.
  */
 export const MAX_PAYLOAD_LENGTH = 1_048_576;
+
+/**
+ * NUT-11: Upper bound on the keys in one `pubkeys` or `refund` tag, applied before any per-key
+ * curve work. NUT-28 caps a lock at 11 slots (data + pubkeys + refund), enforced at build; this is
+ * a work bound with headroom, not the exact slot rule.
+ */
+export const MAX_P2PK_PUBKEYS = 16;
+
+/**
+ * NUT-11: Upper bound on untrusted witness size, applied on the verify path so per-signature work
+ * stays bounded rather than scaling with input. SIG_ALL adds a signature per message variant per
+ * signer, so signatures need more headroom than keys ({@link MAX_P2PK_PUBKEYS}).
+ */
+export const MAX_P2PK_SIGNATURES = 64;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2272,7 +2272,8 @@ class Wallet {
    * @param opts.privkeys Static keys to trial-match, for receiver-keyed proofs and leaf keys.
    * @param opts.now Unix seconds to judge locktimes against. Defaults to the current time.
    * @throws If a v3 keyset proof is not a point secret, a NUT-10 secret is of a kind this wallet
-   *   cannot spend, or a disclosed tree holds a leaf it cannot parse (unknown version, type or
+   *   cannot spend, a NUT-11 tag is malformed (a non-integer `n_sigs`, or a scalar tag with more
+   *   than one value), or a disclosed tree holds a leaf it cannot parse (unknown version, type or
    *   constraint field): the same fail-closed rule the receive cascade applies.
    */
   spendOptions(proof: Proof, opts?: { privkeys?: string | string[]; now?: number }): SpendOptions {

--- a/test/crypto/NUT10.test.ts
+++ b/test/crypto/NUT10.test.ts
@@ -103,22 +103,30 @@ describe('NUT10 module core functions', () => {
 
   test('getTagInt finds tags', () => {
     expect(getTagInt(proof.secret, 'locktime')).toEqual(1);
-    expect(getTagInt(proof.secret, 'not_exists')).toBeFalsy();
-    expect(getTagInt(proof.secret, 'sigflag')).toBeFalsy();
+    expect(getTagInt(proof.secret, 'not_exists')).toBeUndefined();
+    expect(() => getTagInt(proof.secret, 'sigflag')).toThrow(/tag "sigflag": must be an integer/);
   });
 
   test('getTagInt rejects non-integer tag values instead of partial-parsing', () => {
     // Number.parseInt would accept these; a spending-condition integer must not
-    // be inferred from a partial or non-decimal value (eg a locktime).
-    for (const bad of ['1700000000abc', '2 of 3', '0x1f', '1e3', '12.5', '  9']) {
+    // be inferred from a partial or non-decimal value (eg a locktime). A present
+    // but unparseable value is an error, not an absent tag.
+    for (const bad of ['1700000000abc', '2 of 3', '0x1f', '1e3', '12.5', '  9', '2 ', 'SIG_ALL']) {
       const secret = createSecret('P2PK', DATA, [['locktime', bad]]);
-      expect(getTagInt(secret, 'locktime')).toBeUndefined();
+      expect(() => getTagInt(secret, 'locktime')).toThrow(/tag "locktime": must be an integer/);
     }
   });
 
   test('getTagInt rejects an integer beyond safe range', () => {
-    const secret = createSecret('P2PK', DATA, [['locktime', '99999999999999999999']]);
-    expect(getTagInt(secret, 'locktime')).toBeUndefined();
+    for (const bad of ['99999999999999999999', '9007199254740992', '-9007199254740992']) {
+      const secret = createSecret('P2PK', DATA, [['locktime', bad]]);
+      expect(() => getTagInt(secret, 'locktime')).toThrow(/tag "locktime": must be an integer/);
+    }
+  });
+
+  test('getTagInt rejects a tag carrying more than one value', () => {
+    const secret = createSecret('P2PK', DATA, [['n_sigs', '1', '2']]);
+    expect(() => getTagInt(secret, 'n_sigs')).toThrow(/tag "n_sigs": must carry a single value/);
   });
 });
 
@@ -297,5 +305,11 @@ describe('NUT10 tag accessors', () => {
 
   test('getTagScalar returns undefined for a missing key', () => {
     expect(getTagScalar(proof.secret, 'not_exists')).toBeUndefined();
+  });
+
+  test('getTagScalar rejects a tag carrying more than one value', () => {
+    expect(() => getTagScalar(proof.secret, 'refund')).toThrow(
+      /tag "refund": must carry a single value/,
+    );
   });
 });

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1816,6 +1816,59 @@ describe('verifyP2PKSpendingConditions — semantic validation', () => {
     );
   });
 
+  test('rejects a malformed n_sigs instead of applying the default threshold', () => {
+    // A present but unparseable threshold must not read as an absent tag.
+    for (const bad of ['2oops', '2 ', '9007199254740992']) {
+      const proof = makeProof(
+        [
+          ['n_sigs', bad],
+          ['pubkeys', pk2],
+        ],
+        PUBKEY,
+      );
+      const signedProof = signP2PKProof(proof, bytesToHex(PRIVKEY));
+      expect(() => verifyP2PKSpendingConditions(signedProof)).toThrow(
+        /tag "n_sigs": must be an integer/,
+      );
+    }
+  });
+
+  test('rejects a malformed n_sigs_refund instead of ignoring it', () => {
+    const badRefund = makeProof([
+      ['locktime', '1'],
+      ['refund', pk2],
+      ['n_sigs_refund', '1.0'],
+    ]);
+    expect(() => verifyP2PKSpendingConditions(badRefund)).toThrow(
+      /tag "n_sigs_refund": must be an integer/,
+    );
+  });
+
+  test('a malformed locktime reads as a permanent lock, not a rejection', () => {
+    // NUT-11: a locktime that is not a valid unix time makes the lock permanent, so the refund
+    // path never opens and only the main key can sign; the mint makes the final call.
+    const proof = makeProof([
+      ['locktime', 'never'],
+      ['refund', pk2],
+    ]);
+    expect(() => verifyP2PKSpendingConditions(proof)).not.toThrow(/must be an integer/);
+    expect(getP2PKExpectedWitnessPubkeys(proof.secret)).toEqual([pk1]);
+  });
+
+  test('rejects a scalar tag carrying more than one value', () => {
+    const nSigs = makeProof([
+      ['n_sigs', '1', '2'],
+      ['pubkeys', pk2],
+    ]);
+    expect(() => verifyP2PKSpendingConditions(nSigs)).toThrow(
+      /tag "n_sigs": must carry a single value/,
+    );
+    const sigflag = makeProof([['sigflag', 'SIG_INPUTS', 'SIG_ALL']]);
+    expect(() => parseP2PKSecret(sigflag.secret)).toThrow(
+      /tag "sigflag": must carry a single value/,
+    );
+  });
+
   test('rejects impossible n_sigs threshold (n_sigs > available keys)', () => {
     // 1 key in data, none in pubkeys, but n_sigs=3
     const proof = makeProof([['n_sigs', '3']]);

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -1,3 +1,5 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { test, describe, expect } from 'vitest';
 
 import {
@@ -759,6 +761,52 @@ describe('payment requests', () => {
       expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(/Duplicate P2PK tag "locktime"/);
     });
 
+    test('rejects a malformed threshold instead of defaulting to one signature', () => {
+      // A present but unparseable integer is an error, not an absent tag.
+      const nut10: NUT10Option = {
+        kind: 'P2PK',
+        data: PUBKEY,
+        tags: [
+          ['pubkeys', PUBKEY_2],
+          ['n_sigs', '2 '],
+        ],
+      };
+      expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(/tag "n_sigs": must be an integer/);
+    });
+
+    test('rejects a scalar tag carrying more than one value', () => {
+      const nut10: NUT10Option = {
+        kind: 'P2PK',
+        data: PUBKEY,
+        tags: [
+          ['pubkeys', PUBKEY_2],
+          ['n_sigs', '1', '2'],
+        ],
+      };
+      expect(() => prWithNut10(nut10).toP2PKOptions()).toThrow(
+        /tag "n_sigs": must carry a single value/,
+      );
+    });
+
+    test('bounds the pubkeys and refund lists before validating each key', () => {
+      const keys = Array.from({ length: 17 }, (_, i) => {
+        const secret = new Uint8Array(32);
+        secret[31] = i + 1;
+        return bytesToHex(secp256k1.getPublicKey(secret, true));
+      });
+      const pubkeys: NUT10Option = { kind: 'P2PK', data: PUBKEY, tags: [['pubkeys', ...keys]] };
+      expect(() => prWithNut10(pubkeys).toP2PKOptions()).toThrow(/Too many pubkeys: 17/);
+      const refund: NUT10Option = {
+        kind: 'P2PK',
+        data: PUBKEY,
+        tags: [
+          ['locktime', '1'],
+          ['refund', ...keys],
+        ],
+      };
+      expect(() => prWithNut10(refund).toP2PKOptions()).toThrow(/Too many refund pubkeys: 17/);
+    });
+
     test('maps an HTLC option to a hashlock with signing keys', () => {
       const nut10: NUT10Option = {
         kind: 'HTLC',
@@ -1011,6 +1059,25 @@ describe('nutroot (v3) request marking', () => {
         nutroot: { receiverKey: carolPub, leaves: [leafAfter], blindKeys: ['not-a-point'] },
       }).toNutrootOptions(),
     ).toThrow(/Invalid pubkey/);
+  });
+
+  test('bounds the blind-me list before validating each key', () => {
+    const keys = Array.from({ length: 17 }, (_, i) => {
+      const secret = new Uint8Array(32);
+      secret[31] = i + 1;
+      return bytesToHex(secp256k1.getPublicKey(secret, true));
+    });
+    expect(() =>
+      new PaymentRequest({
+        nutroot: { receiverKey: carolPub, leaves: [leafAfter], blindKeys: keys },
+      }).toNutrootOptions(),
+    ).toThrow(/Too many blind-me keys: 17/);
+    // The bound is the tree's own key count; within it the keys are still checked against the tree.
+    expect(() =>
+      new PaymentRequest({
+        nutroot: { receiverKey: carolPub, leaves: [leafAfter], blindKeys: keys.slice(0, 1) },
+      }).toNutrootOptions(),
+    ).toThrow(/not in the requested tree/);
   });
 
   test('a leaf the payer cannot reproduce byte for byte is refused', () => {


### PR DESCRIPTION
A P2PK secret whose `n_sigs`, `n_sigs_refund` or `sigflag` tag is malformed, or carries more than one value, is now rejected instead of being read as if the tag were absent.

## Why

`getTagInt` returned `undefined` for a value that failed to parse, and every caller then applied its default, so a malformed `n_sigs` read as 1-of-n. `getTagScalar` returned the first of several values, so two readers of one secret could disagree. [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md) requires a non-positive-integer `n_sigs` or `n_sigs_refund` to be rejected as unspendable, and cdk already errors on both shapes.

## Changes

The arity and integer checks live in the two accessors every consumer reads through, so there is no second parser left to differ. `"01"` and JSON numbers still parse.

`locktime` is the deliberate exception: NUT-11 says a value that is not a valid unix time makes the lock permanent, so `getLocktime` reads it that way and a foreign proof is passed on for the mint to judge. Lock creation from a payment request stays strict.

`MAX_P2PK_PUBKEYS` and `MAX_P2PK_SIGNATURES` move to `utils/limits.ts`; the key bound now also applies to a payment request's `pubkeys` and `refund` tags before any per-key curve work; it sits above the 11-slot rule NUT-28 sets, which the builder enforces on creation. A nutroot blind-me list is bounded by the requested tree's own key count instead, since a tree can carry far more keys than a P2PK tag.

## Impact

`verifyP2PKSpendingConditions`, `getP2PKExpectedWitnessPubkeys`, `Wallet.spendOptions` and `PaymentRequest.toP2PKOptions` now throw a `CTSError` on the malformed shapes above; all already documented `@throws` for a malformed secret. No API surface change.
