### PR TITLE
fix(model): tighten Amount construction and strict wire JSON parsing

### DIFF
--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -29,12 +29,16 @@ export type AmountLike = number | bigint | string | Amount;
  *     Amount.one();
  */
 export class Amount {
+  // Proves the constructor ran; instanceof alone does not, so from() requires it.
+  #brand = true;
   private readonly value: bigint;
 
   private constructor(value: bigint) {
-    // Single choke point for the u64 ceiling: every Amount, including arithmetic results, is
-    // <= u64 max. Muldiv helpers keep their wide intermediate in bigint and only construct the
-    // divided-down result, so a valid `a*n/d` still works while an out-of-range result throws.
+    // Single choke point for the [0, u64 max] invariant; muldiv helpers construct only their
+    // divided-down result, so a wide intermediate never hits this check.
+    if (value < 0n) {
+      throw new AmountError(`Amount must be >= 0, got ${value}`);
+    }
     if (value > U64_MAX) {
       throw new AmountError(`Amount exceeds u64 max, got ${value}`);
     }
@@ -53,7 +57,12 @@ export class Amount {
    *   is above the safe integer limit for a `number`.
    */
   static from(input: AmountLike): Amount {
-    if (input instanceof Amount) return input;
+    if (input instanceof Amount) {
+      if (!(#brand in input)) {
+        throw new AmountError('Invalid Amount instance');
+      }
+      return input;
+    }
 
     if (typeof input === 'bigint') {
       if (input < 0n) {
@@ -210,12 +219,12 @@ export class Amount {
    * @throws If numerator is a negative or non-integer, or denominator is not a positive integer.
    */
   ceilPercent(numerator: number, denominator: number = 100): Amount {
-    if (!Number.isInteger(numerator) || numerator < 0) {
+    if (!Number.isSafeInteger(numerator) || numerator < 0) {
       throw new AmountError(
         `ceilPercent: numerator must be a non-negative integer, got ${numerator}`,
       );
     }
-    if (!Number.isInteger(denominator) || denominator <= 0) {
+    if (!Number.isSafeInteger(denominator) || denominator <= 0) {
       throw new AmountError(
         `ceilPercent: denominator must be a positive integer, got ${denominator}`,
       );
@@ -240,12 +249,12 @@ export class Amount {
    * @throws If numerator is a negative or non-integer, or denominator is not a positive integer.
    */
   floorPercent(numerator: number, denominator: number = 100): Amount {
-    if (!Number.isInteger(numerator) || numerator < 0) {
+    if (!Number.isSafeInteger(numerator) || numerator < 0) {
       throw new AmountError(
         `floorPercent: numerator must be a non-negative integer, got ${numerator}`,
       );
     }
-    if (!Number.isInteger(denominator) || denominator <= 0) {
+    if (!Number.isSafeInteger(denominator) || denominator <= 0) {
       throw new AmountError(
         `floorPercent: denominator must be a positive integer, got ${denominator}`,
       );
@@ -314,10 +323,10 @@ export class Amount {
   scaledBy(numerator: AmountLike, denominator: AmountLike): Amount {
     const n = Amount.from(numerator).value;
     const d = Amount.from(denominator).value;
-    if (n === 0n) return Amount.zero();
     if (d === 0n) {
       throw new AmountError('scaledBy: denominator must be > 0');
     }
+    if (n === 0n) return Amount.zero();
     // round(a × n / d) = floor((2 × a × n + d) / (2 × d)); the 2*a*n intermediate stays in bigint
     return new Amount((2n * this.value * n + d) / (2n * d));
   }

--- a/src/model/ScriptPath.ts
+++ b/src/model/ScriptPath.ts
@@ -253,6 +253,8 @@ function deserializePackage(input: string): ScriptPathSigningPackage {
   try {
     data = JSONInt.parse(
       bytesToUtf8(decodeBase64UrlToUint8(input.slice(SCRIPT_PATH_PREFIX.length))),
+      undefined,
+      { strict: true },
     );
   } catch (e) {
     throw new CTSError('Failed to parse signing package', { cause: e });

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -131,7 +131,7 @@ function deserializePackage(input: string): SigAllSigningPackage {
   let data: unknown;
 
   try {
-    data = JSONInt.parse(json);
+    data = JSONInt.parse(json, undefined, { strict: true });
   } catch (e) {
     throw new CTSError(
       `Failed to parse signing package JSON: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -317,8 +317,9 @@ export class WSConnection {
     const message = this.messageQueue.dequeue() as string;
 
     try {
-      // Same bigint-safe parse as the HTTP transport, so a u64 amount is not rounded on the way in
-      const parsed = JSONInt.parse(message) as JsonRpcMessage;
+      // Same bigint-safe, strict parse as the HTTP transport, so a u64 amount is not rounded and
+      // a duplicate key cannot pick a different result than an earlier check saw.
+      const parsed = JSONInt.parse(message, undefined, { strict: true }) as JsonRpcMessage;
 
       if ('result' in parsed && parsed.id != undefined) {
         if (this.rpcListeners[parsed.id]) {

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -765,7 +765,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
       if (!responseText) {
         throw new CTSError('Empty response body');
       }
-      return JSONInt.parse(responseText);
+      return JSONInt.parse(responseText, undefined, { strict: true });
     } catch (err) {
       requestLogger.error('Failed to parse HTTP response', { err });
       throw new HttpResponseError('bad response', response.status, { cause: err });
@@ -783,7 +783,7 @@ function parseErrorBody(errorText: string): ApiError {
   if (!errorText) return { detail: 'bad response' };
   let parsed: unknown;
   try {
-    parsed = JSONInt.parse(errorText);
+    parsed = JSONInt.parse(errorText, undefined, { strict: true });
   } catch {
     return { detail: errorText };
   }

--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -376,6 +376,25 @@ class Parser {
   }
 }
 
+/**
+ * Writes a reviver's returned value back as an own data property, not an assignment.
+ *
+ * Uses Reflect, not Object: a reviver can leave a key non-configurable mid-walk, and native
+ * JSON.parse silently keeps the existing value there rather than throwing.
+ */
+function defineReviverResult(
+  target: Record<string, unknown> | unknown[],
+  key: string,
+  value: unknown,
+): void {
+  Reflect.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
 function walkReviver(
   holder: Record<string, unknown> | unknown[],
   key: string,
@@ -385,14 +404,20 @@ function walkReviver(
   if (Array.isArray(current)) {
     for (let i = 0; i < current.length; i += 1) {
       const v = walkReviver(current, String(i), reviver);
-      if (v === undefined) Reflect.deleteProperty(current, i);
-      else current[i] = v;
+      if (v === undefined) {
+        Reflect.deleteProperty(current, i);
+      } else {
+        defineReviverResult(current, String(i), v);
+      }
     }
   } else if (isRecord(current)) {
     for (const k of Object.keys(current)) {
       const v = walkReviver(current, k, reviver);
-      if (v === undefined) delete current[k];
-      else current[k] = v;
+      if (v === undefined) {
+        delete current[k];
+      } else {
+        defineReviverResult(current, k, v);
+      }
     }
   }
   return reviver.call(holder, key, current);
@@ -448,14 +473,23 @@ function stringify(
   if (typeof space === 'number') {
     indent = ' '.repeat(Math.min(10, Math.max(0, Math.floor(space))));
   } else if (typeof space === 'string') {
-    indent = space;
+    indent = space.slice(0, 10);
   }
 
   if (replacer && typeof replacer !== 'function' && !Array.isArray(replacer)) {
     throw new CTSError('stringify: replacer must be a function or array');
   }
 
-  const propertyList = Array.isArray(replacer) ? replacer.map((k) => String(k)) : undefined;
+  // Native keeps only string and number entries, then drops repeats
+  const propertyList = Array.isArray(replacer)
+    ? Array.from(
+        new Set(
+          replacer
+            .filter((k) => typeof k === 'string' || typeof k === 'number')
+            .map((k) => String(k)),
+        ),
+      )
+    : undefined;
 
   const serialize = (holder: Record<string, unknown>, key: string): string | undefined => {
     let val: unknown = holder[key];

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -82,11 +82,12 @@ function encodeJsonToBase64Url(jsonObj: unknown): string {
  *
  * Integers within `±MAX_SAFE_INTEGER` are returned as `number`; integers outside that range are
  * returned as `bigint`. This preserves precision for large amounts encoded by
- * {@link encodeJsonToBase64Url}.
+ * {@link encodeJsonToBase64Url}. Parses strictly: a duplicate object key throws rather than silently
+ * taking the last value, since this decodes wire payloads (v3 tokens).
  */
 function decodeBase64UrlToJson<T extends object>(base64String: string): T {
   const jsonString = decodeUtf8Document(decodeBase64UrlToUint8(base64String));
-  return JSONInt.parse(jsonString) as T;
+  return JSONInt.parse(jsonString, undefined, { strict: true }) as T;
 }
 
 /**

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -57,6 +57,7 @@ import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
 import {
   ABSOLUTE_MAX_ARRAY_LENGTH,
+  MAX_BOLT11_HRP_LENGTH,
   MAX_PAYLOAD_DECODE_ATTEMPTS,
   MAX_PAYLOAD_LENGTH,
   MAX_SPLIT_OUTPUTS,
@@ -86,6 +87,9 @@ export function splitAmount(
   let normalizedSplit = split?.map((amt) => toAmount(amt, 'splitAmount.split', true));
 
   if (normalizedSplit) {
+    if (normalizedSplit.length > MAX_SPLIT_OUTPUTS) {
+      throw new CTSError(`Cannot split amount: split would exceed ${MAX_SPLIT_OUTPUTS} outputs`);
+    }
     const totalSplitAmount = Amount.sum(normalizedSplit);
 
     // Special case: explicit "zero-total" outputs (restore or NUT-08 blanks)
@@ -1406,7 +1410,12 @@ export function bolt11AmountMsat(pr: string): bigint | null {
   const lower = pr.toLowerCase();
   // The bech32 charset excludes '1', so the last '1' is the HRP separator.
   const sep = lower.lastIndexOf('1');
-  if (!lower.startsWith('ln') || sep < 3 || sep === lower.length - 1) {
+  if (
+    !lower.startsWith('ln') ||
+    sep < 3 ||
+    sep > MAX_BOLT11_HRP_LENGTH ||
+    sep === lower.length - 1
+  ) {
     throw new CTSError('Invalid BOLT11 invoice');
   }
   const match = /^ln[a-z]+?(\d*)([munp]?)$/.exec(lower.slice(0, sep));

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -127,6 +127,14 @@ export const U64_MAX = 2n ** 64n - 1n;
 export const MAX_CBOR_NODES = 262_144;
 
 /**
+ * Upper bound on a BOLT11 invoice's human-readable prefix, checked before the amount digits reach
+ * `BigInt`.
+ *
+ * Real invoices need a handful of characters here; this clears them with headroom.
+ */
+export const MAX_BOLT11_HRP_LENGTH = 100;
+
+/**
  * Maximum number of candidate payloads `findCashuPayload` will attempt to decode in one scan.
  * Prevents pathological input from causing excessive parsing work. Real pastes carry one payload
  * and a few near-misses, so 16 clears them; scans that exhaust the budget return null.

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2398,9 +2398,10 @@ class Wallet {
     this.failIf(
       !Number.isSafeInteger(batchSize) ||
         batchSize < 1 ||
+        batchSize > this.maxArrayLength ||
         !(Number.isSafeInteger(gapLimit) || gapLimit === Infinity) ||
         gapLimit < 1,
-      'batchSize must be a positive integer and gapLimit a positive integer or Infinity',
+      `batchSize must be a positive integer up to ${this.maxArrayLength} and gapLimit a positive integer or Infinity`,
     );
     const probeSize = Math.min(gapLimit, this.maxArrayLength);
     const restoredProofs: Proof[] = [];

--- a/src/wallet/_internal.ts
+++ b/src/wallet/_internal.ts
@@ -3,6 +3,7 @@
  */
 import { isBlsKeyset } from '../crypto/curves';
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import { type OutputDataLike } from '../model/OutputData';
 import type {
   HasKeysetKeys,
@@ -13,6 +14,7 @@ import type {
 } from '../model/types';
 import { BATCH_POOL_SIZE } from '../transport';
 import { splitAmount } from '../utils/core';
+import { MAX_SPLIT_OUTPUTS } from '../utils/limits';
 
 import { type OutputType } from './types';
 
@@ -62,6 +64,14 @@ function getKeysetAmountsAsc(keys: Keys): Amount[] {
   return amounts;
 }
 
+function assertSplitBudget(count: number): void {
+  if (count > MAX_SPLIT_OUTPUTS) {
+    throw new CTSError(
+      `Cannot split amount: optimized split would exceed ${MAX_SPLIT_OUTPUTS} outputs`,
+    );
+  }
+}
+
 /**
  * Creates a list of amounts to keep based on the proofs we have and the proofs we want to reach.
  *
@@ -89,13 +99,16 @@ export function getKeepAmounts(
       if (nextTotal.greaterThan(normalizedAmountToKeep)) {
         break;
       }
+      assertSplitBudget(amountsWeWant.length + 1);
       amountsWeWant.push(amt);
       runningTotal = nextTotal;
     }
   }
   const amountDiff = normalizedAmountToKeep.subtract(runningTotal);
   if (!amountDiff.isZero()) {
-    for (const amt of splitAmount(amountDiff, keys)) {
+    const fillAmounts = splitAmount(amountDiff, keys);
+    assertSplitBudget(amountsWeWant.length + fillAmounts.length);
+    for (const amt of fillAmounts) {
       amountsWeWant.push(amt);
       runningTotal = runningTotal.add(amt);
     }

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -30,6 +30,16 @@ describe('Amount.from validation', () => {
     expect(() => Amount.from({} as unknown as Amount)).toThrow('Unsupported amount input type');
   });
 
+  it('rejects a negative value passed directly to the exported constructor', () => {
+    expect(() => Reflect.construct(Amount, [-1n])).toThrow('Amount must be >= 0');
+  });
+
+  it('rejects an object forged with Amount.prototype without running the constructor', () => {
+    const forged = Object.create(Amount.prototype) as Amount;
+    Object.defineProperty(forged, 'value', { value: -7n });
+    expect(() => Amount.from(forged)).toThrow(AmountError);
+  });
+
   it('accepts the u64 max at the boundary', () => {
     const u64Max = 2n ** 64n - 1n;
     expect(Amount.from(u64Max).toBigInt()).toBe(u64Max);
@@ -119,6 +129,11 @@ describe('Amount.floorPercent', () => {
     expect(() => Amount.from(100).floorPercent(2, 0)).toThrow('floorPercent');
     expect(() => Amount.from(100).floorPercent(-1)).toThrow('floorPercent');
   });
+  it('rejects unsafe integer ratio operands', () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => Amount.from(100).floorPercent(unsafe)).toThrow('floorPercent');
+    expect(() => Amount.from(100).floorPercent(1, unsafe)).toThrow('floorPercent');
+  });
   it('works with large (unsafe integer) amounts', () => {
     const large = Amount.from(BigInt(Number.MAX_SAFE_INTEGER) + 1000n);
     const result = large.floorPercent(2);
@@ -149,6 +164,11 @@ describe('Amount.ceilPercent', () => {
     expect(Amount.from(100).ceilPercent(0).toBigInt()).toBe(0n);
     expect(() => Amount.from(100).ceilPercent(2, 0)).toThrow('ceilPercent');
     expect(() => Amount.from(100).ceilPercent(-1)).toThrow('ceilPercent');
+  });
+  it('rejects unsafe integer ratio operands', () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => Amount.from(100).ceilPercent(unsafe)).toThrow('ceilPercent');
+    expect(() => Amount.from(100).ceilPercent(1, unsafe)).toThrow('ceilPercent');
   });
 });
 
@@ -324,10 +344,13 @@ describe('AmountError metadata', () => {
   });
 });
 
-describe('Amount.scaledBy zero-numerator short-circuit', () => {
-  it('returns zero for scaledBy(0, 0) without reaching the divisor guard', () => {
-    // numerator zero short-circuits to zero before the denominator-zero check throws
-    expect(Amount.from(500).scaledBy(0, 0).toBigInt()).toBe(0n);
+describe('Amount.scaledBy denominator validation', () => {
+  it('rejects a 0/0 ratio instead of returning zero', () => {
+    expect(() => Amount.from(500).scaledBy(0, 0)).toThrow('denominator must be > 0');
+  });
+
+  it('still short-circuits a zero numerator once the denominator is valid', () => {
+    expect(Amount.from(500).scaledBy(0, 100).toBigInt()).toBe(0n);
   });
 });
 

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -137,6 +137,20 @@ describe('DefaultOutputDataCreator', () => {
       { amount: '2', counter: 8, keysetId: keyset.id },
     ]);
   });
+
+  test('rejects an exact custom split above the output cap before generating any output', () => {
+    const keyset: HasKeysetKeys = {
+      id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
+      keys: { '1': 'unused' },
+    };
+    const creator = new DefaultOutputDataCreator();
+    const singleSpy = vi.spyOn(OutputData, 'createSingleRandomData');
+    const oversizedSplit = Array.from({ length: 8_193 }, () => 1);
+
+    expect(() => creator.createRandomData(8_193, keyset, oversizedSplit)).toThrow(/output/i);
+    expect(singleSpy).not.toHaveBeenCalled();
+    singleSpy.mockRestore();
+  });
 });
 
 describe('OutputData helpers', () => {

--- a/test/model/ScriptPath.test.ts
+++ b/test/model/ScriptPath.test.ts
@@ -1,5 +1,6 @@
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -18,6 +19,7 @@ import { Amount } from '../../src/model/Amount';
 import { OutputData } from '../../src/model/OutputData';
 import { ScriptPath } from '../../src/model/ScriptPath';
 import type { Proof } from '../../src/model/types';
+import { encodeUint8ToBase64Url } from '../../src/utils';
 import type { MeltPreview, SwapPreview } from '../../src/wallet/types';
 
 const keysetId = `02${'11'.repeat(32)}`;
@@ -246,6 +248,9 @@ describe('ScriptPath signing packages', () => {
     const pkg = ScriptPath.extractSwapPackage(preview, [{ secret: proof.secret, leafIndex: 1 }]);
     expect(() => ScriptPath.deserializePackage('cashuA0000')).toThrow(/must start with/);
     expect(() => ScriptPath.deserializePackage('nutspA!!!not-base64!!!')).toThrow(/parse/);
+    const dupKeyPackage =
+      'nutspA' + encodeUint8ToBase64Url(utf8ToBytes('{"type":"swap","type":"melt"}'));
+    expect(() => ScriptPath.deserializePackage(dupKeyPackage)).toThrow(/parse/);
     // Shallow clone: structuredClone would strip the Amount prototypes off the inputs.
     const reserialize = (mangle: (p: typeof pkg) => unknown) =>
       ScriptPath.serializePackage(

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -316,6 +316,12 @@ describe('SigAll — serializePackage / deserializePackage', () => {
     expect(() => SigAll.deserializePackage(encoded)).toThrow('Failed to parse signing package');
   });
 
+  test('rejects a duplicate JSON key rather than taking the last value', () => {
+    const encoded =
+      'sigallA' + btoa('{"version":"sigallA","type":"swap","type":"melt"}').replace(/=+$/, '');
+    expect(() => SigAll.deserializePackage(encoded)).toThrow('Failed to parse signing package');
+  });
+
   test('throws on invalid version', () => {
     expect(() =>
       SigAll.deserializePackage(

--- a/test/transport/WSConnection.test.ts
+++ b/test/transport/WSConnection.test.ts
@@ -503,6 +503,37 @@ describe('WSConnection – message handling', () => {
     srv.close();
   });
 
+  test('a response with a duplicate JSON key is dropped rather than taking the last value', async () => {
+    const url = 'ws://localhost:3346/v1/ws';
+    const srv = new Server(url, { mock: false });
+
+    srv.on('connection', (socket) => {
+      socket.on('message', (m) => {
+        const parsed = JSON.parse(m.toString());
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            `{"jsonrpc":"2.0","error":{"message":"first"},"id":${parsed.id},"error":{"message":"second"}}`,
+          );
+          socket.send(`{"jsonrpc":"2.0","error":{"message":"after"},"id":${parsed.id}}`);
+        }
+      });
+    });
+
+    const conn = new WSConnection(url);
+    await conn.connect();
+
+    const errorCb = vi.fn();
+    await new Promise<void>((res) => {
+      conn.createSubscription({ kind: 'bolt11_mint_quote', filters: [] }, vi.fn(), errorCb);
+      setTimeout(res, 100);
+    });
+
+    // The malformed frame is dropped and the connection keeps serving the same id.
+    expect(errorCb).toHaveBeenCalledTimes(1);
+    expect(errorCb.mock.calls[0][0]).toMatchObject({ message: 'after' });
+    srv.close();
+  });
+
   test('notification without subId is silently ignored', async () => {
     const url = 'ws://localhost:3343/v1/ws';
     const srv = new Server(url, { mock: false });

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -393,6 +393,20 @@ describe('requests', { timeout: 7500 }, () => {
     await expect(wallet.checkMeltQuoteBolt11('test')).rejects.toThrow('primitive failure');
   });
 
+  test('falls back to raw text for an error body with a duplicate JSON key', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
+        return new HttpResponse('{"detail":"trusted","detail":"attacker"}', { status: 404 });
+      }),
+    );
+
+    const wallet = new Wallet(mintUrl);
+    wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
+    await expect(wallet.checkMeltQuoteBolt11('test')).rejects.toThrow(
+      '{"detail":"trusted","detail":"attacker"}',
+    );
+  });
+
   test('maps empty error response body to bad response', async () => {
     server.use(
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
@@ -417,6 +431,19 @@ describe('requests', { timeout: 7500 }, () => {
     expect(thrown).toBeInstanceOf(HttpResponseError);
     expect(thrown).toMatchObject({ message: 'bad response', status: 200 });
     expect((thrown as HttpResponseError).cause).toMatchObject({ message: 'Empty response body' });
+  });
+
+  test('rejects a response body with a duplicate JSON key instead of taking the last value', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    server.use(
+      http.get(endpoint, () => {
+        return new HttpResponse('{"id":"trusted","id":"attacker"}', { status: 200 });
+      }),
+    );
+
+    const thrown = await request({ endpoint }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect(thrown).toMatchObject({ message: 'bad response', status: 200 });
   });
 
   test('maps malformed success JSON to bad response and logs parsing failure', async () => {

--- a/test/utils/JSONInt.test.ts
+++ b/test/utils/JSONInt.test.ts
@@ -91,6 +91,28 @@ describe('native BigInt support: stringify', () => {
     expect(output).toBe('{\n  "b": 2,\n  "c": 3\n}');
   });
 
+  test('deduplicates repeated replacer keys like native JSON.stringify', () => {
+    const payload = 'x'.repeat(2_048);
+    const repeatedKeys = Array.from({ length: 64 }, () => 'payload');
+    expect(JSONInt.stringify({ payload }, repeatedKeys)).toBe(
+      JSON.stringify({ payload }, repeatedKeys),
+    );
+  });
+
+  test('skips replacer entries that are not strings or numbers like native JSON.stringify', () => {
+    const value = { a: 1, null: 2, '[object Object]': 3, true: 4, 5: 6 };
+    const replacer = ['a', null, {}, true, 5] as unknown as string[];
+    expect(JSONInt.stringify(value, replacer)).toBe(JSON.stringify(value, replacer));
+  });
+
+  test('caps a string space argument to 10 characters like native JSON.stringify', () => {
+    const value = { outer: { value: 1 }, sibling: 2 };
+    const longSpace = ' '.repeat(1_000);
+    expect(JSONInt.stringify(value, undefined, longSpace)).toBe(
+      JSON.stringify(value, undefined, longSpace),
+    );
+  });
+
   test('supports replacer function for filtering', () => {
     const output = JSONInt.stringify({ a: 1, b: 2 }, (key, value) =>
       key === 'b' ? undefined : value,
@@ -202,6 +224,37 @@ describe('__proto__ and constructor assignment', () => {
       admin?: boolean;
     };
     expect(obj2.admin).not.toBe(true);
+  });
+
+  test('reviver write-back keeps __proto__ as an own data property', () => {
+    const parsed = JSONInt.parse('{"__proto__":{"admin":true}}', function (key, value) {
+      if (key === '__proto__') {
+        Reflect.deleteProperty(this as object, key);
+      }
+      return value;
+    }) as { admin?: boolean };
+
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(true);
+    expect(parsed.admin).toBeUndefined();
+  });
+
+  test('reviver write-back keeps the earlier value when a key was made non-configurable mid-walk', () => {
+    // Matches native JSON.parse: CreateDataProperty ignores a failed define instead of throwing.
+    const parsed = JSONInt.parse('{"a":1}', function (key, value) {
+      if (key === 'a') {
+        Object.defineProperty(this as object, key, {
+          value: 99,
+          writable: false,
+          enumerable: true,
+          configurable: false,
+        });
+        return 2;
+      }
+      return value;
+    }) as { a: number };
+
+    expect(parsed.a).toBe(99);
   });
 });
 

--- a/test/utils/base64.test.ts
+++ b/test/utils/base64.test.ts
@@ -206,6 +206,12 @@ test('base64url JSON still decodes a document with a leading BOM', () => {
   expect(decodeBase64UrlToJson(encoded)).toEqual({ a: 1 });
 });
 
+test('v3 token path rejects a duplicate key rather than taking the last value', () => {
+  const ambiguousJson = '{"mint":"https://trusted.example","mint":"https://attacker.example"}';
+  const encoded = encodeUint8ToBase64(new TextEncoder().encode(ambiguousJson));
+  expect(() => decodeBase64UrlToJson(encoded)).toThrow(/Duplicate key/);
+});
+
 describe('alphabet split', () => {
   test('decodes a deprecated keyset ID, which is standard base64', () => {
     expect(decodeBase64ToUint8Legacy('+//wAAAAAAAA')).toEqual(

--- a/test/utils/bolt11.test.ts
+++ b/test/utils/bolt11.test.ts
@@ -43,4 +43,15 @@ describe('bolt11AmountMsat', () => {
   it('throws on non-string input', () => {
     expect(() => bolt11AmountMsat(null as unknown as string)).toThrow();
   });
+
+  it('rejects an amount digit run far longer than any real invoice needs', () => {
+    const invoice = `lnbc${'9'.repeat(100_000)}1pfake`;
+    expect(() => bolt11AmountMsat(invoice)).toThrow('Invalid BOLT11 invoice');
+  });
+
+  it('bounds the prefix at exactly 100 characters', () => {
+    // An all-letter prefix parses as amountless once it clears the length check.
+    expect(bolt11AmountMsat(`ln${'x'.repeat(98)}1pfake`)).toBeNull();
+    expect(() => bolt11AmountMsat(`ln${'x'.repeat(99)}1pfake`)).toThrow('Invalid BOLT11 invoice');
+  });
 });

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -145,6 +145,34 @@ describe('splitAmount output bound', () => {
     // One more output must be rejected, not allocated.
     expect(() => utils.splitAmount(8_193, onlyOnes)).toThrow(/would exceed .* outputs/);
   });
+
+  test('rejects an exact custom split above the output cap', () => {
+    // An exact caller-supplied split (sums to the requested value) returns before the fill
+    // logic's own budget check; it needs the same cap.
+    const oversizedSplit = Array.from({ length: 8_193 }, () => 1);
+    expect(() => utils.splitAmount(8_193, onlyOnes, oversizedSplit)).toThrow(
+      /would exceed .* outputs/,
+    );
+  });
+
+  test('allows an exact custom split at exactly the cap', () => {
+    const split = Array.from({ length: 8_192 }, () => 1);
+    expect(utils.splitAmount(8_192, onlyOnes, split)).toHaveLength(8_192);
+  });
+
+  test('rejects a zero-total custom split above the output cap', () => {
+    // Zero value and zero-total split (restore/NUT-08 blanks) returns before the fill logic's
+    // own budget check too; it needs the same cap as the exact-positive-split path.
+    const oversizedZeroSplit = Array.from({ length: 8_193 }, () => 0);
+    expect(() => utils.splitAmount(0, onlyOnes, oversizedZeroSplit)).toThrow(
+      /would exceed .* outputs/,
+    );
+  });
+
+  test('allows a zero-total custom split at exactly the cap', () => {
+    const zeroSplit = Array.from({ length: 8_192 }, () => 0);
+    expect(utils.splitAmount(0, onlyOnes, zeroSplit)).toHaveLength(8_192);
+  });
 });
 
 describe('test split different key amount', () => {

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -67,6 +67,22 @@ describe('getKeepAmounts', () => {
     amountsToKeep = getKeepAmounts(proofsWeHave, '22', keys, 2);
     expect(amountsToKeep.map((a) => a.toNumber())).toEqual([1, 1, 2, 2, 8, 8]);
   });
+
+  test('rejects an optimized split that would exceed the output cap', () => {
+    const singleDenominationKeys = { 1: '02'.padEnd(66, '1') } as Keys;
+    const unrelatedProof = { amount: Amount.from(2) } as Pick<Proof, 'amount'>;
+
+    expect(() => getKeepAmounts([unrelatedProof], 8193, singleDenominationKeys, 8193)).toThrow(
+      /8192 outputs/,
+    );
+  });
+
+  test('rejects an optimized split even when only the fill remainder tips it over the cap', () => {
+    const singleDenominationKeys = { 1: '02'.padEnd(66, '1') } as Keys;
+    // The optimize loop alone stays under the cap (8000 < 8192); only combined with the 300-output
+    // fill for the remainder does the total exceed it.
+    expect(() => getKeepAmounts([], 8300, singleDenominationKeys, 8000)).toThrow(/8192 outputs/);
+  });
 });
 
 describe('stringifyOutputTypeForLog', () => {

--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -453,6 +453,8 @@ describe('restore', () => {
     );
     // a zero batch never advances the counter, so the scan would loop forever
     await expect(wallet.batchRestore({ batchSize: 0 })).rejects.toThrow(/batchSize must be/);
+    // above the mint's advertised max_array_length (the library default here)
+    await expect(wallet.batchRestore({ batchSize: 501 })).rejects.toThrow(/batchSize must be/);
     await expect(wallet.batchRestore({ gapLimit: 0 })).rejects.toThrow(/gapLimit/);
     // a fractional gap would leave the probe width and gap count fractional
     await expect(wallet.batchRestore({ gapLimit: 2.5 })).rejects.toThrow(/gapLimit/);


### PR DESCRIPTION
Amounts are now non-negative by construction and `Amount.from` accepts only instances the library built. JSON arriving over the wire is parsed strictly, `JSONInt` matches native `JSON` on revivers and replacers, and the output-count cap covers every split path.

## Why

`Amount` checked only its upper bound, and `from()` returned any object carrying its prototype without looking at it. The v3 token decoder, HTTP and WebSocket transports and both signing-package decoders accepted a duplicate JSON key by taking the last value, where cdk rejects it. `JSONInt` diverged from native on three edges: reviver results were assigned rather than defined, a replacer array was not deduplicated, and a string `space` was not capped. `splitAmount` bounded only its fill path, so an exact or zero-total split could exceed `MAX_SPLIT_OUTPUTS`, and `getKeepAmounts` never checked it. `bolt11AmountMsat` handed an unbounded digit run to `BigInt`.

## Changes

A `#brand` private field marks constructor-built `Amount`s; esbuild lowers it to a WeakMap at the ES2020 target. Percent helpers require safe integers; `scaledBy` checks the denominator before its zero shortcut. `JSONInt.parse` runs with `strict: true` on every wire path; consumer storage keeps the lenient default. `walkReviver` writes results back with `Reflect.defineProperty`. `splitAmount` checks the split length once after normalisation, and `batchRestore` bounds an explicit `batchSize` at the mint's `max_array_length`, as its default already was. A 100-character prefix bound precedes the BOLT11 amount parse. Exponent and fraction number tokens still round through `Number`, as native does.

## Impact

`Amount.from` now rejects a deep clone or Proxy of an `Amount`; use the library's own factories. A wire payload with a duplicate object key is rejected. `batchRestore` refuses a `batchSize` above the mint's `max_array_length`. No public API change.
