### PR TITLE
feat(crypto): sign SIG_ALL over the length-framed NUT-11 message [backport v4-dev]

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -247,13 +247,13 @@ export type CompleteMeltOptions = {
 };
 
 // @public
-export function computeMessageDigest(message: string): Uint8Array;
+export function computeMessageDigest(message: MessageInput): Uint8Array;
 
 // @public (undocumented)
-export function computeMessageDigest(message: string, asHex: false): Uint8Array;
+export function computeMessageDigest(message: MessageInput, asHex: false): Uint8Array;
 
 // @public (undocumented)
-export function computeMessageDigest(message: string, asHex: true): string;
+export function computeMessageDigest(message: MessageInput, asHex: true): string;
 
 // @public
 export class ConsoleLogger implements Logger {
@@ -574,7 +574,7 @@ export function getTagScalar(secret: Secret | string, key: string): string | und
 export function getTokenMetadata(token: string): TokenMetadata;
 
 // @public
-export function getValidSigners(signatures: string[], message: string, pubkeys: string[]): string[];
+export function getValidSigners(signatures: string[], message: MessageInput, pubkeys: string[]): string[];
 
 // @public
 export function hasCorrespondingKey(amount: AmountLike, keyset: Keys): boolean;
@@ -597,7 +597,7 @@ export type HasKeysetKeys = {
 };
 
 // @public
-export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: string): boolean;
+export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: MessageInput): boolean;
 
 // @public
 export function hasTag(secret: Secret | string, key: string): boolean;
@@ -629,13 +629,13 @@ export function injectWebSocketImpl(ws: typeof WebSocket): void;
 export type IntRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>;
 
 // @public
-export function isHTLCSpendAuthorised(proof: Proof, logger?: Logger, message?: string): boolean;
+export function isHTLCSpendAuthorised(proof: Proof, logger?: Logger, message?: MessageInput): boolean;
 
 // @public
 export function isMintOperationError(e: unknown): e is MintOperationError;
 
 // @public
-export function isP2PKSpendAuthorised(proof: Proof, logger?: Logger, message?: string): boolean;
+export function isP2PKSpendAuthorised(proof: Proof, logger?: Logger, message?: MessageInput): boolean;
 
 // @public
 export const JSONInt: JSONIntApi;
@@ -786,7 +786,7 @@ export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
 export function maybeDeriveP2BKPrivateKeys(privateKey: string | string[], proof: Proof): string[];
 
 // @public
