### PR TITLE
fix(mint): validate and bound mint response shapes [backport v4-dev]

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -48,7 +48,10 @@ import request, {
 } from '../transport';
 import {
   isObj,
+  isRecord,
   joinUrls,
+  MAX_KEYSET_LIST,
+  MAX_MINT_INFO_LIST,
   normalizeMintKeys,
   normalizeMintKeyset,
   normalizeMintUrl,
@@ -62,6 +65,14 @@ import type {
   CheckStatePayload,
   PostRestorePayload,
 } from './types';
+
+/**
+ * Names the shape of a refused response for logs, without handing the value itself to a
+ * consumer-supplied logger that would enumerate it.
+ */
+function describeShape(value: unknown): string {
+  return Array.isArray(value) ? 'array' : typeof value;
+}
 
 /**
  * Class represents Cashu Mint API.
@@ -157,7 +168,7 @@ class Mint {
       endpoint: joinUrls(this._mintUrl, '/v1/info'),
       onResponseMeta: this._captureResponseMetadata,
     });
-    return MintInfo.normalizeInfo(response);
+    return MintInfo.normalizeInfo(response, this._logger);
   }
 
   /**
@@ -204,6 +215,7 @@ class Mint {
       this._logger.error('Invalid response from mint...', { data, op: 'swap' });
       throw new CTSError('Invalid response from mint');
     }
+    this.assertSignatureCount(data.signatures, swapPayload.outputs, 'swap');
     data.signatures = this.normalizeSignatureAmounts(data.signatures);
 
     return data;
@@ -553,6 +565,7 @@ class Mint {
       this._logger.error('Invalid response from mint...', { data, op: `mint.${method}` });
       throw new CTSError('Invalid response from mint');
     }
+    this.assertSignatureCount(data.signatures, mintPayload.outputs, `mint.${method}`);
     data.signatures = this.normalizeSignatureAmounts(data.signatures);
     return options?.normalize ? options.normalize(data) : data;
   }
@@ -628,6 +641,7 @@ class Mint {
       this._logger.error('Invalid response from mint...', { data, op: `mintBatch.${method}` });
       throw new CTSError('Invalid response from mint');
     }
+    this.assertSignatureCount(data.signatures, mintPayload.outputs, `mintBatch.${method}`);
     data.signatures = this.normalizeSignatureAmounts(data.signatures);
     return options?.normalize ? options.normalize(data) : data;
   }
@@ -935,10 +949,17 @@ class Mint {
       customRequest,
     );
 
-    if (!isObj(data) || !Array.isArray(data?.states)) {
+    // Per NUT-07 the mint returns one state per requested Y, so the request bounds the response.
+    if (
+      !isObj(data) ||
+      !Array.isArray(data?.states) ||
+      data.states.length > checkPayload.Ys.length
+    ) {
       this._logger.error('Invalid response from mint...', { data, op: 'check' });
       throw new CTSError('Invalid response from mint');
     }
+
+    this.assertRecordEntries(data.states, 'check');
 
     // Per NUT-07, ProofState.witness is `<str | null>`. Some mints may omit the
     // field instead of sending null; coerce undefined → null so consumers
@@ -982,6 +1003,7 @@ class Mint {
       this._logger.error('Invalid response from mint...', { data, op: 'getKeys' });
       throw new CTSError('Invalid response from mint');
     }
+    this.assertKeysetList(data.keysets, 'getKeys');
 
     return {
       ...data,
@@ -1005,6 +1027,7 @@ class Mint {
       this._logger.error('Invalid response from mint...', { data, op: 'getKeySets' });
       throw new CTSError('Invalid response from mint');
     }
+    this.assertKeysetList(data.keysets, 'getKeySets');
     return {
       ...data,
       keysets: data.keysets.map((keyset) => normalizeMintKeyset(keyset)),
@@ -1030,7 +1053,14 @@ class Mint {
       onResponseMeta: this._captureResponseMetadata,
     });
 
-    if (!isObj(data) || !Array.isArray(data?.outputs) || !Array.isArray(data?.signatures)) {
+    // Per NUT-09 the mint returns paired outputs and signatures, one pair per requested output.
+    if (
+      !isObj(data) ||
+      !Array.isArray(data?.outputs) ||
+      !Array.isArray(data?.signatures) ||
+      data.outputs.length !== data.signatures.length ||
+      data.outputs.length > restorePayload.outputs.length
+    ) {
       this._logger.error('Invalid response from mint...', { data, op: 'restore' });
       throw new CTSError('Invalid response from mint');
     }
@@ -1213,6 +1243,7 @@ class Mint {
   private normalizeSignatureAmounts(
     signatures: SerializedBlindedSignature[],
   ): SerializedBlindedSignature[] {
+    this.assertRecordEntries(signatures, 'signatures');
     return signatures.map((signature) => ({
       ...signature,
       amount: Amount.from(signature.amount),
@@ -1222,10 +1253,52 @@ class Mint {
   private normalizeMessageAmounts(
     messages: SerializedBlindedMessage[],
   ): SerializedBlindedMessage[] {
+    this.assertRecordEntries(messages, 'outputs');
     return messages.map((message) => ({
       ...message,
       amount: Amount.from(message.amount),
     }));
+  }
+
+  /**
+   * Rejects list entries that are not records, before any spread copies them. A response element is
+   * whatever the JSON held, and spreading a string or an array expands it into indexed properties.
+   */
+  private assertRecordEntries(entries: unknown[], op: string): void {
+    if (entries.every((entry) => isRecord(entry))) return;
+    this._logger.error('Invalid response from mint...', { entries: entries.length, op });
+    throw new CTSError('Invalid response from mint');
+  }
+
+  /**
+   * Rejects a response carrying more signatures than the request had outputs. The mint signs the
+   * outputs it was sent, so the request bounds the per-entry work a response can cause.
+   */
+  private assertSignatureCount(signatures: unknown[], outputs: unknown[], op: string): void {
+    if (signatures.length <= outputs.length) return;
+    this._logger.error('Invalid response from mint...', {
+      signatures: signatures.length,
+      outputs: outputs.length,
+      op,
+    });
+    // Only used on paths where the mint has already settled, so carry the same recovery route the
+    // wallet gives for a short response.
+    throw new CTSError(
+      `Invalid response from mint: ${signatures.length} signatures, expected ${outputs.length}. ` +
+        'The operation may already have been applied; if the wallet is seeded, try restoring ' +
+        '(NUT-09) to recover.',
+    );
+  }
+
+  /**
+   * Bounds a mint-supplied keyset list before normalization copies every entry.
+   */
+  private assertKeysetList(keysets: unknown[], op: string): void {
+    if (keysets.length > MAX_KEYSET_LIST) {
+      this._logger.error('Invalid response from mint...', { keysets: keysets.length, op });
+      throw new CTSError('Invalid response from mint');
+    }
+    this.assertRecordEntries(keysets, op);
   }
 
   /**
@@ -1238,6 +1311,11 @@ class Mint {
     response: TRes,
     normalize?: (raw: Record<string, unknown>) => TRes,
   ): TRes {
+    const op = `${method} mint quote`;
+    if (!isRecord(response)) {
+      this._logger.error('Invalid response from mint...', { type: describeShape(response), op });
+      throw new CTSError('Invalid response from mint');
+    }
     const data: Record<string, unknown> = { ...response };
     this.normalizeMintBaseFields(data);
     if (method === 'bolt11') {
@@ -1345,6 +1423,10 @@ class Mint {
     normalize?: (raw: Record<string, unknown>) => TRes,
   ): TRes {
     const op = `${method} melt quote`;
+    if (!isRecord(response)) {
+      this._logger.error('Invalid response from mint...', { type: describeShape(response), op });
+      throw new CTSError('Invalid response from mint');
+    }
     const data: Record<string, unknown> = { ...response };
     this.normalizeMeltBaseFields(data, op);
     if (method === 'bolt11' || method === 'bolt12') {
@@ -1366,6 +1448,14 @@ class Mint {
       undefined,
     );
     if (data.change) {
+      // Bounded before any per-entry work; the wallet still owns the blanks-vs-change comparison.
+      if (!Array.isArray(data.change) || data.change.length > MAX_MINT_INFO_LIST) {
+        this._logger.error('Invalid response from mint...', {
+          type: describeShape(data.change),
+          op,
+        });
+        throw new CTSError('Invalid response from mint');
+      }
       data.change = this.normalizeSignatureAmounts(data.change as SerializedBlindedSignature[]);
     }
     if (
@@ -1401,16 +1491,20 @@ class Mint {
    * Mutates `data` in place, normalizing onchain-specific melt fields.
    */
   private normalizeMeltOnchainFields(data: Record<string, unknown>): void {
-    if (!Array.isArray(data.fee_options) || data.fee_options.length === 0) {
+    if (
+      !Array.isArray(data.fee_options) ||
+      data.fee_options.length === 0 ||
+      data.fee_options.length > MAX_MINT_INFO_LIST
+    ) {
       this._logger.error('Invalid response from mint...', { data, op: 'onchain melt quote' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
     data.fee_options = data.fee_options.map((raw) => {
       const opt = raw as Record<string, unknown>;
       // fee_index is the load-bearing selector for the melt request
       if (!Number.isSafeInteger(opt.fee_index)) {
         this._logger.error('Invalid response from mint...', { data, op: 'onchain melt quote' });
-        throw new Error('Invalid response from mint');
+        throw new CTSError('Invalid response from mint');
       }
       return {
         ...opt,
@@ -1426,7 +1520,7 @@ class Mint {
       (data.outpoint !== null && typeof data.outpoint !== 'string')
     ) {
       this._logger.error('Invalid response from mint...', { data, op: 'onchain melt quote' });
-      throw new Error('Invalid response from mint');
+      throw new CTSError('Invalid response from mint');
     }
   }
 }

--- a/src/model/MintInfo.ts
+++ b/src/model/MintInfo.ts
@@ -1,10 +1,11 @@
 import { type Logger, NULL_LOGGER } from '../logger';
-import { nullIfUndefined } from '../utils/core';
+import { isRecord, nullIfUndefined } from '../utils/core';
 import {
   ABSOLUTE_MAX_ARRAY_LENGTH,
   ABSOLUTE_MAX_BATCH_SIZE,
   ABSOLUTE_MAX_PER_MINT,
   DEFAULT_MAX_ARRAY_LENGTH,
+  MAX_MINT_INFO_DEPTH,
   MAX_MINT_INFO_LIST,
 } from '../utils/limits';
 import { normalizeSafeIntegerMetadata } from '../utils/normalizeNumbers';
@@ -58,38 +59,72 @@ export class MintInfo {
   }
 
   static normalizeInfo(info: GetInfoResponse, logger: Logger = NULL_LOGGER): GetInfoResponse {
+    // The response is untrusted JSON: check the shape before any spread copies it.
+    if (!isRecord(info) || !isRecord(info.nuts)) {
+      logger.error('MintInfo: malformed info response', { op: 'normalizeInfo' });
+      throw new CTSError('Invalid response from mint');
+    }
     return {
       ...info,
+      ...(Array.isArray(info.contact)
+        ? { contact: MintInfo.capList(info.contact, 'contact', logger) }
+        : {}),
+      ...(Array.isArray(info.urls) ? { urls: MintInfo.capList(info.urls, 'urls', logger) } : {}),
       nuts: {
         ...info.nuts,
         ...(info.nuts['4']
-          ? {
-              '4': {
-                ...info.nuts['4'],
-                methods: MintInfo.normalizeSwapMethods(info.nuts['4'].methods, logger),
-              },
-            }
+          ? { '4': MintInfo.normalizeSwapSection(info.nuts['4'], 'nuts.4', logger) }
           : {}),
         ...(info.nuts['5']
-          ? {
-              '5': {
-                ...info.nuts['5'],
-                methods: MintInfo.normalizeSwapMethods(info.nuts['5'].methods, logger),
-              },
-            }
+          ? { '5': MintInfo.normalizeSwapSection(info.nuts['5'], 'nuts.5', logger) }
           : {}),
-        ...(info.nuts['19'] ? { '19': MintInfo.normalizeNut19(info.nuts['19']) } : {}),
+        ...(info.nuts['15'] ? { '15': MintInfo.normalizeNut15(info.nuts['15'], logger) } : {}),
+        ...(info.nuts['17'] ? { '17': MintInfo.normalizeNut17(info.nuts['17'], logger) } : {}),
+        ...(info.nuts['19'] ? { '19': MintInfo.normalizeNut19(info.nuts['19'], logger) } : {}),
+        ...(info.nuts['21'] ? { '21': MintInfo.normalizeNut21(info.nuts['21'], logger) } : {}),
         ...(info.nuts['22'] ? { '22': MintInfo.normalizeNut22(info.nuts['22'], logger) } : {}),
         ...(info.nuts['29'] ? { '29': MintInfo.normalizeNut29(info.nuts['29'], logger) } : {}),
       },
     };
   }
 
+  /**
+   * Warns that a malformed optional section was dropped. Sections arrive as untrusted JSON, so one
+   * that is not a record is omitted rather than spread.
+   */
+  private static dropSection(label: string, logger: Logger): undefined {
+    logger.warn(`MintInfo: ${label} is malformed and was omitted`);
+    return undefined;
+  }
+
+  /**
+   * NUT-04/05 are mandatory sections, so a malformed one fails the whole response rather than
+   * leaving the wallet to guess what the mint supports.
+   */
+  private static normalizeSwapSection(
+    section: GetInfoResponse['nuts']['4'],
+    label: string,
+    logger: Logger,
+  ): GetInfoResponse['nuts']['4'] {
+    if (!isRecord(section)) {
+      logger.error('MintInfo: malformed info response', { op: label });
+      throw new CTSError('Invalid response from mint');
+    }
+    return { ...section, methods: MintInfo.normalizeSwapMethods(section.methods, logger) };
+  }
+
   // Per NUT-04/05/25/XX, `min_amount` and `max_amount` are `<int|null>`. Mints that omit
   // them entirely (older Nutshell, etc.) leave the field as `undefined`; coerce to null
   // so the runtime value matches the `AmountLike | null` type.
   private static normalizeSwapMethods(methods: SwapMethod[], logger: Logger): SwapMethod[] {
-    const bounded = MintInfo.capList(methods, 'nuts.4/5.methods', logger);
+    if (!Array.isArray(methods)) {
+      logger.warn('MintInfo: nuts.4/5.methods is malformed and was omitted');
+      return [];
+    }
+    // Entries are untrusted JSON; drop any that is not a record before spreading it.
+    const bounded = MintInfo.capList(methods, 'nuts.4/5.methods', logger).filter((m) =>
+      isRecord(m),
+    );
     return bounded.map((m) => {
       const next = { ...m } as Record<string, unknown>;
       nullIfUndefined(next, 'min_amount', 'max_amount');
@@ -127,14 +162,61 @@ export class MintInfo {
     return max;
   }
 
+  private static normalizeNut15(
+    nut15: GetInfoResponse['nuts']['15'],
+    logger: Logger,
+  ): GetInfoResponse['nuts']['15'] {
+    if (!isRecord(nut15)) return MintInfo.dropSection('nuts.15', logger);
+    if (!Array.isArray(nut15.methods)) return nut15;
+
+    return { ...nut15, methods: MintInfo.capList(nut15.methods, 'nuts.15.methods', logger) };
+  }
+
+  private static normalizeNut17(
+    nut17: GetInfoResponse['nuts']['17'],
+    logger: Logger,
+  ): GetInfoResponse['nuts']['17'] {
+    if (!isRecord(nut17)) return MintInfo.dropSection('nuts.17', logger);
+    if (!Array.isArray(nut17.supported)) return nut17;
+
+    return { ...nut17, supported: MintInfo.capList(nut17.supported, 'nuts.17.supported', logger) };
+  }
+
   private static normalizeNut19(
     nut19: GetInfoResponse['nuts']['19'],
+    logger: Logger,
   ): GetInfoResponse['nuts']['19'] {
-    if (!nut19) return nut19;
+    if (!isRecord(nut19)) return MintInfo.dropSection('nuts.19', logger);
 
     return {
       ...nut19,
+      ...(Array.isArray(nut19.cached_endpoints)
+        ? {
+            cached_endpoints: MintInfo.capList(
+              nut19.cached_endpoints,
+              'nuts.19.cached_endpoints',
+              logger,
+            ),
+          }
+        : {}),
       ttl: normalizeSafeIntegerMetadata(nut19.ttl, 'nuts.19.ttl', null),
+    };
+  }
+
+  private static normalizeNut21(
+    nut21: GetInfoResponse['nuts']['21'],
+    logger: Logger,
+  ): GetInfoResponse['nuts']['21'] {
+    if (!isRecord(nut21)) return MintInfo.dropSection('nuts.21', logger);
+    if (!Array.isArray(nut21.protected_endpoints)) return nut21;
+
+    return {
+      ...nut21,
+      protected_endpoints: MintInfo.capList(
+        nut21.protected_endpoints,
+        'nuts.21.protected_endpoints',
+        logger,
+      ),
     };
   }
 
@@ -142,7 +224,7 @@ export class MintInfo {
     nut22: GetInfoResponse['nuts']['22'],
     logger: Logger,
   ): GetInfoResponse['nuts']['22'] {
-    if (!nut22) return nut22;
+    if (!isRecord(nut22)) return MintInfo.dropSection('nuts.22', logger);
 
     let bat_max_mint = ABSOLUTE_MAX_PER_MINT;
     try {
@@ -168,6 +250,15 @@ export class MintInfo {
 
     return {
       ...nut22,
+      ...(Array.isArray(nut22.protected_endpoints)
+        ? {
+            protected_endpoints: MintInfo.capList(
+              nut22.protected_endpoints,
+              'nuts.22.protected_endpoints',
+              logger,
+            ),
+          }
+        : {}),
       bat_max_mint,
     };
   }
@@ -176,7 +267,7 @@ export class MintInfo {
     nut29: GetInfoResponse['nuts']['29'],
     logger: Logger,
   ): GetInfoResponse['nuts']['29'] {
-    if (!nut29) return nut29;
+    if (!isRecord(nut29)) return MintInfo.dropSection('nuts.29', logger);
 
     let max_batch_size = ABSOLUTE_MAX_BATCH_SIZE;
     try {
@@ -203,7 +294,9 @@ export class MintInfo {
     // Explicit reconstruction — do not spread ...nut29 here.
     // A spread would reintroduce a malformed max_batch_size from the original object.
     return {
-      methods: nut29.methods,
+      methods: Array.isArray(nut29.methods)
+        ? MintInfo.capList(nut29.methods, 'nuts.29.methods', logger)
+        : nut29.methods,
       max_batch_size,
     };
   }
@@ -406,16 +499,20 @@ export class MintInfo {
    * Preserves bigints (AmountLike fields may hold them; JSON round-trips would not) and Amount
    * instances (which AmountLike also admits): Amount is frozen and immutable, so sharing the
    * reference is safe and structural copying would strip its prototype into a bare `{value}`.
+   * Nesting past MAX_MINT_INFO_DEPTH throws rather than running the stack out.
    */
-  private static snapshot<T>(value: T): T {
+  private static snapshot<T>(value: T, depth = 0): T {
     if (value === null || typeof value !== 'object') return value;
     if (value instanceof Amount) return value;
+    if (depth > MAX_MINT_INFO_DEPTH) {
+      throw new CTSError(`Mint info nesting exceeds ${MAX_MINT_INFO_DEPTH} levels`);
+    }
     if (Array.isArray(value)) {
-      return (value as unknown[]).map((v) => MintInfo.snapshot(v)) as T;
+      return (value as unknown[]).map((v) => MintInfo.snapshot(v, depth + 1)) as T;
     }
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = MintInfo.snapshot(v);
+      out[k] = MintInfo.snapshot(v, depth + 1);
     }
     return out as T;
   }

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -540,6 +540,18 @@ export function isObj(v: unknown): v is object {
 }
 
 /**
+ * Type guard: returns `true` if `v` is a record, i.e. a non-null object that is not an array.
+ *
+ * @remarks
+ * Use this over {@link isObj} on anything off the wire: JSON admits an array or a string where a
+ * record is declared, and spreading one of those materializes a property per element/character.
+ * @internal
+ */
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return isObj(v) && !Array.isArray(v);
+}
+
+/**
  * In-place: set listed keys to `null` if currently `undefined`. Used when normalizing mint
  * responses where the spec defines a nullable wire field but the mint omits it (Postel-style).
  * Pairs with TS types declared as `T | null`.

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -84,6 +84,21 @@ export const MIN_SEED_BYTES = 16;
 export const MAX_SEED_BYTES = 64;
 
 /**
+ * Upper bound on entries we process from a mint's keyset lists. `/v1/keysets` is historical: it
+ * grows with every rotation and never shrinks, so this sits far above any plausible mint rather
+ * than at the mint-info list cap. It only bounds the per-entry normalization work; the transport
+ * byte cap still applies.
+ */
+export const MAX_KEYSET_LIST = 10_000;
+
+/**
+ * Upper bound on how deeply mint-advertised metadata may nest before a snapshot of it is refused.
+ * Real `/v1/info` metadata nests a handful of levels; the recursive copy overflows the call stack
+ * well before this is a limitation. Mirrors the parser depth caps in JSONInt and cbor.
+ */
+export const MAX_MINT_INFO_DEPTH = 64;
+
+/**
  * Max u64 (2^64 - 1): the ceiling every Amount is held to. Enforced in the Amount constructor, so
  * arithmetic results are bounded too; muldiv helpers keep their wide intermediate in bigint and
  * only construct the divided-down result.

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -14,6 +14,7 @@ import {
   Amount,
 } from '../../src';
 import type { AuthProvider, Logger, RequestFn } from '../../src';
+import { MAX_KEYSET_LIST, MAX_MINT_INFO_LIST } from '../../src/utils/limits';
 import { MINTINFORESP } from '../consts';
 
 type ReqArgs = {
@@ -32,6 +33,10 @@ const makeRequest = <T>(payload: T): RequestFn => {
     return payload;
   }) as RequestFn;
 };
+
+// Minimal wire-shaped fixtures: Mint checks response counts against the request.
+const blankOutput = (amount = 1) => ({ amount: Amount.from(amount), id: '00', B_: '02blank' });
+const blindSignature = (amount = 1) => ({ amount, C_: '02sig', id: '00' });
 
 function createLogger(): Logger {
   return {
@@ -298,7 +303,7 @@ describe('Mint normalization', () => {
       },
     });
 
-    const response = await mint.swap({ inputs: [], outputs: [] });
+    const response = await mint.swap({ inputs: [], outputs: [blankOutput()] });
 
     expect(authProvider.ensureCAT).toHaveBeenCalled();
     expect(authProvider.getCAT).not.toHaveBeenCalled();
@@ -337,7 +342,7 @@ describe('Mint normalization', () => {
       },
     });
 
-    await mint.swap({ inputs: [], outputs: [] });
+    await mint.swap({ inputs: [], outputs: [blankOutput()] });
 
     expect(authProvider.getCAT).toHaveBeenCalled();
   });
@@ -501,9 +506,31 @@ describe('Mint normalization', () => {
     }) as RequestFn;
     const mint = new Mint(mintUrl, { customRequest: requestSpy });
 
-    const response = await mint.mintBolt11({ quote: 'q1', outputs: [] });
+    const response = await mint.mintBolt11({ quote: 'q1', outputs: [blankOutput()] });
 
     expect(response.signatures[0].amount.toBigInt()).toBe(2n);
+  });
+
+  it.each([
+    ['not an array', { amount: 3, C_: '02change', id: '00' }],
+    [
+      'oversized',
+      Array.from({ length: MAX_MINT_INFO_LIST + 1 }, () => ({ amount: 1, C_: '02c', id: '00' })),
+    ],
+  ])('checkMeltQuoteBolt11 rejects a change list that is %s', async (_label, change) => {
+    const requestSpy = vi.fn(async () => ({
+      quote: 'q1',
+      amount: 12,
+      unit: 'sat',
+      state: MeltQuoteState.PAID,
+      expiry: 123,
+      request: 'lnbc1...',
+      fee_reserve: 1,
+      change,
+    })) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    await expect(mint.checkMeltQuoteBolt11('q1')).rejects.toThrow('Invalid response from mint');
   });
 
   it('checkMeltQuoteBolt11 normalizes amount, fee reserve, and change signatures', async () => {
@@ -1122,7 +1149,7 @@ describe('Mint normalization', () => {
     }) as RequestFn;
     const mint = new Mint(mintUrl, { customRequest: requestSpy });
 
-    const response = await mint.mintOnchain({ quote: 'q1', outputs: [] });
+    const response = await mint.mintOnchain({ quote: 'q1', outputs: [blankOutput()] });
 
     expect(response.signatures).toHaveLength(1);
     expect(response.signatures[0].amount.toBigInt()).toBe(4n);
@@ -1170,7 +1197,7 @@ describe('Mint normalization', () => {
     const response = await mint.mintBatchBolt11({
       quotes: ['q1', 'q2'],
       quote_amounts: [Amount.from(1), Amount.from(2)],
-      outputs: [],
+      outputs: [blankOutput(1), blankOutput(2)],
     });
 
     expect(response.signatures).toHaveLength(2);
@@ -1191,7 +1218,7 @@ describe('Mint normalization', () => {
     const response = await mint.mintBatchBolt12({
       quotes: ['q1'],
       quote_amounts: [Amount.from(4)],
-      outputs: [],
+      outputs: [blankOutput(4)],
     });
 
     expect(response.signatures).toHaveLength(1);
@@ -1442,5 +1469,215 @@ describe('Mint.lastResponseMetadata', () => {
 
     expect(mint1.lastResponseMetadata!.rateLimit).toBe('limit=100, remaining=99, reset=60');
     expect(mint2.lastResponseMetadata!.rateLimit).toBe('limit=50, remaining=10, reset=30');
+  });
+});
+
+describe('Mint response shape and cardinality', () => {
+  // A response element the transport hands back may be any JSON value; a Proxy makes it observable
+  // whether it is copied before the shape is checked.
+  const watchedArray = (seen: { enumerated: boolean }) =>
+    new Proxy([] as unknown[], {
+      ownKeys(target) {
+        seen.enumerated = true;
+        return Reflect.ownKeys(target);
+      },
+    });
+
+  it('rejects a mint quote response that is not a record', async () => {
+    const seen = { enumerated: false };
+    const mint = new Mint(mintUrl, { customRequest: makeRequest(watchedArray(seen)) });
+
+    await expect(mint.checkMintQuote('bolt11', 'q1')).rejects.toThrow('Invalid response from mint');
+    expect(seen.enumerated).toBe(false);
+  });
+
+  it('rejects a scalar mint quote response', async () => {
+    const mint = new Mint(mintUrl, { customRequest: makeRequest('x'.repeat(64)) });
+
+    await expect(mint.checkMintQuote('bolt11', 'q1')).rejects.toThrow('Invalid response from mint');
+  });
+
+  it('rejects a melt quote response that is not a record', async () => {
+    const seen = { enumerated: false };
+    const mint = new Mint(mintUrl, { customRequest: makeRequest(watchedArray(seen)) });
+
+    await expect(mint.checkMeltQuote('bolt11', 'q1')).rejects.toThrow('Invalid response from mint');
+    expect(seen.enumerated).toBe(false);
+  });
+
+  it('rejects a signature entry that is not a record', async () => {
+    const seen = { enumerated: false };
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ signatures: [watchedArray(seen)] }),
+    });
+
+    await expect(mint.mintBolt11({ quote: 'q1', outputs: [blankOutput(1)] })).rejects.toThrow(
+      'Invalid response from mint',
+    );
+    expect(seen.enumerated).toBe(false);
+  });
+
+  it('rejects a restored output entry that is not a record', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ outputs: ['not-an-output'], signatures: [blindSignature(1)] }),
+    });
+
+    await expect(mint.restore({ outputs: [blankOutput(1)] })).rejects.toThrow(
+      'Invalid response from mint',
+    );
+  });
+
+  it('rejects a keyset entry that is not a record in getKeys', async () => {
+    const seen = { enumerated: false };
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ keysets: [watchedArray(seen)] }),
+    });
+
+    await expect(mint.getKeys()).rejects.toThrow('Invalid response from mint');
+    expect(seen.enumerated).toBe(false);
+  });
+
+  it('rejects a keyset entry that is not a record in getKeySets', async () => {
+    const mint = new Mint(mintUrl, { customRequest: makeRequest({ keysets: ['00'] }) });
+
+    await expect(mint.getKeySets()).rejects.toThrow('Invalid response from mint');
+  });
+
+  it.each([
+    ['getKeys', (mint: Mint) => mint.getKeys()],
+    ['getKeySets', (mint: Mint) => mint.getKeySets()],
+  ])('rejects an oversized keyset list in %s', async (_label, call) => {
+    const keysets = Array.from({ length: MAX_KEYSET_LIST + 1 }, () => ({
+      id: '00',
+      unit: 'sat',
+      active: true,
+    }));
+    const mint = new Mint(mintUrl, { customRequest: makeRequest({ keysets }) });
+
+    await expect(call(mint)).rejects.toThrow('Invalid response from mint');
+  });
+
+  it('accepts a keyset list far larger than the mint info list cap', async () => {
+    const keysets = Array.from({ length: MAX_MINT_INFO_LIST + 1 }, (_, i) => ({
+      id: `00${i}`,
+      unit: 'sat',
+      active: false,
+    }));
+    const mint = new Mint(mintUrl, { customRequest: makeRequest({ keysets }) });
+
+    const response = await mint.getKeySets();
+
+    expect(response.keysets).toHaveLength(MAX_MINT_INFO_LIST + 1);
+  });
+
+  it('rejects an oversized onchain fee option list', async () => {
+    const fee_options = Array.from({ length: MAX_MINT_INFO_LIST + 1 }, (_, i) => ({
+      fee_index: i,
+      fee_reserve: 2,
+      estimated_blocks: 6,
+    }));
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({
+        quote: 'q1',
+        amount: 10,
+        unit: 'sat',
+        state: MeltQuoteState.UNPAID,
+        expiry: 123,
+        request: 'bc1qrecipient',
+        fee_options,
+      }),
+    });
+
+    await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
+  });
+
+  it('rejects more swap signatures than outputs and points at recovery', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ signatures: [blindSignature(1), blindSignature(2)] }),
+    });
+
+    await expect(mint.swap({ inputs: [], outputs: [blankOutput(1)] })).rejects.toThrow(
+      /Invalid response from mint: 2 signatures, expected 1\..*NUT-09/,
+    );
+  });
+
+  it('rejects more mint signatures than outputs', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ signatures: [blindSignature(1), blindSignature(2)] }),
+    });
+
+    await expect(mint.mintBolt11({ quote: 'q1', outputs: [blankOutput(1)] })).rejects.toThrow(
+      'Invalid response from mint',
+    );
+  });
+
+  it('rejects more batch mint signatures than outputs', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ signatures: [blindSignature(1), blindSignature(2)] }),
+    });
+
+    await expect(
+      mint.mintBatchBolt11({
+        quotes: ['q1'],
+        quote_amounts: [Amount.from(1)],
+        outputs: [blankOutput(1)],
+      }),
+    ).rejects.toThrow('Invalid response from mint');
+  });
+
+  it('returns restored outputs paired with their signatures', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ outputs: [blankOutput(1)], signatures: [blindSignature(1)] }),
+    });
+
+    const response = await mint.restore({ outputs: [blankOutput(1), blankOutput(2)] });
+
+    expect(response.outputs).toHaveLength(1);
+    expect(response.signatures[0].amount.toBigInt()).toBe(1n);
+  });
+
+  it('rejects a restore response whose outputs and signatures do not pair up', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ outputs: [blankOutput(1)], signatures: [] }),
+    });
+
+    await expect(mint.restore({ outputs: [blankOutput(1)] })).rejects.toThrow(
+      'Invalid response from mint',
+    );
+  });
+
+  it('rejects a restore response with more entries than were requested', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({
+        outputs: [blankOutput(1), blankOutput(2)],
+        signatures: [blindSignature(1), blindSignature(2)],
+      }),
+    });
+
+    await expect(mint.restore({ outputs: [blankOutput(1)] })).rejects.toThrow(
+      'Invalid response from mint',
+    );
+  });
+
+  it('rejects a proof state entry that is not a record', async () => {
+    const mint = new Mint(mintUrl, { customRequest: makeRequest({ states: ['UNSPENT'] }) });
+
+    await expect(mint.check({ Ys: ['02y'] })).rejects.toThrow('Invalid response from mint');
+  });
+
+  it('rejects more proof states than identifiers checked', async () => {
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest({ states: [{ Y: '02y', state: 'UNSPENT' }] }),
+    });
+
+    await expect(mint.check({ Ys: [] })).rejects.toThrow('Invalid response from mint');
+  });
+
+  it('accepts fewer proof states than identifiers checked', async () => {
+    const mint = new Mint(mintUrl, { customRequest: makeRequest({ states: [] }) });
+
+    const response = await mint.check({ Ys: ['02y'] });
+
+    expect(response.states).toHaveLength(0);
   });
 });

--- a/test/model/MintInfo.test.ts
+++ b/test/model/MintInfo.test.ts
@@ -867,3 +867,262 @@ describe('MintInfo NUT-06 informational fields', () => {
     expect(info.tos_url).toBeUndefined();
   });
 });
+
+describe('MintInfo malformed sections', () => {
+  function spyLogger() {
+    return {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+  }
+
+  it.each([
+    ['an array response', [] as unknown],
+    ['a string response', 'x'.repeat(64)],
+    ['a response without nuts', { name: 'mint' }],
+    ['a response whose nuts is an array', { name: 'mint', nuts: [] }],
+  ])('rejects %s without enumerating it', (_label, response) => {
+    expect(() => new MintInfo(response as never)).toThrow('Invalid response from mint');
+  });
+
+  it('does not enumerate the properties of a non-record response', () => {
+    let enumerated = false;
+    const malformed = new Proxy([] as unknown[], {
+      ownKeys(target) {
+        enumerated = true;
+        return Reflect.ownKeys(target);
+      },
+    });
+
+    expect(() => new MintInfo(malformed as never)).toThrow('Invalid response from mint');
+    expect(enumerated).toBe(false);
+  });
+
+  it('rejects a NUT-04 section that is not a record', () => {
+    expect(
+      () => new MintInfo({ ...MINTINFORESP, nuts: { ...MINTINFORESP.nuts, 4: ['methods'] } }),
+    ).toThrow('Invalid response from mint');
+  });
+
+  it('rejects a NUT-05 section that is not a record', () => {
+    expect(
+      () => new MintInfo({ ...MINTINFORESP, nuts: { ...MINTINFORESP.nuts, 5: 'x'.repeat(64) } }),
+    ).toThrow('Invalid response from mint');
+  });
+
+  it('treats a NUT-04 section without a methods array as advertising none', () => {
+    const logger = spyLogger();
+    const info = new MintInfo(
+      { ...MINTINFORESP, nuts: { ...MINTINFORESP.nuts, 4: { disabled: false, methods: 'all' } } },
+      logger,
+    );
+
+    expect(info.nuts[4]?.methods).toEqual([]);
+    expect(info.isSupported(4).disabled).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/methods/i));
+  });
+
+  it('drops method entries that are not records', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        4: {
+          disabled: false,
+          methods: ['x'.repeat(1_024), { method: 'bolt11', unit: 'sat' }],
+        },
+      },
+    });
+
+    const methods = info.nuts[4]?.methods;
+    expect(methods).toHaveLength(1);
+    expect(methods?.[0].method).toBe('bolt11');
+  });
+
+  it.each([15, 17, 19, 21, 22, 29])('omits a NUT-%s section that is not a record', (nut) => {
+    const logger = spyLogger();
+    const info = new MintInfo(
+      { ...MINTINFORESP, nuts: { ...MINTINFORESP.nuts, [nut]: 'x'.repeat(1_024) } },
+      logger,
+    );
+
+    expect(info.nuts[nut as 19]).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`nuts.${nut}`)));
+  });
+});
+
+describe('MintInfo retained list caps', () => {
+  function spyLogger() {
+    return {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+  }
+
+  const oversized = <T>(entry: () => T) =>
+    Array.from({ length: MAX_MINT_INFO_LIST + 5 }, () => entry());
+
+  it('caps the contact list', () => {
+    const logger = spyLogger();
+    const info = new MintInfo(
+      { ...MINTINFORESP, contact: oversized(() => ({ method: 'email', info: 'a@b.c' })) },
+      logger,
+    );
+
+    expect(info.contact).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/contact/i),
+      expect.objectContaining({ advertised: MAX_MINT_INFO_LIST + 5 }),
+    );
+  });
+
+  it('caps the urls list', () => {
+    const logger = spyLogger();
+    const info = new MintInfo(
+      { ...MINTINFORESP, urls: oversized(() => 'https://mint.example') },
+      logger,
+    );
+
+    expect(info.urls).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/urls/i),
+      expect.objectContaining({ advertised: MAX_MINT_INFO_LIST + 5 }),
+    );
+  });
+
+  it('accepts info without a contact list', () => {
+    const { contact: _contact, ...rest } = MINTINFORESP;
+    const info = new MintInfo(rest);
+    expect(info.contact).toBeUndefined();
+  });
+
+  it('caps the NUT-15 method list', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        15: { methods: oversized(() => ({ method: 'bolt11', unit: 'sat' })) },
+      },
+    });
+
+    expect(info.nuts[15]?.methods).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(info.isSupported(15).params).toHaveLength(MAX_MINT_INFO_LIST);
+  });
+
+  it('caps the NUT-17 support list', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        17: { supported: oversized(() => ({ method: 'bolt11', unit: 'sat', commands: [] })) },
+      },
+    });
+
+    expect(info.nuts[17]?.supported).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(info.isSupported(17).params).toHaveLength(MAX_MINT_INFO_LIST);
+  });
+
+  it('caps the NUT-19 cached endpoint list', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        19: { ttl: 60, cached_endpoints: oversized(() => ({ method: 'POST', path: '/v1/swap' })) },
+      },
+    });
+
+    expect(info.nuts[19]?.cached_endpoints).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(info.isSupported(19).params?.cached_endpoints).toHaveLength(MAX_MINT_INFO_LIST);
+  });
+
+  it('caps the retained NUT-21 and NUT-22 endpoint lists', () => {
+    const endpoints = oversized(() => ({ method: 'POST', path: '/v1/swap' }));
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        21: {
+          openid_discovery: 'https://mint.host',
+          client_id: 'cashu',
+          protected_endpoints: endpoints,
+        },
+        22: { bat_max_mint: 100, protected_endpoints: endpoints },
+      },
+    });
+
+    expect(info.nuts[21]?.protected_endpoints).toHaveLength(MAX_MINT_INFO_LIST);
+    expect(info.nuts[22]?.protected_endpoints).toHaveLength(MAX_MINT_INFO_LIST);
+  });
+
+  it('leaves NUT-21 and NUT-22 sections without endpoint lists alone', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        21: { openid_discovery: 'https://mint.host', client_id: 'cashu' },
+        22: { bat_max_mint: 100 },
+      },
+    });
+
+    expect(info.nuts[21]?.protected_endpoints).toBeUndefined();
+    expect(info.nuts[22]?.bat_max_mint).toBe(100);
+  });
+
+  it('leaves sections without their advertised lists alone', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        15: {},
+        17: {},
+        19: { ttl: 60 },
+      },
+    });
+
+    expect(info.nuts[15]?.methods).toBeUndefined();
+    expect(info.nuts[17]?.supported).toBeUndefined();
+    expect(info.nuts[19]?.cached_endpoints).toBeUndefined();
+    expect(info.nuts[19]?.ttl).toBe(60);
+  });
+
+  it('caps the NUT-29 method list', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: {
+        ...MINTINFORESP.nuts,
+        29: { max_batch_size: 10, methods: oversized(() => 'bolt11') },
+      },
+    });
+
+    expect(info.nuts[29]?.methods).toHaveLength(MAX_MINT_INFO_LIST);
+  });
+
+  it('leaves a NUT-29 section without a method list alone', () => {
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: { ...MINTINFORESP.nuts, 29: { max_batch_size: 10 } },
+    });
+
+    expect(info.nuts[29]?.methods).toBeUndefined();
+  });
+
+  it('rejects metadata nested past the snapshot depth limit', () => {
+    let nested: Record<string, unknown> = { end: true };
+    for (let i = 0; i < 128; i++) nested = { nested };
+    const info = new MintInfo({
+      ...MINTINFORESP,
+      nuts: { ...MINTINFORESP.nuts, 7: { supported: true, extra: nested } },
+    });
+
+    expect(() => info.nuts).toThrow('nesting');
+    expect(() => info.cache).toThrow('nesting');
+  });
+});

--- a/test/wallet/wallet-send-mutants.node.test.ts
+++ b/test/wallet/wallet-send-mutants.node.test.ts
@@ -216,7 +216,23 @@ describe('validateReturnedSignatures', () => {
     );
   });
 
-  test('completeSwap rejects a signature count that differs from outputs', async () => {
+  test('completeSwap rejects fewer signatures than outputs', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/swap', () =>
+        // one output requested, none returned
+        HttpResponse.json({ signatures: [] }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.receive([makeProof(1)])).rejects.toThrow(
+      'Mint returned 0 signatures, expected 1',
+    );
+  });
+
+  // The upper bound belongs to the Mint layer, which carries the same recovery route.
+  test('completeSwap rejects more signatures than outputs', async () => {
     server.use(
       http.post(mintUrl + '/v1/swap', () =>
         HttpResponse.json({
@@ -232,7 +248,7 @@ describe('validateReturnedSignatures', () => {
     await wallet.loadMint();
 
     await expect(wallet.receive([makeProof(1)])).rejects.toThrow(
-      'Mint returned 2 signatures, expected 1',
+      /2 signatures, expected 1\..*NUT-09/,
     );
   });
 });


### PR DESCRIPTION
Backport of #1116 to v4-dev, built by hand. Mint responses are shape-checked and bounded before the wallet touches them: list entries must be records, signature and state counts cannot exceed what was requested, and mint info is validated, capped and copied to a bounded depth.

## Changes

Same as #1116. The only differences are in adjacent code: v4's `MintInfo` has no `method_name` derivation and its `Mint` quote normalizer has no base-field step, so the conflicting import lines and docblocks kept v4's versions. The `fee_options` bound applies as on main.

## Impact

Malformed entries, over-counts and a malformed NUT-04/05 section now fail with `CTSError` instead of being partially accepted. No public API change.
