### PR TITLE
fix(wallet): require a 64-byte seed at construction

### DIFF
--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -514,6 +514,12 @@ try {
 
 ---
 
+## The seed is exactly 64 bytes
+
+`new Wallet(mint, { bip39seed })` now requires a 64-byte seed, the output of a BIP-39 derivation (`mnemonicToSeedSync(mnemonic)`), and throws a `CTSError` for any other length; v4 accepts 16 to 64 bytes. The NUT-13 derivation helpers called directly (`deriveSecretAndBlindingFactor`, `deriveKeyPair`, `deriveQuoteLockKey` and the v3 helpers) still accept 16 to 64 bytes. Wallets that already pass the BIP-39 seed, which is every known one, are unaffected; a wallet passing raw entropy of another length must derive the BIP-39 seed from it instead, or its existing proofs will not restore.
+
+---
+
 ## `deriveSecret` and `deriveBlindingFactor` removed
 
 The single-value NUT-13 derivation helpers `deriveSecret` and `deriveBlindingFactor` are removed. Use `deriveSecretAndBlindingFactor`, which derives both values for a counter in one call (and, for legacy BIP-32 keysets, avoids repeating the shared path derivation).

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -516,7 +516,7 @@ try {
 
 ## The seed is exactly 64 bytes
 
-`new Wallet(mint, { bip39seed })` now requires a 64-byte seed, the output of a BIP-39 derivation (`mnemonicToSeedSync(mnemonic)`), and throws a `CTSError` for any other length; v4 accepts 16 to 64 bytes. The NUT-13 derivation helpers called directly (`deriveSecretAndBlindingFactor`, `deriveKeyPair`, `deriveQuoteLockKey` and the v3 helpers) still accept 16 to 64 bytes. Wallets that already pass the BIP-39 seed, which is every known one, are unaffected; a wallet passing raw entropy of another length must derive the BIP-39 seed from it instead, or its existing proofs will not restore.
+`new Wallet(mint, { bip39seed })` now requires a 64-byte seed, the output of a BIP-39 derivation (`mnemonicToSeedSync(mnemonic)`), and throws a `CTSError` for any other length; v4 accepts 16 to 64 bytes. The NUT-13 derivation helpers called directly (`deriveSecretAndBlindingFactor`, `deriveKeyPair`, `deriveQuoteLockKey` and the v3 helpers) still accept 16 to 64 bytes. Wallets that already pass the BIP-39 seed, which is every known one, are unaffected. A wallet that had been passing raw entropy of another length cannot convert it: no 64-byte seed derives the same secrets, so its existing proofs are reachable only through the derivation helpers with the old bytes. Restore them that way (NUT-09), sweep them into a wallet built on a BIP-39 seed, and retire the old bytes.
 
 ---
 

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -96,9 +96,15 @@ export const NUTROOT_MAX_SLOTS = 121;
 export const MAX_P2BK_SLOTS = 11;
 
 /**
- * NUT-13: accepted length range for a deterministic-secrets seed. BIP-32's 16-byte floor at the
- * bottom, the 64 bytes a BIP-39 mnemonic produces at the top; every derived secret and blinding
- * factor inherits the seed's strength.
+ * NUT-13: the seed a wallet is built on is a BIP-39 derivation, 64 bytes, which is what every
+ * wallet and mint implementation hands over. Enforced by the Wallet constructor.
+ */
+export const SEED_BYTES = 64;
+
+/**
+ * NUT-13: accepted length range for a seed passed straight to a derivation helper. BIP-32's 16-byte
+ * floor at the bottom, the 64 bytes a BIP-39 mnemonic produces at the top; the helpers stay usable
+ * on the spec's own vectors.
  */
 export const MIN_SEED_BYTES = 16;
 export const MAX_SEED_BYTES = 64;

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -87,8 +87,7 @@ import {
   DEFAULT_MAX_ARRAY_LENGTH,
   getDecodedToken,
   invoiceHasAmountInHRP,
-  MAX_SEED_BYTES,
-  MIN_SEED_BYTES,
+  SEED_BYTES,
   normalizeMintUrl,
   normalizeProofAmounts,
   REPAIR_COOLDOWN_MS,
@@ -259,7 +258,7 @@ class Wallet {
    * @param options Optional settings.
    * @param options.unit Wallet unit, default 'sat'.
    * @param options.keysetId Bind to this keyset id, else bind on `loadMint`.
-   * @param options.bip39seed BIP39 seed for deterministic secrets, 16 to 64 bytes.
+   * @param options.bip39seed BIP39 seed for deterministic secrets, 64 bytes.
    * @param options.secretsPolicy Secrets policy, default 'auto'.
    * @param options.counterSource Counter source for deterministic outputs. If provided, this takes
    *   precedence over counterInit. Use when you need persistence across processes or devices.
@@ -340,8 +339,8 @@ class Wallet {
       // Fail here rather than at the first derivation: a wallet on a seed NUT-13 will refuse is
       // broken, and the deriver's own guard would surface it mid-operation.
       this.failIf(
-        options.bip39seed.length < MIN_SEED_BYTES || options.bip39seed.length > MAX_SEED_BYTES,
-        `bip39seed must be ${MIN_SEED_BYTES} to ${MAX_SEED_BYTES} bytes`,
+        options.bip39seed.length !== SEED_BYTES,
+        `bip39seed must be ${SEED_BYTES} bytes`,
         { length: options.bip39seed.length },
       );
       this._seed = options.bip39seed;

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -19,7 +19,7 @@ import type { HasKeysetKeys, SerializedBlindedSignature, Proof } from '../../src
 describe('DefaultOutputDataCreator', () => {
   test('delegates single deterministic output creation to OutputData', () => {
     const creator = new DefaultOutputDataCreator();
-    const seed = new Uint8Array(32).fill(1);
+    const seed = new Uint8Array(64).fill(1);
     const keysetId = '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30';
 
     expect(creator.createSingleDeterministicData(1, seed, 7, keysetId)).toEqual(
@@ -32,7 +32,7 @@ describe('DefaultOutputDataCreator', () => {
       id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
       keys: { '1': 'unused', '2': 'unused' },
     };
-    const seed = new Uint8Array(32).fill(1);
+    const seed = new Uint8Array(64).fill(1);
     const creator = new DefaultOutputDataCreator();
     const batchSpy = vi.spyOn(OutputData, 'createDeterministicData');
 
@@ -89,7 +89,7 @@ describe('DefaultOutputDataCreator', () => {
       keys: { '1': 'unused', '2': 'unused' },
     };
     const creator = new DefaultOutputDataCreator();
-    const seed = new Uint8Array(32).fill(1);
+    const seed = new Uint8Array(64).fill(1);
 
     // The first output is fine; the second lands on 2^53, where counter + 1 stops
     // producing a distinct value, so a batch would derive one counter twice.

--- a/test/wallet/wallet-legacy-keysets.node.test.ts
+++ b/test/wallet/wallet-legacy-keysets.node.test.ts
@@ -200,7 +200,7 @@ describe('Legacy (pre-v1) keyset output gating', () => {
       http.post(mintUrl + '/v1/restore', () => HttpResponse.json({ outputs: [], signatures: [] })),
     );
 
-    const wallet = new Wallet(mint, { bip39seed: randomBytes(32) });
+    const wallet = new Wallet(mint, { bip39seed: randomBytes(64) });
     await wallet.loadMint();
 
     const res = await wallet.restore(0, 2, { keysetId: legacyId });

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -537,7 +537,7 @@ describe('melt proofs', () => {
 
   describe('melt, NUT-08 blanks', () => {
     test('includes zero-amount blanks covering fee reserve (bolt11)', async () => {
-      const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32) });
+      const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
       await wallet.loadMint();
       const meltQuote: MeltQuoteBolt11Response = {
         quote: 'test_melt_quote',
@@ -605,7 +605,7 @@ describe('melt proofs', () => {
     });
 
     test('includes zero-amount blanks covering fee reserve (bolt12)', async () => {
-      const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32) });
+      const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
       await wallet.loadMint();
       const meltQuote: MeltQuoteBolt12Response = {
         quote: 'test_melt_quote',

--- a/test/wallet/wallet-quotes-mutants.node.test.ts
+++ b/test/wallet/wallet-quotes-mutants.node.test.ts
@@ -63,15 +63,13 @@ describe('constructor mutants', () => {
     );
   });
 
-  test('rejects a bip39seed outside the accepted length range', () => {
-    for (const length of [1, 15, 65]) {
+  test('rejects a bip39seed that is not 64 bytes', () => {
+    for (const length of [1, 32, 63, 65]) {
       expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(length) })).toThrow(
-        /bip39seed must be 16 to 64 bytes/,
+        /bip39seed must be 64 bytes/,
       );
     }
-    for (const length of [16, 32, 64]) {
-      expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(length) })).not.toThrow();
-    }
+    expect(() => new Wallet(mint, { unit, bip39seed: new Uint8Array(64) })).not.toThrow();
   });
 
   test('never logs the rejected seed value', () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -83,7 +83,7 @@ describe('Restoring deterministic proofs', () => {
         });
       }),
     );
-    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32), logger });
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64), logger });
     await wallet.loadMint();
     const scan = (wallet as unknown as { restoreUnspent: Scan }).restoreUnspent.bind(wallet);
     expect(await scan(0, 3)).toEqual({ proofs: [], lastCounterWithSignature: 2, used: true });
@@ -246,7 +246,7 @@ describe('restoreAll', () => {
 
 describe('restore', () => {
   test('sends zero-amount blanks and maps signatures to proofs', async () => {
-    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32), logger });
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64), logger });
     await wallet.loadMint();
     interface RestoreBody {
       outputs: unknown[];
@@ -311,7 +311,7 @@ describe('restore', () => {
         });
       }),
     );
-    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32), logger });
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64), logger });
     await wallet.loadMint();
 
     const res = await wallet.restore(0, 3);
