### PR TITLE
fix(nut11): validate a SIG_ALL signing package before signing it [backport v4-dev]

### DIFF
--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -422,6 +422,28 @@ export function signP2PKProofs(
 }
 
 /**
+ * Asserts the lock currently expects a signature from `privateKey`.
+ *
+ * @remarks
+ * Compared x-only, since Schnorr verification ignores parity. Nostr pubkeys prepend 02 by
+ * convention, ignoring actual Y-parity.
+ * @param secretStr - The NUT-11 P2PK secret.
+ * @param privateKey - A single private key (hex string or Uint8Array).
+ * @returns The signer's x-only pubkey.
+ * @throws If the secret is malformed or does not name the key.
+ * @internal
+ */
+export function assertSignerAuthorised(secretStr: string | Secret, privateKey: PrivKey): string {
+  const privKeyBytes = typeof privateKey === 'string' ? hexToBytes(privateKey) : privateKey;
+  const pubkey = bytesToHex(schnorr.getPublicKey(privKeyBytes)); // x-only
+  const witnesses = getP2PKExpectedWitnessPubkeys(secretStr);
+  if (!witnesses.some((w) => w.slice(2) === pubkey)) {
+    throw new CTSError(`Signature not required from [02|03]${pubkey}`);
+  }
+  return pubkey;
+}
+
+/**
  * Signs a single proof with the provided private key if required.
  *
  * @remarks
@@ -445,15 +467,7 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
   }
   message = message ?? proof.secret; // default message is secret
 
-  // Check if the private key is required to sign by checking its
-  // X-only pubkey (no 02/03 prefix) against the expected witness pubkeys
-  // NB: Nostr pubkeys prepend 02 by convention, ignoring actual Y-parity
-  const privKeyBytes = typeof privateKey === 'string' ? hexToBytes(privateKey) : privateKey;
-  const pubkey = bytesToHex(schnorr.getPublicKey(privKeyBytes)); // x-only
-  const witnesses = getP2PKExpectedWitnessPubkeys(secret);
-  if (!witnesses.length || !witnesses.some((w) => w.includes(pubkey))) {
-    throw new CTSError(`Signature not required from [02|03]${pubkey}`);
-  }
+  const pubkey = assertSignerAuthorised(secret, privateKey);
 
   // Check if the public key has already signed
   const signatures = getP2PKWitnessSignatures(proof.witness);
@@ -680,11 +694,11 @@ export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof:
 /**
  * Validates SIG_ALL inputs have matching secrets and tags.
  *
- * @param inputs Array of Proofs.
+ * @param inputs Array of Proofs (only `secret` is required).
  * @throws If proofs are not valid for SIG_ALL.
  * @internal
  */
