### PR TITLE
fix(model): tighten Amount construction and strict wire JSON parsing [backport v4-dev]

### DIFF
--- a/src/model/Amount.ts
+++ b/src/model/Amount.ts
@@ -29,12 +29,16 @@ export type AmountLike = number | bigint | string | Amount;
  *     Amount.one();
  */
 export class Amount {
+  // Proves the constructor ran; instanceof alone does not, so from() requires it.
+  #brand = true;
   private readonly value: bigint;
 
   private constructor(value: bigint) {
-    // Single choke point for the u64 ceiling: every Amount, including arithmetic results, is
-    // <= u64 max. Muldiv helpers keep their wide intermediate in bigint and only construct the
-    // divided-down result, so a valid `a*n/d` still works while an out-of-range result throws.
+    // Single choke point for the [0, u64 max] invariant; muldiv helpers construct only their
+    // divided-down result, so a wide intermediate never hits this check.
+    if (value < 0n) {
+      throw new AmountError(`Amount must be >= 0, got ${value}`);
+    }
     if (value > U64_MAX) {
       throw new AmountError(`Amount exceeds u64 max, got ${value}`);
     }
@@ -53,7 +57,12 @@ export class Amount {
    *   is above the safe integer limit for a `number`.
    */
   static from(input: AmountLike): Amount {
-    if (input instanceof Amount) return input;
+    if (input instanceof Amount) {
+      if (!(#brand in input)) {
+        throw new AmountError('Invalid Amount instance');
+      }
+      return input;
+    }
 
     if (typeof input === 'bigint') {
       if (input < 0n) {
@@ -210,12 +219,12 @@ export class Amount {
    * @throws If numerator is a negative or non-integer, or denominator is not a positive integer.
    */
   ceilPercent(numerator: number, denominator: number = 100): Amount {
-    if (!Number.isInteger(numerator) || numerator < 0) {
+    if (!Number.isSafeInteger(numerator) || numerator < 0) {
       throw new AmountError(
         `ceilPercent: numerator must be a non-negative integer, got ${numerator}`,
       );
     }
-    if (!Number.isInteger(denominator) || denominator <= 0) {
+    if (!Number.isSafeInteger(denominator) || denominator <= 0) {
       throw new AmountError(
         `ceilPercent: denominator must be a positive integer, got ${denominator}`,
       );
@@ -240,12 +249,12 @@ export class Amount {
    * @throws If numerator is a negative or non-integer, or denominator is not a positive integer.
    */
   floorPercent(numerator: number, denominator: number = 100): Amount {
-    if (!Number.isInteger(numerator) || numerator < 0) {
+    if (!Number.isSafeInteger(numerator) || numerator < 0) {
       throw new AmountError(
         `floorPercent: numerator must be a non-negative integer, got ${numerator}`,
       );
     }
-    if (!Number.isInteger(denominator) || denominator <= 0) {
+    if (!Number.isSafeInteger(denominator) || denominator <= 0) {
       throw new AmountError(
         `floorPercent: denominator must be a positive integer, got ${denominator}`,
       );
@@ -314,10 +323,10 @@ export class Amount {
   scaledBy(numerator: AmountLike, denominator: AmountLike): Amount {
     const n = Amount.from(numerator).value;
     const d = Amount.from(denominator).value;
-    if (n === 0n) return Amount.zero();
     if (d === 0n) {
       throw new AmountError('scaledBy: denominator must be > 0');
     }
+    if (n === 0n) return Amount.zero();
     // round(a × n / d) = floor((2 × a × n + d) / (2 × d)); the 2*a*n intermediate stays in bigint
     return new Amount((2n * this.value * n + d) / (2n * d));
   }

--- a/src/model/SigAll.ts
+++ b/src/model/SigAll.ts
@@ -129,7 +129,7 @@ function deserializePackage(input: string): SigAllSigningPackage {
   let data: unknown;
 
   try {
-    data = JSONInt.parse(json);
+    data = JSONInt.parse(json, undefined, { strict: true });
   } catch (e) {
     throw new CTSError(
       `Failed to parse signing package JSON: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -314,8 +314,9 @@ export class WSConnection {
     const message = this.messageQueue.dequeue() as string;
 
     try {
-      // Same bigint-safe parse as the HTTP transport, so a u64 amount is not rounded on the way in
-      const parsed = JSONInt.parse(message) as JsonRpcMessage;
+      // Same bigint-safe, strict parse as the HTTP transport, so a u64 amount is not rounded and
+      // a duplicate key cannot pick a different result than an earlier check saw.
+      const parsed = JSONInt.parse(message, undefined, { strict: true }) as JsonRpcMessage;
 
       if ('result' in parsed && parsed.id != undefined) {
         if (this.rpcListeners[parsed.id]) {

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -622,7 +622,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
       if (!responseText) {
         throw new CTSError('Empty response body');
       }
-      return JSONInt.parse(responseText);
+      return JSONInt.parse(responseText, undefined, { strict: true });
     } catch (err) {
       requestLogger.error('Failed to parse HTTP response', { err });
       throw new HttpResponseError('bad response', response.status, { cause: err });
@@ -640,7 +640,7 @@ function parseErrorBody(errorText: string): ApiError {
   if (!errorText) return { detail: 'bad response' };
   let parsed: unknown;
   try {
-    parsed = JSONInt.parse(errorText);
+    parsed = JSONInt.parse(errorText, undefined, { strict: true });
   } catch {
     return { detail: errorText };
   }

--- a/src/utils/JSONInt.ts
+++ b/src/utils/JSONInt.ts
@@ -368,6 +368,25 @@ class Parser {
   }
 }
 
+/**
+ * Writes a reviver's returned value back as an own data property, not an assignment.
+ *
+ * Uses Reflect, not Object: a reviver can leave a key non-configurable mid-walk, and native
+ * JSON.parse silently keeps the existing value there rather than throwing.
+ */
+function defineReviverResult(
+  target: Record<string, unknown> | unknown[],
+  key: string,
+  value: unknown,
+): void {
+  Reflect.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
 function walkReviver(
   holder: Record<string, unknown> | unknown[],
   key: string,
@@ -377,14 +396,20 @@ function walkReviver(
   if (Array.isArray(current)) {
     for (let i = 0; i < current.length; i += 1) {
       const v = walkReviver(current, String(i), reviver);
-      if (v === undefined) Reflect.deleteProperty(current, i);
-      else current[i] = v;
+      if (v === undefined) {
+        Reflect.deleteProperty(current, i);
+      } else {
+        defineReviverResult(current, String(i), v);
+      }
     }
   } else if (isRecord(current)) {
     for (const k of Object.keys(current)) {
       const v = walkReviver(current, k, reviver);
-      if (v === undefined) delete current[k];
-      else current[k] = v;
+      if (v === undefined) {
+        delete current[k];
+      } else {
+        defineReviverResult(current, k, v);
+      }
     }
   }
   return reviver.call(holder, key, current);
@@ -440,14 +465,23 @@ function stringify(
   if (typeof space === 'number') {
     indent = ' '.repeat(Math.min(10, Math.max(0, Math.floor(space))));
   } else if (typeof space === 'string') {
-    indent = space;
+    indent = space.slice(0, 10);
   }
 
   if (replacer && typeof replacer !== 'function' && !Array.isArray(replacer)) {
     throw new CTSError('stringify: replacer must be a function or array');
   }
 
-  const propertyList = Array.isArray(replacer) ? replacer.map((k) => String(k)) : undefined;
+  // Native keeps only string and number entries, then drops repeats
+  const propertyList = Array.isArray(replacer)
+    ? Array.from(
+        new Set(
+          replacer
+            .filter((k) => typeof k === 'string' || typeof k === 'number')
+            .map((k) => String(k)),
+        ),
+      )
+    : undefined;
 
   const serialize = (holder: Record<string, unknown>, key: string): string | undefined => {
     let val: unknown = holder[key];

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -101,11 +101,12 @@ function encodeJsonToBase64Url(jsonObj: unknown): string {
  *
  * Integers within `±MAX_SAFE_INTEGER` are returned as `number`; integers outside that range are
  * returned as `bigint`. This preserves precision for large amounts encoded by
- * {@link encodeJsonToBase64Url}.
+ * {@link encodeJsonToBase64Url}. Parses strictly: a duplicate object key throws rather than silently
+ * taking the last value, since this decodes wire payloads.
  */
 function decodeBase64UrlToJson<T extends object>(base64String: string): T {
   const jsonString = decodeUtf8Document(decodeBase64UrlToUint8(base64String));
-  return JSONInt.parse(jsonString) as T;
+  return JSONInt.parse(jsonString, undefined, { strict: true }) as T;
 }
 
 /**
@@ -113,10 +114,11 @@ function decodeBase64UrlToJson<T extends object>(base64String: string): T {
  *
  * @remarks
  * The deprecated cashuA format predates the base64url convention, so tokens in the wild use both.
+ * Parses strictly, as {@link decodeBase64UrlToJson} does: this is the v3 token path.
  */
 function decodeBase64AnyToJson<T extends object>(base64String: string): T {
   const jsonString = decodeUtf8Document(decodeBase64AnyToUint8(base64String));
-  return JSONInt.parse(jsonString) as T;
+  return JSONInt.parse(jsonString, undefined, { strict: true }) as T;
 }
 
 /**

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -26,7 +26,7 @@ import {
 } from './base64';
 import { decodeCBOR, encodeCBOR } from './cbor';
 import { JSONInt } from './JSONInt';
-import { MAX_SPLIT_OUTPUTS } from './limits';
+import { MAX_BOLT11_HRP_LENGTH, MAX_SPLIT_OUTPUTS } from './limits';
 
 /**
  * Splits the amount into denominations of the provided keyset.
@@ -52,6 +52,9 @@ export function splitAmount(
   let normalizedSplit = split?.map((amt) => toAmount(amt, 'splitAmount.split', true));
 
   if (normalizedSplit) {
+    if (normalizedSplit.length > MAX_SPLIT_OUTPUTS) {
+      throw new CTSError(`Cannot split amount: split would exceed ${MAX_SPLIT_OUTPUTS} outputs`);
+    }
     const totalSplitAmount = Amount.sum(normalizedSplit);
 
     // Special case: explicit "zero-total" outputs (restore or NUT-08 blanks)
@@ -875,7 +878,12 @@ export function bolt11AmountMsat(pr: string): bigint | null {
   const lower = pr.toLowerCase();
   // The bech32 charset excludes '1', so the last '1' is the HRP separator.
   const sep = lower.lastIndexOf('1');
-  if (!lower.startsWith('ln') || sep < 3 || sep === lower.length - 1) {
+  if (
+    !lower.startsWith('ln') ||
+    sep < 3 ||
+    sep > MAX_BOLT11_HRP_LENGTH ||
+    sep === lower.length - 1
+  ) {
     throw new CTSError('Invalid BOLT11 invoice');
   }
   const match = /^ln[a-z]+?(\d*)([munp]?)$/.exec(lower.slice(0, sep));

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -101,6 +101,14 @@ export const U64_MAX = 2n ** 64n - 1n;
 export const MAX_CBOR_NODES = 262_144;
 
 /**
+ * Upper bound on a BOLT11 invoice's human-readable prefix, checked before the amount digits reach
+ * `BigInt`.
+ *
+ * Real invoices need a handful of characters here; this clears them with headroom.
+ */
+export const MAX_BOLT11_HRP_LENGTH = 100;
+
+/**
  * NUT-11: Upper bound on the keys in one `pubkeys` or `refund` tag, applied before any per-key
  * curve work. NUT-28 caps a lock at 11 slots (data + pubkeys + refund), enforced at build; this is
  * a work bound with headroom, not the exact slot rule. A string secret past

--- a/src/wallet/_internal.ts
+++ b/src/wallet/_internal.ts
@@ -2,8 +2,10 @@
  * Internal wallet utilities — not part of the public API.
  */
 import { Amount, type AmountLike } from '../model/Amount';
+import { CTSError } from '../model/Errors';
 import type { Keys, Proof } from '../model/types';
 import { splitAmount } from '../utils/core';
+import { MAX_SPLIT_OUTPUTS } from '../utils/limits';
 
 import { type OutputType } from './types';
 
@@ -19,6 +21,14 @@ function getKeysetAmountsAsc(keys: Keys): Amount[] {
   const amounts = Object.keys(keys).map((k) => Amount.from(k));
   amounts.sort((a, b) => a.compareTo(b));
   return amounts;
+}
+
+function assertSplitBudget(count: number): void {
+  if (count > MAX_SPLIT_OUTPUTS) {
+    throw new CTSError(
+      `Cannot split amount: optimized split would exceed ${MAX_SPLIT_OUTPUTS} outputs`,
+    );
+  }
 }
 
 /**
@@ -48,13 +58,16 @@ export function getKeepAmounts(
       if (nextTotal.greaterThan(normalizedAmountToKeep)) {
         break;
       }
+      assertSplitBudget(amountsWeWant.length + 1);
       amountsWeWant.push(amt);
       runningTotal = nextTotal;
     }
   }
   const amountDiff = normalizedAmountToKeep.subtract(runningTotal);
   if (!amountDiff.isZero()) {
-    for (const amt of splitAmount(amountDiff, keys)) {
+    const fillAmounts = splitAmount(amountDiff, keys);
+    assertSplitBudget(amountsWeWant.length + fillAmounts.length);
+    for (const amt of fillAmounts) {
       amountsWeWant.push(amt);
       runningTotal = runningTotal.add(amt);
     }

--- a/test/model/Amount.test.ts
+++ b/test/model/Amount.test.ts
@@ -30,6 +30,16 @@ describe('Amount.from validation', () => {
     expect(() => Amount.from({} as unknown as Amount)).toThrow('Unsupported amount input type');
   });
 
+  it('rejects a negative value passed directly to the exported constructor', () => {
+    expect(() => Reflect.construct(Amount, [-1n])).toThrow('Amount must be >= 0');
+  });
+
+  it('rejects an object forged with Amount.prototype without running the constructor', () => {
+    const forged = Object.create(Amount.prototype) as Amount;
+    Object.defineProperty(forged, 'value', { value: -7n });
+    expect(() => Amount.from(forged)).toThrow(AmountError);
+  });
+
   it('accepts the u64 max at the boundary', () => {
     const u64Max = 2n ** 64n - 1n;
     expect(Amount.from(u64Max).toBigInt()).toBe(u64Max);
@@ -119,6 +129,11 @@ describe('Amount.floorPercent', () => {
     expect(() => Amount.from(100).floorPercent(2, 0)).toThrow('floorPercent');
     expect(() => Amount.from(100).floorPercent(-1)).toThrow('floorPercent');
   });
+  it('rejects unsafe integer ratio operands', () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => Amount.from(100).floorPercent(unsafe)).toThrow('floorPercent');
+    expect(() => Amount.from(100).floorPercent(1, unsafe)).toThrow('floorPercent');
+  });
   it('works with large (unsafe integer) amounts', () => {
     const large = Amount.from(BigInt(Number.MAX_SAFE_INTEGER) + 1000n);
     const result = large.floorPercent(2);
@@ -149,6 +164,11 @@ describe('Amount.ceilPercent', () => {
     expect(Amount.from(100).ceilPercent(0).toBigInt()).toBe(0n);
     expect(() => Amount.from(100).ceilPercent(2, 0)).toThrow('ceilPercent');
     expect(() => Amount.from(100).ceilPercent(-1)).toThrow('ceilPercent');
+  });
+  it('rejects unsafe integer ratio operands', () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => Amount.from(100).ceilPercent(unsafe)).toThrow('ceilPercent');
+    expect(() => Amount.from(100).ceilPercent(1, unsafe)).toThrow('ceilPercent');
   });
 });
 
@@ -324,10 +344,13 @@ describe('AmountError metadata', () => {
   });
 });
 
-describe('Amount.scaledBy zero-numerator short-circuit', () => {
-  it('returns zero for scaledBy(0, 0) without reaching the divisor guard', () => {
-    // numerator zero short-circuits to zero before the denominator-zero check throws
-    expect(Amount.from(500).scaledBy(0, 0).toBigInt()).toBe(0n);
+describe('Amount.scaledBy denominator validation', () => {
+  it('rejects a 0/0 ratio instead of returning zero', () => {
+    expect(() => Amount.from(500).scaledBy(0, 0)).toThrow('denominator must be > 0');
+  });
+
+  it('still short-circuits a zero numerator once the denominator is valid', () => {
+    expect(Amount.from(500).scaledBy(0, 100).toBigInt()).toBe(0n);
   });
 });
 

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -140,6 +140,20 @@ describe('DefaultOutputDataCreator', () => {
       { amount: '2', counter: 8, keysetId: keyset.id },
     ]);
   });
+
+  test('rejects an exact custom split above the output cap before generating any output', () => {
+    const keyset: HasKeysetKeys = {
+      id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
+      keys: { '1': 'unused' },
+    };
+    const creator = new DefaultOutputDataCreator();
+    const singleSpy = vi.spyOn(OutputData, 'createSingleRandomData');
+    const oversizedSplit = Array.from({ length: 8_193 }, () => 1);
+
+    expect(() => creator.createRandomData(8_193, keyset, oversizedSplit)).toThrow(/output/i);
+    expect(singleSpy).not.toHaveBeenCalled();
+    singleSpy.mockRestore();
+  });
 });
 
 describe('OutputData helpers', () => {

--- a/test/model/SigAll.test.ts
+++ b/test/model/SigAll.test.ts
@@ -316,6 +316,12 @@ describe('SigAll — serializePackage / deserializePackage', () => {
     expect(() => SigAll.deserializePackage(encoded)).toThrow('Failed to parse signing package');
   });
 
+  test('rejects a duplicate JSON key rather than taking the last value', () => {
+    const encoded =
+      'sigallA' + btoa('{"version":"sigallA","type":"swap","type":"melt"}').replace(/=+$/, '');
+    expect(() => SigAll.deserializePackage(encoded)).toThrow('Failed to parse signing package');
+  });
+
   test('throws on invalid version', () => {
     expect(() =>
       SigAll.deserializePackage(

--- a/test/transport/WSConnection.test.ts
+++ b/test/transport/WSConnection.test.ts
@@ -503,6 +503,37 @@ describe('WSConnection – message handling', () => {
     srv.close();
   });
 
+  test('a response with a duplicate JSON key is dropped rather than taking the last value', async () => {
+    const url = 'ws://localhost:3346/v1/ws';
+    const srv = new Server(url, { mock: false });
+
+    srv.on('connection', (socket) => {
+      socket.on('message', (m) => {
+        const parsed = JSON.parse(m.toString());
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            `{"jsonrpc":"2.0","error":{"message":"first"},"id":${parsed.id},"error":{"message":"second"}}`,
+          );
+          socket.send(`{"jsonrpc":"2.0","error":{"message":"after"},"id":${parsed.id}}`);
+        }
+      });
+    });
+
+    const conn = new WSConnection(url);
+    await conn.connect();
+
+    const errorCb = vi.fn();
+    await new Promise<void>((res) => {
+      conn.createSubscription({ kind: 'bolt11_mint_quote', filters: [] }, vi.fn(), errorCb);
+      setTimeout(res, 100);
+    });
+
+    // The malformed frame is dropped and the connection keeps serving the same id.
+    expect(errorCb).toHaveBeenCalledTimes(1);
+    expect(errorCb.mock.calls[0][0]).toMatchObject({ message: 'after' });
+    srv.close();
+  });
+
   test('notification without subId is silently ignored', async () => {
     const url = 'ws://localhost:3343/v1/ws';
     const srv = new Server(url, { mock: false });

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -325,6 +325,20 @@ describe('requests', { timeout: 7500 }, () => {
     await expect(wallet.checkMeltQuoteBolt11('test')).rejects.toThrow('primitive failure');
   });
 
+  test('falls back to raw text for an error body with a duplicate JSON key', async () => {
+    server.use(
+      http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
+        return new HttpResponse('{"detail":"trusted","detail":"attacker"}', { status: 404 });
+      }),
+    );
+
+    const wallet = new Wallet(mintUrl);
+    wallet.loadMintFromCache(MINTCACHE.mintInfo, MINTCACHE.keychainCache);
+    await expect(wallet.checkMeltQuoteBolt11('test')).rejects.toThrow(
+      '{"detail":"trusted","detail":"attacker"}',
+    );
+  });
+
   test('maps empty error response body to bad response', async () => {
     server.use(
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
@@ -349,6 +363,19 @@ describe('requests', { timeout: 7500 }, () => {
     expect(thrown).toBeInstanceOf(HttpResponseError);
     expect(thrown).toMatchObject({ message: 'bad response', status: 200 });
     expect((thrown as HttpResponseError).cause).toMatchObject({ message: 'Empty response body' });
+  });
+
+  test('rejects a response body with a duplicate JSON key instead of taking the last value', async () => {
+    const endpoint = mintUrl + '/v1/keys';
+    server.use(
+      http.get(endpoint, () => {
+        return new HttpResponse('{"id":"trusted","id":"attacker"}', { status: 200 });
+      }),
+    );
+
+    const thrown = await request({ endpoint }).catch((e) => e);
+    expect(thrown).toBeInstanceOf(HttpResponseError);
+    expect(thrown).toMatchObject({ message: 'bad response', status: 200 });
   });
 
   test('maps malformed success JSON to bad response and logs parsing failure', async () => {

--- a/test/utils/JSONInt.test.ts
+++ b/test/utils/JSONInt.test.ts
@@ -82,6 +82,28 @@ describe('native BigInt support: stringify', () => {
     expect(output).toBe('{\n  "b": 2,\n  "c": 3\n}');
   });
 
+  test('deduplicates repeated replacer keys like native JSON.stringify', () => {
+    const payload = 'x'.repeat(2_048);
+    const repeatedKeys = Array.from({ length: 64 }, () => 'payload');
+    expect(JSONInt.stringify({ payload }, repeatedKeys)).toBe(
+      JSON.stringify({ payload }, repeatedKeys),
+    );
+  });
+
+  test('skips replacer entries that are not strings or numbers like native JSON.stringify', () => {
+    const value = { a: 1, null: 2, '[object Object]': 3, true: 4, 5: 6 };
+    const replacer = ['a', null, {}, true, 5] as unknown as string[];
+    expect(JSONInt.stringify(value, replacer)).toBe(JSON.stringify(value, replacer));
+  });
+
+  test('caps a string space argument to 10 characters like native JSON.stringify', () => {
+    const value = { outer: { value: 1 }, sibling: 2 };
+    const longSpace = ' '.repeat(1_000);
+    expect(JSONInt.stringify(value, undefined, longSpace)).toBe(
+      JSON.stringify(value, undefined, longSpace),
+    );
+  });
+
   test('supports replacer function for filtering', () => {
     const output = JSONInt.stringify({ a: 1, b: 2 }, (key, value) =>
       key === 'b' ? undefined : value,
@@ -193,6 +215,37 @@ describe('__proto__ and constructor assignment', () => {
       admin?: boolean;
     };
     expect(obj2.admin).not.toBe(true);
+  });
+
+  test('reviver write-back keeps __proto__ as an own data property', () => {
+    const parsed = JSONInt.parse('{"__proto__":{"admin":true}}', function (key, value) {
+      if (key === '__proto__') {
+        Reflect.deleteProperty(this as object, key);
+      }
+      return value;
+    }) as { admin?: boolean };
+
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(true);
+    expect(parsed.admin).toBeUndefined();
+  });
+
+  test('reviver write-back keeps the earlier value when a key was made non-configurable mid-walk', () => {
+    // Matches native JSON.parse: CreateDataProperty ignores a failed define instead of throwing.
+    const parsed = JSONInt.parse('{"a":1}', function (key, value) {
+      if (key === 'a') {
+        Object.defineProperty(this as object, key, {
+          value: 99,
+          writable: false,
+          enumerable: true,
+          configurable: false,
+        });
+        return 2;
+      }
+      return value;
+    }) as { a: number };
+
+    expect(parsed.a).toBe(99);
   });
 });
 

--- a/test/utils/base64.test.ts
+++ b/test/utils/base64.test.ts
@@ -201,6 +201,15 @@ describe('v4 keeps decoding permissive', () => {
     expect(() => decodeBase64UrlToUint8('o2F0gaJhaUgA/9SLj17PgGFw')).toThrow();
   });
 
+  test('v3 token path rejects a duplicate key rather than taking the last value', () => {
+    const ambiguousJson = '{"mint":"https://trusted.example","mint":"https://attacker.example"}';
+    const encoded = encodeUint8ToBase64(new TextEncoder().encode(ambiguousJson));
+    expect(() => decodeBase64AnyToJson(encoded)).toThrow(/Duplicate key/);
+    expect(() =>
+      decodeBase64UrlToJson(encodeUint8ToBase64Url(new TextEncoder().encode(ambiguousJson))),
+    ).toThrow(/Duplicate key/);
+  });
+
   test('decodes a deprecated keyset ID, which is standard base64', () => {
     expect(decodeBase64ToUint8Legacy('+//wAAAAAAAA')).toEqual(
       new Uint8Array([251, 255, 240, 0, 0, 0, 0, 0, 0]),

--- a/test/utils/bolt11.test.ts
+++ b/test/utils/bolt11.test.ts
@@ -43,4 +43,15 @@ describe('bolt11AmountMsat', () => {
   it('throws on non-string input', () => {
     expect(() => bolt11AmountMsat(null as unknown as string)).toThrow();
   });
+
+  it('rejects an amount digit run far longer than any real invoice needs', () => {
+    const invoice = `lnbc${'9'.repeat(100_000)}1pfake`;
+    expect(() => bolt11AmountMsat(invoice)).toThrow('Invalid BOLT11 invoice');
+  });
+
+  it('bounds the prefix at exactly 100 characters', () => {
+    // An all-letter prefix parses as amountless once it clears the length check.
+    expect(bolt11AmountMsat(`ln${'x'.repeat(98)}1pfake`)).toBeNull();
+    expect(() => bolt11AmountMsat(`ln${'x'.repeat(99)}1pfake`)).toThrow('Invalid BOLT11 invoice');
+  });
 });

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -127,6 +127,34 @@ describe('splitAmount output bound', () => {
     // One more output must be rejected, not allocated.
     expect(() => utils.splitAmount(8_193, onlyOnes)).toThrow(/would exceed .* outputs/);
   });
+
+  test('rejects an exact custom split above the output cap', () => {
+    // An exact caller-supplied split (sums to the requested value) returns before the fill
+    // logic's own budget check; it needs the same cap.
+    const oversizedSplit = Array.from({ length: 8_193 }, () => 1);
+    expect(() => utils.splitAmount(8_193, onlyOnes, oversizedSplit)).toThrow(
+      /would exceed .* outputs/,
+    );
+  });
+
+  test('allows an exact custom split at exactly the cap', () => {
+    const split = Array.from({ length: 8_192 }, () => 1);
+    expect(utils.splitAmount(8_192, onlyOnes, split)).toHaveLength(8_192);
+  });
+
+  test('rejects a zero-total custom split above the output cap', () => {
+    // Zero value and zero-total split (restore/NUT-08 blanks) returns before the fill logic's
+    // own budget check too; it needs the same cap as the exact-positive-split path.
+    const oversizedZeroSplit = Array.from({ length: 8_193 }, () => 0);
+    expect(() => utils.splitAmount(0, onlyOnes, oversizedZeroSplit)).toThrow(
+      /would exceed .* outputs/,
+    );
+  });
+
+  test('allows a zero-total custom split at exactly the cap', () => {
+    const zeroSplit = Array.from({ length: 8_192 }, () => 0);
+    expect(utils.splitAmount(0, onlyOnes, zeroSplit)).toHaveLength(8_192);
+  });
 });
 
 describe('test split different key amount', () => {

--- a/test/wallet/_internal.test.ts
+++ b/test/wallet/_internal.test.ts
@@ -61,6 +61,22 @@ describe('getKeepAmounts', () => {
     amountsToKeep = getKeepAmounts(proofsWeHave, '22', keys, 2);
     expect(amountsToKeep.map((a) => a.toNumber())).toEqual([1, 1, 2, 2, 8, 8]);
   });
+
+  test('rejects an optimized split that would exceed the output cap', () => {
+    const singleDenominationKeys = { 1: '02'.padEnd(66, '1') } as Keys;
+    const unrelatedProof = { amount: Amount.from(2) } as Pick<Proof, 'amount'>;
+
+    expect(() => getKeepAmounts([unrelatedProof], 8193, singleDenominationKeys, 8193)).toThrow(
+      /8192 outputs/,
+    );
+  });
+
+  test('rejects an optimized split even when only the fill remainder tips it over the cap', () => {
+    const singleDenominationKeys = { 1: '02'.padEnd(66, '1') } as Keys;
+    // The optimize loop alone stays under the cap (8000 < 8192); only combined with the 300-output
+    // fill for the remainder does the total exceed it.
+    expect(() => getKeepAmounts([], 8300, singleDenominationKeys, 8000)).toThrow(/8192 outputs/);
+  });
 });
 
 describe('stringifyOutputTypeForLog', () => {


### PR DESCRIPTION
Backport of #1114 to v4-dev, built by hand. Amounts are non-negative by construction and `Amount.from` accepts only instances the library built; wire JSON is parsed strictly; `JSONInt` matches native `JSON` on revivers, replacers and `space`; the output-count cap covers every split path; the BOLT11 prefix is bounded before `BigInt`.

## Changes

Same as #1114 with three differences. The strict parse is applied to `decodeBase64AnyToJson`, which is v4's v3 token path, as well as `decodeBase64UrlToJson`. The `batchRestore` argument bound is not carried: v4's positional `batchRestore` has no argument validation, and `splitAmount`'s cap already bounds the split. `ScriptPath` does not exist on v4.

## Impact

`Amount.from` now rejects a deep clone or Proxy of an `Amount`; use the library's own factories. A wire payload with a duplicate object key is rejected. No public API change.
