### PR TITLE
refactor(crypto): sign and verify P2PK over a digest

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -750,7 +750,7 @@ export function getTagScalar(secret: Secret | string, key: string): string | und
 export function getTokenMetadata(token: string): TokenMetadata;
 
 // @public
-export function getValidSigners(signatures: string[], message: string, pubkeys: string[]): string[];
+export function getValidSigners(signatures: string[], digest: DigestInput, pubkeys: string[]): string[];
 
 // @public
 export function hasCorrespondingKey(amount: AmountLike, keyset: Keys): boolean;
@@ -779,7 +779,7 @@ export type HasKeysetKeys = {
 };
 
 // @public
-export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: string): boolean;
+export function hasP2PKSignedProof(pubkey: string, proof: Proof, digest?: DigestInput): boolean;
 
 // @public
 export function hasTag(secret: Secret | string, key: string): boolean;
@@ -827,13 +827,13 @@ export function isBlsKeyset(keysetId: string): boolean;
 export function isBlsProof(proof: Pick<Proof, 'id'>): boolean;
 
 // @public
-export function isHTLCSpendAuthorised(proof: Proof, logger?: Logger, message?: string): boolean;
+export function isHTLCSpendAuthorised(proof: Proof, logger?: Logger, digest?: DigestInput): boolean;
 
 // @public
 export function isMintOperationError(e: unknown): e is MintOperationError;
 
 // @public
-export function isP2PKSpendAuthorised(proof: Proof, logger?: Logger, message?: string): boolean;
+export function isP2PKSpendAuthorised(proof: Proof, logger?: Logger, digest?: DigestInput): boolean;
 
 // @public
 export function isV3PointSecret(secret: string): boolean;
@@ -1012,7 +1012,7 @@ export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
 export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof: Proof): string[];
 
 // @public
-export const meetsSignerThreshold: (signatures: string[], message: string, pubkeys: string[], threshold?: number) => boolean;
+export const meetsSignerThreshold: (signatures: string[], digest: DigestInput, pubkeys: string[], threshold?: number) => boolean;
 
 // @public
 export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'> = MeltQuoteBolt11Response> {
@@ -2506,10 +2506,10 @@ export const SigFlags: {
 export function signMintQuote(privkey: string, quote: string, blindedMessages: SerializedBlindedMessage[]): string;
 
 // @public
-export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: string): Proof;
+export function signP2PKProof(proof: Proof, privateKey: PrivKey, digest?: DigestInput): Proof;
 
 // @public
-export function signP2PKProofs(proofs: Proof[], privateKey: PrivKey | PrivKey[], logger?: Logger, message?: string): Proof[];
+export function signP2PKProofs(proofs: Proof[], privateKey: PrivKey | PrivKey[], logger?: Logger, digest?: DigestInput): Proof[];
 
 // @public
 export function sortProofsById(proofs: Proof[]): Proof[];
@@ -2720,13 +2720,13 @@ A: WeierstrassPoint<bigint>) => boolean;
 export function verifyHTLCHash(preimage: string, hash: string): boolean;
 
 // @public
-export function verifyHTLCSpendingConditions(proof: Proof, logger?: Logger, message?: string): P2PKVerificationResult;
+export function verifyHTLCSpendingConditions(proof: Proof, logger?: Logger, digest?: DigestInput): P2PKVerificationResult;
 
 // @public (undocumented)
 export function verifyMintQuoteSignature(pubkey: string, quote: string, blindedMessages: SerializedBlindedMessage[], signature: string): boolean;
 
 // @public
