### PR TITLE
test(wallet): give the restore state-check scan a 15s budget

### DIFF
--- a/test/wallet/wallet-restore.node.test.ts
+++ b/test/wallet/wallet-restore.node.test.ts
@@ -389,7 +389,7 @@ describe('restore', () => {
       (b) => (counterByB_.get(b) ?? Infinity) <= SPENT_THROUGH,
     );
     expect(spentRevealed).toEqual([]);
-  });
+  }, 15_000);
 
   test('skips an invalid-scalar counter and recovers proofs past it', async () => {
     const seed = randomBytes(64);


### PR DESCRIPTION
The restore state-check test derives about 120 counters twice before the scan starts. That work is CPU-bound and sits near the 5s default on shared CI runners (464ms locally), so it timed out once on #1118 with no related change. This gives that one test a 15s budget.