-export const meetsSignerThreshold: (signatures: string[], message: string, pubkeys: string[], threshold?: number) => boolean;
+export const meetsSignerThreshold: (signatures: string[], message: MessageInput, pubkeys: string[], threshold?: number) => boolean;
 
 // @public
 export class MeltBuilder<TQuote extends Pick<MeltQuoteBaseResponse, 'amount' | 'quote'> = MeltQuoteBolt11Response> {
@@ -933,6 +933,11 @@ export type MeltRequest = {
     outputs?: SerializedBlindedMessage[];
     prefer_async?: boolean;
 } & Record<string, unknown>;
+
+// @public (undocumented)
+export type MessageInput = string | {
+    digest: Uint8Array;
+};
 
 // @public
 export class Mint {
@@ -1782,13 +1787,13 @@ export type RpcSubKinds = 'bolt11_mint_quote' | 'bolt11_melt_quote' | 'proof_sta
 export const schnorrSignDigest: (digest: DigestInput, privateKey: PrivKey) => string;
 
 // @public
-export const schnorrSignMessage: (message: string, privateKey: PrivKey) => string;
+export const schnorrSignMessage: (message: MessageInput, privateKey: PrivKey) => string;
 
 // @public
 export const schnorrVerifyDigest: (signature: string, digest: DigestInput, pubkey: string, throws?: boolean) => boolean;
 
 // @public
-export const schnorrVerifyMessage: (signature: string, message: string, pubkey: string, throws?: boolean) => boolean;
+export const schnorrVerifyMessage: (signature: string, message: MessageInput, pubkey: string, throws?: boolean) => boolean;
 
 // @public (undocumented)
 export type Secret = [SecretKind, SecretData];
@@ -1962,6 +1967,7 @@ export type SigAllApi = {
 // @public
 export type SigAllDigests = {
     v0: string;
+    v1: string;
 };
 
 // @public
@@ -1989,10 +1995,10 @@ export const SigFlags: {
 export function signMintQuote(privkey: string, quote: string, blindedMessages: SerializedBlindedMessage[]): string;
 
 // @public
-export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: string): Proof;
+export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: MessageInput): Proof;
 
 // @public
-export function signP2PKProofs(proofs: Proof[], privateKey: PrivKey | PrivKey[], logger?: Logger, message?: string): Proof[];
+export function signP2PKProofs(proofs: Proof[], privateKey: PrivKey | PrivKey[], logger?: Logger, message?: MessageInput): Proof[];
 
 // @public
 export function sortProofsById(proofs: Proof[]): Proof[];
@@ -2067,6 +2073,9 @@ export type SwapTransaction = {
 };
 
 // @public
+export function taggedHash(tag: string, ...messages: Uint8Array[]): Uint8Array;
+
+// @public
 export type Token = {
     mint: string;
     proofs: Proof[];
@@ -2131,13 +2140,13 @@ A: WeierstrassPoint<bigint>) => boolean;
 export function verifyHTLCHash(preimage: string, hash: string): boolean;
 
 // @public
-export function verifyHTLCSpendingConditions(proof: Proof, logger?: Logger, message?: string): P2PKVerificationResult;
+export function verifyHTLCSpendingConditions(proof: Proof, logger?: Logger, message?: MessageInput): P2PKVerificationResult;
 
 // @public (undocumented)
 export function verifyMintQuoteSignature(pubkey: string, quote: string, blindedMessages: SerializedBlindedMessage[], signature: string): boolean;
 
 // @public
-export function verifyP2PKSpendingConditions(proof: Proof, logger?: Logger, message?: string): P2PKVerificationResult;
+export function verifyP2PKSpendingConditions(proof: Proof, logger?: Logger, message?: MessageInput): P2PKVerificationResult;
 
 // @public (undocumented)
 export function verifyUnblindedSignature(proof: UnblindedSignature, privKey: Uint8Array): boolean;

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -1,5 +1,6 @@
 import { schnorr } from '@noble/curves/secp256k1.js';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { numberToBytesBE } from '@noble/curves/utils.js';
+import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
@@ -12,7 +13,14 @@ import {
   MAX_WITNESS_LENGTH,
 } from '../utils/limits';
 
-import { getValidSigners, schnorrSignMessage, schnorrVerifyMessage, type PrivKey } from './core';
+import {
+  getValidSigners,
+  schnorrSignMessage,
+  schnorrVerifyMessage,
+  taggedHash,
+  type MessageInput,
+  type PrivKey,
+} from './core';
 import {
   getTagInt,
   getTagScalar,
@@ -24,6 +32,7 @@ import {
   type Secret,
   getSecretKind,
 } from './NUT10';
+import { amountToMinimalBytes } from './NUT20';
 import { deriveP2BKSecretKeys } from './NUT28';
 
 export const SigFlags = {
@@ -391,7 +400,7 @@ export function parseWitnessData(witness: Proof['witness']): WitnessData | undef
  * @param proofs - An array of proofs to sign.
  * @param privateKey - A single private key or array of private keys (hex string or Uint8Array).
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param message - Optional. The message to sign (SIG_ALL only): a string, or `{ digest }`.
  * @returns Signed proofs.
  * @throws On general errors.
  */
@@ -399,7 +408,7 @@ export function signP2PKProofs(
   proofs: Proof[],
   privateKey: PrivKey | PrivKey[],
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  message?: MessageInput,
 ): Proof[] {
   // Convert to hex strings for maybeDeriveP2BKPrivateKeys
   const toHex = (k: PrivKey): string => (typeof k === 'string' ? k : bytesToHex(k));
@@ -455,7 +464,7 @@ export function assertSignerAuthorised(secretStr: string | Secret, privateKey: P
  * @throws Error if signature is not required, proof is already signed, a message is missing for a
  *   SIG_ALL proof, or given for a SIG_INPUTS proof.
  */
-export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: string): Proof {
+export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: MessageInput): Proof {
   const secret: Secret = parseP2PKSecret(proof.secret);
   // SIG_INPUTS signs the secret and nothing else; only SIG_ALL takes a transaction message.
   const sigAll = getP2PKSigFlag(secret) === 'SIG_ALL';
@@ -505,7 +514,7 @@ export function signP2PKProof(proof: Proof, privateKey: PrivKey, message?: strin
  * @param message - Optional. The message that was signed (SIG_ALL only; ignored otherwise)
  * @returns True if one of the signatures is theirs, false otherwise.
  */
-export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: string): boolean {
+export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: MessageInput): boolean {
   if (!proof.witness) {
     return false;
   }
@@ -555,7 +564,7 @@ export function hasP2PKSignedProof(pubkey: string, proof: Proof, message?: strin
 export function verifyP2PKSpendingConditions(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  message?: MessageInput,
 ): P2PKVerificationResult {
   // SIG_INPUTS signatures are over the secret; only SIG_ALL verifies against the given message.
   if (!isP2PKSigAll([proof])) {
@@ -644,14 +653,14 @@ export function verifyP2PKSpendingConditions(
  *
  * @param proof - The Proof to check.
  * @param logger - Optional logger (default: NULL_LOGGER)
- * @param message - Optional. The message to sign (for SIG_ALL)
+ * @param message - Optional. The message to sign (SIG_ALL only): a string, or `{ digest }`.
  * @returns True if the witness threshold was reached, false otherwise.
  * @throws If verification is impossible.
  */
 export function isP2PKSpendAuthorised(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  message?: MessageInput,
 ): boolean {
   return verifyP2PKSpendingConditions(proof, logger, message).success;
 }
@@ -747,6 +756,59 @@ export function buildP2PKSigAllMessageV0(
     parts.push(quoteId);
   }
   return parts.join('');
+}
+
+/**
+ * Message aggregation for SIG_ALL (spec v1): the length-framed `message` bytes.
+ *
+ * NOTE: Use `assertSigAllInputs()` to ensure valid message inputs.
+ *
+ * @remarks
+ * Melt transactions MUST include the quoteId; swaps commit an empty quote field. The value that is
+ * signed is `hashP2PKSigAllMessageV1(message)`, not a plain SHA-256 of these bytes.
+ * @param inputs Array of Proofs (only `secret` and `C` fields required).
+ * @param outputs Array of OutputDataLike objects (OutputData, Factory etc).
+ * @param quoteId Optional. Quote id for Melt transactions.
+ * @internal
+ */
+export function buildP2PKSigAllMessageV1(
+  inputs: Array<Pick<Proof, 'secret' | 'C'>>,
+  outputs: Array<Pick<OutputDataLike, 'blindedMessage'>>,
+  quoteId?: string,
+): Uint8Array {
+  const parts: Uint8Array[] = [];
+  const pushFramed = (bytes: Uint8Array): void => {
+    parts.push(numberToBytesBE(bytes.length, 4), bytes);
+  };
+  pushFramed(utf8ToBytes(quoteId ?? ''));
+  for (const p of inputs) {
+    pushFramed(utf8ToBytes(p.secret));
+    pushFramed(hexToBytes(p.C));
+  }
+  for (const o of outputs) {
+    pushFramed(amountToMinimalBytes(o.blindedMessage));
+    pushFramed(hexToBytes(o.blindedMessage.B_));
+  }
+  // Manual copy rather than concatBytes(...parts): spreading per-field chunks
+  // would hit V8's argument-count limit on large transactions.
+  const message = new Uint8Array(parts.reduce((n, part) => n + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    message.set(part, offset);
+    offset += part.length;
+  }
+  return message;
+}
+
+/**
+ * The 32-byte value signed for SIG_ALL v1: the BIP-340 tagged hash of the framed message.
+ *
+ * @remarks
+ * Shared by P2PK and HTLC. Pass it to the P2PK sign and verify functions as `{ digest }`.
+ * @internal
+ */
+export function hashP2PKSigAllMessageV1(message: Uint8Array): Uint8Array {
+  return taggedHash('Cashu_SigAllSig_v1', message);
 }
 
 /**

--- a/src/crypto/NUT14.ts
+++ b/src/crypto/NUT14.ts
@@ -5,6 +5,7 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type Proof } from '../model/types';
 
+import { type MessageInput } from './core';
 import { assertSecretKind, createSecret, type Secret, getDataField, getSecretKind } from './NUT10';
 import {
   type P2PKVerificationResult,
@@ -106,7 +107,7 @@ export function verifyHTLCHash(preimage: string, hash: string): boolean {
 export function verifyHTLCSpendingConditions(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  message?: MessageInput,
 ): P2PKVerificationResult {
   // Init
   let result: P2PKVerificationResult;
@@ -183,7 +184,7 @@ export function verifyHTLCSpendingConditions(
 export function isHTLCSpendAuthorised(
   proof: Proof,
   logger: Logger = NULL_LOGGER,
-  message?: string,
+  message?: MessageInput,
 ): boolean {
   return verifyHTLCSpendingConditions(proof, logger, message).success;
 }

--- a/src/crypto/NUT20.ts
+++ b/src/crypto/NUT20.ts
@@ -12,7 +12,8 @@ const MINT_QUOTE_SIG_DST = utf8ToBytes('Cashu_MintQuoteSig_v1');
 
 // Canonical minimal BE bytes of a non-negative amount (0 → empty, 1 → 0x01, 256 → 0x0100).
 // Amount.from defensively normalizes a raw JSON number/string (Amount passes through).
-function amountToMinimalBytes(blindedMessage: SerializedBlindedMessage): Uint8Array {
+// Shared with the NUT-11 SIG_ALL v1 message builder.
+export function amountToMinimalBytes(blindedMessage: SerializedBlindedMessage): Uint8Array {
   const value = Amount.from(blindedMessage.amount).toBigInt();
   if (value === 0n) return new Uint8Array(0);
   const hex = value.toString(16);

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -19,6 +19,8 @@ import { hasLoneSurrogate } from '../utils/bytes';
  */
 export type PrivKey = Uint8Array | string;
 export type DigestInput = Uint8Array | string; // hex string or bytes
+// A UTF-8 string to hash, or the 32-byte digest BIP-340 signs (eg a tagged hash).
+export type MessageInput = string | { digest: Uint8Array };
 export type BlindSignature = {
   C_: WeierstrassPoint<bigint>;
   id: string;
@@ -156,16 +158,29 @@ export function constructUnblindedSignature(
 // ------------------------------
 
 /**
+ * BIP340-style tagged hash: `SHA256(SHA256(tag) || SHA256(tag) || messages)`.
+ */
+export function taggedHash(tag: string, ...messages: Uint8Array[]): Uint8Array {
+  const tagHash = sha256(utf8ToBytes(tag));
+  return sha256(concatBytes(tagHash, tagHash, ...messages));
+}
+
+/**
  * Computes the SHA-256 hash of a UTF-8 message string.
  *
- * @param message To hash (UTF-8 encoded before hashing).
+ * @remarks
+ * A `{ digest }` input is returned unchanged, for callers that sign a prehashed value.
+ * @param message To hash (UTF-8 encoded before hashing), or a prehashed digest.
  * @param asHex Optional: True returns a hex-encoded hash string; otherwise returns raw bytes.
  * @returns SHA-256 hash as raw bytes or hex string, depending on `asHex`.
  */
-export function computeMessageDigest(message: string): Uint8Array;
-export function computeMessageDigest(message: string, asHex: false): Uint8Array;
-export function computeMessageDigest(message: string, asHex: true): string;
-export function computeMessageDigest(message: string, asHex = false): string | Uint8Array {
+export function computeMessageDigest(message: MessageInput): Uint8Array;
+export function computeMessageDigest(message: MessageInput, asHex: false): Uint8Array;
+export function computeMessageDigest(message: MessageInput, asHex: true): string;
+export function computeMessageDigest(message: MessageInput, asHex = false): string | Uint8Array {
+  if (typeof message !== 'string') {
+    return asHex ? bytesToHex(message.digest) : message.digest;
+  }
   // Ill-formed UTF-16 would hash as its U+FFFD replacement, aliasing distinct messages.
   if (hasLoneSurrogate(message)) {
     throw new CTSError('Message must be well-formed UTF-16');
@@ -201,7 +216,7 @@ export const schnorrSignDigest = (digest: DigestInput, privateKey: PrivKey): str
  * @param privateKey - The private key to sign with (hex string or Uint8Array).
  * @returns The signature in hex format.
  */
-export const schnorrSignMessage = (message: string, privateKey: PrivKey): string => {
+export const schnorrSignMessage = (message: MessageInput, privateKey: PrivKey): string => {
   const msghash = computeMessageDigest(message);
   return schnorrSignDigest(msghash, privateKey);
 };
@@ -221,7 +236,7 @@ export const schnorrSignMessage = (message: string, privateKey: PrivKey): string
  */
 export const schnorrVerifyMessage = (
   signature: string,
-  message: string,
+  message: MessageInput,
   pubkey: string,
   throws: boolean = false,
 ): boolean => {
@@ -317,7 +332,7 @@ export function findSigningKey(pubkey: string, privkeys: string | string[]): str
  */
 export function getValidSigners(
   signatures: string[],
-  message: string,
+  message: MessageInput,
   pubkeys: string[],
 ): string[] {
   // Dedupe by x-only identity: BIP-340 ignores the parity prefix, so 02|X, 03|X
@@ -344,7 +359,7 @@ export function getValidSigners(
  */
 export const meetsSignerThreshold = (
   signatures: string[],
-  message: string,
+  message: MessageInput,
   pubkeys: string[],
   threshold: number = 1,
 ): boolean => {

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -1,10 +1,12 @@
-import { utf8ToBytes } from '@noble/hashes/utils.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import {
   assertSigAllInputs,
   assertSignerAuthorised,
   buildP2PKSigAllMessageV0,
+  buildP2PKSigAllMessageV1,
   computeMessageDigest,
+  hashP2PKSigAllMessageV1,
   pointFromHex,
   schnorrSignDigest,
 } from '../crypto';
@@ -38,6 +40,10 @@ export type SigAllDigests = {
    * Unframed concatenation format (CDK >= 0.14.0, Nutshell > 0.20.2).
    */
   v0: string;
+  /**
+   * Length-framed spec format: BIP-340 tagged hash (`Cashu_SigAllSig_v1`) of the framed message.
+   */
+  v1: string;
 };
 
 /**
@@ -82,9 +88,11 @@ function computeDigests(
 ): SigAllDigests {
   const sigAllOutputs = outputs.map((blindedMessage) => ({ blindedMessage }));
   const v0Msg = buildP2PKSigAllMessageV0(inputs, sigAllOutputs, quoteId);
+  const v1Msg = buildP2PKSigAllMessageV1(inputs, sigAllOutputs, quoteId);
 
   return {
     v0: computeMessageDigest(v0Msg, true),
+    v1: bytesToHex(hashP2PKSigAllMessageV1(v1Msg)),
   };
 }
 
@@ -270,7 +278,7 @@ function signPackage(pkg: SigAllSigningPackage, privkey: string): SigAllSigningP
   // Sign transcripts recomputed from the package contents; a signer only ever
   // signs what the package shows, never a digest chosen elsewhere.
   const digests = computeDigests(pkg.inputs, pkg.outputs, pkg.quote);
-  const newSigs = [schnorrSignDigest(digests.v0, privkey)];
+  const newSigs = [schnorrSignDigest(digests.v1, privkey), schnorrSignDigest(digests.v0, privkey)];
 
   return {
     ...pkg,

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -13,6 +13,9 @@ import {
   hashToCurve,
   isP2PKSigAll,
   buildP2PKSigAllMessageV0,
+  buildP2PKSigAllMessageV1,
+  hashP2PKSigAllMessageV1,
+  type MessageInput,
   assertSigAllInputs,
   parseSecret,
 } from '../crypto';
@@ -1759,7 +1762,14 @@ class Wallet {
     // supported message format...
     const [first, ...rest] = normalizedProofs;
     let signedFirst = first;
-    const messages = [buildP2PKSigAllMessageV0(normalizedProofs, outputData, quoteId)];
+    const messages: MessageInput[] = [
+      {
+        digest: hashP2PKSigAllMessageV1(
+          buildP2PKSigAllMessageV1(normalizedProofs, outputData, quoteId),
+        ),
+      },
+      buildP2PKSigAllMessageV0(normalizedProofs, outputData, quoteId),
+    ];
     for (const msg of messages) {
       signedFirst = cryptoSignP2PKProofs([signedFirst], privkey, this._logger, msg)[0];
     }

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1,6 +1,12 @@
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
+import {
+  concatBytes,
+  hexToBytes,
+  bytesToHex,
+  randomBytes,
+  utf8ToBytes,
+} from '@noble/hashes/utils.js';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { Amount, type OutputDataLike } from '../../src';
@@ -22,6 +28,9 @@ import {
   deriveP2BKBlindedPubkeys,
   P2BK_DST,
   buildP2PKSigAllMessageV0,
+  buildP2PKSigAllMessageV1,
+  hashP2PKSigAllMessageV1,
+  schnorrVerifyDigest,
   assertSigAllInputs,
   createSecret,
   dedupeP2PKPubkeys,
@@ -2259,5 +2268,97 @@ describe('SIG_ALL edge cases', () => {
     expect(isP2PKSigAll([sigInputs, sigAll])).toBe(true);
     expect(isP2PKSigAll([sigInputs])).toBe(false);
     expect(isP2PKSigAll([])).toBe(false);
+  });
+});
+
+describe('buildP2PKSigAllMessageV1, length-framed SIG_ALL aggregation', () => {
+  const mkProof = (secret: string, C: string) => ({ secret, C }) as any;
+  const mkOutput = (amount: number, B_: string) => ({ blindedMessage: { amount, B_ } }) as any;
+
+  // Canonical vectors from nuts tests/11-test.md ("SIG_ALL Test Vectors"), pinned
+  // byte-for-byte in the nutshell and cdk suites too.
+  const VECTOR_PUB = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+  const vectorInputs = [
+    mkProof(
+      `["P2PK",{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"${VECTOR_PUB}","tags":[["sigflag","SIG_ALL"]]}]`,
+      '02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904',
+    ),
+    mkProof(
+      `["P2PK",{"nonce":"16d937a29ae4e5d4a6e9f9959c4d4b9a8d6f2f7b2f0a1b3c4d5e6f708192a3b4","data":"${VECTOR_PUB}","tags":[["sigflag","SIG_ALL"]]}]`,
+      '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+    ),
+  ];
+  const vectorOutputs = [
+    mkOutput(8, '035015e6d7ade60ba8426cefaf1832bbd27257636e44a76b922d78e79b47cb689d'),
+    mkOutput(2, '0288d7649652d0a83fc9c966c969fb217f15904431e61a44b14999fabc1b5d9ac6'),
+  ];
+  const vectorQuote = '9d745270-1405-46de-b5c5-e2762b4f5e00';
+
+  test('matches the canonical cross-implementation vector', () => {
+    const swapMsg = buildP2PKSigAllMessageV1(vectorInputs, vectorOutputs);
+    expect(swapMsg.length).toBe(554);
+    const swapHash = hashP2PKSigAllMessageV1(swapMsg);
+    expect(bytesToHex(swapHash)).toBe(
+      'b2a0a8ee2d8911585d97adce15c8d7e664c712baa31c0f3d8a6e32b909fdda2b',
+    );
+    // Pinned signature by the well-known test key (privkey 0x...01)
+    expect(
+      schnorrVerifyDigest(
+        '55c4e0d72598a64af2a04d1d348af7beb97b35fe1af91711e205414a24c869ba047b5bd298b87c7b58b439833e244b5498136fd4cccdf9d41b0fe72db8279722',
+        swapHash,
+        VECTOR_PUB,
+      ),
+    ).toBe(true);
+
+    const meltMsg = buildP2PKSigAllMessageV1(vectorInputs, vectorOutputs, vectorQuote);
+    expect(meltMsg.length).toBe(590);
+    const meltHash = hashP2PKSigAllMessageV1(meltMsg);
+    expect(bytesToHex(meltHash)).toBe(
+      '2cdffe8a0eed5d22da07adc0f149d49e0ddca5cdafa6d872630d0c52e167e548',
+    );
+    expect(
+      schnorrVerifyDigest(
+        'b22645e507c51a37070402ccc36b5b41cc33fe5bdc2ff3f3ee12d0b7340f9742dfaf64c49e9b1243e7a71b31329a63d9c174fd82f133491b16723f8dcd3f7693',
+        meltHash,
+        VECTOR_PUB,
+      ),
+    ).toBe(true);
+  });
+
+  test('swaps commit an empty quote frame first', () => {
+    const msg = buildP2PKSigAllMessageV1(vectorInputs, vectorOutputs);
+    expect(bytesToHex(msg.slice(0, 4))).toBe('00000000');
+  });
+
+  test('the signed value is the BIP-340 tagged hash of the message', () => {
+    const msg = buildP2PKSigAllMessageV1(vectorInputs, vectorOutputs);
+    const tagHash = sha256(utf8ToBytes('Cashu_SigAllSig_v1'));
+    expect(bytesToHex(tagHash)).toBe(
+      'c83c413c874b6f3da4c6310558d0d174c56f1a0a034023ae225ab3648e9626b3',
+    );
+    expect(hashP2PKSigAllMessageV1(msg)).toEqual(sha256(concatBytes(tagHash, tagHash, msg)));
+  });
+
+  test('amounts commit as canonical minimal big-endian bytes', () => {
+    const zero = buildP2PKSigAllMessageV1([], [mkOutput(0, 'b1')]);
+    expect(bytesToHex(zero)).toBe('00000000' + '00000000' + '00000001' + 'b1');
+
+    const big = buildP2PKSigAllMessageV1([], [mkOutput(256, 'b1')]);
+    expect(bytesToHex(big)).toBe('00000000' + '00000002' + '0100' + '00000001' + 'b1');
+  });
+
+  test('length framing prevents boundary-shift collisions', () => {
+    const outputs = [mkOutput(1, 'b1')];
+    const shiftedA = [mkProof('ab', 'cccc')];
+    const shiftedB = [mkProof('abcc', 'cc')];
+
+    // The v0 string concatenation cannot tell these apart...
+    expect(buildP2PKSigAllMessageV0(shiftedA, outputs)).toBe(
+      buildP2PKSigAllMessageV0(shiftedB, outputs),
+    );
+    // ...the framed format can.
+    const mA = buildP2PKSigAllMessageV1(shiftedA, outputs);
+    const mB = buildP2PKSigAllMessageV1(shiftedB, outputs);
+    expect(hashP2PKSigAllMessageV1(mA)).not.toEqual(hashP2PKSigAllMessageV1(mB));
   });
 });

--- a/test/crypto/NUT14-vectors.test.ts
+++ b/test/crypto/NUT14-vectors.test.ts
@@ -1,0 +1,87 @@
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { describe, expect, test } from 'vitest';
+
+import { Amount } from '../../src';
+import {
+  buildP2PKSigAllMessageV1,
+  hashP2PKSigAllMessageV1,
+  isHTLCSpendAuthorised,
+  schnorrVerifyDigest,
+} from '../../src/crypto';
+import { type Proof } from '../../src/model/types';
+
+// NUT-14 test vectors from cashubtc/nuts tests/14-test.md. Signing key is the
+// well-known test key (privkey 0x...01); all hashlocks commit to the
+// all-zeros-then-one preimage.
+const PUB = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+const PREIMAGE = '0000000000000000000000000000000000000000000000000000000000000001';
+const HASHLOCK = 'ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5';
+
+describe('NUT-14 spec vectors', () => {
+  const sigInputsSecret = `["HTLC",{"nonce":"5d11913ee0f92fefdc82a6764fd2457a1585d418f0265b5575eb14cd3be76d94","data":"${HASHLOCK}","tags":[["pubkeys","${PUB}"],["sigflag","SIG_INPUTS"]]}]`;
+  const sigInputsSig =
+    '8d6da34f529edccdb6a5d2122f16293b01b38263e58733acca0ff6595515224f69b80c0933f96a729899249bc7c1a5f34efcb7cf4347f1135625449bae51f86b';
+
+  const mkProof = (secret: string, witness: string): Proof => ({
+    amount: Amount.from(8),
+    id: '009a1f293253e41e',
+    secret,
+    C: '02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904',
+    witness,
+  });
+
+  test('valid preimage and signature is spendable', () => {
+    const proof = mkProof(
+      sigInputsSecret,
+      `{"preimage":"${PREIMAGE}","signatures":["${sigInputsSig}"]}`,
+    );
+    expect(isHTLCSpendAuthorised(proof)).toBe(true);
+  });
+
+  test('wrong preimage is not spendable, regardless of the signature', () => {
+    const wrongPreimage = PREIMAGE.slice(0, 63) + '2';
+    const proof = mkProof(
+      sigInputsSecret,
+      `{"preimage":"${wrongPreimage}","signatures":["${sigInputsSig}"]}`,
+    );
+    expect(isHTLCSpendAuthorised(proof)).toBe(false);
+  });
+
+  test('keyless hashlock is spendable with the preimage alone', () => {
+    const keylessSecret = `["HTLC",{"nonce":"09ef07c284bcda9a413723b8bb5d1a4bbee0e9564ba91e0d5e2b2a1071ab5c53","data":"${HASHLOCK}"}]`;
+    const proof = mkProof(keylessSecret, `{"preimage":"${PREIMAGE}"}`);
+    expect(isHTLCSpendAuthorised(proof)).toBe(true);
+  });
+
+  test('SIG_ALL swap vector: message, digest, signature and spend', () => {
+    const sigAllSecret = `["HTLC",{"nonce":"da62796403af76c80cd6ce9153ed3746","data":"${HASHLOCK}","tags":[["pubkeys","${PUB}"],["sigflag","SIG_ALL"]]}]`;
+    const sigAllSig =
+      '8971f1c3f1de7aa2e401b75eee841a60c61ab4833c2b3ba2e0fde7911893a481d264f858e64dc9bfe614d785ef7ce0a487942850e78839eebdf260046c241d79';
+    const proof = mkProof(sigAllSecret, `{"preimage":"${PREIMAGE}","signatures":["${sigAllSig}"]}`);
+    const outputs = [
+      {
+        blindedMessage: {
+          amount: Amount.from(8),
+          id: '009a1f293253e41e',
+          B_: '035015e6d7ade60ba8426cefaf1832bbd27257636e44a76b922d78e79b47cb689d',
+        },
+      },
+      {
+        blindedMessage: {
+          amount: Amount.from(2),
+          id: '009a1f293253e41e',
+          B_: '0288d7649652d0a83fc9c966c969fb217f15904431e61a44b14999fabc1b5d9ac6',
+        },
+      },
+    ];
+
+    const msg = buildP2PKSigAllMessageV1([proof], outputs);
+    expect(msg.length).toBe(368);
+    const digest = hashP2PKSigAllMessageV1(msg);
+    expect(bytesToHex(digest)).toBe(
+      '0eb7eda21bdfc7ffbe74868d32db3981727cfaedc61ef3256681c33fb92512d1',
+    );
+    expect(schnorrVerifyDigest(sigAllSig, digest, PUB)).toBe(true);
+    expect(isHTLCSpendAuthorised(proof, undefined, { digest })).toBe(true);
+  });
+});

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -247,3 +247,11 @@ describe('findSigningKey', () => {
     );
   });
 });
+
+describe('computeMessageDigest with a prehashed digest', () => {
+  test('returns the digest unchanged, as bytes or hex', () => {
+    const digest = sha256(new TextEncoder().encode('hello'));
+    expect(computeMessageDigest({ digest })).toEqual(digest);
+    expect(computeMessageDigest({ digest }, true)).toBe(bytesToHex(digest));
+  });
+});

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -209,7 +209,11 @@ describe('SigAll — serializePackage / deserializePackage', () => {
 
   test('round-trip preserves large (unsafe integer) output amounts', () => {
     const largeAmount = Amount.from(9007199254740993n); // > MAX_SAFE_INTEGER
-    const largeBm: SerializedBlindedMessage = { amount: largeAmount, id: 'bm-large', B_: 'dummyB' };
+    const largeBm: SerializedBlindedMessage = {
+      amount: largeAmount,
+      id: 'bm-large',
+      B_: '02' + '2'.repeat(64),
+    };
     const pkg: SigAllSigningPackage = {
       version: 'sigallA',
       type: 'swap',
@@ -226,7 +230,7 @@ describe('SigAll — serializePackage / deserializePackage', () => {
         version: 'sigallA',
         type: 'swap',
         inputs: [{ secret: 'testsecret', C: '02' + '1'.repeat(64) }],
-        outputs: [{ amount: 32, id: 'bm1', B_: 'dummyB' }],
+        outputs: [{ amount: 32, id: 'bm1', B_: '02' + '2'.repeat(64) }],
       }),
     );
 
@@ -235,7 +239,11 @@ describe('SigAll — serializePackage / deserializePackage', () => {
 
   test('serializePackage emits unquoted integer amounts', () => {
     const largeAmount = Amount.from(9007199254740993n);
-    const largeBm: SerializedBlindedMessage = { amount: largeAmount, id: 'bm-large', B_: 'dummyB' };
+    const largeBm: SerializedBlindedMessage = {
+      amount: largeAmount,
+      id: 'bm-large',
+      B_: '02' + '2'.repeat(64),
+    };
     const pkg: SigAllSigningPackage = {
       version: 'sigallA',
       type: 'swap',
@@ -292,7 +300,7 @@ describe('SigAll — serializePackage / deserializePackage', () => {
       version: 'sigallA',
       type: 'swap',
       inputs: [{ secret: 'testsecret', C: '02' + '1'.repeat(64) }],
-      outputs: [{ amount: 32, id: 'bm1', B_: 'dummyB' }],
+      outputs: [{ amount: 32, id: 'bm1', B_: '02' + '2'.repeat(64) }],
     });
     const bytes = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(json)]);
     const encoded = 'sigallA' + encodeUint8ToBase64Url(bytes);
@@ -523,7 +531,7 @@ describe('SigAll — signPackage', () => {
 
   test('signs a melt package with a UUID quote id', () => {
     const pkg = makeMeltPackage('019218a3-7c4e-7f2b-9a1d-3e5f6a7b8c9d');
-    expect(SigAll.signPackage(pkg, dummyPrivkey).witness!.signatures.length).toBe(1);
+    expect(SigAll.signPackage(pkg, dummyPrivkey).witness!.signatures.length).toBe(2);
   });
 
   test('rejects a melt quote id that is not a UUID', () => {
@@ -566,7 +574,7 @@ describe('SigAll — signPackage', () => {
     };
     const signed = SigAll.signPackage(pkg, otherPrivkey);
     const digest = SigAll.computeDigests(pkg.inputs, pkg.outputs).v0;
-    expect(schnorrVerifyDigest(signed.witness!.signatures[0], digest, otherPubkey)).toBe(true);
+    expect(schnorrVerifyDigest(signed.witness!.signatures[1], digest, otherPubkey)).toBe(true);
   });
 });
 
@@ -839,13 +847,26 @@ describe('SigAll — mergeSignatures edge cases', () => {
 describe('SigAll — signing binds to package contents', () => {
   const signerPubkey = () => bytesToHex(getPubKeyFromPrivKey(hexToBytes(dummyPrivkey)));
 
+  test('signs one signature per accepted format (v1, then v0)', () => {
+    const pkg = SigAll.extractSwapPackage(makeSwapPreview());
+    const signed = SigAll.signPackage(pkg, dummyPrivkey);
+    const digests = SigAll.computeDigests(pkg.inputs, pkg.outputs);
+    expect(signed.witness?.signatures).toHaveLength(2);
+    expect(schnorrVerifyDigest(signed.witness!.signatures[0], digests.v1, signerPubkey())).toBe(
+      true,
+    );
+    expect(schnorrVerifyDigest(signed.witness!.signatures[1], digests.v0, signerPubkey())).toBe(
+      true,
+    );
+  });
+
   test('signPackage emits one signature, verifiable over the recomputed v0 digest', () => {
     const pkg = SigAll.extractSwapPackage(makeSwapPreview());
     const signed = SigAll.signPackage(pkg, dummyPrivkey);
 
-    expect(signed.witness?.signatures).toHaveLength(1);
+    expect(signed.witness?.signatures).toHaveLength(2);
     const digest = SigAll.computeDigests(pkg.inputs, pkg.outputs).v0;
-    expect(schnorrVerifyDigest(signed.witness!.signatures[0], digest, signerPubkey())).toBe(true);
+    expect(schnorrVerifyDigest(signed.witness!.signatures[1], digest, signerPubkey())).toBe(true);
   });
 
   test('signPackage does not sign the amount-blind concat of secrets and B_ values', () => {
@@ -868,8 +889,8 @@ describe('SigAll — signing binds to package contents', () => {
 
     const signed = SigAll.signPackage(dirty, dummyPrivkey);
     const digest = SigAll.computeDigests(pkg.inputs, pkg.outputs).v0;
-    expect(signed.witness?.signatures).toHaveLength(1);
-    expect(schnorrVerifyDigest(signed.witness!.signatures[0], digest, signerPubkey())).toBe(true);
+    expect(signed.witness?.signatures).toHaveLength(2);
+    expect(schnorrVerifyDigest(signed.witness!.signatures[1], digest, signerPubkey())).toBe(true);
 
     const rounded = SigAll.deserializePackage(SigAll.serializePackage(dirty));
     expect('digests' in rounded).toBe(false);
@@ -881,10 +902,10 @@ describe('SigAll — signing binds to package contents', () => {
 
     const withQuote = SigAll.computeDigests(pkg.inputs, pkg.outputs, pkg.quote).v0;
     const withoutQuote = SigAll.computeDigests(pkg.inputs, pkg.outputs).v0;
-    expect(schnorrVerifyDigest(signed.witness!.signatures[0], withQuote, signerPubkey())).toBe(
+    expect(schnorrVerifyDigest(signed.witness!.signatures[1], withQuote, signerPubkey())).toBe(
       true,
     );
-    expect(schnorrVerifyDigest(signed.witness!.signatures[0], withoutQuote, signerPubkey())).toBe(
+    expect(schnorrVerifyDigest(signed.witness!.signatures[1], withoutQuote, signerPubkey())).toBe(
       false,
     );
   });
@@ -903,7 +924,7 @@ describe('SigAll — transport format', () => {
         version: 'sigallA',
         type: 'swap',
         inputs: [{ secret: 'testsecret', C: '02' + '1'.repeat(64) }],
-        outputs: [{ amount: 32, id: 'bm1', B_: 'dummyB' }],
+        outputs: [{ amount: 32, id: 'bm1', B_: '02' + '2'.repeat(64) }],
         digests: { current: 'a'.repeat(64), legacy: 'b'.repeat(64) },
       }),
     );


### PR DESCRIPTION
# NUTS:

- cashubtc/nuts#404
- cashubtc/nuts#407

Backport of #811 to v4: wallets sign SIG_ALL over the length-framed [NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md) message as well as the current format, so v4 keeps spending SIG_ALL tokens once mints retire the old format. On hold until the spec change merges.

## Why

The v1 format signs a BIP-340 tagged hash of the framed message, not a SHA-256 of a string, so it cannot pass through the `message?: string` parameter of the P2PK functions. v5 changes those signatures to take a digest (#1108); that is breaking and stays v5-only. This backport widens the parameter instead.

## Changes

- `MessageInput = string | { digest: Uint8Array }` on the P2PK and HTLC sign and verify functions and the Schnorr string helpers. String callers are unchanged; the v1 tagged hash travels as `{ digest }`.
- `buildP2PKSigAllMessageV1`, `hashP2PKSigAllMessageV1` and a `taggedHash` helper matching v5's. The NUT-20 minimal-amount helper is shared.
- `Wallet.signP2PKProofs` and the `SigAll` package emit the v1 signature first, then v0. Mints ignore signatures they cannot verify and count unique pubkeys, so the witness verifies on either side of the upgrade.
- Canonical NUT-11 and NUT-14 vectors from the spec are pinned in the unit tests.

## Impact

Additive API only; `etc/cashu-ts.api.md` updated. Witnesses carry one extra signature per signer.