@@ -321,7 +321,7 @@ describe('restore', () => {
   });
 
   test('state checks before restoring: skips spent, keeps pending, scans past a spent wave', async () => {
-    const seed = randomBytes(32);
+    const seed = randomBytes(64);
     const keysetId = dummyKeysResp.keysets[0].id;
     const wallet = new Wallet(mint, { unit, bip39seed: seed, logger });
     await wallet.loadMint();
@@ -392,7 +392,7 @@ describe('restore', () => {
   });
 
   test('skips an invalid-scalar counter and recovers proofs past it', async () => {
-    const seed = randomBytes(32);
+    const seed = randomBytes(64);
     const keysetId = dummyKeysResp.keysets[0].id;
     const VALID_POINT = '021179b095a67380ab3285424b563b7aab9818bd38068e1930641b3dceb364d422';
     const counterByB_ = new Map<string, number>();
@@ -446,7 +446,7 @@ describe('restore', () => {
   });
 
   test('an invalid counter rejects rather than reporting an empty scan', async () => {
-    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(32) });
+    const wallet = new Wallet(mint, { unit, bip39seed: randomBytes(64) });
     await wallet.loadMint();
     await expect(wallet.batchRestore({ counter: 0.5, gapLimit: 3 })).rejects.toThrow(
       /non-negative safe integers/,

--- a/test/wallet/wallet-rotation.node.test.ts
+++ b/test/wallet/wallet-rotation.node.test.ts
@@ -836,7 +836,7 @@ describe('strictCachedKeysets', () => {
     const { counts } = useRotatedMint(server);
     const wallet = new Wallet(mint, {
       unit,
-      bip39seed: randomBytes(32),
+      bip39seed: randomBytes(64),
       strictCachedKeysets: true,
     });
     await wallet.loadMint(); // single load against rotated handlers: A known-but-keyless
@@ -851,7 +851,7 @@ describe('strictCachedKeysets', () => {
     const { counts } = useRotatedMint(server);
     const wallet = new Wallet(mint, {
       unit,
-      bip39seed: randomBytes(32),
+      bip39seed: randomBytes(64),
       strictCachedKeysets: true,
     });
     await wallet.loadMint(); // single load against rotated handlers: A known-but-keyless


### PR DESCRIPTION
`new Wallet(mint, { bip39seed })` now requires a 64-byte seed, the output of a BIP-39 derivation, and throws a `CTSError` for any other length.

## Why

[NUT-13](https://github.com/cashubtc/nuts/blob/main/13.md) defines the seed as a BIP-39 derivation, which is 64 bytes, and that is what every implementation hands over: cashu.me and Minibits call `mnemonicToSeedSync`, nutshell's wallet uses `Mnemonic.to_seed`, and cdk's `Wallet::new` takes `[u8; 64]`. #1111 gave the constructor a 16 to 64 byte range; no known wallet needs the slack, so v5 takes the exact rule while it is still a release candidate.

## Changes

`SEED_BYTES = 64` is enforced at the constructor. The NUT-13 derivation helpers keep `MIN_SEED_BYTES`..`MAX_SEED_BYTES` (16 to 64) for direct use: cdk's and nutshell's derivers accept any key length, and the spec's own v3 vectors derive from a short seed, so the primitives stay usable on them. Test wallets built on 32-byte seeds are widened to 64; no derived values were pinned. A migration-guide section is added. The v4 line keeps the range throughout.

Based on #1111; retarget to `main` once that merges.

## Impact

`new Wallet` throws for any seed that is not 64 bytes. Wallets passing the BIP-39 seed are unaffected. No API surface change.