-export function assertSigAllInputs(inputs: Proof[]): void {
+export function assertSigAllInputs(inputs: Array<Pick<Proof, 'secret'>>): void {
   if (inputs.length === 0) throw new CTSError('No proofs');
   // Check first proof
   const first = parseP2PKSecret(inputs[0].secret);

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -1,8 +1,21 @@
 import { utf8ToBytes } from '@noble/hashes/utils.js';
 
-import { computeMessageDigest, buildP2PKSigAllMessageV0, schnorrSignDigest } from '../crypto';
+import {
+  assertSigAllInputs,
+  assertSignerAuthorised,
+  buildP2PKSigAllMessageV0,
+  computeMessageDigest,
+  pointFromHex,
+  schnorrSignDigest,
+} from '../crypto';
 import { parseWitnessData } from '../crypto/NUT11';
-import { JSONInt, decodeBase64UrlToUint8, encodeUint8ToBase64Url } from '../utils';
+import {
+  JSONInt,
+  MAX_P2PK_SIGNATURES,
+  MAX_SIGNING_PACKAGE_LENGTH,
+  decodeBase64UrlToUint8,
+  encodeUint8ToBase64Url,
+} from '../utils';
 import { decodeUtf8Document } from '../utils/bytes';
 import type { MeltPreview, SwapPreview } from '../wallet/types';
 
@@ -95,6 +108,10 @@ function serializePackage(pkg: SigAllSigningPackage): string {
 function deserializePackage(input: string): SigAllSigningPackage {
   if (!input.startsWith(SIGALL_PREFIX)) {
     throw new CTSError(`Invalid signing package: must start with "${SIGALL_PREFIX}"`);
+  }
+
+  if (input.length - SIGALL_PREFIX.length > MAX_SIGNING_PACKAGE_LENGTH) {
+    throw new CTSError(`Signing package exceeds ${MAX_SIGNING_PACKAGE_LENGTH} characters`);
   }
 
   const base64url = input.slice(SIGALL_PREFIX.length);
@@ -200,7 +217,56 @@ function deserializePackage(input: string): SigAllSigningPackage {
   };
 }
 
+// NUT-04/05 quote ids are UUIDs, and every current mint issues UUIDv7 ids.
+const UUID_QUOTE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PRIVKEY_HEX_RE = /^[0-9a-f]{64}$/i;
+const COMPRESSED_POINT_RE = /^0[23][0-9a-f]{64}$/i;
+
+// pointFromHex also decodes uncompressed points; the transcript carries the compressed form.
+function isCompressedSecpPoint(hex: string): boolean {
+  if (!COMPRESSED_POINT_RE.test(hex)) return false;
+  try {
+    pointFromHex(hex);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Refuses to sign anything but a well-formed SIG_ALL transaction the key is a party to.
+ *
+ * @remarks
+ * C, B_ and the quote are hashed into the transcript, so each must be a real point and the quote a
+ * UUID. The witness is bounded before another signature is added to it.
+ */
+function assertSignable(pkg: SigAllSigningPackage, privkey: string): void {
+  if (!PRIVKEY_HEX_RE.test(privkey)) {
+    throw new CTSError('Private key must be 64 hex characters');
+  }
+  if ((pkg.witness?.signatures.length ?? 0) >= MAX_P2PK_SIGNATURES) {
+    throw new CTSError(`Witness already at the ${MAX_P2PK_SIGNATURES}-signature limit`);
+  }
+  assertSigAllInputs(pkg.inputs);
+  pkg.inputs.forEach((input, i) => {
+    if (!isCompressedSecpPoint(input.C)) {
+      throw new CTSError(`Input ${i}: C must be a compressed secp256k1 point`);
+    }
+  });
+  pkg.outputs.forEach((output, i) => {
+    if (!isCompressedSecpPoint(output.B_)) {
+      throw new CTSError(`Output ${i}: B_ must be a compressed secp256k1 point`);
+    }
+  });
+  if (pkg.quote !== undefined && !UUID_QUOTE_RE.test(pkg.quote)) {
+    throw new CTSError('Melt quote id must be a UUID');
+  }
+  // SIG_ALL inputs share one lock, so the first secret names every expected signer.
+  assertSignerAuthorised(pkg.inputs[0].secret, privkey);
+}
+
 function signPackage(pkg: SigAllSigningPackage, privkey: string): SigAllSigningPackage {
+  assertSignable(pkg, privkey);
   // Sign transcripts recomputed from the package contents; a signer only ever
   // signs what the package shows, never a digest chosen elsewhere.
   const digests = computeDigests(pkg.inputs, pkg.outputs, pkg.quote);
@@ -358,6 +424,11 @@ export type SigAllApi = {
    * @param pkg The signing package (from extract*SigningPackage or another signer)
    * @param privkey Private key to sign with.
    * @returns Package with signatures appended to witness field.
+   * @throws {@link CTSError} If the inputs are not a valid SIG_ALL set, a C or B_ is not a
+   *   compressed point, the melt quote id is not a UUID, the private key is not 64 hex characters,
+   *   the witness is already at its signature limit, or the lock does not currently name the
+   *   signing key. That last case includes an expired lock with no refund keys (nothing to sign)
+   *   and a P2BK lock, whose keys are blinded: derive the blinded key before signing.
    * @experimental
    */
   signPackage: (pkg: SigAllSigningPackage, privkey: string) => SigAllSigningPackage;

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -101,3 +101,9 @@ export const MAX_P2PK_PUBKEYS = 16;
  * signer, so signatures need more headroom than keys ({@link MAX_P2PK_PUBKEYS}).
  */
 export const MAX_P2PK_SIGNATURES = 64;
+
+/**
+ * Cap on a serialized SIG_ALL signing package, checked before it is decoded. 1 MiB admits about
+ * 2,000 plain P2PK inputs, or 700 under a maximal 11-slot lock (data plus ten keys).
+ */
+export const MAX_SIGNING_PACKAGE_LENGTH = 1_048_576;

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -7,6 +7,7 @@ import {
   MeltQuoteState,
   Amount,
   computeMessageDigest,
+  createP2PKsecret,
   CTSError,
   getPubKeyFromPrivKey,
   schnorrVerifyDigest,
@@ -18,18 +19,44 @@ import {
   type SwapPreview,
 } from '../../src';
 import { encodeUint8ToBase64Url } from '../../src/utils/base64';
+import { MAX_SIGNING_PACKAGE_LENGTH } from '../../src/utils/limits';
+
+const dummyPrivkey = '1'.repeat(64);
+const otherPrivkey = '2'.repeat(64);
+
+function pubkeyOf(privkey: string): string {
+  return bytesToHex(getPubKeyFromPrivKey(hexToBytes(privkey)));
+}
+
+const dummyPubkey = pubkeyOf(dummyPrivkey);
+const otherPubkey = pubkeyOf(otherPrivkey);
+// Any valid compressed points will do for C and B_; derive them so they decompress.
+const dummyC = pubkeyOf('3'.repeat(64));
+const dummyB = pubkeyOf('4'.repeat(64));
+
+const sigAllSecret = createP2PKsecret(dummyPubkey, [['sigflag', 'SIG_ALL']]);
+
+function makeMeltPackage(quote: string): SigAllSigningPackage {
+  return {
+    version: 'sigallA',
+    type: 'melt',
+    quote,
+    inputs: [{ secret: sigAllSecret, C: dummyC }],
+    outputs: [dummyBlindedMessage],
+  };
+}
 
 const dummyProof: Proof = {
   id: 'testid',
   amount: Amount.from(32),
-  secret: 'dummysecret',
-  C: '02' + '1'.repeat(64),
+  secret: sigAllSecret,
+  C: dummyC,
 };
 
 const dummyBlindedMessage: SerializedBlindedMessage = {
   amount: Amount.from(32),
   id: 'bm1',
-  B_: 'dummyB',
+  B_: dummyB,
 };
 
 const dummyOutput: OutputDataLike = {
@@ -38,8 +65,6 @@ const dummyOutput: OutputDataLike = {
   secret: new Uint8Array(),
   toProof: () => dummyProof,
 };
-
-const dummyPrivkey = '1'.repeat(64);
 
 function makeSwapPreview() {
   return {
@@ -59,7 +84,7 @@ function makeMeltPreview() {
     inputs: [dummyProof],
     outputData: [dummyOutput],
     quote: {
-      quote: 'dummyquote',
+      quote: '019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d',
       amount: Amount.from(32),
       unit: 'sat',
       state: MeltQuoteState.PENDING,
@@ -90,7 +115,11 @@ function decodeRawJson(input: string): string {
 
 describe('SigAll — computeDigests', () => {
   test('produces hex strings of correct length', () => {
-    const digests = SigAll.computeDigests([dummyProof], [dummyBlindedMessage], 'dummyquote');
+    const digests = SigAll.computeDigests(
+      [dummyProof],
+      [dummyBlindedMessage],
+      '019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d',
+    );
     expect(typeof digests.v0).toBe('string');
     expect(digests.v0.length).toBe(64);
   });
@@ -137,14 +166,14 @@ describe('SigAll — extractMeltPackage', () => {
     const pkg = SigAll.extractMeltPackage(makeMeltPreview());
     expect(pkg.version).toBe('sigallA');
     expect(pkg.type).toBe('melt');
-    expect(pkg.quote).toBe('dummyquote');
+    expect(pkg.quote).toBe('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d');
     expect(pkg.inputs.length).toBe(1);
     expect(pkg.outputs.length).toBe(1);
   });
 
   test('includes quote id', () => {
     const pkg = SigAll.extractMeltPackage(makeMeltPreview());
-    expect(pkg.quote).toBe('dummyquote');
+    expect(pkg.quote).toBe('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d');
   });
 });
 
@@ -174,7 +203,7 @@ describe('SigAll — serializePackage / deserializePackage', () => {
   test('round-trip preserves melt quote', () => {
     const pkg = SigAll.extractMeltPackage(makeMeltPreview());
     const parsed = SigAll.deserializePackage(SigAll.serializePackage(pkg));
-    expect(parsed.quote).toBe('dummyquote');
+    expect(parsed.quote).toBe('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d');
     expect(parsed.type).toBe('melt');
   });
 
@@ -228,6 +257,17 @@ describe('SigAll — serializePackage / deserializePackage', () => {
     expect(() => SigAll.deserializePackage('notasigallstring')).toThrow(
       'must start with "sigallA"',
     );
+  });
+
+  test('rejects an oversized package before decoding it', () => {
+    const oversized = encodeRaw({
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: 'x'.repeat(MAX_SIGNING_PACKAGE_LENGTH), C: dummyC }],
+      outputs: [],
+    });
+    expect(oversized.length).toBeGreaterThan(MAX_SIGNING_PACKAGE_LENGTH);
+    expect(() => SigAll.deserializePackage(oversized)).toThrow(/exceeds/);
   });
 
   test('throws on invalid base64', () => {
@@ -432,6 +472,101 @@ describe('SigAll — signPackage', () => {
     const pkg = SigAll.extractSwapPackage(makeSwapPreview());
     SigAll.signPackage(pkg, dummyPrivkey);
     expect(pkg.witness).toBeUndefined();
+  });
+
+  test('rejects a package with no inputs', () => {
+    const pkg: SigAllSigningPackage = { version: 'sigallA', type: 'swap', inputs: [], outputs: [] };
+    expect(() => SigAll.signPackage(pkg, dummyPrivkey)).toThrow(CTSError);
+  });
+
+  test('rejects an input whose secret is not a NUT-10 P2PK secret', () => {
+    const pkg: SigAllSigningPackage = {
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: 'plain-text-secret', C: '' }],
+      outputs: [],
+    };
+    const received = SigAll.deserializePackage(SigAll.serializePackage(pkg));
+    expect(() => SigAll.signPackage(received, dummyPrivkey)).toThrow(CTSError);
+  });
+
+  test('rejects inputs locked with SIG_INPUTS', () => {
+    const pkg: SigAllSigningPackage = {
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: createP2PKsecret(dummyPubkey), C: dummyC }],
+      outputs: [dummyBlindedMessage],
+    };
+    expect(() => SigAll.signPackage(pkg, dummyPrivkey)).toThrow(/SIG_ALL/);
+  });
+
+  test('rejects an input C that is not a compressed secp256k1 point', () => {
+    const pkg: SigAllSigningPackage = {
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: sigAllSecret, C: '02' + 'c'.repeat(64) }],
+      outputs: [dummyBlindedMessage],
+    };
+    expect(() => SigAll.signPackage(pkg, dummyPrivkey)).toThrow(/Input 0: C/);
+  });
+
+  test('rejects an output B_ that is not a compressed secp256k1 point', () => {
+    const pkg: SigAllSigningPackage = {
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: sigAllSecret, C: dummyC }],
+      outputs: [{ amount: Amount.from(1), id: 'bm1', B_: dummyB + '32' }],
+    };
+    const received = SigAll.deserializePackage(SigAll.serializePackage(pkg));
+    expect(() => SigAll.signPackage(received, dummyPrivkey)).toThrow(/Output 0: B_/);
+  });
+
+  test('signs a melt package with a UUID quote id', () => {
+    const pkg = makeMeltPackage('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d');
+    expect(SigAll.signPackage(pkg, dummyPrivkey).witness!.signatures.length).toBe(1);
+  });
+
+  test('rejects a melt quote id that is not a UUID', () => {
+    // The v0 transcript appends the quote unframed, so only the hyphenated UUID shape is signed.
+    for (const quote of ['12' + dummyB, '1234' + 'ab'.repeat(62), 'melt-quote-x']) {
+      expect(() => SigAll.signPackage(makeMeltPackage(quote), dummyPrivkey)).toThrow(/UUID/);
+    }
+  });
+
+  test('rejects a private key that is not 64 hex characters', () => {
+    const pkg = makeMeltPackage('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d');
+    expect(() => SigAll.signPackage(pkg, 'abc')).toThrow(CTSError);
+    expect(() => SigAll.signPackage(pkg, 'zz'.repeat(32))).toThrow(/64 hex/);
+  });
+
+  test('refuses to add a signature to a witness already at the limit', () => {
+    const pkg = {
+      ...makeMeltPackage('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d'),
+      witness: { signatures: Array.from({ length: 64 }, () => 'ab'.repeat(64)) },
+    };
+    expect(() => SigAll.signPackage(pkg, dummyPrivkey)).toThrow(/signature limit/);
+  });
+
+  test('rejects a key the lock does not name', () => {
+    const pkg = SigAll.extractSwapPackage(makeSwapPreview());
+    expect(() => SigAll.signPackage(pkg, otherPrivkey)).toThrow(/Signature not required/);
+  });
+
+  test('accepts a refund key once the locktime has passed', () => {
+    const refundSecret = createP2PKsecret(dummyPubkey, [
+      ['sigflag', 'SIG_ALL'],
+      ['locktime', '1'],
+      ['refund', otherPubkey],
+    ]);
+    const pkg: SigAllSigningPackage = {
+      version: 'sigallA',
+      type: 'swap',
+      inputs: [{ secret: refundSecret, C: dummyC }],
+      outputs: [dummyBlindedMessage],
+    };
+    const signed = SigAll.signPackage(pkg, otherPrivkey);
+    const digest = SigAll.computeDigests(pkg.inputs, pkg.outputs).v0;
+    expect(schnorrVerifyDigest(signed.witness!.signatures[0], digest, otherPubkey)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Backport of #1106. `SigAll.signPackage` on the LTS line now refuses anything but a well-formed SIG_ALL transaction the signing key is a party to, and a signing package is size-bounded before it is decoded.

## Why

`signPackage` signed a package without checking that it described a SIG_ALL transaction the key was a party to: an arbitrary secret, an empty `C`, no outputs or a lock that did not name the key all went through. Every rejection added here applies to malformed input only, so no legitimate caller changes behaviour.

## Changes

Ported by hand rather than by the backport bot. v4 has no `MAX_PAYLOAD_LENGTH` (deliberately, see #887), so the package cap is its own `MAX_SIGNING_PACKAGE_LENGTH` in `utils/limits.ts`. v4 has no BLS keysets or shared point validators, so `C` and `B_` go through one file-private compressed-secp256k1 check; the three v3-output tests from #1106 are not applicable and were dropped. The NUT-11 half (shared `assertSignerAuthorised` helper, `assertSigAllInputs` accepting `Pick<Proof, 'secret'>[]`) applied as-is.

A melt package is only signed when its quote id is a UUID, the shape [NUT-05](https://github.com/cashubtc/nuts/blob/main/05.md) specifies and every current mint issues (nutshell since 0.20.2, cdk since 0.17.0).

## Impact

`signPackage` throws a `CTSError` on each shape above, including an expired lock with no refund keys and a P2BK lock unless the blinded key is derived first; the TSDoc lists them. No API surface change.
