### PR TITLE
fix(crypto): validate helper inputs at the boundary

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1840,9 +1840,6 @@ export type OutputType = ({
 };
 
 // @public
-export const P2BK_DST: Uint8Array<ArrayBufferLike>;
-
-// @public
 export type P2PKOptions = SpendingConditionsBase & LockConditions & {
     kind: 'P2PK' | 'HTLC';
 };

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -6,6 +6,7 @@ import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
 import {
+  MAX_P2BK_SLOTS,
   MAX_P2PK_PUBKEYS,
   MAX_P2PK_SIGNATURES,
   MAX_SECRET_LENGTH,
@@ -144,13 +145,9 @@ type WitnessData = {
   signatures: string[];
 };
 
-/**
- * NUT-11 tag keys that map onto structured {@link LockConditions} fields, rather than being carried
- * as free-form `additionalTags`, and are therefore reserved (not settable as additional tags).
- *
- * @internal
- */
-export const P2PK_KNOWN_TAG_KEYS = new Set([
+// Parsing reads this set, so the exported one is a detached copy: an exported Set stays
+// mutable whatever its declared type.
+const KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',
   'n_sigs',
@@ -158,6 +155,23 @@ export const P2PK_KNOWN_TAG_KEYS = new Set([
   'n_sigs_refund',
   'sigflag',
 ]);
+
+/**
+ * NUT-11 tag keys that map onto structured {@link LockConditions} fields, rather than being carried
+ * as free-form `additionalTags`, and are therefore reserved (not settable as additional tags).
+ *
+ * @internal
+ */
+export const P2PK_KNOWN_TAG_KEYS: ReadonlySet<string> = new Set(KNOWN_TAG_KEYS);
+
+/**
+ * True if a tag key is one NUT-11 reserves.
+ *
+ * @internal
+ */
+export function isP2PKKnownTagKey(key: string): boolean {
+  return KNOWN_TAG_KEYS.has(key);
+}
 
 // ------------------------------
 // NUT-11 Secrets
@@ -281,12 +295,12 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
 
   // Signers: P2PK - data key + pubkeys; HTLC - data is a hash, so only pubkeys.
   const signerCount = (kind === 'P2PK' ? 1 : 0) + pubkeys.length;
-  // NUT-28: up to 11 locking slots in [data, ...pubkeys, ...refund] (i_byte 0x00..0x0A). `data`
-  // always fills slot 0 (a pubkey for P2PK, a hashlock for HTLC), so HTLC allows one fewer key.
+  // NUT-28 slot map: [data, ...pubkeys, ...refund]. `data` always fills slot 0 (a pubkey for
+  // P2PK, a hashlock for HTLC), so HTLC allows one fewer key.
   const slotCount = 1 + pubkeys.length + refundKeys.length;
-  if (slotCount > 11) {
+  if (slotCount > MAX_P2BK_SLOTS) {
     throw new CTSError(
-      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is 11 in total`,
+      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is ${MAX_P2BK_SLOTS} in total`,
     );
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
@@ -336,7 +350,7 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
  */
 export function assertValidTagKey(key: string) {
   if (!key || typeof key !== 'string') throw new CTSError('tag key must be a non empty string');
-  if (P2PK_KNOWN_TAG_KEYS.has(key)) {
+  if (isP2PKKnownTagKey(key)) {
     throw new CTSError(`additionalTags must not use reserved key "${key}"`);
   }
 }
@@ -951,7 +965,7 @@ function assertNoDuplicateP2PKTags(tags: string[][]): void {
   const seen = new Set<string>();
   for (const tag of tags) {
     const key = tag[0];
-    if (!P2PK_KNOWN_TAG_KEYS.has(key)) continue;
+    if (!isP2PKKnownTagKey(key)) continue;
     if (seen.has(key)) {
       throw new CTSError(`Duplicate P2PK tag "${key}"`);
     }

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -157,14 +157,6 @@ const KNOWN_TAG_KEYS = new Set([
 ]);
 
 /**
- * NUT-11 tag keys that map onto structured {@link LockConditions} fields, rather than being carried
- * as free-form `additionalTags`, and are therefore reserved (not settable as additional tags).
- *
- * @internal
- */
-export const P2PK_KNOWN_TAG_KEYS: ReadonlySet<string> = new Set(KNOWN_TAG_KEYS);
-
-/**
  * True if a tag key is one NUT-11 reserves.
  *
  * @internal

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -147,7 +147,7 @@ type WitnessData = {
 
 // Parsing reads this set, so the exported one is a detached copy: an exported Set stays
 // mutable whatever its declared type.
-const KNOWN_TAG_KEYS = new Set([
+const P2PK_KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',
   'n_sigs',
@@ -162,7 +162,7 @@ const KNOWN_TAG_KEYS = new Set([
  * @internal
  */
 export function isP2PKKnownTagKey(key: string): boolean {
-  return KNOWN_TAG_KEYS.has(key);
+  return P2PK_KNOWN_TAG_KEYS.has(key);
 }
 
 // ------------------------------

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -145,8 +145,7 @@ type WitnessData = {
   signatures: string[];
 };
 
-// Parsing reads this set, so the exported one is a detached copy: an exported Set stays
-// mutable whatever its declared type.
+// NUT-11 tag keys that map onto structured lock fields, so they are reserved as additional tags.
 const P2PK_KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -68,14 +68,14 @@ export const verifyDLEQProof_reblind = (
  * https://github.com/cashubtc/cashu-crypto-ts/pull/2 for more details See:
  * https://en.wikipedia.org/wiki/Timing_attack for information about timing attacks.
  */
-export const createDLEQProof = (B_: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
-  const B = assertSecpPoint(B_);
+export const createDLEQProof = (blinded: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
+  const B_ = assertSecpPoint(blinded); // the blinded message, as a checked point
   const scalar_a = secp256k1.Point.Fn.fromBytes(a);
   const A = secp256k1.Point.BASE.multiply(scalar_a); // A  = aG
-  const C_ = B.multiply(scalar_a); // C_ = aB_
-  const r = deriveDLEQNonce(a, A, B, C_);
+  const C_ = B_.multiply(scalar_a); // C_ = aB_
+  const r = deriveDLEQNonce(a, A, B_, C_);
   const R_1 = secp256k1.Point.BASE.multiply(r); // R1 = rG
-  const R_2 = B.multiply(r); // R2 = rB_
+  const R_2 = B_.multiply(r); // R2 = rB_
   const e = hash_e([R_1, R_2, A, C_]); // e = hash(R1, R2, A, C_)
   const scalar_e = secp256k1.Point.Fn.fromBytes(e);
   // Use field operations for constant-time addition and multiplication

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -68,8 +68,8 @@ export const verifyDLEQProof_reblind = (
  * https://github.com/cashubtc/cashu-crypto-ts/pull/2 for more details See:
  * https://en.wikipedia.org/wiki/Timing_attack for information about timing attacks.
  */
-export const createDLEQProof = (blinded: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
-  const B_ = assertSecpPoint(blinded); // the blinded message, as a checked point
+export const createDLEQProof = (B_: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
+  B_ = assertSecpPoint(B_); // the point type is structural, so parse before multiplying
   const scalar_a = secp256k1.Point.Fn.fromBytes(a);
   const A = secp256k1.Point.BASE.multiply(scalar_a); // A  = aG
   const C_ = B_.multiply(scalar_a); // C_ = aB_

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -8,7 +8,7 @@ import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 import { CTSError } from '../model/Errors';
 
 import { type DLEQ } from './core';
-import { hash_e, hashToCurve } from './curve_secp';
+import { assertSecpPoint, hash_e, hashToCurve } from './curve_secp';
 
 const DST_R = utf8ToBytes('Cashu_DLEQ_R_v1');
 
@@ -69,12 +69,13 @@ export const verifyDLEQProof_reblind = (
  * https://en.wikipedia.org/wiki/Timing_attack for information about timing attacks.
  */
 export const createDLEQProof = (B_: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
+  const B = assertSecpPoint(B_);
   const scalar_a = secp256k1.Point.Fn.fromBytes(a);
   const A = secp256k1.Point.BASE.multiply(scalar_a); // A  = aG
-  const C_ = B_.multiply(scalar_a); // C_ = aB_
-  const r = deriveDLEQNonce(a, A, B_, C_);
+  const C_ = B.multiply(scalar_a); // C_ = aB_
+  const r = deriveDLEQNonce(a, A, B, C_);
   const R_1 = secp256k1.Point.BASE.multiply(r); // R1 = rG
-  const R_2 = B_.multiply(r); // R2 = rB_
+  const R_2 = B.multiply(r); // R2 = rB_
   const e = hash_e([R_1, R_2, A, C_]); // e = hash(R1, R2, A, C_)
   const scalar_e = secp256k1.Point.Fn.fromBytes(e);
   // Use field operations for constant-time addition and multiplication

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -6,11 +6,11 @@ import { HDKey, HARDENED_OFFSET } from '@scure/bip32';
 
 import { CTSError, InvalidScalarError } from '../model/Errors';
 import { isBase64String } from '../utils';
+import { MAX_SEED_BYTES, MIN_SEED_BYTES, NUTROOT_MAX_SLOTS } from '../utils/limits';
 
 import { BLS_FR_ORDER } from './curve_bls';
 import { getPubKeyFromPrivKey } from './curve_secp';
-import { getKeysetIdInt, isBlsKeyset } from './curves';
-import { NUTROOT_MAX_SLOTS } from './nutroot';
+import { getKeysetIdInt, isBlsKeyset, LEGACY_KEYSET_ID_LENGTH } from './curves';
 
 const STANDARD_DERIVATION_PATH = `m/129372'/0'`;
 
@@ -63,8 +63,8 @@ type SecretAndBlindingFactorDeriver = (counter: number) => DerivedSecretAndBlind
  * @param keysetId - Mint keyset ID that selects the derivation method.
  * @param counter - Deterministic counter for the output.
  * @returns The derived secret bytes and blinding factor bytes.
- * @throws {@link CTSError} If the keyset ID version is unsupported or if derivation produces an
- *   invalid private key.
+ * @throws {@link CTSError} If the seed is not 16 to 64 bytes, the keyset ID version is unsupported,
+ *   or derivation produces an invalid private key.
  */
 export function deriveSecretAndBlindingFactor(
   seed: Uint8Array,
@@ -91,8 +91,8 @@ export function deriveSecretAndBlindingFactor(
  * @param purpose - Key purpose (`'P2PK'` or `'QuoteLock'`), which selects the path's purpose index.
  * @param counter - Non-hardened BIP-32 child index.
  * @returns The derived keypair, both hex-encoded: compressed (02/03) `pubkey` and `privkey`.
- * @throws {@link CTSError} If the counter is not a non-hardened index (integer below 2^31) or
- *   derivation produces an invalid private key.
+ * @throws {@link CTSError} If the seed is not 16 to 64 bytes, the counter is not a non-hardened
+ *   index (integer below 2^31), or derivation produces an invalid private key.
  */
 export function deriveKeyPair(
   seed: Uint8Array,
@@ -118,11 +118,13 @@ export function deriveKeyPair(
  * @param seed - Wallet seed used for deterministic derivation.
  * @param purpose - Key purpose, which selects the path's purpose index.
  * @returns A function mapping a non-hardened counter to its hex keypair.
+ * @throws {@link CTSError} If the seed is not 16 to 64 bytes.
  */
 export function createKeyPairDeriver(
   seed: Uint8Array,
   purpose: Bip32KeyPurpose,
 ): (counter: number) => { pubkey: string; privkey: string } {
+  assertSeed(seed);
   const index = PURPOSE_INDEX[purpose];
   const parentKey = HDKey.fromMasterSeed(seed).derive(`m/129373'/${index}'/0'/0'`);
   return (counter: number) => {
@@ -156,6 +158,7 @@ export function createSecretAndBlindingFactorDeriver(
   seed: Uint8Array,
   keysetId: string,
 ): SecretAndBlindingFactorDeriver {
+  assertSeed(seed);
   switch (getDerivationKind(keysetId)) {
     case DerivationKind.DEPRECATED_BIP32: {
       const keysetIdInt = getKeysetIdInt(keysetId);
@@ -170,6 +173,11 @@ export function createSecretAndBlindingFactorDeriver(
 }
 
 function getDerivationKind(keysetId: string): DerivationKind {
+  // Legacy ids are 12-character base64 and predate the version byte, so length tells them from a
+  // modern id: their alphabet overlaps hex.
+  if (keysetId.length === LEGACY_KEYSET_ID_LENGTH && isBase64String(keysetId)) {
+    return DerivationKind.DEPRECATED_BIP32;
+  }
   const isValidHex = /^[a-fA-F0-9]+$/.test(keysetId);
   const isHmacHexVersion = keysetId.startsWith('01') || keysetId.startsWith('02');
   if (isValidHex && isHmacHexVersion && keysetId.length % 2 !== 0) {
@@ -268,6 +276,18 @@ export const DERIVATION_TYPE = {
   quoteLock: 0x04,
 } as const;
 
+function assertSeed(seed: Uint8Array): void {
+  // Every secret, blinding factor and key derived here inherits the seed's strength, and types
+  // are erased for JS callers.
+  if (
+    !(seed instanceof Uint8Array) ||
+    seed.length < MIN_SEED_BYTES ||
+    seed.length > MAX_SEED_BYTES
+  ) {
+    throw new CTSError(`seed must be a ${MIN_SEED_BYTES} to ${MAX_SEED_BYTES} byte Uint8Array`);
+  }
+}
+
 function assertCounter(counter: number): void {
   // NUT-13 encodes the counter as u64, but cap at MAX_SAFE_INTEGER: past it
   // `counter + 1 === counter`, so a batch would derive one counter twice.
@@ -308,6 +328,7 @@ function deriveV3Scalar(
   suffix?: Uint8Array,
   order: bigint = SECP256K1_N,
 ): Uint8Array {
+  assertSeed(seed);
   assertCounter(counter);
   const keysetIdBytes = keysetId === undefined ? new Uint8Array(0) : hexToBytes(keysetId);
   const base = concatBytes(

--- a/src/crypto/NUT20.ts
+++ b/src/crypto/NUT20.ts
@@ -50,9 +50,10 @@ function constructLegacyMessage(
   return sha256(utf8ToBytes(message));
 }
 
-// NUT-20 quote pubkeys are compressed 33-byte SEC1 (66 hex chars).
+// NUT-20 quote pubkeys are compressed 33-byte SEC1 (66 hex chars). Types are erased for JS
+// callers, so a value from JSON must fail closed rather than throw on the length read.
 function isCompressedPubkey(pubkey: string): boolean {
-  return pubkey.length === 66;
+  return typeof pubkey === 'string' && pubkey.length === 66;
 }
 
 /**

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -10,13 +10,8 @@ import { MAX_P2BK_SLOTS, NUTROOT_MAX_SLOTS } from '../utils/limits';
 
 import { pointFromHex } from './curve_secp';
 
-// Derivation reads this copy, so the exported one is inert: a Uint8Array cannot be frozen.
-const P2BK_DST_BYTES = utf8ToBytes('Cashu_P2BK_v1');
-
-/**
- * BIP340-style domain separation tag (DST) for P2BK.
- */
-export const P2BK_DST: Uint8Array<ArrayBufferLike> = P2BK_DST_BYTES.slice();
+// BIP340-style domain separation tag (DST) for P2BK.
+const P2BK_DST = utf8ToBytes('Cashu_P2BK_v1');
 
 /**
  * Blind a sequence of public keys using ECDH derived tweaks, one tweak per slot.
@@ -218,11 +213,11 @@ function deriveP2BKBlindingTweakFromECDH(
   // Derive deterministic blinding factor (r):
   // Note: bytesToNumberBE is safe here because we explicitly guard against
   // out-of-range values below, throwing rather than silently normalizing.
-  let r = bytesToNumberBE(sha256(concatBytes(P2BK_DST_BYTES, Zx, iByte)));
+  let r = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, iByte)));
   /* c8 ignore next 6 — retry needs sha256 to land outside the curve order (~2^-128). */
   if (r === 0n || r >= secp256k1.Point.CURVE().n) {
     // Very unlikely to get here!
-    r = bytesToNumberBE(sha256(concatBytes(P2BK_DST_BYTES, Zx, iByte, new Uint8Array([0xff]))));
+    r = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, iByte, new Uint8Array([0xff]))));
     if (r === 0n || r >= secp256k1.Point.CURVE().n) {
       throw new CTSError('P2BK: tweak derivation failed');
     }

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -6,13 +6,17 @@ import { bytesToHex, concatBytes, hexToBytes, utf8ToBytes } from '@noble/hashes/
 
 import { CTSError } from '../model/Errors';
 import { hexToNumber, numberToHexPadded64 } from '../utils';
+import { MAX_P2BK_SLOTS, NUTROOT_MAX_SLOTS } from '../utils/limits';
 
 import { pointFromHex } from './curve_secp';
+
+// Derivation reads this copy, so the exported one is inert: a Uint8Array cannot be frozen.
+const P2BK_DST_BYTES = utf8ToBytes('Cashu_P2BK_v1');
 
 /**
  * BIP340-style domain separation tag (DST) for P2BK.
  */
-export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1');
+export const P2BK_DST: Uint8Array<ArrayBufferLike> = P2BK_DST_BYTES.slice();
 
 /**
  * Blind a sequence of public keys using ECDH derived tweaks, one tweak per slot.
@@ -27,7 +31,7 @@ export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1'
  * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
  *   first pubkey takes slot 1.
  * @returns Blinded pubkeys in the same order, and Ehex as SEC1 compressed hex, 33 bytes.
- * @throws If a blinded key is at infinity.
+ * @throws If there are more keys than slots, or a blinded key is at infinity.
  */
 export function deriveP2BKBlindedPubkeys(
   pubkeys: string[],
@@ -35,6 +39,12 @@ export function deriveP2BKBlindedPubkeys(
   dataIsPubkey = true,
 ): { blinded: string[]; Ehex: string } {
   const slotOffset = dataIsPubkey ? 0 : 1;
+  const slotCount = pubkeys.length + slotOffset;
+  if (slotCount > MAX_P2BK_SLOTS) {
+    throw new CTSError(
+      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is ${MAX_P2BK_SLOTS} in total`,
+    );
+  }
   if (!pubkeys.length) return { blinded: [], Ehex: '' };
   // Create fresh ephemeral secret (e) if not supplied, and calculate pubkey (E)
   const secret = eBytes ?? secp256k1.utils.randomSecretKey(); // 32 bytes
@@ -189,26 +199,30 @@ export function deriveP2BKSecretKey(
  * Both yield the same Z and therefore the same r thanks to the magic of ECDH!
  * @param point Ephemeral public key (E) or recipient public key (P)
  * @param scalar Private scalar (p) or ephemeral scalar (e) in [1, n − 1]
- * @param slotIndex Zero based slot index, only lowest 8 bits (0–255) are used.
+ * @param slotIndex Zero based slot index, below {@link NUTROOT_MAX_SLOTS}.
  * @returns Tweak (r) in [1, n − 1]
- * @throws If r reduces to zero after the retry.
+ * @throws If the slot index is out of range, or r reduces to zero after the retry.
  */
 function deriveP2BKBlindingTweakFromECDH(
   point: WeierstrassPoint<bigint>, // E or P
   scalar: bigint, // p or e
   slotIndex: number, // i
 ): bigint {
+  // The index byte is masked, so an out-of-range slot would silently alias onto another one.
+  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex >= NUTROOT_MAX_SLOTS) {
+    throw new CTSError(`P2BK: slot index must be an integer in [0, ${NUTROOT_MAX_SLOTS - 1}]`);
+  }
   // Calculate x-only ECDH shared point (Zx)
   const Zx = point.multiply(scalar).toBytes(true).slice(1);
   const iByte = new Uint8Array([slotIndex & 0xff]);
   // Derive deterministic blinding factor (r):
   // Note: bytesToNumberBE is safe here because we explicitly guard against
   // out-of-range values below, throwing rather than silently normalizing.
-  let r = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, iByte)));
+  let r = bytesToNumberBE(sha256(concatBytes(P2BK_DST_BYTES, Zx, iByte)));
   /* c8 ignore next 6 — retry needs sha256 to land outside the curve order (~2^-128). */
   if (r === 0n || r >= secp256k1.Point.CURVE().n) {
     // Very unlikely to get here!
-    r = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, iByte, new Uint8Array([0xff]))));
+    r = bytesToNumberBE(sha256(concatBytes(P2BK_DST_BYTES, Zx, iByte, new Uint8Array([0xff]))));
     if (r === 0n || r >= secp256k1.Point.CURVE().n) {
       throw new CTSError('P2BK: tweak derivation failed');
     }

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -246,8 +246,9 @@ export function getValidSigners(
  * @param digest - The 32-byte digest that was signed (hex string or bytes).
  * @param pubkeys - The Cashu P2PK public key(s) (hex-encoded, X-only or with 02/03 prefix) to
  *   check.
- * @param threshold - The minimum number of unique witnesses required.
- * @returns True if the witness threshold was reached, false otherwise.
+ * @param threshold - The minimum number of unique witnesses required; at least 1.
+ * @returns True if the witness threshold was reached, false otherwise (a threshold below 1
+ *   included, which no set of witnesses can satisfy).
  */
 export const meetsSignerThreshold = (
   signatures: string[],
@@ -255,6 +256,7 @@ export const meetsSignerThreshold = (
   pubkeys: string[],
   threshold: number = 1,
 ): boolean => {
+  if (!Number.isInteger(threshold) || threshold < 1) return false;
   const validSigners = getValidSigners(signatures, digest, pubkeys);
   return validSigners.length >= threshold;
 };

--- a/src/crypto/curve_secp.ts
+++ b/src/crypto/curve_secp.ts
@@ -40,6 +40,23 @@ export function pointFromHex(hex: string) {
   return secp256k1.Point.fromHex(hex);
 }
 
+/**
+ * Reparses a point as secp256k1, for entry points that take the structural point type.
+ *
+ * @remarks
+ * `WeierstrassPoint<bigint>` is shared with the other curves and scalar multiplication does not
+ * check membership, so a point that never went through a secp parser has to be sent through one.
+ * @throws {@link CTSError} If the point is not a secp256k1 point.
+ * @internal
+ */
+export function assertSecpPoint(point: WeierstrassPoint<bigint>): WeierstrassPoint<bigint> {
+  try {
+    return pointFromHex(point.toHex(true));
+  } catch (e) {
+    throw new CTSError('Invalid point: not a valid secp256k1 point', { cause: e });
+  }
+}
+
 // Decompression-validated keys; callers typically share keys, so repeat parses are common. Naive
 // clear-on-full, swap for LRU if churn ever matters.
 const VALIDATED_PUBKEYS = new Set<string>();
@@ -119,7 +136,7 @@ export function createBlindSignature(
   id: string,
 ): BlindSignature {
   const a = secp256k1.Point.Fn.fromBytes(privateKey);
-  const C_: WeierstrassPoint<bigint> = B_.multiply(a);
+  const C_: WeierstrassPoint<bigint> = assertSecpPoint(B_).multiply(a);
   return { C_, id };
 }
 

--- a/src/crypto/curves.ts
+++ b/src/crypto/curves.ts
@@ -3,7 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToNumberBE } from '@noble/curves/utils.js';
 
 import { CTSError } from '../model/Errors';
-import { decodeBase64ToUint8Legacy, hexToNumber, isValidHex } from '../utils';
+import { decodeBase64ToUint8Legacy, hexToNumber, isBase64String, isValidHex } from '../utils';
 
 import { type G1Point, hashToCurveBls, pointFromHexG1 } from './curve_bls';
 import { hashToCurve } from './curve_secp';
@@ -65,13 +65,28 @@ export function hashToCurveHex(secret: string, keysetId: string): string {
   return (isBlsKeyset(keysetId) ? hashToCurveBls(msg) : hashToCurve(msg)).toHex(true);
 }
 
+/**
+ * Length of a legacy (pre-2024) base64 keyset id, which has no version byte.
+ *
+ * @internal
+ */
+export const LEGACY_KEYSET_ID_LENGTH = 12;
+
 export const getKeysetIdInt = (keysetId: string): bigint => {
   let keysetIdInt: bigint;
-  if (/^[a-fA-F0-9]+$/.test(keysetId)) {
+  // Length and alphabet separate the two encodings, the same rule getDerivationKind applies.
+  // Legacy ids travelled URL-safe in `GET /keys/{id}`; fold that spelling back to the standard one.
+  const legacy = (id: string): bigint =>
+    bytesToNumberBE(decodeBase64ToUint8Legacy(id.replace(/-/g, '+').replace(/_/g, '/'))) %
+    BigInt(2 ** 31 - 1);
+  if (keysetId.length === LEGACY_KEYSET_ID_LENGTH && isBase64String(keysetId)) {
+    keysetIdInt = legacy(keysetId);
+  } else if (isValidHex(keysetId)) {
     keysetIdInt = hexToNumber(keysetId) % BigInt(2 ** 31 - 1);
+  } else if (isBase64String(keysetId)) {
+    keysetIdInt = legacy(keysetId);
   } else {
-    //legacy keyset compatibility
-    keysetIdInt = bytesToNumberBE(decodeBase64ToUint8Legacy(keysetId)) % BigInt(2 ** 31 - 1);
+    throw new CTSError('Invalid keyset id: neither hex nor base64');
   }
   return keysetIdInt;
 };

--- a/src/crypto/nutroot.ts
+++ b/src/crypto/nutroot.ts
@@ -4,6 +4,7 @@ import { concatBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 import { bytesToHex, compareBytes, hexToBytes, minimalBytesBE } from '../utils';
+import { NUTROOT_MAX_SLOTS } from '../utils/limits';
 
 import { taggedHash } from './core';
 import { getPubKeyFromPrivKey, pointFromBytes, pointFromHex } from './curve_secp';
@@ -65,11 +66,7 @@ export const NUTROOT_MAX_TREE_LEAVES = 2 ** NUTROOT_MAX_TREE_DEPTH;
  */
 export const NUTROOT_MAX_LEAF_TIME = Number.MAX_SAFE_INTEGER;
 
-/**
- * Occupied blinding slots per secret: slot 0 plus NUT-10's 120 leaf-key cap (8 leaves of 15 keys),
- * well inside NUT-28's one index byte. Bounds every receiver-side slot scan.
- */
-export const NUTROOT_MAX_SLOTS = 121;
+export { NUTROOT_MAX_SLOTS };
 
 /**
  * A parsed declarative leaf (version 0x00).

--- a/src/crypto/nutroot.ts
+++ b/src/crypto/nutroot.ts
@@ -66,8 +66,6 @@ export const NUTROOT_MAX_TREE_LEAVES = 2 ** NUTROOT_MAX_TREE_DEPTH;
  */
 export const NUTROOT_MAX_LEAF_TIME = Number.MAX_SAFE_INTEGER;
 
-export { NUTROOT_MAX_SLOTS };
-
 /**
  * A parsed declarative leaf (version 0x00).
  *

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -3,7 +3,7 @@ import { equalBytes } from '@noble/curves/utils.js';
 import { normalizeSecpPubkey } from '../crypto/curve_secp';
 import { getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
 import type { P2PKOptions, P2PKTag } from '../crypto/NUT11';
-import { P2PK_KNOWN_TAG_KEYS, p2pkOptionsToPRNut10, parseP2PKSecret } from '../crypto/NUT11';
+import { isP2PKKnownTagKey, p2pkOptionsToPRNut10, parseP2PKSecret } from '../crypto/NUT11';
 import {
   parseNutrootLeaf,
   serializeNutrootLeaf,
@@ -967,7 +967,7 @@ export function nut10ToP2PKOptions(nut10: NUT10Option | undefined): P2PKOptions 
 
   // Forward any non-standard tags verbatim.
   const additionalTags = (nut10.tags ?? []).filter(
-    (t) => t.length > 0 && !P2PK_KNOWN_TAG_KEYS.has(t[0]),
+    (t) => t.length > 0 && !isP2PKKnownTagKey(t[0]),
   ) as P2PKTag[];
   if (additionalTags.length > 0) {
     options.additionalTags = additionalTags;

--- a/src/model/ScriptPath.ts
+++ b/src/model/ScriptPath.ts
@@ -7,7 +7,6 @@ import { isBlsKeyset } from '../crypto/curves';
 import {
   buildScriptPathWitness,
   enumerateLeafKeySlots,
-  NUTROOT_MAX_SLOTS,
   parseNutrootLeaf,
   selectRequiredLeafSignatures,
   slotKeysByBlindedPubkey,
@@ -25,6 +24,7 @@ import {
   JSONInt,
   encodeUint8ToBase64Url,
 } from '../utils';
+import { NUTROOT_MAX_SLOTS } from '../utils/limits';
 import { orderOutputsForPayload } from '../wallet/_internal';
 import type { MeltPreview, ScriptPathPlan, SwapPreview } from '../wallet/types';
 

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -2,6 +2,8 @@ import { numberToVarBytesBE } from '@noble/curves/utils.js';
 
 import { CTSError } from '../model/Errors';
 
+import { U64_MAX } from './limits';
+
 const utf8Decoder = new TextDecoder('utf-8');
 
 /**
@@ -92,9 +94,11 @@ export function compareBytes(a: Uint8Array, b: Uint8Array): number {
  * @remarks
  * The empty encoding of zero is the difference from noble's `numberToVarBytesBE`, which emits
  * `0x00`. Length-framed fields (NUT-02 keyset ids) need the empty form.
- * @throws RangeError If `value` is negative.
+ * @throws RangeError If `value` is negative or above the u64 range every Cashu amount is held to.
  */
 export function minimalBytesBE(value: bigint): Uint8Array {
   if (value < 0n) throw new RangeError('value must be non-negative');
+  // Bound the encoder before it allocates: the fields framed here are all u64 amounts.
+  if (value > U64_MAX) throw new RangeError('value must not exceed u64 max');
   return value === 0n ? new Uint8Array(0) : numberToVarBytesBE(value);
 }

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -55,7 +55,12 @@ import {
 import { decodeUtf8Document, minimalBytesBE } from './bytes';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
-import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_PAYLOAD_LENGTH, MAX_SPLIT_OUTPUTS } from './limits';
+import {
+  ABSOLUTE_MAX_ARRAY_LENGTH,
+  MAX_PAYLOAD_DECODE_ATTEMPTS,
+  MAX_PAYLOAD_LENGTH,
+  MAX_SPLIT_OUTPUTS,
+} from './limits';
 
 /**
  * Splits the amount into denominations of the provided keyset.
@@ -176,7 +181,10 @@ function getKeysetAmountsAsAmount(keyset: Keys, order: 'asc' | 'desc'): Amount[]
  * @returns True if the amount is in the keyset, false otherwise.
  */
 export function hasCorrespondingKey(amount: AmountLike, keyset: Keys): boolean {
-  return toAmount(amount, 'hasCorrespondingKey.amount', true).toString() in keyset;
+  // Own denominations only: a `Keys` object inherits from Object.prototype, and only the keys
+  // the keyset id commits to count.
+  const denomination = toAmount(amount, 'hasCorrespondingKey.amount', true).toString();
+  return Object.prototype.hasOwnProperty.call(keyset, denomination);
 }
 
 function toAmount(amount: AmountLike, op: string, allowZero = false): Amount {
@@ -588,6 +596,12 @@ export type DeriveKeysetIdOptions = {
  * @throws If keyset versionByte is not valid.
  */
 export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): string {
+  // A u64 denomination is at most 20 digits; bound every key before any amount is parsed.
+  for (const amount of Object.keys(keys)) {
+    if (amount.length > 20) {
+      throw new CTSError('Invalid keyset denomination: exceeds 20 digits');
+    }
+  }
   const unit = options?.unit ?? 'sat'; // default: sat
   const expiry = options?.expiry;
   const versionByte = options?.versionByte ?? 1; // default: 1
@@ -1212,13 +1226,21 @@ export function hasValidDleq(
  * @param getKeyset Lookup callback (e.g. `(id) => keyChain.getKeyset(id)`).
  * @param opts.requireDleq Forwarded to {@link hasValidDleq} as `require` for v0/v1/v2 proofs;
  *   ignored for v3.
- * @throws CTSError if any proof's amount is not in its keyset, or DLEQ/pairing verification fails.
+ * @throws CTSError if the batch is over the proof-count cap, if any proof's amount is not in its
+ *   keyset, or if DLEQ/pairing verification fails.
  */
 export function verifyProofsForReceive(
   proofs: ProofLike[],
   getKeyset: (id: string) => HasKeysetKeys,
   opts?: { requireDleq?: boolean },
 ): void {
+  // Every proof costs curve work, so bound the batch before any of it: a token is untrusted
+  // input and the cap is far above any real one.
+  if (proofs.length > ABSOLUTE_MAX_ARRAY_LENGTH) {
+    throw new CTSError(
+      `Token contains too many proofs: ${proofs.length}, maximum is ${ABSOLUTE_MAX_ARRAY_LENGTH}`,
+    );
+  }
   const normalized = normalizeProofAmounts(proofs);
   const requireDleq = opts?.requireDleq ?? false;
   const failMsg = requireDleq

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -34,6 +34,12 @@ export const DEFAULT_MAX_ARRAY_LENGTH = 500;
 export const ABSOLUTE_MAX_ARRAY_LENGTH = 10_000;
 
 /**
+ * Upper bound on the proofs one receive-side verification will check. Every proof costs curve work,
+ * so the batch is bounded before any of it; far above any real token or blind-auth batch.
+ */
+export const MAX_RECEIVE_PROOFS = 10_000;
+
+/**
  * NUT-02: Hard ceiling on the number of denominations a mint-supplied keyset may carry, checked
  * before any per-key work (id derivation hashes every pubkey). Real keysets carry ~64 keys (powers
  * of two to 2^63), so 256 is ample headroom. Oversized keysets fail id verification.
@@ -76,6 +82,26 @@ export const MAX_SECRET_LENGTH = 1024;
  * verify path keeps a full witness under 9 KiB, so 16 KiB leaves ample headroom.
  */
 export const MAX_WITNESS_LENGTH = 16_384;
+
+/**
+ * Occupied blinding slots per secret: slot 0 plus NUT-10's 120 leaf-key cap (8 leaves of 15 keys),
+ * well inside NUT-28's one index byte. Bounds every receiver-side slot scan.
+ */
+export const NUTROOT_MAX_SLOTS = 121;
+
+/**
+ * NUT-28: locking slots in a P2BK lock, `[data, ...pubkeys, ...refund]` at index bytes
+ * `0x00..0x0A`. `data` always fills slot 0, so an HTLC lock has one fewer key to give away.
+ */
+export const MAX_P2BK_SLOTS = 11;
+
+/**
+ * NUT-13: accepted length range for a deterministic-secrets seed. BIP-32's 16-byte floor at the
+ * bottom, the 64 bytes a BIP-39 mnemonic produces at the top; every derived secret and blinding
+ * factor inherits the seed's strength.
+ */
+export const MIN_SEED_BYTES = 16;
+export const MAX_SEED_BYTES = 64;
 
 /**
  * Max u64 (2^64 - 1): the ceiling every Amount is held to. Enforced in the Amount constructor, so

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -122,13 +122,17 @@ export class Keyset {
   /**
    * Verifies that a MintKeys DTO has a correct id for its keys/unit/expiry.
    *
-   * @returns True if verification succeeds, false otherwise (e.g: no keys, too many keys, or
-   *   mismatch).
+   * @returns True if verification succeeds, false otherwise (e.g: no keys, too many keys, one key
+   *   serving two denominations, or mismatch).
    */
   static verifyKeysetId(keys: MintKeys): boolean {
     try {
       const count = keys.keys ? Object.keys(keys.keys).length : 0;
       if (count === 0 || count > MAX_KEYSET_DENOMINATIONS) return false;
+
+      // A keyset id selects one key per amount, so a key repeated across denominations is malformed.
+      const distinct = new Set(Object.values(keys.keys).map((k) => k.toLowerCase()));
+      if (distinct.size !== count) return false;
 
       const isDeprecatedBase64 = isBase64String(keys.id) && !isValidHex(keys.id);
       const versionByte = isValidHex(keys.id) ? hexToBytes(keys.id)[0] : 0;

--- a/src/wallet/LockBuilder.ts
+++ b/src/wallet/LockBuilder.ts
@@ -262,6 +262,15 @@ export class LockBuilder {
    */
   static fromOptions(lock: LockOptions): LockBuilder {
     const b = new LockBuilder();
+    // The setters take a key or a list; stored options are lists, so a bare string here is
+    // malformed input rather than a shorthand. `blindKeys` doubles as a flag, so it also takes a
+    // boolean.
+    for (const field of ['mainKeys', 'refundKeys', 'blindKeys'] as const) {
+      const value = lock[field];
+      if (value === undefined || Array.isArray(value)) continue;
+      if (field === 'blindKeys' && typeof value === 'boolean') continue;
+      throw new CTSError(`${field} must be an array of pubkeys`);
+    }
     if (lock.hashlock !== undefined) b.addHashlock(lock.hashlock);
     if (lock.mainKeys?.length) b.addMainPubkey(lock.mainKeys);
     // lock.locktime is already canonical Unix seconds; assign directly so lockUntil's

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -87,6 +87,8 @@ import {
   DEFAULT_MAX_ARRAY_LENGTH,
   getDecodedToken,
   invoiceHasAmountInHRP,
+  MAX_SEED_BYTES,
+  MIN_SEED_BYTES,
   normalizeMintUrl,
   normalizeProofAmounts,
   REPAIR_COOLDOWN_MS,
@@ -257,7 +259,7 @@ class Wallet {
    * @param options Optional settings.
    * @param options.unit Wallet unit, default 'sat'.
    * @param options.keysetId Bind to this keyset id, else bind on `loadMint`.
-   * @param options.bip39seed BIP39 seed for deterministic secrets.
+   * @param options.bip39seed BIP39 seed for deterministic secrets, 16 to 64 bytes.
    * @param options.secretsPolicy Secrets policy, default 'auto'.
    * @param options.counterSource Counter source for deterministic outputs. If provided, this takes
    *   precedence over counterInit. Use when you need persistence across processes or devices.
@@ -334,6 +336,13 @@ class Wallet {
         !(options.bip39seed instanceof Uint8Array),
         'bip39seed must be a valid Uint8Array',
         { received: typeof options.bip39seed },
+      );
+      // Fail here rather than at the first derivation: a wallet on a seed NUT-13 will refuse is
+      // broken, and the deriver's own guard would surface it mid-operation.
+      this.failIf(
+        options.bip39seed.length < MIN_SEED_BYTES || options.bip39seed.length > MAX_SEED_BYTES,
+        `bip39seed must be ${MIN_SEED_BYTES} to ${MAX_SEED_BYTES} bytes`,
+        { length: options.bip39seed.length },
       );
       this._seed = options.bip39seed;
     }

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -23,7 +23,9 @@ import {
   schnorrSignDigest,
   schnorrVerifyMessage,
   deriveP2BKBlindedPubkeys,
+  assertValidTagKey,
   P2BK_DST,
+  P2PK_KNOWN_TAG_KEYS,
   buildP2PKSigAllMessageV0,
   assertSigAllInputs,
   createSecret,
@@ -1773,6 +1775,22 @@ describe('parseP2PKSecret — duplicate tag rejection', () => {
   function makeSecret(tags: string[][]): string {
     return JSON.stringify(['P2PK', { nonce: bytesToHex(randomBytes(32)), data: pk1, tags }]);
   }
+
+  test('editing the exported reserved-key set leaves duplicate rejection alone', () => {
+    const exported = P2PK_KNOWN_TAG_KEYS as Set<string>;
+    exported.delete('n_sigs');
+    try {
+      const secret = makeSecret([
+        ['pubkeys', pk2],
+        ['n_sigs', '1'],
+        ['n_sigs', '2'],
+      ]);
+      expect(() => parseP2PKSecret(secret)).toThrow(/Duplicate P2PK tag "n_sigs"/);
+      expect(() => assertValidTagKey('n_sigs')).toThrow(/reserved key/);
+    } finally {
+      exported.add('n_sigs');
+    }
+  });
 
   test('rejects duplicate locktime tags', () => {
     const secret = makeSecret([

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -23,9 +23,7 @@ import {
   schnorrSignDigest,
   schnorrVerifyMessage,
   deriveP2BKBlindedPubkeys,
-  assertValidTagKey,
   P2BK_DST,
-  P2PK_KNOWN_TAG_KEYS,
   buildP2PKSigAllMessageV0,
   assertSigAllInputs,
   createSecret,
@@ -1775,22 +1773,6 @@ describe('parseP2PKSecret — duplicate tag rejection', () => {
   function makeSecret(tags: string[][]): string {
     return JSON.stringify(['P2PK', { nonce: bytesToHex(randomBytes(32)), data: pk1, tags }]);
   }
-
-  test('editing the exported reserved-key set leaves duplicate rejection alone', () => {
-    const exported = P2PK_KNOWN_TAG_KEYS as Set<string>;
-    exported.delete('n_sigs');
-    try {
-      const secret = makeSecret([
-        ['pubkeys', pk2],
-        ['n_sigs', '1'],
-        ['n_sigs', '2'],
-      ]);
-      expect(() => parseP2PKSecret(secret)).toThrow(/Duplicate P2PK tag "n_sigs"/);
-      expect(() => assertValidTagKey('n_sigs')).toThrow(/reserved key/);
-    } finally {
-      exported.add('n_sigs');
-    }
-  });
 
   test('rejects duplicate locktime tags', () => {
     const secret = makeSecret([

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -1,6 +1,6 @@
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { hexToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
+import { hexToBytes, bytesToHex, randomBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { Amount, type OutputDataLike } from '../../src';
@@ -23,7 +23,6 @@ import {
   schnorrSignDigest,
   schnorrVerifyMessage,
   deriveP2BKBlindedPubkeys,
-  P2BK_DST,
   buildP2PKSigAllMessageV0,
   assertSigAllInputs,
   createSecret,
@@ -729,7 +728,9 @@ describe('P2BK fixed-vector ECDH tweak', () => {
     const Z = E.multiply(pBig);
     const Zx = Z.toBytes(false).slice(1, 33); // 32B X from uncompressed SEC1
     const i0 = new Uint8Array([0x00]);
-    const r = secp256k1.Point.Fn.fromBytes(sha256(new Uint8Array([...P2BK_DST, ...Zx, ...i0])));
+    const r = secp256k1.Point.Fn.fromBytes(
+      sha256(new Uint8Array([...utf8ToBytes('Cashu_P2BK_v1'), ...Zx, ...i0])),
+    );
 
     // Check blinded point matches P + r·G
     const expectPprime = P.add(secp256k1.Point.BASE.multiply(r));

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -1,3 +1,4 @@
+import { bls12_381 } from '@noble/curves/bls12-381.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
@@ -26,6 +27,16 @@ describe('test hash_e', () => {
     console.log('e = ' + bytesToHex(e));
     expect(bytesToHex(e)).toEqual(
       'a4dc034b74338c28c6bc3ea49731f2a24440fc7c4affc08b31a93fc9fbe6401e',
+    );
+  });
+});
+
+describe('createDLEQProof', () => {
+  test('rejects a blinded message from another curve', () => {
+    // The point type is structural, so a BLS12-381 G1 point satisfies it at compile time.
+    const foreign = bls12_381.G1.Point.fromAffine({ x: 0n, y: 2n });
+    expect(() => createDLEQProof(foreign, hexToBytes('0'.repeat(63) + '2'))).toThrow(
+      /secp256k1 point/,
     );
   });
 });

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -11,12 +11,16 @@ import {
 } from '../../src/crypto';
 import { getPubKeyFromPrivKey } from '../../src/crypto/curve_secp';
 import {
+  createKeyPairDeriver,
+  createSecretAndBlindingFactorDeriver,
+  deriveKeyPair,
   deriveLeafKey,
   deriveNumsOffset,
   deriveQuoteLockKey,
   recoverV3LeafKeys,
 } from '../../src/crypto/NUT13';
 import { CTSError } from '../../src/model/Errors';
+import { decodeBase64ToUint8Legacy } from '../../src/utils';
 import { nut13_v3 as nut13Vectors } from '../vectors/nutroot-v3.json';
 
 // The standalone deriveBlindingFactor() helper was removed in v5; derive it locally for these tests.
@@ -240,6 +244,39 @@ describe('HMAC counter range', () => {
   });
 });
 
+describe('seed length', () => {
+  const v2KeysetId = '01abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567';
+  const v3KeysetId = '02b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f6';
+  const bad = /seed must be a 16 to 64 byte Uint8Array/;
+
+  test('every seeded derivation takes 16 to 64 bytes and nothing else', () => {
+    for (const length of [16, 32, 64]) {
+      const seed = new Uint8Array(length).fill(7);
+      expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 0)).not.toThrow();
+      expect(() => deriveKeyPair(seed, 'P2PK', 0)).not.toThrow();
+      expect(() => deriveQuoteLockKey(seed, 0)).not.toThrow();
+    }
+    for (const length of [0, 15, 65]) {
+      const seed = new Uint8Array(length);
+      expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 0)).toThrow(bad);
+      expect(() => createSecretAndBlindingFactorDeriver(seed, v2KeysetId)).toThrow(bad);
+      expect(() => deriveKeyPair(seed, 'P2PK', 0)).toThrow(bad);
+      expect(() => createKeyPairDeriver(seed, 'QuoteLock')).toThrow(bad);
+      expect(() => deriveQuoteLockKey(seed, 0)).toThrow(bad);
+      expect(() => deriveNumsOffset(seed, v3KeysetId, 0)).toThrow(bad);
+      expect(() => deriveLeafKey(seed, v3KeysetId, 0, 0)).toThrow(bad);
+      expect(() => recoverV3LeafKeys(seed, v3KeysetId, 0, ['02'.padEnd(66, 'a')])).toThrow(bad);
+    }
+  });
+
+  test('a seed that is not a Uint8Array is rejected the same way', () => {
+    const notBytes = 'dd44ee516b0647e80b488e8dcc56d736' as unknown as Uint8Array;
+    expect(() => deriveSecretAndBlindingFactor(notBytes, v2KeysetId, 0)).toThrow(bad);
+    expect(() => deriveKeyPair(notBytes, 'P2PK', 0)).toThrow(bad);
+    expect(() => deriveQuoteLockKey(notBytes, 0)).toThrow(bad);
+  });
+});
+
 describe('derivation kind selection', () => {
   // Known BIP-32 seed (NUT-13 spec / NUT-09 fixtures).
   const seed = hexToBytes(
@@ -262,6 +299,31 @@ describe('derivation kind selection', () => {
     const { secret, blindingFactor } = deriveSecretAndBlindingFactor(seed, base64KeysetId, counter);
     expect(bytesToHex(secret)).toBe(bytesToHex(expectedSecret as Uint8Array));
     expect(bytesToHex(blindingFactor)).toBe(bytesToHex(expectedR as Uint8Array));
+  });
+
+  test('a 12-character all-hex keyset id still takes the deprecated BIP-32 path', () => {
+    // Legacy ids predate the version byte and their base64 alphabet overlaps hex, so length
+    // is what separates them from a modern id.
+    const legacyKeysetId = 'd9f0F7F2875b';
+    const counter = 2;
+    const keysetIdInt =
+      bytesToNumberBE(decodeBase64ToUint8Legacy(legacyKeysetId)) % BigInt(2 ** 31 - 1);
+    expect(getKeysetIdInt(legacyKeysetId)).toBe(keysetIdInt);
+
+    const hdkey = HDKey.fromMasterSeed(seed);
+    const path = `m/129372'/0'/${keysetIdInt}'/${counter}'`;
+    const expectedSecret = hdkey.derive(`${path}/0`).privateKey;
+    const expectedR = hdkey.derive(`${path}/1`).privateKey;
+    expect(expectedSecret).not.toBeNull();
+
+    const { secret, blindingFactor } = deriveSecretAndBlindingFactor(seed, legacyKeysetId, counter);
+    expect(bytesToHex(secret)).toBe(bytesToHex(expectedSecret as Uint8Array));
+    expect(bytesToHex(blindingFactor)).toBe(bytesToHex(expectedR as Uint8Array));
+
+    // Length alone is not enough: a 12-character id outside both alphabets is still rejected.
+    expect(() => deriveSecretAndBlindingFactor(seed, '!'.repeat(12), 0)).toThrow(
+      /Unrecognized keyset ID version/,
+    );
   });
 
   test('rejects a negative counter on the deprecated BIP-32 path', () => {

--- a/test/crypto/NUT20.test.ts
+++ b/test/crypto/NUT20.test.ts
@@ -273,6 +273,12 @@ describe('mint quote signature verification rejects malformed input (no throw)',
   const withOutputs = (outputs: unknown) =>
     outputs as Array<{ amount: Amount; id: string; B_: string }>;
 
+  test('a non-string pubkey verifies as false in both message formats', () => {
+    const missing = null as unknown as string;
+    expect(verifyMintQuoteSignature(missing, 'q', [], sig)).toBe(false);
+    expect(verifyMintQuoteSignatureLegacy(missing, 'q', [], sig)).toBe(false);
+  });
+
   test('amended: negative amount verifies as false', () => {
     const outputs = withOutputs([{ amount: -1, id: keysetId, B_: goodB_ }]);
     expect(verifyMintQuoteSignature(pubkey, 'q', outputs, sig)).toBe(false);

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, test } from 'vitest';
 
 import { Amount } from '../../src';
 import {
-  P2BK_DST,
   pointFromHex,
   deriveP2BKSecretKey,
   deriveP2BKBlindedPubkeyAtSlot,
@@ -303,16 +302,6 @@ describe('NUT28 uncovered branches and guards', () => {
     expect(deriveP2BKBlindedPubkeyAtSlot(key, eBytes, 120)).toHaveLength(66);
     for (const slot of [-1, 121, 1.5]) {
       expect(() => deriveP2BKBlindedPubkeyAtSlot(key, eBytes, slot)).toThrow(/slot/i);
-    }
-  });
-
-  test('mutating the exported domain separator leaves derivation alone', () => {
-    const before = deriveP2BKBlindedPubkeys([slot0Blinded], hexToBytes('11'.repeat(32)));
-    P2BK_DST[0] ^= 0xff;
-    try {
-      expect(deriveP2BKBlindedPubkeys([slot0Blinded], hexToBytes('11'.repeat(32)))).toEqual(before);
-    } finally {
-      P2BK_DST[0] ^= 0xff;
     }
   });
 

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, test } from 'vitest';
 
 import { Amount } from '../../src';
 import {
+  P2BK_DST,
   pointFromHex,
   deriveP2BKSecretKey,
+  deriveP2BKBlindedPubkeyAtSlot,
   deriveP2BKBlindedPubkeys,
   deriveP2BKSecretKeys,
   maybeDeriveP2BKPrivateKeys,
@@ -279,6 +281,39 @@ describe('NUT28 uncovered branches and guards', () => {
 
   test('deriveP2BKBlindedPubkeys returns empty result for empty input', () => {
     expect(deriveP2BKBlindedPubkeys([])).toEqual({ blinded: [], Ehex: '' });
+  });
+
+  test('deriveP2BKBlindedPubkeys fills every slot up to the cap and refuses more', () => {
+    const key = bytesToHex(secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true));
+    const eBytes = secp256k1.utils.randomSecretKey();
+    expect(deriveP2BKBlindedPubkeys(Array(11).fill(key), eBytes).blinded).toHaveLength(11);
+    expect(() => deriveP2BKBlindedPubkeys(Array(12).fill(key), eBytes)).toThrow(
+      /maximum allowed is 11/,
+    );
+    // Slot 0 is taken by the hashlock, so an HTLC lock has one fewer to give away.
+    expect(deriveP2BKBlindedPubkeys(Array(10).fill(key), eBytes, false).blinded).toHaveLength(10);
+    expect(() => deriveP2BKBlindedPubkeys(Array(11).fill(key), eBytes, false)).toThrow(
+      /maximum allowed is 11/,
+    );
+  });
+
+  test('deriveP2BKBlindedPubkeyAtSlot refuses a slot index outside the cap', () => {
+    const key = bytesToHex(secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true));
+    const eBytes = secp256k1.utils.randomSecretKey();
+    expect(deriveP2BKBlindedPubkeyAtSlot(key, eBytes, 120)).toHaveLength(66);
+    for (const slot of [-1, 121, 1.5]) {
+      expect(() => deriveP2BKBlindedPubkeyAtSlot(key, eBytes, slot)).toThrow(/slot/i);
+    }
+  });
+
+  test('mutating the exported domain separator leaves derivation alone', () => {
+    const before = deriveP2BKBlindedPubkeys([slot0Blinded], hexToBytes('11'.repeat(32)));
+    P2BK_DST[0] ^= 0xff;
+    try {
+      expect(deriveP2BKBlindedPubkeys([slot0Blinded], hexToBytes('11'.repeat(32)))).toEqual(before);
+    } finally {
+      P2BK_DST[0] ^= 0xff;
+    }
   });
 
   test('deriveP2BKSecretKeys accepts a single (non-array) blinded pubkey', () => {

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -32,6 +32,7 @@ import {
   findSigningKey,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
+import { decodeBase64ToUint8Legacy } from '../../src/utils';
 
 const SECRET_MESSAGE = 'test_message';
 
@@ -235,6 +236,23 @@ describe('getKeysetIdInt', () => {
     const expected = BigInt(0x010203) % MOD;
     expect(getKeysetIdInt(b64Id)).toBe(expected);
   });
+
+  test('a 12-character id is legacy base64 even when every character is a hex digit', () => {
+    // Same rule as getDerivationKind: length decides, since the base64 alphabet overlaps hex.
+    const MOD = BigInt(2 ** 31 - 1);
+    const id = 'abcdef012345';
+    const expected = bytesToNumberBE(decodeBase64ToUint8Legacy(id)) % MOD;
+    expect(getKeysetIdInt(id)).toBe(expected);
+    expect(getKeysetIdInt(id)).not.toBe(BigInt('0x' + id) % MOD);
+  });
+
+  test('a URL-safe spelling of a legacy id derives the same path', () => {
+    expect(getKeysetIdInt('22aBcD-_eFgH')).toBe(getKeysetIdInt('22aBcD+/eFgH'));
+  });
+
+  test('rejects an id that is neither hex nor base64', () => {
+    expect(() => getKeysetIdInt('not-a-keyset!')).toThrow(/Invalid keyset id/);
+  });
 });
 
 describe('schnorrVerifyDigest', () => {
@@ -298,6 +316,13 @@ describe('getValidSigners / meetsSignerThreshold', () => {
 
   test('one signature cannot meet a 2-of-2 threshold across 02/03 encodings', () => {
     expect(meetsSignerThreshold([signature], message, [compressed, '03' + xOnly], 2)).toBe(false);
+  });
+
+  test('a threshold below one is rejected instead of passing on no signatures', () => {
+    expect(meetsSignerThreshold([], message, [compressed], 0)).toBe(false);
+    expect(meetsSignerThreshold([], message, [compressed], -1)).toBe(false);
+    expect(meetsSignerThreshold([signature], message, [compressed], 1.5)).toBe(false);
+    expect(meetsSignerThreshold([signature], message, [compressed], 1)).toBe(true);
   });
 
   test('non-string pubkey entries fail closed without throwing', () => {

--- a/test/crypto/curve_secp.test.ts
+++ b/test/crypto/curve_secp.test.ts
@@ -1,3 +1,4 @@
+import { bls12_381 } from '@noble/curves/bls12-381.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, test, expect, vi } from 'vitest';
@@ -7,6 +8,8 @@ import {
   isValidSecpPubkey,
   normalizeXOnlySecretKey,
   getPubKeyFromPrivKey,
+  createBlindSignature,
+  pointFromHex,
 } from '../../src';
 
 // A valid compressed secp256k1 point (the generator).
@@ -87,5 +90,22 @@ describe('normalizeXOnlySecretKey', () => {
     expect(bytesToHex(getPubKeyFromPrivKey(normalized)).slice(2)).toBe(
       bytesToHex(getPubKeyFromPrivKey(oddBytes)).slice(2),
     );
+  });
+});
+
+describe('createBlindSignature', () => {
+  const a = hexToBytes('0'.repeat(63) + '2');
+
+  test('signs a secp256k1 blinded message', () => {
+    const B_ = pointFromHex(VALID);
+    const sig = createBlindSignature(B_, a, 'keyset-id');
+    expect(sig.id).toBe('keyset-id');
+    expect(sig.C_.toHex(true)).toBe(B_.multiply(2n).toHex(true));
+  });
+
+  test('rejects a blinded message from another curve', () => {
+    // The point type is structural, so a BLS12-381 G1 point satisfies it at compile time.
+    const foreign = bls12_381.G1.Point.fromAffine({ x: 0n, y: 2n });
+    expect(() => createBlindSignature(foreign, a, 'keyset-id')).toThrow(/secp256k1 point/);
   });
 });

--- a/test/crypto/nutroot.test.ts
+++ b/test/crypto/nutroot.test.ts
@@ -18,7 +18,6 @@ import {
   NUTROOT_NUMS_KEY,
   NUTROOT_MAX_LEAF_BYTES,
   NUTROOT_MAX_LEAF_TIME,
-  NUTROOT_MAX_SLOTS,
   NUTROOT_MAX_TREE_DEPTH,
   verifyNutrootSpendInfo,
   verifyNutrootRequestTree,
@@ -45,6 +44,7 @@ import {
   NUTROOT_BRANCH_TAG,
   NUTROOT_TWEAK_TAG,
 } from '../../src/crypto/nutroot';
+import { NUTROOT_MAX_SLOTS } from '../../src/utils/limits';
 import vectors from '../vectors/nutroot-v3.json';
 
 const vRefund = vectors.receiver_keyed_refund;

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -1,7 +1,7 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, bytesToNumberBE } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { concatBytes } from '@noble/hashes/utils.js';
+import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -10,7 +10,6 @@ import {
   createDLEQProof,
   getPubKeyFromPrivKey,
   pointFromHex,
-  P2BK_DST,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 import { Amount } from '../../src/model/Amount';
@@ -271,7 +270,9 @@ describe('OutputData.createSingleP2PKData tag construction', () => {
     // Independent receiver-side NUT-28 math: r1 = sha256(DST || Zx || 0x01), P' = P + r1·G
     const p = secp256k1.Point.Fn.fromBytes(lockPriv);
     const Zx = secp256k1.Point.fromHex(out.ephemeralE!).multiply(p).toBytes(true).slice(1);
-    const r1 = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, Uint8Array.of(1))));
+    const r1 = bytesToNumberBE(
+      sha256(concatBytes(utf8ToBytes('Cashu_P2BK_v1'), Zx, Uint8Array.of(1))),
+    );
     const expected = pointFromHex(lock1).add(secp256k1.Point.BASE.multiply(r1)).toHex(true);
     expect(blinded).toBe(expected);
   });

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -11,7 +11,6 @@ import {
   getPubKeyFromPrivKey,
   pointFromHex,
   P2BK_DST,
-  P2PK_KNOWN_TAG_KEYS,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
 import { Amount } from '../../src/model/Amount';
@@ -166,7 +165,8 @@ describe('OutputData secp round-trip (secp256k1 + NUT-12 DLEQ)', () => {
 
 describe('OutputData.assertValidTagKey and reserved tags', () => {
   test('rejects every reserved P2PK tag key', () => {
-    for (const key of P2PK_KNOWN_TAG_KEYS) {
+    const reserved = ['pubkeys', 'locktime', 'refund', 'n_sigs', 'n_sigs_refund', 'sigflag'];
+    for (const key of reserved) {
       expect(() => assertValidTagKey(key)).toThrowError(/reserved key/);
     }
     // Explicit check for the last reserved entry, guarding against a dropped set member.

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -19,7 +19,7 @@ import type { HasKeysetKeys, SerializedBlindedSignature, Proof } from '../../src
 describe('DefaultOutputDataCreator', () => {
   test('delegates single deterministic output creation to OutputData', () => {
     const creator = new DefaultOutputDataCreator();
-    const seed = new Uint8Array([1]);
+    const seed = new Uint8Array(32).fill(1);
     const keysetId = '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30';
 
     expect(creator.createSingleDeterministicData(1, seed, 7, keysetId)).toEqual(
@@ -32,7 +32,7 @@ describe('DefaultOutputDataCreator', () => {
       id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
       keys: { '1': 'unused', '2': 'unused' },
     };
-    const seed = new Uint8Array([1]);
+    const seed = new Uint8Array(32).fill(1);
     const creator = new DefaultOutputDataCreator();
     const batchSpy = vi.spyOn(OutputData, 'createDeterministicData');
 
@@ -89,7 +89,7 @@ describe('DefaultOutputDataCreator', () => {
       keys: { '1': 'unused', '2': 'unused' },
     };
     const creator = new DefaultOutputDataCreator();
-    const seed = new Uint8Array([1]);
+    const seed = new Uint8Array(32).fill(1);
 
     // The first output is fine; the second lands on 2^53, where counter + 1 stops
     // producing a distinct value, so a batch would derive one counter twice.

--- a/test/utils/bytes.test.ts
+++ b/test/utils/bytes.test.ts
@@ -78,4 +78,9 @@ describe('minimalBytesBE', () => {
   test('refuses a negative value', () => {
     expect(() => minimalBytesBE(-1n)).toThrow(RangeError);
   });
+
+  test('encodes the largest amount but refuses anything above it', () => {
+    expect(minimalBytesBE(2n ** 64n - 1n)).toEqual(new Uint8Array(8).fill(0xff));
+    expect(() => minimalBytesBE(2n ** 64n)).toThrow(RangeError);
+  });
 });

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -856,6 +856,16 @@ describe('test output selection', () => {
     expect(utils.hasCorrespondingKey('8', keys)).toBe(true);
     expect(utils.hasCorrespondingKey(Amount.from(3), keys)).toBe(false);
   });
+
+  test('hasCorrespondingKey counts own denominations only', () => {
+    Object.defineProperty(Object.prototype, '3', { value: 'inherited', configurable: true });
+    try {
+      expect(utils.hasCorrespondingKey(3, keys)).toBe(false);
+      expect(utils.hasCorrespondingKey(8, keys)).toBe(true);
+    } finally {
+      Reflect.deleteProperty(Object.prototype, '3');
+    }
+  });
 });
 describe('test zero-knowledge utilities', () => {
   // create private public key pair
@@ -1062,6 +1072,17 @@ describe('test zero-knowledge utilities', () => {
       const getKeyset = () => secpKeyset;
       expect(() => utils.verifyProofsForReceive([tampered], getKeyset)).toThrow(
         /Undefined key for amount 3 in keyset 00/,
+      );
+    });
+
+    test('verifies a batch at the proof-count cap but refuses one above it', () => {
+      const { dleq, ...noDleq } = serializedProof;
+      void dleq;
+      const getKeyset = () => secpKeyset;
+      const capacity = Array.from({ length: 10_000 }, () => noDleq);
+      expect(() => utils.verifyProofsForReceive(capacity, getKeyset)).not.toThrow();
+      expect(() => utils.verifyProofsForReceive([...capacity, noDleq], getKeyset)).toThrow(
+        /too many proofs/i,
       );
     });
 
@@ -1708,6 +1729,17 @@ describe('deriveKeysetId edge cases', () => {
     expect(() => utils.deriveKeysetId(keys, { versionByte: 99 })).toThrow(
       /Unrecognized keyset ID version/,
     );
+  });
+
+  test('rejects a denomination key over 20 digits before parsing it', () => {
+    const oversized = { ...keys, ['1'.repeat(21)]: Object.values(keys)[0] };
+    expect(() => utils.deriveKeysetId(oversized, { versionByte: 2 })).toThrow(/exceeds 20 digits/);
+    expect(
+      utils.deriveKeysetId(
+        { ...keys, ['1'.repeat(20)]: Object.values(keys)[0] },
+        { versionByte: 2 },
+      ),
+    ).toMatch(/^02[0-9a-f]{64}$/);
   });
 });
 

--- a/test/wallet/Keyset.node.test.ts
+++ b/test/wallet/Keyset.node.test.ts
@@ -50,6 +50,19 @@ describe('Keyset.verifyKeysetId', () => {
     expect(Keyset.verifyKeysetId(mk)).toBe(false);
   });
 
+  test('returns false when one key serves two denominations, id notwithstanding', () => {
+    // A keyset id selects one key per amount, so a key repeated across denominations is malformed.
+    const shared = (PUBKEYS as Keys)[1];
+    const duplicated: Keys = { 1: shared, 2: shared };
+    const mk: MintKeys = {
+      id: deriveKeysetId(duplicated, { versionByte: 1, unit: 'sat' }),
+      unit: 'sat',
+      active: true,
+      keys: duplicated,
+    };
+    expect(Keyset.verifyKeysetId(mk)).toBe(false);
+  });
+
   test('returns false when derived id does not match a tampered key', () => {
     const tampered: Keys = { ...(PUBKEYS as Keys), 1: (PUBKEYS as Keys)[2] };
     const mk: MintKeys = { id: GENUINE_ID, unit: 'sat', active: true, keys: tampered };

--- a/test/wallet/lock.node.test.ts
+++ b/test/wallet/lock.node.test.ts
@@ -506,6 +506,25 @@ describe('LockBuilder', () => {
     expect(LockBuilder.fromOptions(options).toOptions()).toEqual(options);
   });
 
+  test('fromOptions takes key lists as arrays only', () => {
+    const scalar = (field: 'mainKeys' | 'refundKeys' | 'blindKeys') =>
+      ({ mainKeys: [PUB_A], [field]: PUB_A, locktime: 4102444800 }) as unknown as LockOptions;
+    for (const field of ['mainKeys', 'refundKeys', 'blindKeys'] as const) {
+      expect(() => LockBuilder.fromOptions(scalar(field))).toThrow(
+        new RegExp(`${field} must be an array`),
+      );
+    }
+    const options = { mainKeys: [PUB_A], refundKeys: [PUB_B], locktime: 4102444800 };
+    expect(LockBuilder.fromOptions(options).toOptions()).toEqual(options);
+    // blindKeys doubles as a flag: a boolean and a key list are both accepted.
+    expect(LockBuilder.fromOptions({ ...options, blindKeys: true }).toOptions().blindKeys).toBe(
+      true,
+    );
+    expect(
+      LockBuilder.fromOptions({ ...options, blindKeys: [PUB_A] }).toOptions().blindKeys,
+    ).toEqual([PUB_A]);
+  });
+
   test('P2PKBuilder is gone: the v5 break is clean', async () => {
     const api = (await import('../../src')) as Record<string, unknown>;
     expect(api.P2PKBuilder).toBeUndefined();

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -63,6 +63,17 @@ describe('constructor mutants', () => {
     );
   });
 
+  test('rejects a bip39seed outside the accepted length range', () => {
+    for (const length of [1, 15, 65]) {
+      expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(length) })).toThrow(
+        /bip39seed must be 16 to 64 bytes/,
+      );
+    }
+    for (const length of [16, 32, 64]) {
+      expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(length) })).not.toThrow();
+    }
+  });
+
   test('never logs the rejected seed value', () => {
     // failIf logs its context before throwing, so the value must not appear there.
     const mnemonic = 'abandon abandon abandon abandon about';


### PR DESCRIPTION
The crypto helpers now check their inputs at the boundary: points are reparsed before mint-side signing, thresholds, seeds, slot indices, keyset keys and key lists are validated where they enter, and two module constants that were only ever read by tests are no longer exported.

## Why

Several helpers trusted their arguments' shape: `createBlindSignature` and `createDLEQProof` multiplied whatever point object arrived, `meetsSignerThreshold` accepted a non-positive count, a JSON `null` pubkey threw out of the quote verifiers, an inherited `Object.prototype` key counted as a denomination, seeds of any length derived, a P2BK slot index was truncated to one byte, a keyset reusing one key across amounts verified, and `P2BK_DST` and `P2PK_KNOWN_TAG_KEYS` were exported live although nothing outside the module read them.

## Changes

One `assertSecpPoint` reparses a point through `pointFromHex` before the multiply (about 4% of its cost). Seeds are held to 16..64 bytes at the `Wallet` constructor and in NUT-13's derivers (BIP-32's floor; a raw 32-byte seed is a common caller shape). `deriveP2BKBlindedPubkeys` caps at [NUT-28](https://github.com/cashubtc/nuts/blob/main/28.md)'s 11 slots and the tweak derivation bounds the index at 0..120 for the v3 tree path. `verifyKeysetId` refuses a repeated key. A 12-character keyset id takes the legacy base64 path in both `getDerivationKind` and `getKeysetIdInt`, and the URL-safe spelling the old `GET /keys/{id}` route used decodes as its standard form. `LockBuilder.fromOptions` rejects non-array key lists. Receive-side verification is bounded by a new `MAX_RECEIVE_PROOFS`, and a denomination key is bounded to 20 digits before it is parsed as a bigint. Both exports are removed; the sets stay private and the tests derive the bytes they need themselves. `NUTROOT_MAX_SLOTS` moves to `limits.ts`, which also removes the `NUT28 <-> nutroot` import cycle.

## Impact

Seeds outside 16..64 bytes now throw; `getKeysetIdInt` treats a 12-character all-hex id as base64 and throws on an id that is neither hex nor base64. `P2BK_DST` leaves the API report; it had no consumer.
