### PR TITLE
fix(nut11): bind SIG_INPUTS signatures to the secret and honour overlapping HTLC refunds

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -5,7 +5,12 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
-import { MAX_P2PK_PUBKEYS, MAX_P2PK_SIGNATURES } from '../utils/limits';
+import {
+  MAX_P2PK_PUBKEYS,
+  MAX_P2PK_SIGNATURES,
+  MAX_SECRET_LENGTH,
+  MAX_WITNESS_LENGTH,
+} from '../utils/limits';
 import { type NUT10Option } from '../wallet/types/payment-requests';
 
 import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
@@ -173,9 +178,16 @@ export function createP2PKsecret(pubkey: string, tags?: string[][]): string {
  * {@link verifyP2PKSpendingConditions} for full semantic validation.
  * @param secret - The Proof secret.
  * @returns Secret object.
- * @throws If the NUT-10 secret is malformed, tags are duplicated, or sigflag is unrecognised.
+ * @throws If the NUT-10 secret is oversized or malformed, tags are duplicated, or sigflag is
+ *   unrecognised.
  */
 export function parseP2PKSecret(secret: string | Secret): Secret {
+  // Bound the parse work up front; the mint caps secrets at this length too.
+  if (typeof secret === 'string' && secret.length > MAX_SECRET_LENGTH) {
+    throw new CTSError(
+      `Secret too long (${secret.length} characters), maximum is ${MAX_SECRET_LENGTH}`,
+    );
+  }
   // HTLC extends P2PK, so we include it in our expected list.
   const parsed = assertSecretKind(['P2PK', 'HTLC'], secret);
   assertNoDuplicateP2PKTags(getTags(parsed));
@@ -462,18 +474,24 @@ export function getP2PKWitnessSignatures(witness: Proof['witness']): string[] {
  *
  * @param witness From Proof.
  * @returns WitnessData object or undefined.
+ * @throws If a serialized witness is oversized.
  * @internal
  */
 export function parseWitnessData(witness: Proof['witness']): WitnessData | undefined {
   if (!witness) return undefined;
+  if (typeof witness === 'string' && witness.length > MAX_WITNESS_LENGTH) {
+    throw new CTSError(
+      `Witness too long (${witness.length} characters), maximum is ${MAX_WITNESS_LENGTH}`,
+    );
+  }
   let parsed: Partial<HTLCWitness & P2PKWitness>;
   try {
     parsed =
       typeof witness === 'string'
         ? (JSON.parse(witness) as Partial<HTLCWitness & P2PKWitness>)
         : witness;
-  } catch (e) {
-    console.error('Failed to parse witness string:', e);
+  } catch {
+    // Unparseable JSON is treated as no witness; the verdict reports the missing signatures.
     return undefined;
   }
   // A parsed primitive (eg "null", "1", "true") is not a witness; treat it as absent.
@@ -542,12 +560,21 @@ export function signP2PKProofs(
  * Will only sign if the proof requires a signature from the key.
  * @param proof - A proof to sign.
  * @param privateKey - A single private key (hex string or Uint8Array).
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param message - Required for SIG_ALL proofs; not accepted for SIG_INPUTS proofs.
  * @returns Signed proofs.
- * @throws Error if signature is not required or proof is already signed.
+ * @throws Error if signature is not required, proof is already signed, a message is missing for a
+ *   SIG_ALL proof, or given for a SIG_INPUTS proof.
  */
 export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: string): Proof {
   const secret: Secret = parseP2PKSecret(proof.secret);
+  // SIG_INPUTS signs the secret and nothing else; only SIG_ALL takes a transaction message.
+  const sigAll = getP2PKSigFlag(secret) === 'SIG_ALL';
+  if (sigAll && message === undefined) {
+    throw new CTSError('Cannot sign a SIG_ALL proof without the message to sign');
+  }
+  if (!sigAll && message !== undefined) {
+    throw new CTSError('A message override is only valid for SIG_ALL proofs');
+  }
   message = message ?? proof.secret; // default message is secret
 
   // Check if the private key is required to sign by checking its
@@ -593,18 +620,19 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
  *
  * @param pubkey - The Cashu P2PK public key (hex-encoded, X-only or with 02/03 prefix).
  * @param proof - A Cashu proof.
- * @param message - Optional. The message that was signed (for SIG_ALL)
+ * @param message - Optional. The message that was signed (SIG_ALL only; ignored otherwise)
  * @returns True if one of the signatures is theirs, false otherwise.
  */
 export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: string): boolean {
   if (!proof.witness) {
     return false;
   }
-  // Check if message is needed
-  if (isP2PKSigAll([proof]) && !message) {
+  // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given message.
+  if (!isP2PKSigAll([proof])) {
+    message = proof.secret;
+  } else if (!message) {
     throw new CTSError('Cannot verify a SIG_ALL proof without the message to sign');
   }
-  message = message ?? proof.secret; // default message is secret
 
   const signatures = getP2PKWitnessSignatures(proof.witness);
   // See if any of the signatures belong to this pubkey. We need to do this
@@ -638,7 +666,7 @@ export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: strin
  * isP2PKSpendAuthorised().
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param message - Optional. The message to sign (SIG_ALL only; ignored otherwise)
  * @returns A P2PKVerificationResult describing the spending outcome.
  * @throws If spending conditions are malformed, or verification is impossible.
  */
@@ -647,14 +675,15 @@ export function verifyP2PKSpendingConditions(
   logger: Logger = NULL_LOGGER,
   message?: string,
 ): P2PKVerificationResult {
-  // Check if message is needed
-  if (isP2PKSigAll([proof]) && !message) {
+  // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given message.
+  if (!isP2PKSigAll([proof])) {
+    message = proof.secret;
+  } else if (!message) {
     logger.error('Cannot verify a SIG_ALL proof without the message to sign');
     throw new CTSError('Cannot verify a SIG_ALL proof without the message to sign');
   }
 
   // Parse once — all tag reads below use the pre-parsed Secret (no re-parsing)
-  message = message ?? proof.secret;
   const secret: Secret = parseP2PKSecret(proof.secret);
 
   // Extract keys and validate cross-tag semantics

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -5,16 +5,11 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type HTLCWitness, type Proof, type ProofLike } from '../model/types';
 
+import { assertSecretKind, createSecret, type Secret, getDataField, getSecretKind } from './NUT10';
 import {
-  assertSecretKind,
-  createSecret,
-  type Secret,
-  getDataField,
-  parseSecret,
-  getSecretKind,
-} from './NUT10';
-import {
+  normalizeHashlock,
   type P2PKVerificationResult,
+  parseP2PKSecret,
   parseWitnessData,
   verifyP2PKSpendingConditions,
 } from './NUT11';
@@ -28,22 +23,23 @@ import {
  *
  * @remarks
  * Use `createHTLCHash()` for hash creation.
- * @param hash - The HTLC hash to add to Secret.data.
+ * @param hash - The HTLC hash to add to Secret.data (64 hex characters, stored lowercase).
  * @param tags - Optional. Additional P2PK tags.
+ * @throws If the hash is not a 64-character hex string.
  */
 export function createHTLCsecret(hash: string, tags?: string[][]): string {
-  return createSecret('HTLC', hash, tags);
+  return createSecret('HTLC', normalizeHashlock(hash), tags);
 }
 
 /**
- * Parse an HTLC Secret and validate NUT-10 shape.
+ * Parse an HTLC Secret and validate NUT-10 shape and NUT-11 tag-level constraints.
  *
  * @param secret - The Proof secret.
  * @returns Secret object.
- * @throws If the JSON is invalid or NUT-10 secret is malformed.
+ * @throws If the secret is oversized or malformed, or is not an HTLC.
  */
 export function parseHTLCSecret(secret: string | Secret): Secret {
-  return assertSecretKind('HTLC', secret);
+  return assertSecretKind('HTLC', parseP2PKSecret(secret));
 }
 
 // ------------------------------
@@ -101,9 +97,9 @@ export function verifyHTLCHash(preimage: string, hash: string): boolean {
  * result, use isP2PKSpendAuthorised().
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param message - Optional. The message to sign (SIG_ALL only; ignored otherwise)
  * @returns A P2PKVerificationResult describing the spending outcome.
- * @throws If verification is impossible.
+ * @throws If the hashlock is malformed or verification is impossible.
  */
 export function verifyHTLCSpendingConditions(
   proof: Proof,
@@ -112,14 +108,16 @@ export function verifyHTLCSpendingConditions(
 ): P2PKVerificationResult {
   // Init
   let result: P2PKVerificationResult;
-  message = message ?? proof.secret; // default message is proof secret
 
-  // Verify the underlying P2PK conditions first. Only the hashlock (receiver)
+  const secret = parseP2PKSecret(proof.secret);
+  const isHTLC = getSecretKind(secret) === 'HTLC';
+  const hash = isHTLC ? getDataField(secret) : '';
+
+  // Verify the underlying P2PK conditions. Only the hashlock (receiver)
   // pathway is HTLC-specific; the refund and unlocked outcomes are plain P2PK
   // verdicts and pass straight through.
-  const secret = parseSecret(proof.secret); // no assert
   const p2pkResult = verifyP2PKSpendingConditions(proof, logger, message);
-  if (getSecretKind(secret) !== 'HTLC') {
+  if (!isHTLC) {
     return p2pkResult; // not an HTLC proof
   }
 
@@ -140,21 +138,28 @@ export function verifyHTLCSpendingConditions(
     return p2pkResult;
   }
 
-  // From here, the spend depends solely on a valid preimage.
+  // From here, the receiver pathway depends solely on a valid preimage.
   const preimage = getHTLCWitnessPreimage(proof.witness);
-  if (!preimage) {
-    result = { ...p2pkResult, success: false, path: 'FAILED' };
-    logger.debug('Hashlock spend failed, no preimage found', { result });
-    return result;
-  }
-
-  // Confirm the preimage hashes to the lock in Secret.data.
-  const hash = getDataField(secret);
-  if (verifyHTLCHash(preimage, hash)) {
+  if (preimage && verifyHTLCHash(preimage, hash)) {
     // Authorised via the receiver pathway. A keyless HTLC carries a FAILED P2PK
     // verdict (no keys to meet a threshold), so stamp the successful MAIN result.
     result = { ...p2pkResult, success: true, path: 'MAIN' };
     logger.debug('Spending condition satisfied via hashlock (receiver) pathway', { result });
+    return result;
+  }
+
+  // P2PK reports MAIN when a key sits on both paths, so an expired refund
+  // threshold met by that same signature is honoured here instead.
+  const { refund } = p2pkResult;
+  if (refund.requiredSigners > 0 && refund.receivedSigners.length >= refund.requiredSigners) {
+    result = { ...p2pkResult, success: true, path: 'REFUND' };
+    logger.debug('Spending condition satisfied via refund pubkeys', { result });
+    return result;
+  }
+
+  if (!preimage) {
+    result = { ...p2pkResult, success: false, path: 'FAILED' };
+    logger.debug('Hashlock spend failed, no preimage found', { result });
     return result;
   }
 
@@ -186,21 +191,10 @@ export function isHTLCSpendAuthorised(
  *
  * @param witness From a Proof.
  * @returns Preimage if present.
+ * @throws If a serialized witness is oversized.
  */
 export function getHTLCWitnessPreimage(witness: Proof['witness']): string | undefined {
-  if (!witness) return undefined;
-  let parsed: Partial<HTLCWitness>;
-  try {
-    parsed = typeof witness === 'string' ? (JSON.parse(witness) as Partial<HTLCWitness>) : witness;
-  } catch (e) {
-    console.error('Failed to parse HTLC witness string:', e);
-    return undefined;
-  }
-  // A parsed primitive (eg "null", "1", "true") is not a witness; treat it as absent.
-  if (!parsed || typeof parsed !== 'object') return undefined;
-  // Check preimage is a non-empty string
-  const preimage = parsed.preimage;
-  return typeof preimage === 'string' && preimage.length > 0 ? preimage : undefined;
+  return parseWitnessData(witness)?.preimage;
 }
 
 /**
@@ -221,7 +215,7 @@ export function attachHTLCPreimage<T extends ProofLike>(proofs: T[], preimage: s
   return proofs.map((proof) => {
     let secret: Secret;
     try {
-      secret = parseSecret(proof.secret);
+      secret = parseP2PKSecret(proof.secret);
     } catch {
       return proof;
     }

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -34,6 +34,7 @@ import {
 } from '../crypto';
 import { deriveReceiverKeyedSecret, type ParsedNutrootOption } from '../crypto/nutroot';
 import { numberToHexPadded64, splitAmount } from '../utils';
+import { MAX_SECRET_LENGTH } from '../utils/limits';
 
 import { Amount, type AmountLike } from './Amount';
 import { BlindedMessage } from './BlindedMessage';
@@ -45,15 +46,6 @@ import {
   type SerializedBlindedSignature,
   type SpendInfo,
 } from './types';
-
-/**
- * Maximum secret length.
- *
- * @remarks
- * Based on the Nutshell default mint_max_secret_length.
- * @internal
- */
-export const MAX_SECRET_LENGTH = 1024;
 
 const RECOVERY_HINT =
   'Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.';

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -65,6 +65,19 @@ export const MAX_METHOD_LENGTH = 255;
 export const MAX_MINT_INFO_LIST = 1_024;
 
 /**
+ * NUT-10: Cap on a serialized secret, applied when creating outputs and before parsing a received
+ * proof's secret. Matches the Nutshell default `mint_max_secret_length`. Creation counts code
+ * points (as the mint does); the parse-side check counts UTF-16 units, which is never fewer.
+ */
+export const MAX_SECRET_LENGTH = 1024;
+
+/**
+ * NUT-11/14: Cap on a serialized witness, checked before parsing. The 64-signature cap on the
+ * verify path keeps a full witness under 9 KiB, so 16 KiB leaves ample headroom.
+ */
+export const MAX_WITNESS_LENGTH = 16_384;
+
+/**
  * Max u64 (2^64 - 1): the ceiling every Amount is held to. Enforced in the Amount constructor, so
  * arithmetic results are bounded too; muldiv helpers keep their wide intermediate in bigint and
  * only construct the divided-down result.
@@ -101,7 +114,9 @@ export const MAX_PAYLOAD_LENGTH = 1_048_576;
 /**
  * NUT-11: Upper bound on the keys in one `pubkeys` or `refund` tag, applied before any per-key
  * curve work. NUT-28 caps a lock at 11 slots (data + pubkeys + refund), enforced at build; this is
- * a work bound with headroom, not the exact slot rule.
+ * a work bound with headroom, not the exact slot rule. A string secret past
+ * {@link MAX_SECRET_LENGTH} is rejected before it is parsed, so this only gates a pre-parsed
+ * secret.
  */
 export const MAX_P2PK_PUBKEYS = 16;
 

--- a/src/wallet/LockBuilder.ts
+++ b/src/wallet/LockBuilder.ts
@@ -8,7 +8,7 @@ import {
 } from '../crypto';
 import { serializeNutrootLeaf, type NutrootLeaf } from '../crypto/nutroot';
 import { CTSError } from '../model/Errors';
-import { MAX_SECRET_LENGTH } from '../model/OutputData';
+import { MAX_SECRET_LENGTH } from '../utils/limits';
 
 import { lockToNutrootOptions, lockToP2PKOptions, type LockOptions } from './lock';
 

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -67,6 +67,50 @@ describe('test create p2pk secret', () => {
     expect(verify).toBe(true);
   });
 
+  test('rejects an oversized serialized secret before parsing it', () => {
+    const padding = 'a'.repeat(2048);
+    const oversized = `["P2PK",{"nonce":"a","data":"${PUBKEY}","tags":[["padding","${padding}"]]}]`;
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    try {
+      expect(() => parseP2PKSecret(oversized)).toThrow(/Secret too long/);
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  test('rejects an oversized serialized witness before parsing it', () => {
+    const oversized = `{"padding":"${'a'.repeat(65_536)}","signatures":[]}`;
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    try {
+      expect(() => getP2PKWitnessSignatures(oversized)).toThrow(/Witness too long/);
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  test('SIG_INPUTS signatures are always checked against the proof secret', () => {
+    const secret = createP2PKsecret(PUBKEY);
+    const other = 'some other message';
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret,
+      witness: { signatures: [schnorrSignMessage(other, bytesToHex(PRIVKEY))] },
+    };
+    // A signature over anything but the secret never authorises a SIG_INPUTS spend,
+    // whatever message the caller passes along.
+    expect(isP2PKSpendAuthorised(proof)).toBe(false);
+    expect(isP2PKSpendAuthorised(proof, NULL_LOGGER, other)).toBe(false);
+    expect(hasP2PKSignedProof(PUBKEY, proof, other)).toBe(false);
+    // ...and a signature over the secret still verifies when a message is passed.
+    const signed = signP2PKProof({ ...proof, witness: undefined }, bytesToHex(PRIVKEY));
+    expect(isP2PKSpendAuthorised(signed, NULL_LOGGER, other)).toBe(true);
+    expect(hasP2PKSignedProof(PUBKEY, signed, other)).toBe(true);
+  });
+
   test('non-array witness signatures verify as false, not a thrown TypeError', () => {
     const proof: Proof = {
       amount: Amount.from(1),
@@ -122,18 +166,23 @@ describe('test create p2pk secret', () => {
   });
 
   test('a secret with too many pubkeys is rejected before per-key work', () => {
-    const tag = Array.from({ length: 65 }, () => `"${PUBKEY}"`).join(',');
+    const keys = Array.from({ length: 65 }, () => PUBKEY);
+    const tag = keys.map((k) => `"${k}"`).join(',');
     const proof: Proof = {
       amount: Amount.from(1),
       C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       id: '00000000000',
       secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}","tags":[["pubkeys",${tag}]]}]`,
     };
-    expect(() => verifyP2PKSpendingConditions(proof)).toThrow(/Too many pubkeys/);
+    // As a string the secret trips the length cap first; a pre-parsed Secret reaches the key cap.
+    expect(() => verifyP2PKSpendingConditions(proof)).toThrow(/Secret too long/);
+    const secret: Secret = ['P2PK', { nonce: 'a', data: PUBKEY, tags: [['pubkeys', ...keys]] }];
+    expect(() => getP2PKExpectedWitnessPubkeys(secret)).toThrow(/Too many pubkeys/);
   });
 
   test('a secret with too many refund pubkeys is rejected before per-key work', () => {
-    const tag = Array.from({ length: 65 }, () => `"${PUBKEY}"`).join(',');
+    const keys = Array.from({ length: 65 }, () => PUBKEY);
+    const tag = keys.map((k) => `"${k}"`).join(',');
     const proof: Proof = {
       amount: Amount.from(1),
       C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
@@ -141,7 +190,19 @@ describe('test create p2pk secret', () => {
       // A normal main key passes its cap; the oversized refund tag trips the refund cap.
       secret: `["P2PK",{"nonce":"a","data":"${PUBKEY}","tags":[["refund",${tag}]]}]`,
     };
-    expect(() => verifyP2PKSpendingConditions(proof)).toThrow(/Too many refund pubkeys/);
+    expect(() => verifyP2PKSpendingConditions(proof)).toThrow(/Secret too long/);
+    const secret: Secret = [
+      'P2PK',
+      {
+        nonce: 'a',
+        data: PUBKEY,
+        tags: [
+          ['locktime', '1'],
+          ['refund', ...keys],
+        ],
+      },
+    ];
+    expect(() => getP2PKExpectedWitnessPubkeys(secret)).toThrow(/Too many refund pubkeys/);
   });
 
   test('sign and verify proofs', async () => {
@@ -541,6 +602,36 @@ describe('test signP2PKProof', () => {
       `Signature not required from [02|03]${PUBKEY2.slice(2)}`,
     );
   });
+  test('refuses a message override on a SIG_INPUTS proof', () => {
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret: createP2PKsecret(PUBKEY),
+    };
+    // SIG_INPUTS signs the secret and nothing else.
+    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY), 'other message')).toThrow(/SIG_ALL/);
+    // The batch signer logs and leaves the proof unsigned rather than throwing.
+    const logger: Logger = { ...NULL_LOGGER, warn: vi.fn() };
+    const [unsigned] = signP2PKProofs([proof], bytesToHex(PRIVKEY), logger, 'other message');
+    expect(unsigned.witness).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/SIG_ALL/));
+  });
+  test('refuses to sign a SIG_ALL proof without the message to sign', () => {
+    const proof: Proof = {
+      amount: Amount.from(1),
+      C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      id: '00000000000',
+      secret: createP2PKsecret(PUBKEY, [['sigflag', 'SIG_ALL']]),
+    };
+    // A SIG_ALL witness must sign the transaction message, never the bare secret.
+    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY))).toThrow(/message to sign/);
+    // The batch signer logs and leaves the proof unsigned rather than throwing.
+    const logger: Logger = { ...NULL_LOGGER, warn: vi.fn() };
+    const [unsigned] = signP2PKProofs([proof], bytesToHex(PRIVKEY), logger);
+    expect(unsigned.witness).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/message to sign/));
+  });
   test('sign with 02-prepended Nostr key', async () => {
     const PRIVKEY2 = '622320785910d6aac0d5406ce1b6ef1640ab97c2acdea6a246eb6859decd6230'; // produces an Odd Y-parity pubkey
     const PUBKEY2 = '02' + bytesToHex(schnorr.getPublicKey(hexToBytes(PRIVKEY2))); // Prepended x-only pubkey
@@ -568,16 +659,11 @@ describe('test getP2PKWitnessSignatures', () => {
     const result = getP2PKWitnessSignatures(witness);
     expect(result).toStrictEqual([]);
   });
-  test('malformed witness', async () => {
-    // Spy on console.error and mock its implementation to do nothing
+  test('malformed witness is treated as absent without console output', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const witness = 'malformed';
-    const result = getP2PKWitnessSignatures(witness);
+    const result = getP2PKWitnessSignatures('malformed');
     expect(result).toStrictEqual([]);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Failed to parse witness string:',
-      expect.any(Error),
-    ); // Verify console.error was called
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
   test('string witness', async () => {
     const witness =

--- a/test/crypto/NUT14.test.ts
+++ b/test/crypto/NUT14.test.ts
@@ -34,8 +34,19 @@ const makeLogger = (): Logger => ({
 
 describe('NUT14 module core functions', () => {
   test('createHTLCsecret creates a valid secret', () => {
-    const result = createHTLCsecret('deadbeef');
+    const { hash } = createHTLCHash();
+    const result = createHTLCsecret(hash);
     expect(result).toContain('HTLC');
+    expect(parseHTLCSecret(result)[1].data).toBe(hash);
+  });
+
+  test('createHTLCsecret lowercases the hashlock', () => {
+    const { hash } = createHTLCHash();
+    expect(parseHTLCSecret(createHTLCsecret(hash.toUpperCase()))[1].data).toBe(hash);
+  });
+
+  test('createHTLCsecret rejects a hashlock that is not 64 hex characters', () => {
+    expect(() => createHTLCsecret('deadbeef')).toThrow(/64-character hex/);
   });
 
   test('parseHTLCSecret throws for non-HTLC type', () => {
@@ -133,6 +144,38 @@ describe('verifyHTLCSpendingConditions and isHTLCSpendAuthorised', () => {
     };
     const signedProof = signP2PKProof(proof, bytesToHex(PRIVKEY));
     expect(isHTLCSpendAuthorised(signedProof)).toBe(false);
+  });
+  test('a malformed hashlock is judged by its pathways, as the mint does', () => {
+    // The hash shape is enforced on creation only. On verify a garbage hash simply never matches
+    // a preimage, while the other pathways are judged as the mint judges them: an expired keyless
+    // HTLC is anyone-can-spend without the hash ever being inspected.
+    const proof: Proof = {
+      amount: Amount.from(2),
+      id: '00bfa73302d12ffd',
+      secret: '["HTLC",{"nonce":"n","data":"deadbeef","tags":[["locktime","1"]]}]',
+      C: '03ff6567e2e6c31db5cb7189dab2b5121930086791c93899e4eff3dda61cb57273',
+    };
+    const result = verifyHTLCSpendingConditions(proof);
+    expect(result.success).toBe(true);
+    expect(result.path).toBe('UNLOCKED');
+    const locked: Proof = {
+      ...proof,
+      secret: '["HTLC",{"nonce":"n","data":"deadbeef","tags":[]}]',
+      witness: JSON.stringify({ preimage: 'ab'.repeat(32) }),
+    };
+    expect(isHTLCSpendAuthorised(locked)).toBe(false);
+  });
+  test('a SIG_ALL HTLC cannot be verified without the message', () => {
+    const proof: Proof = {
+      amount: Amount.from(2),
+      id: '00bfa73302d12ffd',
+      secret: createHTLCsecret(createHTLCHash().hash, [
+        ['pubkeys', PUBKEY],
+        ['sigflag', 'SIG_ALL'],
+      ]),
+      C: '03ff6567e2e6c31db5cb7189dab2b5121930086791c93899e4eff3dda61cb57273',
+    };
+    expect(() => verifyHTLCSpendingConditions(proof)).toThrow(/SIG_ALL/);
   });
 });
 
@@ -255,11 +298,25 @@ describe('getHTLCWitnessPreimage', () => {
     expect(getHTLCWitnessPreimage(JSON.stringify({ preimage: '' }))).toBeUndefined();
   });
 
-  test('returns undefined and logs error when JSON parse fails', () => {
+  test('returns undefined without console output when JSON parse fails', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(getHTLCWitnessPreimage('{invalid')).toBeUndefined();
-    expect(spy).toHaveBeenCalledWith('Failed to parse HTLC witness string:', expect.anything());
-    spy.mockRestore();
+    try {
+      expect(getHTLCWitnessPreimage('{invalid')).toBeUndefined();
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('rejects an oversized serialized witness before parsing it', () => {
+    const witness = `{"padding":"${'a'.repeat(65_536)}"}`;
+    const parseSpy = vi.spyOn(JSON, 'parse');
+    try {
+      expect(() => getHTLCWitnessPreimage(witness)).toThrow(/Witness too long/);
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
   });
 
   test('returns undefined for a parsed primitive witness (no throw)', () => {
@@ -273,6 +330,7 @@ describe('getHTLCWitnessPreimage', () => {
 
 describe('HTLC refund (sender) pathway', () => {
   const HASH = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+  const PREIMAGE = '0000000000000000000000000000000000000000000000000000000000000001';
 
   const keyedRefundProof = (): Proof => ({
     amount: Amount.from(2),
@@ -299,6 +357,38 @@ describe('HTLC refund (sender) pathway', () => {
   test('unsigned refund proof does not spend', () => {
     // No refund signature and no preimage: nothing authorises the spend.
     expect(isHTLCSpendAuthorised(keyedRefundProof())).toBe(false);
+  });
+
+  describe('a key present in both pubkeys and refund', () => {
+    const overlapProof = (): Proof => ({
+      ...keyedRefundProof(),
+      secret: createHTLCsecret(HASH, [
+        ['pubkeys', PUBKEY],
+        ['locktime', '1'],
+        ['refund', PUBKEY],
+      ]),
+    });
+
+    test('refunds after expiry without a preimage', () => {
+      // NUT-11 allows the same key on both paths; once expired its signature
+      // satisfies the refund threshold on its own.
+      const [signed] = signP2PKProofs([overlapProof()], [bytesToHex(PRIVKEY)]);
+      const result = verifyHTLCSpendingConditions(signed);
+      expect(result.success).toBe(true);
+      expect(result.path).toBe('REFUND');
+    });
+
+    test('still needs a signature to refund', () => {
+      const result = verifyHTLCSpendingConditions(overlapProof());
+      expect(result.success).toBe(false);
+      expect(result.path).toBe('FAILED');
+    });
+
+    test('a signature plus the preimage takes the receiver pathway', () => {
+      const [signed] = signP2PKProofs([overlapProof()], [bytesToHex(PRIVKEY)]);
+      const [stamped] = attachHTLCPreimage([signed], PREIMAGE);
+      expect(verifyHTLCSpendingConditions(stamped).path).toBe('MAIN');
+    });
   });
 });
 

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -16,9 +16,10 @@ import {
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 import { Amount } from '../../src/model/Amount';
 import { CTSError } from '../../src/model/Errors';
-import { MAX_SECRET_LENGTH, OutputData } from '../../src/model/OutputData';
+import { OutputData } from '../../src/model/OutputData';
 import type { HasKeysetKeys, SerializedBlindedSignature } from '../../src/model/types';
 import { deriveKeysetId, numberToHexPadded64 } from '../../src/utils';
+import { MAX_SECRET_LENGTH } from '../../src/utils/limits';
 
 // secp256k1 (v0/v1) round-trip through OutputData -> simulated mint sign+DLEQ -> toProof.
 // The mint side is simulated with createBlindSignature/createDLEQProof: the curve math matches a


### PR DESCRIPTION
A SIG_INPUTS signature is now always made and checked over the proof secret, an HTLC whose sender key is also a receiver key can be refunded after expiry, and P2PK/HTLC secrets and witnesses are size-bounded before they are parsed.

## Why

`signP2PKProof` accepted a `message` override for a SIG_INPUTS proof and the verifiers used one when given, so signer and verifier could disagree on what a signature covers. [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md) fixes the message as `Proof.secret` unless the sigflag says otherwise. Separately, an HTLC with the same key in `pubkeys` and `refund` reported `MAIN` from the P2PK verdict, so its refund path was never reached; cdk selects the refund path whenever the preimage check fails.

## Changes

Signing is symmetric: a message on SIG_INPUTS throws, a missing one on SIG_ALL throws. Verification derives the message from the sigflag. `verifyHTLCSpendingConditions` lost a `message ?? secret` default that had let a SIG_ALL HTLC verify with no message.

`createHTLCsecret` validates and lowercases the hashlock. Verification deliberately does not shape-check it: the reference mints authorise the expiry path without inspecting `Secret.data`, so the wallet's verdict now matches theirs, and a garbage hash simply never matches a preimage.

`MAX_SECRET_LENGTH` moves to `utils/limits.ts` and applies before parsing; `MAX_WITNESS_LENGTH` (16,384) bounds witnesses. A maximal 11-slot lock is 968 characters, a 64-signature witness plus preimage 8,478. Malformed witness JSON reads as no witness, without a `console.error`.

## Impact

`signP2PKProof` throws on the two mismatched sigflag/message shapes; `signP2PKProofs` warns and skips instead. `attachHTLCPreimage` throws on an oversized existing witness. No API surface change.
