### PR TITLE
fix(mint): strip wallet fields from inputs and bind melt responses [backport v4-dev]

### DIFF
--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -33,6 +33,7 @@ import {
   type MintQuoteOnchainResponse,
   type MeltQuoteOnchainRequest,
   type MeltQuoteOnchainResponse,
+  type Proof,
   type SwapRequest,
   type SerializedBlindedMessage,
   type SerializedBlindedSignature,
@@ -204,10 +205,16 @@ class Mint {
    * @returns Signed outputs.
    */
   async swap(swapPayload: SwapRequest, customRequest?: RequestFn): Promise<SwapResponse> {
+    failIf(
+      !Array.isArray(swapPayload?.inputs),
+      'swap: inputs must be an array of proofs',
+      this._logger,
+    );
+    // `dleq` and `p2pk_e` are wallet-side data: keep them off the wire.
     const data = await this.requestWithAuth<SwapResponse>(
       'POST',
       '/v1/swap',
-      { requestBody: swapPayload },
+      { requestBody: { ...swapPayload, inputs: this.stripWalletFields(swapPayload.inputs) } },
       customRequest,
     );
 
@@ -692,11 +699,20 @@ class Mint {
     meltQuotePayload: MeltQuoteBolt11Request,
     customRequest?: RequestFn,
   ): Promise<MeltQuoteBolt11Response> {
-    return this.createMeltQuote<MeltQuoteBolt11Response>(
+    const response = await this.createMeltQuote<MeltQuoteBolt11Response>(
       'bolt11',
       this.normalizeMeltQuoteRequestOptions(meltQuotePayload),
       { customRequest },
     );
+    // The quote must be for the invoice that was asked for. Bech32 is case insensitive, and an
+    // empty request means the mint echoed nothing back for the caller to compare.
+    failIf(
+      response.request !== '' &&
+        response.request.toLowerCase() !== meltQuotePayload.request.toLowerCase(),
+      'Melt quote is for a different payment request',
+      this._logger,
+    );
+    return response;
   }
 
   /**
@@ -772,7 +788,15 @@ class Mint {
       {},
       options?.customRequest,
     );
-    return this.normalizeMeltQuoteResponse(method, response, options?.normalize);
+    const normalized = this.normalizeMeltQuoteResponse(method, response, options?.normalize);
+    if (normalized.quote !== quote) {
+      this._logger.error('Invalid response from mint...', {
+        data: normalized,
+        op: `checkMeltQuote.${method}`,
+      });
+      throw new CTSError('Melt quote response is for a different quote');
+    }
+    return normalized;
   }
 
   /**
@@ -837,7 +861,8 @@ class Mint {
    * constructs the endpoint as `/v1/melt/{method}` and POSTs the payload. The response must contain
    * the common fields: quote, amount, state, expiry. Method-specific fields (e.g. `fee_reserve` for
    * bolt11/bolt12) are normalized when present. Custom methods can supply an optional `normalize`
-   * callback for their own fields.
+   * callback for their own fields. The response may omit quote fields such as `request` and
+   * `fee_reserve` (NUT-05 asynchronous shape): merge it over the quote you already hold.
    * @example
    *
    * ```ts
@@ -860,13 +885,37 @@ class Mint {
     },
   ): Promise<MeltQuoteBaseResponse & TRes> {
     failIf(!this.isValidMethodString(method), `Invalid melt method: ${method}`, this._logger);
+    failIf(
+      !Array.isArray(meltPayload?.inputs),
+      'melt: inputs must be an array of proofs',
+      this._logger,
+    );
+    // `dleq` and `p2pk_e` are wallet-side data: keep them off the wire.
     const response = await this.requestWithAuth<MeltQuoteBaseResponse & TRes>(
       'POST',
       `/v1/melt/${method}`,
-      { requestBody: meltPayload },
+      { requestBody: { ...meltPayload, inputs: this.stripWalletFields(meltPayload.inputs) } },
       options?.customRequest,
     );
-    return this.normalizeMeltQuoteResponse(method, response, options?.normalize);
+    // The proofs are spent by now, so the response is normalized as an execution result.
+    const execution = true;
+    const normalized = this.normalizeMeltQuoteResponse(
+      method,
+      response,
+      options?.normalize,
+      execution,
+    );
+    // The inputs are spent by now, so a mismatched id must not cost the caller the response it
+    // needs to recover its change: keep the id that was asked for and say so.
+    if (normalized.quote !== meltPayload.quote) {
+      this._logger.warn('Melt response reports a different quote id', {
+        op: `melt.${method}`,
+        expected: meltPayload.quote,
+        received: normalized.quote,
+      });
+      normalized.quote = meltPayload.quote;
+    }
+    return normalized;
   }
 
   /**
@@ -875,7 +924,8 @@ class Mint {
    * also contain blank outputs in order to receive back overpaid Lightning fees.
    *
    * @remarks
-   * Thin wrapper around melt('bolt11', ...).
+   * Thin wrapper around melt('bolt11', ...). The response may omit `request` and `fee_reserve`
+   * (NUT-05 asynchronous shape): merge it over the quote you already hold.
    * @param meltPayload The melt payload containing inputs and optional outputs.
    * @param options.customRequest Optional override for the request function.
    * @returns The melt response.
@@ -1261,6 +1311,18 @@ class Mint {
   }
 
   /**
+   * Drops the wallet-side proof fields (`dleq`, `p2pk_e`) before a request goes out.
+   */
+  private stripWalletFields(proofs: Proof[]): Array<Omit<Proof, 'dleq' | 'p2pk_e'>> {
+    return proofs.map((p) => {
+      const { dleq, p2pk_e, ...rest } = p;
+      void dleq;
+      void p2pk_e;
+      return rest;
+    });
+  }
+
+  /**
    * Rejects list entries that are not records, before any spread copies them. A response element is
    * whatever the JSON held, and spreading a string or an array expands it into indexed properties.
    */
@@ -1416,11 +1478,17 @@ class Mint {
    * Stacks normalizers for melt quote responses: base normalization (amount, expiry, change) is
    * always applied, then first-class bolt normalization for known methods, then any custom
    * normalize callback.
+   *
+   * @remarks
+   * `execution` marks the response to `POST /v1/melt/{method}`, which NUT-05 lets the mint answer
+   * with the settled fields only. Absent quote fields are dropped there so the caller keeps the
+   * values it already holds; the quote endpoint stays strict.
    */
   private normalizeMeltQuoteResponse<TRes extends MeltQuoteBaseResponse>(
     method: string,
     response: TRes,
     normalize?: (raw: Record<string, unknown>) => TRes,
+    execution: boolean = false,
   ): TRes {
     const op = `${method} melt quote`;
     if (!isRecord(response)) {
@@ -1428,11 +1496,17 @@ class Mint {
       throw new CTSError('Invalid response from mint');
     }
     const data: Record<string, unknown> = { ...response };
+    if (execution) {
+      // An empty request is a mint that echoed nothing back, same as an absent one. A zero
+      // fee reserve is a real value, so only a nullish one goes.
+      if (data.request == null || data.request === '') delete data.request;
+      if (data.fee_reserve == null) delete data.fee_reserve;
+    }
     this.normalizeMeltBaseFields(data, op);
     if (method === 'bolt11' || method === 'bolt12') {
-      this.normalizeMeltBoltFields(data, op);
+      this.normalizeMeltBoltFields(data, op, execution);
     } else if (method === 'onchain') {
-      this.normalizeMeltOnchainFields(data);
+      this.normalizeMeltOnchainFields(data, execution);
     }
     return normalize ? normalize(data) : (data as TRes);
   }
@@ -1475,9 +1549,21 @@ class Mint {
   /**
    * Mutates `data` in place, normalizing bolt11/bolt12-specific melt fields.
    */
-  private normalizeMeltBoltFields(data: Record<string, unknown>, op: string): void {
-    data.fee_reserve = Amount.from(data.fee_reserve as AmountLike);
-    if (typeof data.request !== 'string' || !(data.fee_reserve instanceof Amount)) {
+  private normalizeMeltBoltFields(
+    data: Record<string, unknown>,
+    op: string,
+    execution: boolean,
+  ): void {
+    // An execution response may omit request and fee_reserve (NUT-05 asynchronous shape); a quote
+    // may not. A zero fee reserve is a real value and still coerces.
+    const omitted = (key: string): boolean => execution && data[key] === undefined;
+    if (!omitted('fee_reserve') && data.fee_reserve != null) {
+      data.fee_reserve = Amount.from(data.fee_reserve as AmountLike);
+    }
+    if (
+      (typeof data.request !== 'string' && !omitted('request')) ||
+      (!(data.fee_reserve instanceof Amount) && !omitted('fee_reserve'))
+    ) {
       this._logger.error('Invalid response from mint...', { data, op });
       throw new CTSError('Invalid response from mint');
     }
@@ -1490,7 +1576,12 @@ class Mint {
   /**
    * Mutates `data` in place, normalizing onchain-specific melt fields.
    */
-  private normalizeMeltOnchainFields(data: Record<string, unknown>): void {
+  private normalizeMeltOnchainFields(data: Record<string, unknown>, execution: boolean): void {
+    // An execution response may carry only the settled fields; the quote endpoint requires them.
+    if (execution && data.fee_options === undefined) {
+      nullIfUndefined(data, 'selected_fee_index', 'outpoint');
+      return;
+    }
     if (
       !Array.isArray(data.fee_options) ||
       data.fee_options.length === 0 ||

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -13,7 +13,8 @@ import {
   RateLimitError,
   Amount,
 } from '../../src';
-import type { AuthProvider, Logger, RequestFn } from '../../src';
+import type { AuthProvider, Logger, Proof, RequestFn } from '../../src';
+import { JSONInt } from '../../src/utils/JSONInt';
 import { MAX_KEYSET_LIST, MAX_MINT_INFO_LIST } from '../../src/utils/limits';
 import { MINTINFORESP } from '../consts';
 
@@ -26,6 +27,11 @@ type ReqArgs = {
 
 const mintUrl = 'https://localhost:3338';
 const fakeWsUrl = 'wss://mint.example/cashu/v1/ws';
+
+// Mint serializes the body before the transport; parse it back to assert on the wire form.
+// v4 hands the transport the object; a string means it was already serialized.
+const sentBody = (body: unknown): unknown =>
+  typeof body === 'string' ? JSONInt.parse(body) : body;
 
 const makeRequest = <T>(payload: T): RequestFn => {
   return (async (options: ReqArgs): Promise<T> => {
@@ -1155,6 +1161,25 @@ describe('Mint normalization', () => {
     expect(response.signatures[0].amount.toBigInt()).toBe(4n);
   });
 
+  it('meltOnchain accepts an execution response without fee_options', async () => {
+    const requestSpy = vi.fn(async () => ({
+      quote: 'q1',
+      amount: 10,
+      unit: 'sat',
+      state: MeltQuoteState.PENDING,
+      expiry: 123,
+    })) as RequestFn;
+    const mint = new Mint(mintUrl, { customRequest: requestSpy });
+
+    const response = await mint.meltOnchain({ quote: 'q1', inputs: [], outputs: [] });
+
+    expect(response.quote).toBe('q1');
+    expect(response.state).toBe(MeltQuoteState.PENDING);
+    expect(response.fee_options).toBeUndefined();
+    expect(response.selected_fee_index).toBeNull();
+    expect(response.outpoint).toBeNull();
+  });
+
   it('meltOnchain posts to /v1/melt/onchain and normalizes onchain fields', async () => {
     const requestSpy = vi.fn(async (options: ReqArgs) => {
       expect(options.endpoint).toBe(mintUrl + '/v1/melt/onchain');
@@ -1349,6 +1374,306 @@ describe('Mint normalization', () => {
       e: expect.any(Error),
     });
     expect(mint.webSocketConnection).toBeUndefined();
+  });
+
+  describe('mint payloads (NUT-03/05 inputs)', () => {
+    const makeProof = (): Proof => ({
+      id: '00keyset',
+      amount: Amount.from(1),
+      secret: 'proof-secret',
+      C: '02signature',
+      witness: '{"signatures":["ff"]}',
+      dleq: { e: 'dleq-challenge', s: 'dleq-response', r: 'blinding-factor' },
+      p2pk_e: 'ephemeral-key',
+    });
+
+    const captureInputs = (
+      sink: { inputs?: Array<Record<string, unknown>> },
+      response: unknown,
+    ): RequestFn =>
+      (async (options: ReqArgs) => {
+        sink.inputs = (
+          sentBody(options.requestBody) as { inputs: Array<Record<string, unknown>> }
+        ).inputs;
+        return response;
+      }) as RequestFn;
+
+    it('sends swap inputs without dleq and leaves the caller proofs alone', async () => {
+      const sink: { inputs?: Array<Record<string, unknown>> } = {};
+      const mint = new Mint(mintUrl, {
+        customRequest: captureInputs(sink, { signatures: [] }),
+      });
+      const proof = makeProof();
+
+      await mint.swap({ inputs: [proof], outputs: [] });
+
+      expect(sink.inputs?.[0]).not.toHaveProperty('dleq');
+      expect(sink.inputs?.[0]).not.toHaveProperty('p2pk_e');
+      expect(sink.inputs?.[0]).toMatchObject({
+        id: '00keyset',
+        secret: 'proof-secret',
+        C: '02signature',
+        witness: '{"signatures":["ff"]}',
+      });
+      expect(sink.inputs?.[0].amount).toBeDefined();
+      expect(proof.dleq).toBeDefined();
+      expect(proof.p2pk_e).toBeDefined();
+    });
+
+    it('sends melt inputs without dleq and leaves the caller proofs alone', async () => {
+      const sink: { inputs?: Array<Record<string, unknown>> } = {};
+      const mint = new Mint(mintUrl, {
+        customRequest: captureInputs(sink, {
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          state: MeltQuoteState.PAID,
+          expiry: 123,
+          request: 'lnbc1...',
+          fee_reserve: 0,
+        }),
+      });
+      const proof = makeProof();
+
+      await mint.meltBolt11({ quote: 'q1', inputs: [proof], outputs: [] });
+
+      expect(sink.inputs?.[0]).not.toHaveProperty('dleq');
+      expect(sink.inputs?.[0]).not.toHaveProperty('p2pk_e');
+      expect(sink.inputs?.[0]).toMatchObject({
+        id: '00keyset',
+        secret: 'proof-secret',
+        C: '02signature',
+        witness: '{"signatures":["ff"]}',
+      });
+      expect(proof.dleq).toBeDefined();
+      expect(proof.p2pk_e).toBeDefined();
+    });
+
+    it('throws when swap inputs are not an array', async () => {
+      const mint = new Mint(mintUrl, { customRequest: makeRequest({ signatures: [] }) });
+
+      await expect(
+        mint.swap({ outputs: [] } as unknown as Parameters<Mint['swap']>[0]),
+      ).rejects.toThrow('swap: inputs must be an array of proofs');
+      await expect(mint.swap(undefined as unknown as Parameters<Mint['swap']>[0])).rejects.toThrow(
+        'swap: inputs must be an array of proofs',
+      );
+    });
+
+    it('throws when melt inputs are not an array', async () => {
+      const mint = new Mint(mintUrl, { customRequest: makeRequest({ quote: 'q1' }) });
+
+      await expect(
+        mint.melt('bolt11', { quote: 'q1' } as unknown as Parameters<Mint['melt']>[1]),
+      ).rejects.toThrow('melt: inputs must be an array of proofs');
+      await expect(
+        mint.melt('bolt11', undefined as unknown as Parameters<Mint['melt']>[1]),
+      ).rejects.toThrow('melt: inputs must be an array of proofs');
+    });
+  });
+
+  describe('melt responses (NUT-05 quote binding)', () => {
+    const meltResponse = (quote: string) => ({
+      quote,
+      amount: 12,
+      unit: 'sat',
+      state: MeltQuoteState.UNPAID,
+      expiry: 123,
+      request: 'lnbc1...',
+      fee_reserve: 1,
+      payment_preimage: null,
+    });
+
+    it('throws when a checked melt quote reports a different quote id', async () => {
+      const logger = createLogger();
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest(meltResponse('other-quote')),
+        logger,
+      });
+
+      await expect(mint.checkMeltQuoteBolt11('my-quote')).rejects.toThrow(/different quote/);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('keeps the requested quote id when a melt reports a different one', async () => {
+      const logger = createLogger();
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest(meltResponse('other-quote')),
+        logger,
+      });
+
+      const response = await mint.meltBolt11({ quote: 'my-quote', inputs: [], outputs: [] });
+
+      expect(response.quote).toBe('my-quote');
+      expect(logger.warn).toHaveBeenCalledWith('Melt response reports a different quote id', {
+        op: 'melt.bolt11',
+        expected: 'my-quote',
+        received: 'other-quote',
+      });
+    });
+
+    it('returns the request and fee reserve a melt response does carry', async () => {
+      const logger = createLogger();
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest(meltResponse('q1')),
+        logger,
+      });
+
+      const response = await mint.meltBolt11({ quote: 'q1', inputs: [], outputs: [] });
+
+      expect(response.request).toBe('lnbc1...');
+      expect(response.fee_reserve.toBigInt()).toBe(1n);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('accepts a melt response that omits the request and fee reserve', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          method: 'bolt11',
+          state: MeltQuoteState.PENDING,
+          expiry: 123,
+        }),
+      });
+
+      const response = await mint.meltBolt11({ quote: 'q1', inputs: [], outputs: [] });
+
+      expect(response.state).toBe(MeltQuoteState.PENDING);
+      expect(response.amount.toBigInt()).toBe(1n);
+      expect(response).not.toHaveProperty('request');
+      expect(response).not.toHaveProperty('fee_reserve');
+    });
+
+    it('drops an empty request from a melt response', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          state: MeltQuoteState.PENDING,
+          expiry: 123,
+          request: '',
+          fee_reserve: 0,
+        }),
+      });
+
+      const response = await mint.meltBolt11({ quote: 'q1', inputs: [], outputs: [] });
+
+      expect(response).not.toHaveProperty('request');
+      expect(response.fee_reserve.toBigInt()).toBe(0n);
+    });
+
+    it('drops a null request and fee reserve from a melt response', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          state: MeltQuoteState.PENDING,
+          expiry: 123,
+          request: null,
+          fee_reserve: null,
+        }),
+      });
+
+      const response = await mint.meltBolt11({ quote: 'q1', inputs: [], outputs: [] });
+
+      expect(response).not.toHaveProperty('request');
+      expect(response).not.toHaveProperty('fee_reserve');
+    });
+
+    it('throws when a melt response carries a non-string request', async () => {
+      const logger = createLogger();
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          state: MeltQuoteState.PENDING,
+          expiry: 123,
+          request: 42,
+          fee_reserve: 1,
+        }),
+        logger,
+      });
+
+      await expect(mint.meltBolt11({ quote: 'q1', inputs: [], outputs: [] })).rejects.toThrow(
+        'Invalid response from mint',
+      );
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('still requires the fee reserve when a bolt melt quote is checked', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          state: MeltQuoteState.PENDING,
+          expiry: 123,
+          request: 'lnbc1...',
+        }),
+      });
+
+      await expect(mint.checkMeltQuoteBolt11('q1')).rejects.toThrow('Invalid response from mint');
+    });
+
+    it('still requires the request when a melt quote is checked', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest({
+          quote: 'q1',
+          amount: 1,
+          unit: 'sat',
+          state: MeltQuoteState.PENDING,
+          expiry: 123,
+        }),
+      });
+
+      await expect(mint.checkMeltQuoteBolt11('q1')).rejects.toThrow('Invalid response from mint');
+    });
+  });
+
+  describe('createMeltQuoteBolt11 invoice binding', () => {
+    const quoteResponse = (request: string) => ({
+      quote: 'q1',
+      amount: 12,
+      unit: 'sat',
+      state: MeltQuoteState.UNPAID,
+      expiry: 123,
+      request,
+      fee_reserve: 1,
+      payment_preimage: null,
+    });
+
+    it('throws when the quote names a different invoice', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest(quoteResponse('lnbc1other')),
+      });
+
+      await expect(
+        mint.createMeltQuoteBolt11({ request: 'lnbc1mine', unit: 'sat' }),
+      ).rejects.toThrow('Melt quote is for a different payment request');
+    });
+
+    it('accepts a quote that echoes the invoice in a different case', async () => {
+      const mint = new Mint(mintUrl, {
+        customRequest: makeRequest(quoteResponse('LNBC1MINE')),
+      });
+
+      const response = await mint.createMeltQuoteBolt11({ request: 'lnbc1mine', unit: 'sat' });
+
+      expect(response.quote).toBe('q1');
+    });
+
+    it('accepts a quote that echoes no invoice', async () => {
+      const mint = new Mint(mintUrl, { customRequest: makeRequest(quoteResponse('')) });
+
+      const response = await mint.createMeltQuoteBolt11({ request: 'lnbc1mine', unit: 'sat' });
+
+      expect(response.request).toBe('');
+    });
   });
 });
 

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -58,7 +58,7 @@ describe('requests', { timeout: 7500 }, () => {
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', ({ request }) => {
         headers = request.headers;
         return HttpResponse.json({
-          quote: 'test_melt_quote_id',
+          quote: 'test',
           amount: 2000,
           fee_reserve: 20,
           payment_preimage: null,
@@ -84,7 +84,7 @@ describe('requests', { timeout: 7500 }, () => {
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', ({ request }) => {
         headers = request.headers;
         return HttpResponse.json({
-          quote: 'test_melt_quote_id',
+          quote: 'test',
           amount: 2000,
           fee_reserve: 20,
           payment_preimage: null,

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -498,7 +498,7 @@ describe('test fees', () => {
     server.use(
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
         return HttpResponse.json({
-          quote: 'test_melt_quote_id',
+          quote: 'test',
           amount: Amount.from(2000),
           unit: 'sat',
           request: 'lnbc20u1pfake', // HRP encodes the quoted 2,000 sat

--- a/test/wallet/wallet-melt.node.test.ts
+++ b/test/wallet/wallet-melt.node.test.ts
@@ -1038,6 +1038,65 @@ describe('async melt preference body', () => {
     });
   });
 
+  test('keeps the prepared quote and blanks when a melt response omits the quote fields', async () => {
+    const asyncMethod = 'bank';
+    server.use(
+      http.get(mintUrl + '/v1/info', () =>
+        HttpResponse.json({
+          ...mintInfoResp,
+          nuts: {
+            ...mintInfoResp.nuts,
+            5: {
+              ...mintInfoResp.nuts[5],
+              methods: [...mintInfoResp.nuts[5].methods, { method: asyncMethod, unit: 'sat' }],
+            },
+          },
+        }),
+      ),
+      http.post(mintUrl + '/v1/melt/' + asyncMethod, () =>
+        // NUT-05 lets an async melt answer with the settled fields only
+        HttpResponse.json({
+          quote: 'q-async-partial',
+          amount: 1,
+          unit: 'sat',
+          method: asyncMethod,
+          state: MeltQuoteState.PENDING,
+          expiry: 1234567890,
+        }),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+    const meltQuote = {
+      quote: 'q-async-partial',
+      request: 'bank-account',
+      amount: Amount.from(1),
+      fee_reserve: Amount.from(1),
+      unit: 'sat',
+      method: asyncMethod,
+      state: MeltQuoteState.UNPAID,
+      expiry: 1234567890,
+    };
+    const proofs: Proof[] = [
+      {
+        id: '00bd033559de27d0',
+        amount: Amount.from(2),
+        secret: '1f98e6837a434644c9411825d7c6d6e13974b931f8f0652217cea29010674a13',
+        C: '034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be',
+      },
+    ];
+
+    const result = await wallet.meltProofs(asyncMethod, meltQuote, proofs);
+
+    expect(result.quote).toMatchObject({
+      quote: meltQuote.quote,
+      request: meltQuote.request,
+      fee_reserve: meltQuote.fee_reserve,
+      state: MeltQuoteState.PENDING,
+    });
+    expect(result.outputData.length).toBeGreaterThan(0);
+  });
+
   test('completeMelt rejects extraPayload keys that collide with the prepared request', async () => {
     const meltQuote = {
       quote: 'q-reserved',
@@ -1340,6 +1399,33 @@ describe('bolt11 melt quote amount validation', () => {
     state: 'UNPAID',
     expiry: 1673972705,
     payment_preimage: null,
+  });
+
+  test('createMeltQuoteBolt11 rejects a quote naming a different invoice', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/melt/quote/bolt11', () =>
+        HttpResponse.json(meltQuoteJson(2000, 'lnbc20u1elsewhere')),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    await expect(wallet.createMeltQuoteBolt11(invoice)).rejects.toThrow(
+      /different payment request/i,
+    );
+  });
+
+  test('createMeltQuoteBolt11 accepts a quote echoing the invoice in upper case', async () => {
+    server.use(
+      http.post(mintUrl + '/v1/melt/quote/bolt11', () =>
+        HttpResponse.json(meltQuoteJson(2000, invoice.toUpperCase())),
+      ),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const quote = await wallet.createMeltQuoteBolt11(invoice);
+    expect(quote.amount.toBigInt()).toBe(2000n);
   });
 
   test('createMeltQuoteBolt11 rejects a quote charging more than the invoice', async () => {


### PR DESCRIPTION
Backport of #1118 to v4-dev, built by hand. Direct `Mint` calls send only the proof fields a mint needs, melt responses are bound to the quote and invoice they were asked for, and a melt execution response may carry just the settled fields without losing the caller its change.

## Changes

Same as #1118 with two adaptations. v4's `Proof` has no `spend_info`, so the strip covers `dleq` and `p2pk_e`. v4 checks `request` and `fee_reserve` in the bolt normalizer rather than the base one, so the execution-path tolerance lives there: on `POST /v1/melt/{method}` an absent `request` or `fee_reserve` is accepted, while the quote endpoints still require both.

## Impact

Direct `Mint.swap`/`Mint.melt` callers no longer transmit `dleq` or `p2pk_e`. A mint answering a quote check or quote creation with a different quote id or invoice is rejected. No public API change.
