### PR TITLE
fix(crypto): validate helper inputs at the boundary [backport v4-dev]

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1507,9 +1507,6 @@ export type OutputType = ({
     data: OutputDataLike[];
 };
 
-// @public
-export const P2BK_DST: Uint8Array<ArrayBufferLike>;
-
 // @public @deprecated (undocumented)
 export const P2PKBuilder: typeof LockBuilder;
 

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -120,8 +120,7 @@ type WitnessData = {
   signatures: string[];
 };
 
-// Parsing reads this set, so the exported one is a detached copy: an exported Set stays
-// mutable whatever its declared type.
+// NUT-11 tag keys that map onto structured lock fields, so they are reserved as additional tags.
 const P2PK_KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -132,14 +132,6 @@ const KNOWN_TAG_KEYS = new Set([
 ]);
 
 /**
- * NUT-11 tag keys that map onto structured {@link P2PKOptions} fields, rather than being carried as
- * free-form `additionalTags`.
- *
- * @internal
- */
-export const P2PK_KNOWN_TAG_KEYS: ReadonlySet<string> = new Set(KNOWN_TAG_KEYS);
-
-/**
  * True if a tag key is one NUT-11 reserves.
  *
  * @internal

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -122,7 +122,7 @@ type WitnessData = {
 
 // Parsing reads this set, so the exported one is a detached copy: an exported Set stays
 // mutable whatever its declared type.
-const KNOWN_TAG_KEYS = new Set([
+const P2PK_KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',
   'n_sigs',
@@ -137,7 +137,7 @@ const KNOWN_TAG_KEYS = new Set([
  * @internal
  */
 export function isP2PKKnownTagKey(key: string): boolean {
-  return KNOWN_TAG_KEYS.has(key);
+  return P2PK_KNOWN_TAG_KEYS.has(key);
 }
 
 // ------------------------------

--- a/src/crypto/NUT11.ts
+++ b/src/crypto/NUT11.ts
@@ -6,6 +6,7 @@ import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import { type HTLCWitness, type P2PKWitness, type Proof } from '../model/types';
 import {
+  MAX_P2BK_SLOTS,
   MAX_P2PK_PUBKEYS,
   MAX_P2PK_SIGNATURES,
   MAX_SECRET_LENGTH,
@@ -119,13 +120,9 @@ type WitnessData = {
   signatures: string[];
 };
 
-/**
- * NUT-11 tag keys that map onto structured {@link P2PKOptions} fields, rather than being carried as
- * free-form `additionalTags`.
- *
- * @internal
- */
-export const P2PK_KNOWN_TAG_KEYS = new Set([
+// Parsing reads this set, so the exported one is a detached copy: an exported Set stays
+// mutable whatever its declared type.
+const KNOWN_TAG_KEYS = new Set([
   'locktime',
   'pubkeys',
   'n_sigs',
@@ -133,6 +130,23 @@ export const P2PK_KNOWN_TAG_KEYS = new Set([
   'n_sigs_refund',
   'sigflag',
 ]);
+
+/**
+ * NUT-11 tag keys that map onto structured {@link P2PKOptions} fields, rather than being carried as
+ * free-form `additionalTags`.
+ *
+ * @internal
+ */
+export const P2PK_KNOWN_TAG_KEYS: ReadonlySet<string> = new Set(KNOWN_TAG_KEYS);
+
+/**
+ * True if a tag key is one NUT-11 reserves.
+ *
+ * @internal
+ */
+export function isP2PKKnownTagKey(key: string): boolean {
+  return KNOWN_TAG_KEYS.has(key);
+}
 
 // ------------------------------
 // NUT-11 Secrets
@@ -240,13 +254,12 @@ export function normalizeP2PKOptions(p2pk: P2PKOptions): P2PKOptions {
   if (pubkeys.length === 0 && !isHTLC) {
     throw new CTSError('P2PK requires at least one pubkey');
   }
-  // NUT-28: up to 11 locking slots in [data, ...pubkeys, ...refund] (i_byte 0x00..0x0A). Slot 0 is
-  // the first pubkey for P2PK, but the hashlock for HTLC, so HTLC's hashlock costs a slot on top of
-  // the keys. P2PK thus allows 11 keys, HTLC 10.
+  // NUT-28 slot map: [data, ...pubkeys, ...refund]. Slot 0 is the first pubkey for P2PK but the
+  // hashlock for HTLC, so HTLC's hashlock costs a slot on top of the keys.
   const slotCount = (isHTLC ? 1 : 0) + pubkeys.length + refundKeys.length;
-  if (slotCount > 11) {
+  if (slotCount > MAX_P2BK_SLOTS) {
     throw new CTSError(
-      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is 11 in total`,
+      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is ${MAX_P2BK_SLOTS} in total`,
     );
   }
   if (p2pk.sigFlag !== undefined) assertSigFlag(p2pk.sigFlag);
@@ -775,7 +788,7 @@ function assertNoDuplicateP2PKTags(tags: string[][]): void {
   const seen = new Set<string>();
   for (const tag of tags) {
     const key = tag[0];
-    if (!P2PK_KNOWN_TAG_KEYS.has(key)) continue;
+    if (!isP2PKKnownTagKey(key)) continue;
     if (seen.has(key)) {
       throw new CTSError(`Duplicate P2PK tag "${key}"`);
     }

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -7,7 +7,7 @@ import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 
-import { type DLEQ, hash_e, hashToCurve } from './core';
+import { type DLEQ, assertSecpPoint, hash_e, hashToCurve } from './core';
 
 const DST_R = utf8ToBytes('Cashu_DLEQ_R_v1');
 
@@ -68,6 +68,7 @@ export const verifyDLEQProof_reblind = (
  * https://en.wikipedia.org/wiki/Timing_attack for information about timing attacks.
  */
 export const createDLEQProof = (B_: WeierstrassPoint<bigint>, a: Uint8Array): DLEQ => {
+  B_ = assertSecpPoint(B_); // the point type is structural, so parse before multiplying
   const scalar_a = secp256k1.Point.Fn.fromBytes(a);
   const A = secp256k1.Point.BASE.multiply(scalar_a); // A  = aG
   const C_ = B_.multiply(scalar_a); // C_ = aB_

--- a/src/crypto/NUT13.ts
+++ b/src/crypto/NUT13.ts
@@ -6,8 +6,9 @@ import { HDKey, HARDENED_OFFSET } from '@scure/bip32';
 
 import { CTSError } from '../model/Errors';
 import { isBase64String } from '../utils';
+import { MAX_SEED_BYTES, MIN_SEED_BYTES } from '../utils/limits';
 
-import { getKeysetIdInt } from './core';
+import { getKeysetIdInt, LEGACY_KEYSET_ID_LENGTH } from './core';
 
 const STANDARD_DERIVATION_PATH = `m/129372'/0'`;
 
@@ -59,8 +60,8 @@ export const deriveBlindingFactor = (
  * @param keysetId - Mint keyset ID that selects the derivation method.
  * @param counter - Deterministic counter for the output.
  * @returns The derived secret bytes and blinding factor bytes.
- * @throws {@link CTSError} If the keyset ID version is unsupported or if derivation produces an
- *   invalid private key.
+ * @throws {@link CTSError} If the seed is not 16 to 64 bytes, the keyset ID version is unsupported,
+ *   or derivation produces an invalid private key.
  */
 export function deriveSecretAndBlindingFactor(
   seed: Uint8Array,
@@ -82,12 +83,14 @@ export function deriveSecretAndBlindingFactor(
  * For deprecated BIP-32 derivation this caches the shared keyset parent node once, so each counter
  * costs three child derivations instead of a full path walk from the master. Constructing an HDKey
  * node computes its public key, so fewer nodes means fewer EC multiplications.
+ * @throws {@link CTSError} If the seed is not 16 to 64 bytes.
  * @internal
  */
 export function createSecretAndBlindingFactorDeriver(
   seed: Uint8Array,
   keysetId: string,
 ): SecretAndBlindingFactorDeriver {
+  assertSeed(seed);
   switch (getDerivationKind(keysetId)) {
     case DerivationKind.DEPRECATED_BIP32: {
       const keysetIdInt = getKeysetIdInt(keysetId);
@@ -102,6 +105,11 @@ export function createSecretAndBlindingFactorDeriver(
 }
 
 function getDerivationKind(keysetId: string): DerivationKind {
+  // Legacy ids are 12-character base64 and predate the version byte, so length tells them from a
+  // modern id: their alphabet overlaps hex.
+  if (keysetId.length === LEGACY_KEYSET_ID_LENGTH && isBase64String(keysetId)) {
+    return DerivationKind.DEPRECATED_BIP32;
+  }
   const isValidHex = /^[a-fA-F0-9]+$/.test(keysetId);
   const isHmacHexVersion = keysetId.startsWith('01');
   if (isValidHex && isHmacHexVersion && keysetId.length % 2 !== 0) {
@@ -117,6 +125,18 @@ function getDerivationKind(keysetId: string): DerivationKind {
     return DerivationKind.HMAC_SHA256;
   }
   throw new CTSError(`Unrecognized keyset ID version ${keysetId.slice(0, 2)}`);
+}
+
+function assertSeed(seed: Uint8Array): void {
+  // Every secret and blinding factor derived here inherits the seed's strength, and types are
+  // erased for JS callers.
+  if (
+    !(seed instanceof Uint8Array) ||
+    seed.length < MIN_SEED_BYTES ||
+    seed.length > MAX_SEED_BYTES
+  ) {
+    throw new CTSError(`seed must be a ${MIN_SEED_BYTES} to ${MAX_SEED_BYTES} byte Uint8Array`);
+  }
 }
 
 function deriveBip32SecretAndBlindingFactor(

--- a/src/crypto/NUT20.ts
+++ b/src/crypto/NUT20.ts
@@ -57,9 +57,10 @@ function constructLegacyMessage(
   return sha256(utf8ToBytes(message));
 }
 
-// NUT-20 quote pubkeys are compressed 33-byte SEC1 (66 hex chars).
+// NUT-20 quote pubkeys are compressed 33-byte SEC1 (66 hex chars). Types are erased for JS
+// callers, so a value from JSON must fail closed rather than throw on the length read.
 function isCompressedPubkey(pubkey: string): boolean {
-  return pubkey.length === 66;
+  return typeof pubkey === 'string' && pubkey.length === 66;
 }
 
 // The released v4 signMintQuote/verifyMintQuoteSignature keep their legacy bytes; the amended

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -15,6 +15,8 @@ const P2BK_DST_BYTES = utf8ToBytes('Cashu_P2BK_v1');
 
 /**
  * BIP340-style domain separation tag (DST) for P2BK.
+ *
+ * @internal
  */
 export const P2BK_DST: Uint8Array<ArrayBufferLike> = P2BK_DST_BYTES.slice();
 

--- a/src/crypto/NUT28.ts
+++ b/src/crypto/NUT28.ts
@@ -6,13 +6,17 @@ import { bytesToHex, concatBytes, hexToBytes, utf8ToBytes } from '@noble/hashes/
 
 import { CTSError } from '../model/Errors';
 import { hexToNumber, numberToHexPadded64 } from '../utils';
+import { MAX_P2BK_SLOTS } from '../utils/limits';
 
 import { pointFromHex } from './core';
+
+// Derivation reads this copy, so the exported one is inert: a Uint8Array cannot be frozen.
+const P2BK_DST_BYTES = utf8ToBytes('Cashu_P2BK_v1');
 
 /**
  * BIP340-style domain separation tag (DST) for P2BK.
  */
-export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1');
+export const P2BK_DST: Uint8Array<ArrayBufferLike> = P2BK_DST_BYTES.slice();
 
 /**
  * Blind a sequence of public keys using ECDH derived tweaks, one tweak per slot.
@@ -27,7 +31,7 @@ export const P2BK_DST: Uint8Array<ArrayBufferLike> = utf8ToBytes('Cashu_P2BK_v1'
  * @param dataIsPubkey Optional. False when slot 0 holds non-key data (eg an HTLC hashlock), so the
  *   first pubkey takes slot 1.
  * @returns Blinded pubkeys in the same order, and Ehex as SEC1 compressed hex, 33 bytes.
- * @throws If a blinded key is at infinity.
+ * @throws If there are more keys than slots, or a blinded key is at infinity.
  */
 export function deriveP2BKBlindedPubkeys(
   pubkeys: string[],
@@ -35,6 +39,12 @@ export function deriveP2BKBlindedPubkeys(
   dataIsPubkey = true,
 ): { blinded: string[]; Ehex: string } {
   const slotOffset = dataIsPubkey ? 0 : 1;
+  const slotCount = pubkeys.length + slotOffset;
+  if (slotCount > MAX_P2BK_SLOTS) {
+    throw new CTSError(
+      `Too many pubkeys, ${slotCount} slots provided, maximum allowed is ${MAX_P2BK_SLOTS} in total`,
+    );
+  }
   if (!pubkeys.length) return { blinded: [], Ehex: '' };
   // Create fresh ephemeral secret (e) if not supplied, and calculate pubkey (E)
   eBytes = eBytes ?? secp256k1.utils.randomSecretKey(); // 32 bytes
@@ -172,25 +182,30 @@ export function deriveP2BKSecretKey(
  * Both yield the same Z and therefore the same r thanks to the magic of ECDH!
  * @param point Ephemeral public key (E) or recipient public key (P)
  * @param scalar Private scalar (p) or ephemeral scalar (e) in [1, n − 1]
- * @param slotIndex Zero based slot index, only lowest 8 bits (0–255) are used.
+ * @param slotIndex Zero based slot index, one byte.
  * @returns Tweak (r) in [1, n − 1]
- * @throws If r reduces to zero after the retry.
+ * @throws If the slot index is out of range, or r reduces to zero after the retry.
  */
 function deriveP2BKBlindingTweakFromECDH(
   point: WeierstrassPoint<bigint>, // E or P
   scalar: bigint, // p or e
   slotIndex: number, // i
 ): bigint {
+  // The index is written as one byte, so a slot past 255 would alias onto another one. The lock
+  // builder holds slots to MAX_P2BK_SLOTS; spending a foreign proof is judged by the mint.
+  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex > 0xff) {
+    throw new CTSError('P2BK: slot index must be an integer in [0, 255]');
+  }
   // Calculate x-only ECDH shared point (Zx)
   const Zx = point.multiply(scalar).toBytes(true).slice(1);
   const iByte = new Uint8Array([slotIndex & 0xff]);
   // Derive deterministic blinding factor (r):
   // Note: bytesToNumberBE is safe here because we explicitly guard against
   // out-of-range values below, throwing rather than silently normalizing.
-  let r = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, iByte)));
+  let r = bytesToNumberBE(sha256(concatBytes(P2BK_DST_BYTES, Zx, iByte)));
   if (r === 0n || r >= secp256k1.Point.CURVE().n) {
     // Very unlikely to get here!
-    r = bytesToNumberBE(sha256(concatBytes(P2BK_DST, Zx, iByte, new Uint8Array([0xff]))));
+    r = bytesToNumberBE(sha256(concatBytes(P2BK_DST_BYTES, Zx, iByte, new Uint8Array([0xff]))));
     if (r === 0n || r >= secp256k1.Point.CURVE().n) {
       throw new CTSError('P2BK: tweak derivation failed');
     }

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -11,7 +11,7 @@ import {
 } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
-import { hexToNumber, decodeBase64AnyToUint8 } from '../utils';
+import { hexToNumber, decodeBase64AnyToUint8, isBase64String, isValidHex } from '../utils';
 import { hasLoneSurrogate } from '../utils/bytes';
 
 /**
@@ -74,13 +74,44 @@ export function pointFromHex(hex: string) {
   return secp256k1.Point.fromHex(hex);
 }
 
+/**
+ * Reparses a point as secp256k1, for entry points that take the structural point type.
+ *
+ * @remarks
+ * `WeierstrassPoint<bigint>` is shared with the other curves and scalar multiplication does not
+ * check membership, so a point that never went through a secp parser has to be sent through one.
+ * @throws {@link CTSError} If the point is not a secp256k1 point.
+ * @internal
+ */
+export function assertSecpPoint(point: WeierstrassPoint<bigint>): WeierstrassPoint<bigint> {
+  try {
+    return pointFromHex(point.toHex(true));
+  } catch (e) {
+    throw new CTSError('Invalid point: not a valid secp256k1 point', { cause: e });
+  }
+}
+
+/**
+ * Length of a legacy (pre-2024) base64 keyset id, which has no version byte.
+ *
+ * @internal
+ */
+export const LEGACY_KEYSET_ID_LENGTH = 12;
+
 export const getKeysetIdInt = (keysetId: string): bigint => {
   let keysetIdInt: bigint;
-  if (/^[a-fA-F0-9]+$/.test(keysetId)) {
+  // Length and alphabet separate the two encodings, the same rule getDerivationKind applies.
+  // Legacy ids travelled URL-safe in `GET /keys/{id}`, which the either-alphabet decoder accepts.
+  const legacy = (id: string): bigint =>
+    bytesToNumberBE(decodeBase64AnyToUint8(id)) % BigInt(2 ** 31 - 1);
+  if (keysetId.length === LEGACY_KEYSET_ID_LENGTH && isBase64String(keysetId)) {
+    keysetIdInt = legacy(keysetId);
+  } else if (isValidHex(keysetId)) {
     keysetIdInt = hexToNumber(keysetId) % BigInt(2 ** 31 - 1);
+  } else if (isBase64String(keysetId)) {
+    keysetIdInt = legacy(keysetId);
   } else {
-    //legacy keyset compatibility
-    keysetIdInt = bytesToNumberBE(decodeBase64AnyToUint8(keysetId)) % BigInt(2 ** 31 - 1);
+    throw new CTSError('Invalid keyset id: neither hex nor base64');
   }
   return keysetIdInt;
 };
@@ -95,7 +126,7 @@ export function createBlindSignature(
   id: string,
 ): BlindSignature {
   const a = secp256k1.Point.Fn.fromBytes(privateKey);
-  const C_: WeierstrassPoint<bigint> = B_.multiply(a);
+  const C_: WeierstrassPoint<bigint> = assertSecpPoint(B_).multiply(a);
   return { C_, id };
 }
 
@@ -339,8 +370,9 @@ export function getValidSigners(
  * @param message - The message to verify.
  * @param pubkeys - The Cashu P2PK public key(s) (hex-encoded, X-only or with 02/03 prefix) to
  *   check.
- * @param threshold - The minimum number of unique witnesses required.
- * @returns True if the witness threshold was reached, false otherwise.
+ * @param threshold - The minimum number of unique witnesses required; at least 1.
+ * @returns True if the witness threshold was reached, false otherwise (a threshold below 1
+ *   included, which no set of witnesses can satisfy).
  */
 export const meetsSignerThreshold = (
   signatures: string[],
@@ -348,6 +380,7 @@ export const meetsSignerThreshold = (
   pubkeys: string[],
   threshold: number = 1,
 ): boolean => {
+  if (!Number.isInteger(threshold) || threshold < 1) return false;
   const validSigners = getValidSigners(signatures, message, pubkeys);
   return validSigners.length >= threshold;
 };

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -1,6 +1,6 @@
 import { getTag, getTagInt, getTagScalar } from '../crypto/NUT10';
 import type { P2PKOptions, P2PKTag } from '../crypto/NUT11';
-import { P2PK_KNOWN_TAG_KEYS, parseP2PKSecret } from '../crypto/NUT11';
+import { isP2PKKnownTagKey, parseP2PKSecret } from '../crypto/NUT11';
 import {
   decodeBase64AnyToUint8,
   decodeCBOR,
@@ -168,7 +168,7 @@ export class PaymentRequest {
 
     // Forward any non-standard tags verbatim.
     const additionalTags = (nut10.tags ?? []).filter(
-      (t) => t.length > 0 && !P2PK_KNOWN_TAG_KEYS.has(t[0]),
+      (t) => t.length > 0 && !isP2PKKnownTagKey(t[0]),
     ) as P2PKTag[];
     if (additionalTags.length > 0) {
       options.additionalTags = additionalTags;

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -147,7 +147,10 @@ function getKeysetAmountsAsAmount(keyset: Keys, order: 'asc' | 'desc'): Amount[]
  * @returns True if the amount is in the keyset, false otherwise.
  */
 export function hasCorrespondingKey(amount: AmountLike, keyset: Keys): boolean {
-  return toAmount(amount, 'hasCorrespondingKey.amount', true).toString() in keyset;
+  // Own denominations only: a `Keys` object inherits from Object.prototype, and only the keys
+  // the keyset id commits to count.
+  const denomination = toAmount(amount, 'hasCorrespondingKey.amount', true).toString();
+  return Object.prototype.hasOwnProperty.call(keyset, denomination);
 }
 
 function toAmount(amount: AmountLike, op: string, allowZero = false): Amount {
@@ -445,9 +448,15 @@ export type DeriveKeysetIdOptions = {
  * @param options.versionByte (optional) version of the keyset ID. Default: 1.
  * @param options.isDeprecatedBase64 (optional) version of the keyset ID. Default: false.
  * @returns Keyset id of the keys.
- * @throws If keyset versionByte is not valid.
+ * @throws If keyset versionByte is not valid, or a denomination key is over 20 digits.
  */
 export function deriveKeysetId(keys: Keys, options?: DeriveKeysetIdOptions): string {
+  // A u64 denomination is at most 20 digits; bound every key before any amount is parsed.
+  for (const amount of Object.keys(keys)) {
+    if (amount.length > 20) {
+      throw new CTSError('Invalid keyset denomination: exceeds 20 digits');
+    }
+  }
   const unit = options?.unit ?? 'sat'; // default: sat
   const expiry = options?.expiry;
   const versionByte = options?.versionByte ?? 1; // default: 1

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -70,6 +70,20 @@ export const MAX_SECRET_LENGTH = 1024;
 export const MAX_WITNESS_LENGTH = 16_384;
 
 /**
+ * NUT-28: locking slots in a P2BK lock, `[data, ...pubkeys, ...refund]` at index bytes
+ * `0x00..0x0A`. `data` always fills slot 0, so an HTLC lock has one fewer key to give away.
+ */
+export const MAX_P2BK_SLOTS = 11;
+
+/**
+ * NUT-13: accepted length range for a deterministic-secrets seed. BIP-32's 16-byte floor at the
+ * bottom, the 64 bytes a BIP-39 mnemonic produces at the top; every derived secret and blinding
+ * factor inherits the seed's strength.
+ */
+export const MIN_SEED_BYTES = 16;
+export const MAX_SEED_BYTES = 64;
+
+/**
  * Max u64 (2^64 - 1): the ceiling every Amount is held to. Enforced in the Amount constructor, so
  * arithmetic results are bounded too; muldiv helpers keep their wide intermediate in bigint and
  * only construct the divided-down result.

--- a/src/wallet/Keyset.ts
+++ b/src/wallet/Keyset.ts
@@ -122,13 +122,17 @@ export class Keyset {
   /**
    * Verifies that a MintKeys DTO has a correct id for its keys/unit/expiry.
    *
-   * @returns True if verification succeeds, false otherwise (e.g: no keys, too many keys, or
-   *   mismatch).
+   * @returns True if verification succeeds, false otherwise (e.g: no keys, too many keys, one key
+   *   serving two denominations, or mismatch).
    */
   static verifyKeysetId(keys: MintKeys): boolean {
     try {
       const count = keys.keys ? Object.keys(keys.keys).length : 0;
       if (count === 0 || count > MAX_KEYSET_DENOMINATIONS) return false;
+
+      // A keyset id selects one key per amount, so a key repeated across denominations is malformed.
+      const distinct = new Set(Object.values(keys.keys).map((k) => k.toLowerCase()));
+      if (distinct.size !== count) return false;
 
       const isDeprecatedBase64 = isBase64String(keys.id) && !isValidHex(keys.id);
       const versionByte = isValidHex(keys.id) ? hexToBytes(keys.id)[0] : 0;

--- a/src/wallet/P2PKBuilder.ts
+++ b/src/wallet/P2PKBuilder.ts
@@ -144,6 +144,14 @@ export class LockBuilder {
 
   static fromOptions(opts: P2PKOptions): LockBuilder {
     const b = new LockBuilder();
+    // The refund setter takes a key or a list; stored options are lists, so a bare string here is
+    // malformed input rather than a shorthand. `blindKeys` is a flag, so it takes a boolean only.
+    if (opts.refundKeys !== undefined && !Array.isArray(opts.refundKeys)) {
+      throw new CTSError('refundKeys must be an array of pubkeys');
+    }
+    if (opts.blindKeys !== undefined && typeof opts.blindKeys !== 'boolean') {
+      throw new CTSError('blindKeys must be a boolean');
+    }
     const locks = Array.isArray(opts.pubkey) ? opts.pubkey : [opts.pubkey];
     b.addMainPubkey(locks);
     if (opts.locktime !== undefined) b.lockUntil(opts.locktime);

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -59,6 +59,8 @@ import {
   getDecodedToken,
   hasValidDleq,
   invoiceHasAmountInHRP,
+  MAX_SEED_BYTES,
+  MIN_SEED_BYTES,
   normalizeMintUrl,
   normalizeProofAmounts,
   splitAmount,
@@ -197,7 +199,7 @@ class Wallet {
    * @param options Optional settings.
    * @param options.unit Wallet unit, default 'sat'.
    * @param options.keysetId Bind to this keyset id, else bind on `loadMint`.
-   * @param options.bip39seed BIP39 seed for deterministic secrets.
+   * @param options.bip39seed BIP39 seed for deterministic secrets, 16 to 64 bytes.
    * @param options.secretsPolicy Secrets policy, default 'auto'.
    * @param options.counterSource Counter source for deterministic outputs. If provided, this takes
    *   precedence over counterInit. Use when you need persistence across processes or devices.
@@ -253,6 +255,13 @@ class Wallet {
         !(options.bip39seed instanceof Uint8Array),
         'bip39seed must be a valid Uint8Array',
         { received: typeof options.bip39seed },
+      );
+      // Fail here rather than at the first derivation: a wallet on a seed NUT-13 will refuse is
+      // broken, and the deriver's own guard would surface it mid-operation.
+      this.failIf(
+        options.bip39seed.length < MIN_SEED_BYTES || options.bip39seed.length > MAX_SEED_BYTES,
+        `bip39seed must be ${MIN_SEED_BYTES} to ${MAX_SEED_BYTES} bytes`,
+        { length: options.bip39seed.length },
       );
       this._seed = options.bip39seed;
     }

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -21,6 +21,7 @@ import {
   schnorrVerifyMessage,
   deriveP2BKBlindedPubkeys,
   P2BK_DST,
+  P2PK_KNOWN_TAG_KEYS,
   buildP2PKSigAllMessageV0,
   assertSigAllInputs,
   createSecret,
@@ -1669,6 +1670,21 @@ describe('parseP2PKSecret — duplicate tag rejection', () => {
   function makeSecret(tags: string[][]): string {
     return JSON.stringify(['P2PK', { nonce: bytesToHex(randomBytes(32)), data: pk1, tags }]);
   }
+
+  test('editing the exported reserved-key set leaves duplicate rejection alone', () => {
+    const exported = P2PK_KNOWN_TAG_KEYS as Set<string>;
+    exported.delete('n_sigs');
+    try {
+      const secret = makeSecret([
+        ['pubkeys', pk2],
+        ['n_sigs', '1'],
+        ['n_sigs', '2'],
+      ]);
+      expect(() => parseP2PKSecret(secret)).toThrow(/Duplicate P2PK tag "n_sigs"/);
+    } finally {
+      exported.add('n_sigs');
+    }
+  });
 
   test('rejects duplicate locktime tags', () => {
     const secret = makeSecret([

--- a/test/crypto/NUT11.test.ts
+++ b/test/crypto/NUT11.test.ts
@@ -21,7 +21,6 @@ import {
   schnorrVerifyMessage,
   deriveP2BKBlindedPubkeys,
   P2BK_DST,
-  P2PK_KNOWN_TAG_KEYS,
   buildP2PKSigAllMessageV0,
   assertSigAllInputs,
   createSecret,
@@ -1670,21 +1669,6 @@ describe('parseP2PKSecret — duplicate tag rejection', () => {
   function makeSecret(tags: string[][]): string {
     return JSON.stringify(['P2PK', { nonce: bytesToHex(randomBytes(32)), data: pk1, tags }]);
   }
-
-  test('editing the exported reserved-key set leaves duplicate rejection alone', () => {
-    const exported = P2PK_KNOWN_TAG_KEYS as Set<string>;
-    exported.delete('n_sigs');
-    try {
-      const secret = makeSecret([
-        ['pubkeys', pk2],
-        ['n_sigs', '1'],
-        ['n_sigs', '2'],
-      ]);
-      expect(() => parseP2PKSecret(secret)).toThrow(/Duplicate P2PK tag "n_sigs"/);
-    } finally {
-      exported.add('n_sigs');
-    }
-  });
 
   test('rejects duplicate locktime tags', () => {
     const secret = makeSecret([

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -1,3 +1,4 @@
+import { bls12_381 } from '@noble/curves/bls12-381.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
@@ -26,6 +27,16 @@ describe('test hash_e', () => {
     console.log('e = ' + bytesToHex(e));
     expect(bytesToHex(e)).toEqual(
       'a4dc034b74338c28c6bc3ea49731f2a24440fc7c4affc08b31a93fc9fbe6401e',
+    );
+  });
+});
+
+describe('createDLEQProof', () => {
+  test('rejects a blinded message from another curve', () => {
+    // The point type is structural, so a BLS12-381 G1 point satisfies it at compile time.
+    const foreign = bls12_381.G1.Point.fromAffine({ x: 0n, y: 2n });
+    expect(() => createDLEQProof(foreign, hexToBytes('0'.repeat(63) + '2'))).toThrow(
+      /secp256k1 point/,
     );
   });
 });

--- a/test/crypto/NUT13.test.ts
+++ b/test/crypto/NUT13.test.ts
@@ -1,13 +1,17 @@
+import { bytesToNumberBE } from '@noble/curves/utils.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { HDKey } from '@scure/bip32';
 import { describe, expect, test } from 'vitest';
 
 import {
+  createSecretAndBlindingFactorDeriver,
   deriveBlindingFactor,
+  deriveSecret,
   deriveSecretAndBlindingFactor,
   getKeysetIdInt,
 } from '../../src/crypto';
 import { CTSError } from '../../src/model/Errors';
+import { decodeBase64ToUint8Legacy } from '../../src/utils';
 
 describe('deriveBlindingFactor', () => {
   test('preserves 32-byte encoding when reduced scalar has leading zeros', () => {
@@ -92,6 +96,34 @@ describe('HMAC counter range', () => {
   });
 });
 
+describe('seed length', () => {
+  const v2KeysetId = '01abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567';
+  const legacyKeysetId = '0NI3TUAs1Sfa';
+  const bad = /seed must be a 16 to 64 byte Uint8Array/;
+
+  test('every seeded derivation takes 16 to 64 bytes and nothing else', () => {
+    for (const length of [16, 32, 64]) {
+      const seed = new Uint8Array(length).fill(7);
+      expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 0)).not.toThrow();
+      expect(() => deriveSecretAndBlindingFactor(seed, legacyKeysetId, 0)).not.toThrow();
+    }
+    for (const length of [0, 15, 65]) {
+      const seed = new Uint8Array(length);
+      expect(() => deriveSecretAndBlindingFactor(seed, v2KeysetId, 0)).toThrow(bad);
+      expect(() => deriveSecretAndBlindingFactor(seed, legacyKeysetId, 0)).toThrow(bad);
+      expect(() => createSecretAndBlindingFactorDeriver(seed, v2KeysetId)).toThrow(bad);
+      expect(() => deriveSecret(seed, v2KeysetId, 0)).toThrow(bad);
+      expect(() => deriveBlindingFactor(seed, v2KeysetId, 0)).toThrow(bad);
+    }
+  });
+
+  test('a seed that is not a Uint8Array is rejected the same way', () => {
+    const notBytes = 'dd44ee516b0647e80b488e8dcc56d736' as unknown as Uint8Array;
+    expect(() => deriveSecretAndBlindingFactor(notBytes, v2KeysetId, 0)).toThrow(bad);
+    expect(() => deriveSecret(notBytes, v2KeysetId, 0)).toThrow(bad);
+  });
+});
+
 describe('derivation kind selection', () => {
   // Known BIP-32 seed (NUT-13 spec / NUT-09 fixtures).
   const seed = hexToBytes(
@@ -114,6 +146,31 @@ describe('derivation kind selection', () => {
     const { secret, blindingFactor } = deriveSecretAndBlindingFactor(seed, base64KeysetId, counter);
     expect(bytesToHex(secret)).toBe(bytesToHex(expectedSecret as Uint8Array));
     expect(bytesToHex(blindingFactor)).toBe(bytesToHex(expectedR as Uint8Array));
+  });
+
+  test('a 12-character all-hex keyset id still takes the deprecated BIP-32 path', () => {
+    // Legacy ids predate the version byte and their base64 alphabet overlaps hex, so length
+    // is what separates them from a modern id.
+    const legacyKeysetId = 'd9f0F7F2875b';
+    const counter = 2;
+    const keysetIdInt =
+      bytesToNumberBE(decodeBase64ToUint8Legacy(legacyKeysetId)) % BigInt(2 ** 31 - 1);
+    expect(getKeysetIdInt(legacyKeysetId)).toBe(keysetIdInt);
+
+    const hdkey = HDKey.fromMasterSeed(seed);
+    const path = `m/129372'/0'/${keysetIdInt}'/${counter}'`;
+    const expectedSecret = hdkey.derive(`${path}/0`).privateKey;
+    const expectedR = hdkey.derive(`${path}/1`).privateKey;
+    expect(expectedSecret).not.toBeNull();
+
+    const { secret, blindingFactor } = deriveSecretAndBlindingFactor(seed, legacyKeysetId, counter);
+    expect(bytesToHex(secret)).toBe(bytesToHex(expectedSecret as Uint8Array));
+    expect(bytesToHex(blindingFactor)).toBe(bytesToHex(expectedR as Uint8Array));
+
+    // Length alone is not enough: a 12-character id outside both alphabets is still rejected.
+    expect(() => deriveSecretAndBlindingFactor(seed, '!'.repeat(12), 0)).toThrow(
+      /Unrecognized keyset ID version/,
+    );
   });
 
   test('throws for an unrecognized keyset id version, naming only the version byte', () => {

--- a/test/crypto/NUT20.test.ts
+++ b/test/crypto/NUT20.test.ts
@@ -290,6 +290,12 @@ describe('mint quote signature verification rejects malformed input (no throw)',
   const withOutputs = (outputs: unknown) =>
     outputs as Array<{ amount: Amount; id: string; B_: string }>;
 
+  test('a non-string pubkey verifies as false in both message formats', () => {
+    const missing = null as unknown as string;
+    expect(verifyMintQuoteSignature(missing, 'q', [], sig)).toBe(false);
+    expect(verifyMintQuoteSignatureAmended(missing, 'q', [], sig)).toBe(false);
+  });
+
   test('amended: negative amount verifies as false', () => {
     const outputs = withOutputs([{ amount: -1, id: keysetId, B_: goodB_ }]);
     expect(verifyMintQuoteSignatureAmended(pubkey, 'q', outputs, sig)).toBe(false);

--- a/test/crypto/NUT28.test.ts
+++ b/test/crypto/NUT28.test.ts
@@ -3,6 +3,7 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
 
 import {
+  P2BK_DST,
   pointFromHex,
   deriveP2BKSecretKey,
   deriveP2BKBlindedPubkeys,
@@ -273,6 +274,40 @@ describe('NUT28 uncovered branches and guards', () => {
 
   test('deriveP2BKBlindedPubkeys returns empty result for empty input', () => {
     expect(deriveP2BKBlindedPubkeys([])).toEqual({ blinded: [], Ehex: '' });
+  });
+
+  test('deriveP2BKBlindedPubkeys fills every slot up to the cap and refuses more', () => {
+    const key = bytesToHex(secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true));
+    const eBytes = secp256k1.utils.randomSecretKey();
+    expect(deriveP2BKBlindedPubkeys(Array(11).fill(key), eBytes).blinded).toHaveLength(11);
+    expect(() => deriveP2BKBlindedPubkeys(Array(12).fill(key), eBytes)).toThrow(
+      /maximum allowed is 11/,
+    );
+    // Slot 0 is taken by the hashlock, so an HTLC lock has one fewer to give away.
+    expect(deriveP2BKBlindedPubkeys(Array(10).fill(key), eBytes, false).blinded).toHaveLength(10);
+    expect(() => deriveP2BKBlindedPubkeys(Array(11).fill(key), eBytes, false)).toThrow(
+      /maximum allowed is 11/,
+    );
+  });
+
+  test('deriveP2BKSecretKeys derives for every slot up to the cap and refuses more', () => {
+    // Spending is judged by the mint, so a foreign proof past the builder's 11 slots still derives;
+    // only an index that would not fit its byte is refused.
+    const atCap = Array(11).fill(slot0Blinded);
+    expect(() => deriveP2BKSecretKeys(Ehex, privKeyBob, atCap)).not.toThrow();
+    expect(() => deriveP2BKSecretKeys(Ehex, privKeyBob, [...atCap, slot0Blinded])).not.toThrow();
+    const pastTheByte = Array(257).fill(slot0Blinded);
+    expect(() => deriveP2BKSecretKeys(Ehex, privKeyBob, pastTheByte)).toThrow(/slot index/);
+  });
+
+  test('mutating the exported domain separator leaves derivation alone', () => {
+    const before = deriveP2BKBlindedPubkeys([slot0Blinded], hexToBytes('11'.repeat(32)));
+    P2BK_DST[0] ^= 0xff;
+    try {
+      expect(deriveP2BKBlindedPubkeys([slot0Blinded], hexToBytes('11'.repeat(32)))).toEqual(before);
+    } finally {
+      P2BK_DST[0] ^= 0xff;
+    }
   });
 
   test('deriveP2BKSecretKeys accepts a single (non-array) blinded pubkey', () => {

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -1,3 +1,4 @@
+import { bls12_381 } from '@noble/curves/bls12-381.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToNumberBE } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -25,6 +26,7 @@ import {
   findSigningKey,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
+import { decodeBase64ToUint8Legacy } from '../../src/utils';
 
 const SECRET_MESSAGE = 'test_message';
 
@@ -149,6 +151,23 @@ describe('getKeysetIdInt', () => {
     const expected = BigInt(0x010203) % MOD;
     expect(getKeysetIdInt(b64Id)).toBe(expected);
   });
+
+  test('a 12-character id is legacy base64 even when every character is a hex digit', () => {
+    // Same rule as getDerivationKind: length decides, since the base64 alphabet overlaps hex.
+    const MOD = BigInt(2 ** 31 - 1);
+    const id = 'abcdef012345';
+    const expected = bytesToNumberBE(decodeBase64ToUint8Legacy(id)) % MOD;
+    expect(getKeysetIdInt(id)).toBe(expected);
+    expect(getKeysetIdInt(id)).not.toBe(BigInt('0x' + id) % MOD);
+  });
+
+  test('a URL-safe spelling of a legacy id derives the same path', () => {
+    expect(getKeysetIdInt('22aBcD-_eFgH')).toBe(getKeysetIdInt('22aBcD+/eFgH'));
+  });
+
+  test('rejects an id that is neither hex nor base64', () => {
+    expect(() => getKeysetIdInt('not-a-keyset!')).toThrow(/Invalid keyset id/);
+  });
 });
 
 describe('schnorrVerifyDigest', () => {
@@ -214,6 +233,13 @@ describe('getValidSigners / meetsSignerThreshold', () => {
     expect(meetsSignerThreshold([signature], message, [compressed, '03' + xOnly], 2)).toBe(false);
   });
 
+  test('a threshold below one is rejected instead of passing on no signatures', () => {
+    expect(meetsSignerThreshold([], message, [compressed], 0)).toBe(false);
+    expect(meetsSignerThreshold([], message, [compressed], -1)).toBe(false);
+    expect(meetsSignerThreshold([signature], message, [compressed], 1.5)).toBe(false);
+    expect(meetsSignerThreshold([signature], message, [compressed], 1)).toBe(true);
+  });
+
   test('non-string pubkey entries fail closed without throwing', () => {
     const pubkeys = [42 as unknown as string, compressed];
     expect(getValidSigners([signature], message, pubkeys)).toEqual([compressed]);
@@ -245,5 +271,24 @@ describe('findSigningKey', () => {
     expect(() => findSigningKey(pub(priv(9)), [priv(1), priv(2)])).toThrow(
       /No private key matches/,
     );
+  });
+});
+
+describe('createBlindSignature', () => {
+  // A valid compressed secp256k1 point (the generator).
+  const VALID = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+  const a = hexToBytes('0'.repeat(63) + '2');
+
+  test('signs a secp256k1 blinded message', () => {
+    const B_ = pointFromHex(VALID);
+    const sig = createBlindSignature(B_, a, 'keyset-id');
+    expect(sig.id).toBe('keyset-id');
+    expect(sig.C_.toHex(true)).toBe(B_.multiply(2n).toHex(true));
+  });
+
+  test('rejects a blinded message from another curve', () => {
+    // The point type is structural, so a BLS12-381 G1 point satisfies it at compile time.
+    const foreign = bls12_381.G1.Point.fromAffine({ x: 0n, y: 2n });
+    expect(() => createBlindSignature(foreign, a, 'keyset-id')).toThrow(/secp256k1 point/);
   });
 });

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -22,7 +22,7 @@ import type { HasKeysetKeys, SerializedBlindedSignature, Proof } from '../../src
 describe('DefaultOutputDataCreator', () => {
   test('delegates single deterministic output creation to OutputData', () => {
     const creator = new DefaultOutputDataCreator();
-    const seed = new Uint8Array([1]);
+    const seed = new Uint8Array(32).fill(1);
     const keysetId = '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30';
 
     expect(creator.createSingleDeterministicData(1, seed, 7, keysetId)).toEqual(
@@ -35,7 +35,7 @@ describe('DefaultOutputDataCreator', () => {
       id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
       keys: { '1': 'unused', '2': 'unused' },
     };
-    const seed = new Uint8Array([1]);
+    const seed = new Uint8Array(32).fill(1);
     const creator = new DefaultOutputDataCreator();
     const batchSpy = vi.spyOn(OutputData, 'createDeterministicData');
 
@@ -92,7 +92,7 @@ describe('DefaultOutputDataCreator', () => {
       keys: { '1': 'unused', '2': 'unused' },
     };
     const creator = new DefaultOutputDataCreator();
-    const seed = new Uint8Array([1]);
+    const seed = new Uint8Array(32).fill(1);
 
     // The first output is fine; the second lands on 2^53, where counter + 1 stops
     // producing a distinct value, so a batch would derive one counter twice.

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -656,6 +656,16 @@ describe('test output selection', () => {
     expect(utils.hasCorrespondingKey('8', keys)).toBe(true);
     expect(utils.hasCorrespondingKey(Amount.from(3), keys)).toBe(false);
   });
+
+  test('hasCorrespondingKey counts own denominations only', () => {
+    Object.defineProperty(Object.prototype, '3', { value: 'inherited', configurable: true });
+    try {
+      expect(utils.hasCorrespondingKey(3, keys)).toBe(false);
+      expect(utils.hasCorrespondingKey(8, keys)).toBe(true);
+    } finally {
+      Reflect.deleteProperty(Object.prototype, '3');
+    }
+  });
 });
 describe('test zero-knowledge utilities', () => {
   // create private public key pair
@@ -1246,6 +1256,17 @@ describe('deriveKeysetId edge cases', () => {
     expect(() => utils.deriveKeysetId(keys, { versionByte: 99 })).toThrow(
       /Unrecognized keyset ID version/,
     );
+  });
+
+  test('rejects a denomination key over 20 digits before parsing it', () => {
+    const oversized = { ...keys, ['1'.repeat(21)]: Object.values(keys)[0] };
+    expect(() => utils.deriveKeysetId(oversized, { versionByte: 1 })).toThrow(/exceeds 20 digits/);
+    expect(
+      utils.deriveKeysetId(
+        { ...keys, ['1'.repeat(20)]: Object.values(keys)[0] },
+        { versionByte: 1 },
+      ),
+    ).toMatch(/^01[0-9a-f]{64}$/);
   });
 });
 

--- a/test/wallet/Keyset.node.test.ts
+++ b/test/wallet/Keyset.node.test.ts
@@ -50,6 +50,19 @@ describe('Keyset.verifyKeysetId', () => {
     expect(Keyset.verifyKeysetId(mk)).toBe(false);
   });
 
+  test('returns false when one key serves two denominations, id notwithstanding', () => {
+    // A keyset id selects one key per amount, so a key repeated across denominations is malformed.
+    const shared = (PUBKEYS as Keys)[1];
+    const duplicated: Keys = { 1: shared, 2: shared };
+    const mk: MintKeys = {
+      id: deriveKeysetId(duplicated, { versionByte: 1, unit: 'sat' }),
+      unit: 'sat',
+      active: true,
+      keys: duplicated,
+    };
+    expect(Keyset.verifyKeysetId(mk)).toBe(false);
+  });
+
   test('returns false when derived id does not match a tampered key', () => {
     const tampered: Keys = { ...(PUBKEYS as Keys), 1: (PUBKEYS as Keys)[2] };
     const mk: MintKeys = { id: GENUINE_ID, unit: 'sat', active: true, keys: tampered };

--- a/test/wallet/P2PKBuilder.test.ts
+++ b/test/wallet/P2PKBuilder.test.ts
@@ -279,6 +279,24 @@ describe('P2PKBuilder.toOptions()', () => {
   it('rejects invalid pubkey formats up front', () => {
     expect(() => new P2PKBuilder().addLockPubkey('zz')).toThrow(/Invalid pubkey/i);
   });
+
+  it('fromOptions takes refund keys as an array and blindKeys as a boolean only', () => {
+    const pubkey = comp('a', '02');
+    const refund = comp('b', '02');
+    expect(() =>
+      P2PKBuilder.fromOptions({
+        pubkey,
+        refundKeys: refund,
+        locktime: 1,
+      } as unknown as P2PKOptions),
+    ).toThrow(/refundKeys must be an array/);
+    expect(() =>
+      P2PKBuilder.fromOptions({ pubkey, blindKeys: 'yes' } as unknown as P2PKOptions),
+    ).toThrow(/blindKeys must be a boolean/);
+    const options: P2PKOptions = { pubkey, refundKeys: [refund], locktime: 4102444800 };
+    expect(P2PKBuilder.fromOptions(options).toOptions()).toEqual(options);
+    expect(P2PKBuilder.fromOptions({ pubkey, blindKeys: true }).toOptions().blindKeys).toBe(true);
+  });
 });
 
 describe('P2PKBuilder, simple fuzzish case', () => {

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -60,6 +60,17 @@ describe('constructor mutants', () => {
     );
   });
 
+  test('rejects a bip39seed outside the accepted length range', () => {
+    for (const length of [1, 15, 65]) {
+      expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(length) })).toThrow(
+        /bip39seed must be 16 to 64 bytes/,
+      );
+    }
+    for (const length of [16, 32, 64]) {
+      expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(length) })).not.toThrow();
+    }
+  });
+
   test('never logs the rejected seed value', () => {
     // failIf logs its context before throwing, so the value must not appear there.
     const mnemonic = 'abandon abandon abandon abandon about';


### PR DESCRIPTION
Backport of #1111. The crypto helpers on the LTS line now check their inputs at the boundary: points are reparsed before mint-side signing, thresholds, seeds, slot indices, keyset keys and key lists are validated where they enter, and two module constants that were only ever read by tests leave the API report.

## Why

Several helpers trusted their arguments' shape: `createBlindSignature` and `createDLEQProof` multiplied whatever point object arrived, `meetsSignerThreshold` accepted a non-positive count, a JSON `null` pubkey threw out of the quote verifiers, an inherited `Object.prototype` key counted as a denomination, seeds of any length derived, a P2BK slot index was truncated to one byte, a keyset reusing one key across amounts verified, and `P2BK_DST` and `P2PK_KNOWN_TAG_KEYS` were exported although nothing outside the module read them. Every rejection added here applies to malformed input only, so no legitimate caller changes behaviour.

## Changes

Ported by hand rather than by the bot: v4 has no `curve_secp.ts`, `curves.ts`, `nutroot.ts`, `bytes.ts` or `LockBuilder`, so `assertSecpPoint` and the 12-character legacy keyset-id rule live in `crypto/core.ts`, the seed range guards v4's single NUT-13 deriver plus the `Wallet` constructor, and the key-list guard is on `P2PKBuilder.fromOptions` (`refundKeys` array, `blindKeys` boolean). `deriveP2BKBlindedPubkeys` caps at [NUT-28](https://github.com/cashubtc/nuts/blob/main/28.md)'s 11 slots; the tweak derivation only refuses an index that would not fit its byte, so spending a foreign proof is left to the mint as on main. A 12-character keyset id is legacy base64 in either alphabet. A denomination key is bounded to 20 digits before it is parsed.

Not ported: the `minimalBytesBE` ceiling and the receive-batch cap (their functions do not exist on v4), and everything nutroot.

## Impact

Seeds outside 16..64 bytes now throw; `getKeysetIdInt` treats a 12-character all-hex id as base64 and throws on an id that is neither hex nor base64; `P2PK_KNOWN_TAG_KEYS` is no longer exported and `P2BK_DST` is marked internal (the runtime export stays); both leave the API report, neither had a consumer.