-export function verifyP2PKSpendingConditions(proof: Proof, logger?: Logger, message?: string): P2PKVerificationResult;
+export function verifyP2PKSpendingConditions(proof: Proof, logger?: Logger, digest?: DigestInput): P2PKVerificationResult;
 
 // @public
 export function verifyProofsForReceive(proofs: ProofLike[], getKeyset: (id: string) => HasKeysetKeys, opts?: {

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -260,6 +260,28 @@ If you were relying on a symbol that is not exported by the package entry point 
 
 ---
 
+## P2PK and HTLC signing functions take a digest, not a message string
+
+`signP2PKProofs`, `signP2PKProof`, `hasP2PKSignedProof`, `verifyP2PKSpendingConditions`, `isP2PKSpendAuthorised`, `verifyHTLCSpendingConditions`, `isHTLCSpendAuthorised`, `getValidSigners` and `meetsSignerThreshold` now take the 32-byte digest that is signed (`DigestInput`, hex or bytes) where they previously took a message string.
+
+SIG_INPUTS callers are unaffected: with no digest the functions still hash the proof secret. SIG_ALL callers hash the aggregated message themselves. Every SIG_ALL format ends in a 32-byte BIP-340 input, and the framed NUT-11 format signs a tagged hash rather than a plain SHA-256, so message construction now lives in the format helper and the signing functions only see the digest, as `signMintQuote` already does.
+
+### Migration
+
+```ts
+// Before
+const message = buildP2PKSigAllMessageV0(inputs, outputs, quoteId);
+signP2PKProofs(proofs, privkey, logger, message);
+isP2PKSpendAuthorised(proof, logger, message);
+
+// After
+const digest = computeMessageDigest(buildP2PKSigAllMessageV0(inputs, outputs, quoteId));
+signP2PKProofs(proofs, privkey, logger, digest);
+isP2PKSpendAuthorised(proof, logger, digest);
+```
+
+---
+
 ## `signMintQuote` / `verifyMintQuoteSignature` now use the amended NUT-20 message
 
 These functions now produce and verify the hardened mint-quote signature message introduced by cashubtc/nuts#375. Legacy signing is supported as an internal transitional fallback and is not exported.

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -13,7 +13,14 @@ import {
 } from '../utils/limits';
 import { type NUT10Option } from '../wallet/types/payment-requests';
 
-import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
+import {
+  computeMessageDigest,
+  type DigestInput,
+  getValidSigners,
+  schnorrSignDigest,
+  schnorrVerifyDigest,
+  type PrivKey,
+} from './core';
 import { isV3PointSecret } from './curve_bls';
 import { normalizeSecpPubkey } from './curve_secp';
 import {
@@ -520,7 +527,7 @@ export function parseWitnessData(witness: Proof['witness']): WitnessData | undef
  * @param proofs - An array of proofs to sign.
  * @param privateKey - A single private key or array of private keys (hex string or Uint8Array).
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param digest - Optional. The 32-byte digest to sign (SIG_ALL only).
  * @returns Signed proofs.
  * @throws On general errors.
  */
@@ -528,7 +535,7 @@ export function signP2PKProofs(
   proofs: Proof[],
   privateKey: PrivKey | PrivKey[],
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  digest?: DigestInput,
 ): Proof[] {
   // Convert to hex strings for maybeDeriveP2BKPrivateKeys
   const toHex = (k: PrivKey): string => (typeof k === 'string' ? k : bytesToHex(k));
@@ -541,7 +548,7 @@ export function signP2PKProofs(
     let signedProof = proof;
     for (const priv of privateKeys) {
       try {
-        signedProof = signP2PKProof(signedProof, priv, message);
+        signedProof = signP2PKProof(signedProof, priv, digest);
       } catch (error: unknown) {
         // Log signature failures only - these are not fatal, just informational
         // as not all keys will be needed for some proofs (eg P2BK, NIP60 etc)
@@ -582,29 +589,30 @@ export function assertSignerAuthorised(secretStr: string | Secret, privateKey: P
  * Will only sign if the proof requires a signature from the key.
  * @param proof - A proof to sign.
  * @param privateKey - A single private key (hex string or Uint8Array).
- * @param message - Required for SIG_ALL proofs; not accepted for SIG_INPUTS proofs.
+ * @param digest - The 32-byte digest to sign. Required for SIG_ALL proofs; not accepted for
+ *   SIG_INPUTS proofs, which sign the secret.
  * @returns Signed proofs.
- * @throws Error if signature is not required, proof is already signed, a message is missing for a
+ * @throws Error if signature is not required, proof is already signed, a digest is missing for a
  *   SIG_ALL proof, or given for a SIG_INPUTS proof.
  */
-export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: string): Proof {
+export function signP2PKProof(proof: Proof, privateKey: PrivKey, digest?: DigestInput): Proof {
   const secret: Secret = parseP2PKSecret(proof.secret);
-  // SIG_INPUTS signs the secret and nothing else; only SIG_ALL takes a transaction message.
+  // SIG_INPUTS signs the secret and nothing else; only SIG_ALL takes a transaction digest.
   const sigAll = getP2PKSigFlag(secret) === 'SIG_ALL';
-  if (sigAll && message === undefined) {
-    throw new CTSError('Cannot sign a SIG_ALL proof without the message to sign');
+  if (sigAll && digest === undefined) {
+    throw new CTSError('Cannot sign a SIG_ALL proof without the digest to sign');
   }
-  if (!sigAll && message !== undefined) {
-    throw new CTSError('A message override is only valid for SIG_ALL proofs');
+  if (!sigAll && digest !== undefined) {
+    throw new CTSError('A digest override is only valid for SIG_ALL proofs');
   }
-  message = message ?? proof.secret; // default message is secret
+  digest = digest ?? computeMessageDigest(proof.secret); // SIG_INPUTS signs the secret
 
   const pubkey = assertSignerAuthorised(secret, privateKey);
 
   // Check if the public key has already signed
   const signatures = getP2PKWitnessSignatures(proof.witness);
   const alreadySigned = signatures.some((sig) => {
-    return schnorrVerifyMessage(sig, message, pubkey);
+    return schnorrVerifyDigest(sig, digest, pubkey);
   });
 
   if (alreadySigned) {
@@ -620,7 +628,7 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
   }
 
   // Add new signature
-  const signature = schnorrSignMessage(message, privateKey);
+  const signature = schnorrSignDigest(digest, privateKey);
   const witness = parseWitnessData(proof.witness);
   const newWitness: WitnessData = {
     ...(witness && witness.preimage !== undefined ? { preimage: witness.preimage } : {}),
@@ -634,25 +642,25 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
  *
  * @param pubkey - The Cashu P2PK public key (hex-encoded, X-only or with 02/03 prefix).
  * @param proof - A Cashu proof.
- * @param message - Optional. The message that was signed (SIG_ALL only; ignored otherwise)
+ * @param digest - Optional. The 32-byte digest that was signed (SIG_ALL only; ignored otherwise)
  * @returns True if one of the signatures is theirs, false otherwise.
  */
-export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: string): boolean {
+export function hasP2PKSignedProof(pubkey: string, proof: Proof, digest?: DigestInput): boolean {
   if (!proof.witness) {
     return false;
   }
-  // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given message.
+  // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given digest.
   if (!isP2PKSigAll([proof])) {
-    message = proof.secret;
-  } else if (!message) {
-    throw new CTSError('Cannot verify a SIG_ALL proof without the message to sign');
+    digest = computeMessageDigest(proof.secret);
+  } else if (!digest) {
+    throw new CTSError('Cannot verify a SIG_ALL proof without the digest to sign');
   }
 
   const signatures = getP2PKWitnessSignatures(proof.witness);
   // See if any of the signatures belong to this pubkey. We need to do this
   // as Schnorr signatures are non-deterministic (see: signMessage)
   return signatures.some((sig) => {
-    return schnorrVerifyMessage(sig, message, pubkey);
+    return schnorrVerifyDigest(sig, digest, pubkey);
   });
 }
 
@@ -680,21 +688,21 @@ export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: strin
  * isP2PKSpendAuthorised().
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (SIG_ALL only; ignored otherwise)
+ * @param digest - Optional. The 32-byte digest to verify (SIG_ALL only; ignored otherwise)
  * @returns A P2PKVerificationResult describing the spending outcome.
  * @throws If spending conditions are malformed, or verification is impossible.
  */
 export function verifyP2PKSpendingConditions(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  digest?: DigestInput,
 ): P2PKVerificationResult {
-  // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given message.
+  // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given digest.
   if (!isP2PKSigAll([proof])) {
-    message = proof.secret;
-  } else if (!message) {
-    logger.error('Cannot verify a SIG_ALL proof without the message to sign');
-    throw new CTSError('Cannot verify a SIG_ALL proof without the message to sign');
+    digest = computeMessageDigest(proof.secret);
+  } else if (!digest) {
+    logger.error('Cannot verify a SIG_ALL proof without the digest to sign');
+    throw new CTSError('Cannot verify a SIG_ALL proof without the digest to sign');
   }
 
   // Parse once — all tag reads below use the pre-parsed Secret (no re-parsing)
@@ -721,8 +729,8 @@ export function verifyP2PKSpendingConditions(
   const nSigsRefund = resolveNSigsRefund(secret, lockState, refundKeys);
 
   // Verify signatures against both key sets
-  const mainSigners = getValidSigners(signatures, message, mainKeys);
-  const refundSigners = refundKeys.length ? getValidSigners(signatures, message, refundKeys) : [];
+  const mainSigners = getValidSigners(signatures, digest, mainKeys);
+  const refundSigners = refundKeys.length ? getValidSigners(signatures, digest, refundKeys) : [];
 
   // Build path info (always fully populated)
   const main: P2PKPathInfo = {
@@ -812,16 +820,16 @@ export function p2pkSpendLeaves(secretStr: string | Secret): NutrootLeaf[] {
  *
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param digest - Optional. The 32-byte digest to sign (SIG_ALL only).
  * @returns True if the witness threshold was reached, false otherwise.
  * @throws If verification is impossible.
  */
 export function isP2PKSpendAuthorised(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  digest?: DigestInput,
 ): boolean {
-  return verifyP2PKSpendingConditions(proof, logger, message).success;
+  return verifyP2PKSpendingConditions(proof, logger, digest).success;
 }
 
 // ------------------------------

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -5,6 +5,7 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type HTLCWitness, type Proof, type ProofLike } from '../model/types';
 
+import { type DigestInput } from './core';
 import { assertSecretKind, createSecret, type Secret, getDataField, getSecretKind } from './NUT10';
 import {
   normalizeHashlock,
@@ -97,14 +98,14 @@ export function verifyHTLCHash(preimage: string, hash: string): boolean {
  * result, use isP2PKSpendAuthorised().
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (SIG_ALL only; ignored otherwise)
+ * @param digest - Optional. The 32-byte digest to verify (SIG_ALL only; ignored otherwise)
  * @returns A P2PKVerificationResult describing the spending outcome.
  * @throws If the hashlock is malformed or verification is impossible.
  */
 export function verifyHTLCSpendingConditions(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  digest?: DigestInput,
 ): P2PKVerificationResult {
   // Init
   let result: P2PKVerificationResult;
@@ -116,7 +117,7 @@ export function verifyHTLCSpendingConditions(
   // Verify the underlying P2PK conditions. Only the hashlock (receiver)
   // pathway is HTLC-specific; the refund and unlocked outcomes are plain P2PK
   // verdicts and pass straight through.
-  const p2pkResult = verifyP2PKSpendingConditions(proof, logger, message);
+  const p2pkResult = verifyP2PKSpendingConditions(proof, logger, digest);
   if (!isHTLC) {
     return p2pkResult; // not an HTLC proof
   }
@@ -174,16 +175,16 @@ export function verifyHTLCSpendingConditions(
  *
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param digest - Optional. The 32-byte digest to verify (for SIG_ALL)
  * @returns True if spending conditions are satisfied, false otherwise.
  * @throws If verification is impossible.
  */
 export function isHTLCSpendAuthorised(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  digest?: DigestInput,
 ): boolean {
-  return verifyHTLCSpendingConditions(proof, logger, message).success;
+  return verifyHTLCSpendingConditions(proof, logger, digest).success;
 }
 
 /**

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -216,7 +216,7 @@ export function findSigningKey(pubkey: string, privkeys: string | string[]): str
  * message.
  *
  * @param signatures - The Schnorr signature(s) (hex-encoded).
- * @param message - The message to verify.
+ * @param digest - The 32-byte digest that was signed (hex string or bytes).
  * @param pubkeys - The Cashu P2PK public key(s) (hex-encoded, X-only or with 02/03 prefix) to
  *   check.
  * @returns Array of public keys who validly signed, duplicates removed. The same key in different
@@ -224,7 +224,7 @@ export function findSigningKey(pubkey: string, privkeys: string | string[]): str
  */
 export function getValidSigners(
   signatures: string[],
-  message: string,
+  digest: DigestInput,
   pubkeys: string[],
 ): string[] {
   // Dedupe by x-only identity: BIP-340 ignores the parity prefix, so 02|X, 03|X
@@ -235,7 +235,7 @@ export function getValidSigners(
     if (!uniquePubs.has(xOnly)) uniquePubs.set(xOnly, pubkey);
   }
   return Array.from(uniquePubs.values()).filter((pubkey) =>
-    signatures.some((sig) => schnorrVerifyMessage(sig, message, pubkey)),
+    signatures.some((sig) => schnorrVerifyDigest(sig, digest, pubkey)),
   );
 }
 
@@ -243,7 +243,7 @@ export function getValidSigners(
  * Checks enough unique pubkeys have signed a message.
  *
  * @param signatures - The Schnorr signature(s) (hex-encoded).
- * @param message - The message to verify.
+ * @param digest - The 32-byte digest that was signed (hex string or bytes).
  * @param pubkeys - The Cashu P2PK public key(s) (hex-encoded, X-only or with 02/03 prefix) to
  *   check.
  * @param threshold - The minimum number of unique witnesses required.
@@ -251,10 +251,10 @@ export function getValidSigners(
  */
 export const meetsSignerThreshold = (
   signatures: string[],
-  message: string,
+  digest: DigestInput,
   pubkeys: string[],
   threshold: number = 1,
 ): boolean => {
-  const validSigners = getValidSigners(signatures, message, pubkeys);
+  const validSigners = getValidSigners(signatures, digest, pubkeys);
   return validSigners.length >= threshold;
 };

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -16,6 +16,7 @@ import {
   isBlsKeyset,
   isP2PKSigAll,
   buildP2PKSigAllMessageV0,
+  computeMessageDigest,
   assertSigAllInputs,
   parseSecret,
   attachHTLCPreimage,
@@ -1918,9 +1919,11 @@ class Wallet {
     // supported message format...
     const [first, ...rest] = normalizedProofs;
     let signedFirst = first;
-    const messages = [buildP2PKSigAllMessageV0(normalizedProofs, outputData, quoteId)];
-    for (const msg of messages) {
-      signedFirst = cryptoSignP2PKProofs([signedFirst], privkey, this._logger, msg)[0];
+    const digests = [
+      computeMessageDigest(buildP2PKSigAllMessageV0(normalizedProofs, outputData, quoteId)),
+    ];
+    for (const digest of digests) {
+      signedFirst = cryptoSignP2PKProofs([signedFirst], privkey, this._logger, digest)[0];
     }
 
     // Return the proofs in same order as before

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -2404,6 +2404,20 @@ describe('SIG_ALL edge cases', () => {
     expect(() => hasP2PKSignedProof(PUBKEY, proof)).toThrow(/Cannot verify a SIG_ALL proof/);
   });
 
+  test('hasP2PKSignedProof verifies a SIG_ALL proof against the supplied digest', () => {
+    const proof: Proof = {
+      amount: Amount.from(1),
+      id: '00000000000',
+      C: '03'.padEnd(66, '0'),
+      secret: createP2PKsecret(PUBKEY, [['sigflag', 'SIG_ALL']]),
+    };
+    const digest = computeMessageDigest('sig-all transaction');
+    const signed = signP2PKProof(proof, bytesToHex(PRIVKEY), digest);
+    expect(hasP2PKSignedProof(PUBKEY, signed, digest)).toBe(true);
+    // The witness signs the digest, not the secret, so another digest does not match.
+    expect(hasP2PKSignedProof(PUBKEY, signed, computeMessageDigest('other'))).toBe(false);
+  });
+
   test('hasP2PKSignedProof returns false for a witness-less SIG_ALL proof (no early throw)', () => {
     // The no-witness guard must short-circuit before the SIG_ALL/message check: a SIG_ALL
     // proof with no witness reports "not signed" rather than throwing for a missing message.

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -18,6 +18,9 @@ import {
   createRandomSecretKey,
   hasP2PKSignedProof,
   schnorrSignMessage,
+  computeMessageDigest,
+  schnorrVerifyDigest,
+  schnorrSignDigest,
   schnorrVerifyMessage,
   deriveP2BKBlindedPubkeys,
   P2BK_DST,
@@ -92,13 +95,13 @@ describe('test create p2pk secret', () => {
 
   test('SIG_INPUTS signatures are always checked against the proof secret', () => {
     const secret = createP2PKsecret(PUBKEY);
-    const other = 'some other message';
+    const other = computeMessageDigest('some other message');
     const proof: Proof = {
       amount: Amount.from(1),
       C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
       id: '00000000000',
       secret,
-      witness: { signatures: [schnorrSignMessage(other, bytesToHex(PRIVKEY))] },
+      witness: { signatures: [schnorrSignDigest(other, bytesToHex(PRIVKEY))] },
     };
     // A signature over anything but the secret never authorises a SIG_INPUTS spend,
     // whatever message the caller passes along.
@@ -610,14 +613,15 @@ describe('test signP2PKProof', () => {
       secret: createP2PKsecret(PUBKEY),
     };
     // SIG_INPUTS signs the secret and nothing else.
-    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY), 'other message')).toThrow(/SIG_ALL/);
+    const other = computeMessageDigest('other message');
+    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY), other)).toThrow(/SIG_ALL/);
     // The batch signer logs and leaves the proof unsigned rather than throwing.
     const logger: Logger = { ...NULL_LOGGER, warn: vi.fn() };
-    const [unsigned] = signP2PKProofs([proof], bytesToHex(PRIVKEY), logger, 'other message');
+    const [unsigned] = signP2PKProofs([proof], bytesToHex(PRIVKEY), logger, other);
     expect(unsigned.witness).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/SIG_ALL/));
   });
-  test('refuses to sign a SIG_ALL proof without the message to sign', () => {
+  test('refuses to sign a SIG_ALL proof without the digest to sign', () => {
     const proof: Proof = {
       amount: Amount.from(1),
       C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
@@ -625,12 +629,12 @@ describe('test signP2PKProof', () => {
       secret: createP2PKsecret(PUBKEY, [['sigflag', 'SIG_ALL']]),
     };
     // A SIG_ALL witness must sign the transaction message, never the bare secret.
-    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY))).toThrow(/message to sign/);
+    expect(() => signP2PKProof(proof, bytesToHex(PRIVKEY))).toThrow(/digest to sign/);
     // The batch signer logs and leaves the proof unsigned rather than throwing.
     const logger: Logger = { ...NULL_LOGGER, warn: vi.fn() };
     const [unsigned] = signP2PKProofs([proof], bytesToHex(PRIVKEY), logger);
     expect(unsigned.witness).toBeUndefined();
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/message to sign/));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/digest to sign/));
   });
   test('sign with 02-prepended Nostr key', async () => {
     const PRIVKEY2 = '622320785910d6aac0d5406ce1b6ef1640ab97c2acdea6a246eb6859decd6230'; // produces an Odd Y-parity pubkey
@@ -1208,7 +1212,7 @@ describe('SIG_ALL, the supported message format is actually signed', () => {
     const quoteId = 'quote-xyz';
 
     // 4. Build the SIG_ALL messages the wallet is supposed to sign
-    const messages = [buildP2PKSigAllMessageV0(proofs, outputs, quoteId)];
+    const messages = [computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs, quoteId))];
 
     // 5. Mimic the wallet SIG_ALL path: start from the first proof, then sign it
     //    once per message, threading the witness through on each call.
@@ -1226,7 +1230,7 @@ describe('SIG_ALL, the supported message format is actually signed', () => {
     // 6. For each message variant, there must be at least one signature that verifies
     //    against that specific message and this pubkey.
     for (const msg of messages) {
-      const hasValid = sigs.some((sig) => schnorrVerifyMessage(sig, msg, pubCompressed));
+      const hasValid = sigs.some((sig) => schnorrVerifyDigest(sig, msg, pubCompressed));
       expect(hasValid).toBe(true);
     }
 
@@ -1383,7 +1387,7 @@ describe('NUT-11 test vectors', () => {
       '038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39',
     );
     expect(() => assertSigAllInputs([proof])).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0([proof], [outputs]);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0([proof], [outputs]));
     expect(isP2PKSpendAuthorised(proof, NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1413,7 +1417,7 @@ describe('NUT-11 test vectors', () => {
     ];
     // The assert catches the error. The signature would otherwise be valid
     expect(() => assertSigAllInputs(proofs)).toThrow(/must share identical Secret\.tags/);
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs));
     expect(isP2PKSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1434,7 +1438,7 @@ describe('NUT-11 test vectors', () => {
     ];
     // The assert catches the error. The signature would otherwise be valid
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs));
     expect(isP2PKSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1454,7 +1458,7 @@ describe('NUT-11 test vectors', () => {
       mkOutput(2, '038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39'),
     ];
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs));
     expect(isP2PKSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1474,7 +1478,7 @@ describe('NUT-11 test vectors', () => {
       mkOutput(2, '038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39'),
     ];
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs));
     expect(isHTLCSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1495,7 +1499,7 @@ describe('NUT-11 test vectors', () => {
       mkOutput(1, '03afe7c87e32d436f0957f1d70a2bca025822a84a8623e3a33aed0a167016e0ca5'),
     ];
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs));
     expect(isHTLCSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(false);
   });
 
@@ -1515,7 +1519,7 @@ describe('NUT-11 test vectors', () => {
       mkOutput(2, '038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39'),
     ];
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs));
     expect(isHTLCSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1561,7 +1565,7 @@ describe('NUT-11 test vectors', () => {
     ];
     const quote = 'cF8911fzT88aEi1d-6boZZkq5lYxbUSVs-HbJxK0';
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs, quote);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs, quote));
     expect(isHTLCSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 
@@ -1582,7 +1586,7 @@ describe('NUT-11 test vectors', () => {
     ];
     const quote = 'Db3qEMVwFN2tf_1JxbZp29aL5cVXpSMIwpYfyOVF';
     expect(() => assertSigAllInputs(proofs)).not.toThrow();
-    const mts = buildP2PKSigAllMessageV0(proofs, outputs, quote);
+    const mts = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs, quote));
     expect(isHTLCSpendAuthorised(proofs[0], NULL_LOGGER, mts)).toBe(true);
   });
 });

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -25,7 +25,6 @@ import {
   meetsSignerThreshold,
   pointFromBytes,
   schnorrSignDigest,
-  schnorrSignMessage,
   schnorrVerifyDigest,
   schnorrVerifyMessage,
   sha256 as sha256Export,
@@ -284,8 +283,8 @@ describe('getValidSigners / meetsSignerThreshold', () => {
   const privkey = '0000000000000000000000000000000000000000000000000000000000000001';
   const compressed = bytesToHex(secp256k1.getPublicKey(hexToBytes(privkey), true)); // 02-prefixed
   const xOnly = compressed.slice(2);
-  const message = 'authorize-spend';
-  const signature = schnorrSignMessage(message, privkey);
+  const message = computeMessageDigest('authorize-spend');
+  const signature = schnorrSignDigest(message, privkey);
 
   test('one key listed under multiple encodings counts as a single signer', () => {
     const signers = getValidSigners([signature], message, [

--- a/test/wallet/wallet-p2pk.node.test.ts
+++ b/test/wallet/wallet-p2pk.node.test.ts
@@ -2,7 +2,12 @@ import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { test, describe, expect } from 'vitest';
 
-import { Wallet, OutputData } from '../../src';
+import { Amount, Wallet, OutputData, type OutputDataLike, type Proof } from '../../src';
+import {
+  buildP2PKSigAllMessageV0,
+  computeMessageDigest,
+  hasP2PKSignedProof,
+} from '../../src/crypto';
 
 import { mint, useTestServer } from './_setup';
 
@@ -241,5 +246,36 @@ describe('P2PK BlindingData', () => {
       expect(s[1].tags).toContainEqual(['n_sigs', '2']);
       expect(s[1].tags).not.toContainEqual(['n_sigs_refund', '1']); // 1 is default
     });
+  });
+});
+
+describe('Wallet.signP2PKProofs with SIG_ALL', () => {
+  const privkey = bytesToHex(new Uint8Array(32).fill(1));
+  const mkProof = (nonce: string): Proof => ({
+    amount: Amount.from(8),
+    id: '009a1f293253e41e',
+    secret: `["P2PK",{"nonce":"${nonce}","data":"${PK1}","tags":[["sigflag","SIG_ALL"]]}]`,
+    C: PK2,
+  });
+  const outputs = [
+    { blindedMessage: { amount: Amount.from(8), id: '009a1f293253e41e', B_: PK3 } },
+  ] as unknown as OutputDataLike[];
+
+  test('signs the first proof over the aggregated transaction digest', () => {
+    const wallet = new Wallet(mint);
+    const proofs = [mkProof('01'), mkProof('02')];
+    const signed = wallet.signP2PKProofs(proofs, privkey, outputs, 'quote-1');
+
+    const digest = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs, 'quote-1'));
+    expect(hasP2PKSignedProof(PK1, signed[0], digest)).toBe(true);
+    // Only the first input carries the witness; the digest binds the quote id.
+    expect(signed[1].witness).toBeUndefined();
+    const other = computeMessageDigest(buildP2PKSigAllMessageV0(proofs, outputs, 'quote-2'));
+    expect(hasP2PKSignedProof(PK1, signed[0], other)).toBe(false);
+  });
+
+  test('refuses to sign SIG_ALL proofs without outputs', () => {
+    const wallet = new Wallet(mint);
+    expect(() => wallet.signP2PKProofs([mkProof('01')], privkey)).toThrow(/OutputData/);
   });
 });


### PR DESCRIPTION
# NUTS:

- cashubtc/nuts#404

The P2PK and HTLC signing and verification functions now take the 32-byte digest that is signed instead of a message string, so every SIG_ALL format hashes in one place and the signing path never sees a message.

## Why

The `message?: string` parameter on `signP2PKProofs`, `hasP2PKSignedProof`, `verifyP2PKSpendingConditions` and the HTLC wrappers exists only for SIG_ALL, where the signed value is not the proof secret. None of those functions read the message: they resolve keys from the secret and hand the message to the Schnorr helpers, which SHA-256 it. That ties the API to one specific derivation. The framed [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md) SIG_ALL format signs a BIP-340 tagged hash rather than a plain SHA-256, so it cannot pass through a string parameter at all. `signMintQuote` already works digest-first for the same reason.

## Changes

- `signP2PKProofs`, `signP2PKProof`, `hasP2PKSignedProof`, `verifyP2PKSpendingConditions`, `isP2PKSpendAuthorised`, `verifyHTLCSpendingConditions`, `isHTLCSpendAuthorised`, `getValidSigners` and `meetsSignerThreshold` take `digest?: DigestInput` (the existing hex-or-bytes type of `schnorrSignDigest`). With no digest they hash the proof secret, so SIG_INPUTS behaviour is unchanged.
- `Wallet.signP2PKProofs` passes `computeMessageDigest(v0Message)`; the v0 message builder itself is untouched.
- Migration entry added to `migration-5.0.0.md`.

## Impact

Breaking for callers that pass a SIG_ALL message string to the functions above, which is the mint-side use of this library; they hash the message first. No wire or storage change. Not for backport to v4.

