### PR TITLE
fix(nut11): reject malformed P2PK tag values and bound key lists [backport v4-dev]

### DIFF
--- a/src/crypto/NUT10.ts
+++ b/src/crypto/NUT10.ts
@@ -193,32 +193,42 @@ export function getTag(secret: Secret | string, key: string): string[] | undefin
 }
 
 /**
- * Get the first scalar value of a tag as a string, or undefined if missing.
+ * Get the single value of a scalar tag as a string, or undefined if missing.
  *
  * @param secret - The Proof secret.
  * @param key - Tag key to lookup.
  * @returns - Tag value or undefined if not present.
+ * @throws If the tag carries more than one value.
  */
 export function getTagScalar(secret: Secret | string, key: string): string | undefined {
   const vals = getTag(secret, key);
-  return vals && vals.length > 0 ? vals[0] : undefined;
+  if (vals === undefined) return undefined;
+  if (vals.length !== 1) {
+    throw new CTSError(`Invalid NUT-10 tag "${key}": must carry a single value`);
+  }
+  return vals[0];
 }
 
 /**
- * Get the first scalar value of a tag parsed as a base-10 integer, or undefined.
+ * Get the single value of a scalar tag parsed as a base-10 integer, or undefined if missing.
  *
+ * @remarks
+ * A present value that is not a safe base-10 integer throws rather than reading as absent, so a
+ * caller's default never replaces a malformed condition.
  * @param secret - The Proof secret.
  * @param key - Tag key to lookup.
- * @returns - Tag value as an integer, undefined if not present or invalid.
+ * @returns - Tag value as an integer, undefined if not present.
+ * @throws If the tag carries more than one value, or a value that is not a safe integer.
  */
 export function getTagInt(secret: Secret | string, key: string): number | undefined {
   const v = getTagScalar(secret, key);
   if (v === undefined) return undefined;
   // Strict integer parse: reject the partial parses ("1700000000abc" -> 1700000000)
   // and hex/exponent/float forms Number.parseInt would accept. The sign is kept so a
-  // caller's semantic check (assertPositiveInteger, getLocktime's `<= 0`) still fails
-  // closed on an out-of-range value instead of it being silently dropped to undefined.
-  if (!/^-?\d+$/.test(v)) return undefined;
-  const n = Number(v);
-  return Number.isSafeInteger(n) ? n : undefined;
+  // caller's semantic check (assertPositiveInteger, getLocktime's `<= 0`) applies.
+  const n = /^-?\d+$/.test(v) ? Number(v) : NaN;
+  if (!Number.isSafeInteger(n)) {
+    throw new CTSError(`Invalid NUT-10 tag "${key}": must be an integer`);
+  }
+  return n;
 }

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -5,6 +5,7 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
+import { MAX_P2PK_PUBKEYS, MAX_P2PK_SIGNATURES } from '../utils/limits';
 
 import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
 import {
@@ -26,14 +27,6 @@ export const SigFlags = {
 } as const;
 export type SigFlag = (typeof SigFlags)[keyof typeof SigFlags];
 const VALID_SIG_FLAGS: ReadonlySet<SigFlag> = new Set(Object.values(SigFlags));
-
-// Upper bounds on untrusted P2PK/HTLC secret and witness sizes, applied on the verify/sign path so
-// per-key and per-signature work stays bounded rather than scaling with input. NUT-28 caps a lock
-// at 11 slots (data + pubkeys + refund); SIG_ALL adds a signature per message variant per signer,
-// so signatures need more headroom than keys. These are work bounds, not the exact NUT-28 rule
-// (still enforced at build).
-const MAX_P2PK_PUBKEYS = 16;
-const MAX_P2PK_SIGNATURES = 64;
 
 export type LockState = 'PERMANENT' | 'ACTIVE' | 'EXPIRED';
 
@@ -830,11 +823,11 @@ function getP2PKWitnessRefundkeys(secret: Secret): string[] {
 }
 
 function getLocktime(secret: Secret): number {
-  const ts = getTagInt(secret, 'locktime');
-  if (ts === undefined || !Number.isFinite(ts) || ts <= 0) {
-    return Infinity;
-  }
-  return ts;
+  // NUT-11: a locktime that is not a valid unix time makes the lock permanent, so a malformed
+  // value is passed through for the mint to judge rather than rejected here. Arity still throws.
+  const v = getTagScalar(secret, 'locktime');
+  const ts = v !== undefined && /^\d+$/.test(v) ? Number(v) : NaN;
+  return Number.isSafeInteger(ts) && ts > 0 ? ts : Infinity;
 }
 
 function deriveLockState(

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -72,3 +72,17 @@ export const U64_MAX = 2n ** 64n - 1n;
  * 90,000; this leaves headroom above that on top of the usual one-allocation-per-input-byte bound.
  */
 export const MAX_CBOR_NODES = 262_144;
+
+/**
+ * NUT-11: Upper bound on the keys in one `pubkeys` or `refund` tag, applied before any per-key
+ * curve work. NUT-28 caps a lock at 11 slots (data + pubkeys + refund), enforced at build; this is
+ * a work bound with headroom, not the exact slot rule.
+ */
+export const MAX_P2PK_PUBKEYS = 16;
+
+/**
+ * NUT-11: Upper bound on untrusted witness size, applied on the verify path so per-signature work
+ * stays bounded rather than scaling with input. SIG_ALL adds a signature per message variant per
+ * signer, so signatures need more headroom than keys ({@link MAX_P2PK_PUBKEYS}).
+ */
+export const MAX_P2PK_SIGNATURES = 64;

--- a/test/crypto/NUT10.test.ts
+++ b/test/crypto/NUT10.test.ts
@@ -103,22 +103,30 @@ describe('NUT10 module core functions', () => {
 
   test('getTagInt finds tags', () => {
     expect(getTagInt(proof.secret, 'locktime')).toEqual(1);
-    expect(getTagInt(proof.secret, 'not_exists')).toBeFalsy();
-    expect(getTagInt(proof.secret, 'sigflag')).toBeFalsy();
+    expect(getTagInt(proof.secret, 'not_exists')).toBeUndefined();
+    expect(() => getTagInt(proof.secret, 'sigflag')).toThrow(/tag "sigflag": must be an integer/);
   });
 
   test('getTagInt rejects non-integer tag values instead of partial-parsing', () => {
     // Number.parseInt would accept these; a spending-condition integer must not
-    // be inferred from a partial or non-decimal value (eg a locktime).
-    for (const bad of ['1700000000abc', '2 of 3', '0x1f', '1e3', '12.5', '  9']) {
+    // be inferred from a partial or non-decimal value (eg a locktime). A present
+    // but unparseable value is an error, not an absent tag.
+    for (const bad of ['1700000000abc', '2 of 3', '0x1f', '1e3', '12.5', '  9', '2 ', 'SIG_ALL']) {
       const secret = createSecret('P2PK', DATA, [['locktime', bad]]);
-      expect(getTagInt(secret, 'locktime')).toBeUndefined();
+      expect(() => getTagInt(secret, 'locktime')).toThrow(/tag "locktime": must be an integer/);
     }
   });
 
   test('getTagInt rejects an integer beyond safe range', () => {
-    const secret = createSecret('P2PK', DATA, [['locktime', '99999999999999999999']]);
-    expect(getTagInt(secret, 'locktime')).toBeUndefined();
+    for (const bad of ['99999999999999999999', '9007199254740992', '-9007199254740992']) {
+      const secret = createSecret('P2PK', DATA, [['locktime', bad]]);
+      expect(() => getTagInt(secret, 'locktime')).toThrow(/tag "locktime": must be an integer/);
+    }
+  });
+
+  test('getTagInt rejects a tag carrying more than one value', () => {
+    const secret = createSecret('P2PK', DATA, [['n_sigs', '1', '2']]);
+    expect(() => getTagInt(secret, 'n_sigs')).toThrow(/tag "n_sigs": must carry a single value/);
   });
 });
 
@@ -297,5 +305,11 @@ describe('NUT10 tag accessors', () => {
 
   test('getTagScalar returns undefined for a missing key', () => {
     expect(getTagScalar(proof.secret, 'not_exists')).toBeUndefined();
+  });
+
+  test('getTagScalar rejects a tag carrying more than one value', () => {
+    expect(() => getTagScalar(proof.secret, 'refund')).toThrow(
+      /tag "refund": must carry a single value/,
+    );
   });
 });

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1716,6 +1716,59 @@ describe('verifyP2PKSpendingConditions — semantic validation', () => {
     );
   });
 
+  test('rejects a malformed n_sigs instead of applying the default threshold', () => {
+    // A present but unparseable threshold must not read as an absent tag.
+    for (const bad of ['2oops', '2 ', '9007199254740992']) {
+      const proof = makeProof(
+        [
+          ['n_sigs', bad],
+          ['pubkeys', pk2],
+        ],
+        PUBKEY,
+      );
+      const signedProof = signP2PKProof(proof, bytesToHex(PRIVKEY));
+      expect(() => verifyP2PKSpendingConditions(signedProof)).toThrow(
+        /tag "n_sigs": must be an integer/,
+      );
+    }
+  });
+
+  test('rejects a malformed n_sigs_refund instead of ignoring it', () => {
+    const badRefund = makeProof([
+      ['locktime', '1'],
+      ['refund', pk2],
+      ['n_sigs_refund', '1.0'],
+    ]);
+    expect(() => verifyP2PKSpendingConditions(badRefund)).toThrow(
+      /tag "n_sigs_refund": must be an integer/,
+    );
+  });
+
+  test('a malformed locktime reads as a permanent lock, not a rejection', () => {
+    // NUT-11: a locktime that is not a valid unix time makes the lock permanent, so the refund
+    // path never opens and only the main key can sign; the mint makes the final call.
+    const proof = makeProof([
+      ['locktime', 'never'],
+      ['refund', pk2],
+    ]);
+    expect(() => verifyP2PKSpendingConditions(proof)).not.toThrow(/must be an integer/);
+    expect(getP2PKExpectedWitnessPubkeys(proof.secret)).toEqual([pk1]);
+  });
+
+  test('rejects a scalar tag carrying more than one value', () => {
+    const nSigs = makeProof([
+      ['n_sigs', '1', '2'],
+      ['pubkeys', pk2],
+    ]);
+    expect(() => verifyP2PKSpendingConditions(nSigs)).toThrow(
+      /tag "n_sigs": must carry a single value/,
+    );
+    const sigflag = makeProof([['sigflag', 'SIG_INPUTS', 'SIG_ALL']]);
+    expect(() => parseP2PKSecret(sigflag.secret)).toThrow(
+      /tag "sigflag": must carry a single value/,
+    );
+  });
+
   test('rejects impossible n_sigs threshold (n_sigs > available keys)', () => {
     // 1 key in data, none in pubkeys, but n_sigs=3
     const proof = makeProof([['n_sigs', '3']]);


### PR DESCRIPTION
# Description
Backport of #1101 to `v4-dev`.