### PR TITLE
fix(transport): bound the WebSocket queue and tear down cleanly

### DIFF
--- a/src/transport/WSConnection.ts
+++ b/src/transport/WSConnection.ts
@@ -2,9 +2,13 @@ import { type Logger, NULL_LOGGER } from '../logger';
 import { CTSError } from '../model/Errors';
 import { type JsonRpcMessage, type JsonRpcReqParams, type RpcSubId } from '../model/types';
 import { JSONInt } from '../utils/JSONInt';
+import { MAX_WS_QUEUED_MESSAGES } from '../utils/limits';
 import { generateUuidV7 } from '../utils/uuid.js';
 
 import { getWebSocketImpl } from './ws';
+
+// RFC 6455 7.4.1: reported locally when a connection drops without a Close frame.
+const WS_ABNORMAL_CLOSURE = 1006;
 
 class MessageNode {
   value: string;
@@ -63,6 +67,8 @@ export class WSConnection {
   private rpcListeners: { [rpcSubId: string]: RpcListener } = {};
   private messageQueue: MessageQueue;
   private handlingInterval?: ReturnType<typeof setInterval>;
+  // Set while a connect is pending so close() can settle it and drop its timer.
+  private abandonConnect?: (err: Error) => void;
   private rpcId = 0;
   private _logger: Logger;
   private onCloseCallbacks: Array<(e: CloseEvent) => void> = [];
@@ -90,8 +96,10 @@ export class WSConnection {
         if (settled) return;
         settled = true;
         if (timer) clearTimeout(timer);
+        this.abandonConnect = undefined;
         fn();
       };
+      this.abandonConnect = (err: Error) => settle(() => reject(err));
 
       const cleanupSocket = () => {
         if (!this.ws) return;
@@ -155,6 +163,20 @@ export class WSConnection {
 
       socket.onmessage = (e: MessageEvent) => {
         if (!isCurrent()) return;
+        if (this.messageQueue.size >= MAX_WS_QUEUED_MESSAGES) {
+          this._logger.error('WebSocket message queue exceeded its bound, closing connection', {
+            size: this.messageQueue.size,
+          });
+          const err = new CTSError('WebSocket message queue exceeded its bound');
+          fail(err);
+          // fail() nulls onclose before closing, so onClose consumers (eg the polling fallback) get
+          // the notification here. Teardown first, callbacks last, as the real close path does: a
+          // callback that reconnects or unsubscribes must not see the dying socket as current.
+          this.onCloseCallbacks.forEach((cb) =>
+            cb({ code: WS_ABNORMAL_CLOSURE, reason: err.message, wasClean: false } as CloseEvent),
+          );
+          return;
+        }
         this.messageQueue.enqueue(e.data as string);
         if (!this.handlingInterval) {
           this.handlingInterval = setInterval(this.handleNextMessage.bind(this), 0);
@@ -226,6 +248,9 @@ export class WSConnection {
     while (this.messageQueue.size > 0) {
       this.messageQueue.dequeue();
     }
+    // Subscriptions are scoped to the connection being torn down, explicit or remote: a mint
+    // replaying an old subId after a reconnect must not reach a stale callback.
+    this.subListeners = {};
   }
 
   private failPendingRpc(err: Error) {
@@ -305,55 +330,66 @@ export class WSConnection {
     }
   }
 
+  // Drains the whole queue in one tick rather than one frame per interval fire, so a legitimate
+  // burst under the queue cap is delivered promptly; a bad frame is logged and does not stop
+  // the rest.
   private handleNextMessage() {
-    if (this.messageQueue.size === 0) {
-      if (this.handlingInterval) {
-        clearInterval(this.handlingInterval);
-        this.handlingInterval = undefined;
+    while (this.messageQueue.size > 0) {
+      const message = this.messageQueue.dequeue() as string;
+
+      try {
+        // Same bigint-safe, strict parse as the HTTP transport, so a u64 amount is not rounded and
+        // a duplicate key cannot pick a different result than an earlier check saw.
+        const parsed = JSONInt.parse(message, undefined, { strict: true }) as JsonRpcMessage;
+
+        if ('result' in parsed && parsed.id != undefined) {
+          if (this.rpcListeners[parsed.id]) {
+            this.rpcListeners[parsed.id].callback();
+            this.removeRpcListener(parsed.id);
+          }
+        } else if ('error' in parsed && parsed.id != undefined) {
+          if (this.rpcListeners[parsed.id]) {
+            this.rpcListeners[parsed.id].errorCallback(new CTSError(parsed.error.message));
+            this.removeRpcListener(parsed.id);
+          }
+        } else if ('method' in parsed) {
+          if ('id' in parsed) {
+            // Do nothing as mints should not send requests
+          } else {
+            const subId = parsed.params?.subId;
+            if (!subId) {
+              continue;
+            }
+
+            if (this.subListeners[subId]?.length > 0) {
+              const notification = parsed;
+              this.subListeners[subId].forEach((cb) => {
+                try {
+                  // A callback typed to return void may still be an async function; a returned
+                  // thenable's rejection needs the same containment as a synchronous throw. Duck
+                  // typed, like safeCallback, so a non-native promise (another realm, a polyfill)
+                  // is still caught.
+                  const result = cb(notification.params?.payload) as void | PromiseLike<unknown>;
+                  if (result && typeof result.then === 'function') {
+                    Promise.resolve(result).catch((e: unknown) => {
+                      this._logger.error('Subscription handler threw', { e });
+                    });
+                  }
+                } catch (e) {
+                  this._logger.error('Subscription handler threw', { e });
+                }
+              });
+            }
+          }
+        }
+      } catch (e) {
+        this._logger.error('Error doing handleNextMessage', { e });
       }
-      return;
     }
 
-    const message = this.messageQueue.dequeue() as string;
-
-    try {
-      // Same bigint-safe, strict parse as the HTTP transport, so a u64 amount is not rounded and
-      // a duplicate key cannot pick a different result than an earlier check saw.
-      const parsed = JSONInt.parse(message, undefined, { strict: true }) as JsonRpcMessage;
-
-      if ('result' in parsed && parsed.id != undefined) {
-        if (this.rpcListeners[parsed.id]) {
-          this.rpcListeners[parsed.id].callback();
-          this.removeRpcListener(parsed.id);
-        }
-      } else if ('error' in parsed && parsed.id != undefined) {
-        if (this.rpcListeners[parsed.id]) {
-          this.rpcListeners[parsed.id].errorCallback(new CTSError(parsed.error.message));
-          this.removeRpcListener(parsed.id);
-        }
-      } else if ('method' in parsed) {
-        if ('id' in parsed) {
-          // Do nothing as mints should not send requests
-        } else {
-          const subId = parsed.params?.subId;
-          if (!subId) {
-            return;
-          }
-
-          if (this.subListeners[subId]?.length > 0) {
-            const notification = parsed;
-            this.subListeners[subId].forEach((cb) => {
-              try {
-                cb(notification.params?.payload);
-              } catch (e) {
-                this._logger.error('Subscription handler threw', { e });
-              }
-            });
-          }
-        }
-      }
-    } catch (e) {
-      this._logger.error('Error doing handleNextMessage', { e });
+    if (this.handlingInterval) {
+      clearInterval(this.handlingInterval);
+      this.handlingInterval = undefined;
     }
   }
 
@@ -435,6 +471,9 @@ export class WSConnection {
   }
 
   close() {
+    const err = new CTSError('WebSocket closed');
+    // A connect still pending settles now rather than when its timer fires.
+    this.abandonConnect?.(err);
     if (this.ws) {
       try {
         this.ws.close();
@@ -444,6 +483,7 @@ export class WSConnection {
       this.ws = undefined;
     }
     this.connectionPromise = undefined;
+    this.failPendingRpc(err);
     this.stopMessageHandling();
   }
 

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -150,6 +150,14 @@ export const MAX_CBOR_NODES = 262_144;
 export const MAX_BOLT11_HRP_LENGTH = 100;
 
 /**
+ * Cap on frames `WSConnection` will buffer between two drain ticks: each tick empties the whole
+ * queue, so this bounds arrivals within a single tick, not messages held overall. Matches
+ * {@link ABSOLUTE_MAX_ARRAY_LENGTH}, since a NUT-17 replay sends one frame per subscribed filter and
+ * a full-size batch must fit in one burst without tripping the cap.
+ */
+export const MAX_WS_QUEUED_MESSAGES = ABSOLUTE_MAX_ARRAY_LENGTH;
+
+/**
  * Maximum number of candidate payloads `findCashuPayload` will attempt to decode in one scan.
  * Prevents pathological input from causing excessive parsing work. Real pastes carry one payload
  * and a few near-misses, so 16 clears them; scans that exhaust the budget return null.

--- a/src/wallet/WalletEvents.ts
+++ b/src/wallet/WalletEvents.ts
@@ -73,6 +73,10 @@ export type ProofStatesStreamOpts<P extends ProofLike = Proof> = WatchOpts & {
  */
 type Poller<T> = { fetch: () => Promise<T[]>; key: (p: T) => string; state: (p: T) => string };
 
+function noop(): void {
+  /* noop */
+}
+
 function safeStringify(obj: unknown): string {
   const seen = new WeakSet<object>();
   try {
@@ -216,9 +220,7 @@ export class WalletEvents {
     if (!signal) return cancel;
     if (signal.aborted) {
       cancel();
-      return () => {
-        /* noop */
-      };
+      return noop;
     }
     const onAbort = () => cancel();
     signal.addEventListener('abort', onAbort, { once: true });
@@ -237,7 +239,11 @@ export class WalletEvents {
     signal?: AbortSignal,
     onClose?: () => void,
   ): Promise<SubscriptionCanceller> {
+    // Filters (eg proof Ys) must never reach the wire for a subscription already cancelled, so an
+    // abort is checked both before the connect and again once it settles.
+    if (signal?.aborted) return noop;
     await this.wallet.mint.connectWebSocket();
+    if (signal?.aborted) return noop;
     const ws = this.wallet.mint.webSocketConnection;
     if (!ws) throw new CTSError('Failed to establish WebSocket connection.');
     const subId = ws.createSubscription<W>({ kind, filters }, cb, err);
@@ -283,7 +289,9 @@ export class WalletEvents {
     const { kind, filters, decode } = socket;
     const deliver = (wire: W) => {
       const p = decode(wire);
-      if (p !== undefined) cb(p);
+      // cb may be an async consumer callback; a rejection must not escape uncontained, matching
+      // WSConnection's own containment (which never sees it, since this wrapper doesn't return it).
+      if (p !== undefined) safeCallback(cb, p, this.wallet.logger, { event: kind });
     };
     const pollMs = opts?.pollMs;
     if (pollMs === undefined) return this._subscribe(kind, filters, deliver, err, opts?.signal);
@@ -360,7 +368,7 @@ export class WalletEvents {
         if (++failures >= POLL_FAILURE_LIMIT) throw normalizeError(e);
       }
       if (signal.aborted) return;
-      for (const item of changed) cb(item);
+      for (const item of changed) safeCallback(cb, item, this.wallet.logger);
       // A failed poll is often a rate limit, so back off before the next one
       await sleep(pollMs * 2 ** failures, signal);
     }

--- a/test/transport/WSConnection.test.ts
+++ b/test/transport/WSConnection.test.ts
@@ -262,6 +262,51 @@ describe('WSConnection – close and lifecycle', () => {
     }
   });
 
+  test('close() during a pending connect settles it and drops the timer', async () => {
+    class NeverOpenWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      readyState = NeverOpenWebSocket.CONNECTING;
+      onopen: (() => void) | null = null;
+      onerror: ((ev: Event) => void) | null = null;
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onclose: ((e: CloseEvent) => void) | null = null;
+      close() {
+        this.readyState = 3;
+      }
+      send() {}
+    }
+
+    injectWebSocketImpl(NeverOpenWebSocket as unknown as typeof WebSocket);
+    vi.useFakeTimers();
+    try {
+      const conn = new WSConnection(fakeUrl);
+      const pending = conn.connect(10_000);
+      conn.close();
+      await expect(pending).rejects.toThrow('WebSocket closed');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+      injectWebSocketImpl(WebSocket);
+    }
+  });
+
+  test('close() fails a subscription still waiting for its acknowledgement', async () => {
+    const conn = new WSConnection(fakeUrl);
+    await conn.connect();
+    const errorCallback = vi.fn();
+    conn.createSubscription(
+      { kind: 'bolt11_mint_quote', filters: ['unacked'] },
+      vi.fn(),
+      errorCallback,
+    );
+
+    conn.close();
+
+    expect(errorCallback).toHaveBeenCalledTimes(1);
+    expect(errorCallback.mock.calls[0][0]).toMatchObject({ message: 'WebSocket closed' });
+  });
+
   test('connect rejects when socket errors before opening', async () => {
     class ErrorBeforeOpenWebSocket {
       static readonly CONNECTING = 0;
@@ -324,6 +369,60 @@ describe('WSConnection – close and lifecycle', () => {
       await expect(conn.connect()).rejects.toThrow(
         'WebSocket closed before open (code 4003, rejected)',
       );
+    } finally {
+      injectWebSocketImpl(WebSocket);
+    }
+  });
+
+  test('close() settles an abandoned connect and leaves the replacement socket alone', async () => {
+    class TimeoutWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly instances: TimeoutWebSocket[] = [];
+
+      readyState = TimeoutWebSocket.CONNECTING;
+      onopen: (() => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+
+      constructor() {
+        TimeoutWebSocket.instances.push(this);
+      }
+
+      open() {
+        this.readyState = TimeoutWebSocket.OPEN;
+        this.onopen?.();
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = TimeoutWebSocket.CLOSING;
+      }
+    }
+
+    injectWebSocketImpl(TimeoutWebSocket as unknown as typeof WebSocket);
+
+    try {
+      const conn = new WSConnection(fakeUrl);
+      const abandonedConnect = conn.connect(20);
+      const abandoned = abandonedConnect.catch((e: unknown) => e);
+
+      conn.close();
+
+      const replacementConnect = conn.connect(200);
+      const replacementSocket = TimeoutWebSocket.instances[1];
+      replacementSocket.open();
+      await replacementConnect;
+
+      const abandonedResult = await abandoned;
+
+      expect(abandonedResult).toBeInstanceOf(Error);
+      expect((abandonedResult as Error).message).toBe('WebSocket closed');
+      expect(replacementSocket.readyState).toBe(TimeoutWebSocket.OPEN);
+      conn.close();
     } finally {
       injectWebSocketImpl(WebSocket);
     }
@@ -673,6 +772,106 @@ describe('WSConnection – message handling', () => {
     });
     srv.close();
   });
+
+  test('a rejecting async subscription callback is contained and logged', async () => {
+    const url = 'ws://localhost:3363/v1/ws';
+    const srv = new Server(url, { mock: false });
+    const logger = createLogger();
+
+    srv.on('connection', (socket) => {
+      socket.on('message', (m) => {
+        const parsed = JSON.parse(m.toString());
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              result: { status: 'OK', subId: parsed.params.subId },
+              id: parsed.id,
+            }),
+          );
+          setTimeout(() => {
+            socket.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'subscribe',
+                params: { subId: parsed.params.subId, payload: { paid: true } },
+              }),
+            );
+          }, 0);
+        }
+      });
+    });
+
+    const conn = new WSConnection(url, logger);
+    await conn.connect();
+
+    await new Promise<void>((res) => {
+      conn.createSubscription(
+        { kind: 'bolt11_mint_quote', filters: [] },
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async-callback tolerance is what's under test
+        async () => {
+          throw new Error('async listener boom');
+        },
+        vi.fn(),
+      );
+      setTimeout(res, 100);
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Subscription handler threw', {
+      e: expect.objectContaining({ message: 'async listener boom' }),
+    });
+    srv.close();
+  });
+
+  test('a rejecting non-native thenable is contained and logged', async () => {
+    const url = 'ws://localhost:3365/v1/ws';
+    const srv = new Server(url, { mock: false });
+    const logger = createLogger();
+
+    srv.on('connection', (socket) => {
+      socket.on('message', (m) => {
+        const parsed = JSON.parse(m.toString());
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              result: { status: 'OK', subId: parsed.params.subId },
+              id: parsed.id,
+            }),
+          );
+          setTimeout(() => {
+            socket.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'subscribe',
+                params: { subId: parsed.params.subId, payload: { paid: true } },
+              }),
+            );
+          }, 0);
+        }
+      });
+    });
+
+    const conn = new WSConnection(url, logger);
+    await conn.connect();
+
+    await new Promise<void>((res) => {
+      conn.createSubscription(
+        { kind: 'bolt11_mint_quote', filters: [] },
+        // Not a native Promise: instanceof Promise would miss this, unlike a duck-typed then check.
+        () => ({
+          then: (_res: unknown, rej: (e: unknown) => void) => rej(new Error('thenable boom')),
+        }),
+        vi.fn(),
+      );
+      setTimeout(res, 100);
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Subscription handler threw', {
+      e: expect.objectContaining({ message: 'thenable boom' }),
+    });
+    srv.close();
+  });
 });
 
 describe('WSConnection – listener management', () => {
@@ -689,6 +888,117 @@ describe('WSConnection – listener management', () => {
     conn.close();
 
     expect(internals.messageQueue.size).toBe(0);
+  });
+
+  test('close discards callbacks from subscriptions made on the old socket', async () => {
+    const url = 'ws://localhost:3362/v1/ws';
+    const srv = new Server(url, { mock: false });
+    const sockets: Client[] = [];
+
+    srv.on('connection', (socket) => {
+      sockets.push(socket);
+      socket.on('message', (message) => {
+        const parsed = JSON.parse(message.toString());
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              result: { status: 'OK', subId: parsed.params.subId },
+              id: parsed.id,
+            }),
+          );
+        }
+      });
+    });
+
+    const conn = new WSConnection(url);
+
+    try {
+      await conn.connect();
+      const callback = vi.fn();
+      const subId = conn.createSubscription(
+        { kind: 'bolt11_mint_quote', filters: ['old-quote'] },
+        callback,
+        vi.fn(),
+      );
+      await waitForSubscription(conn, subId);
+
+      conn.close();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await conn.connect();
+
+      sockets[1].send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'subscribe',
+          params: { subId, payload: { quote: 'old-quote', state: 'PAID' } },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(conn.activeSubscriptions).not.toContain(subId);
+    } finally {
+      conn.close();
+      srv.close();
+    }
+  });
+
+  test('a remote close discards callbacks from subscriptions made on the old socket', async () => {
+    const url = 'ws://localhost:3364/v1/ws';
+    const srv = new Server(url, { mock: false });
+    const sockets: Client[] = [];
+
+    srv.on('connection', (socket) => {
+      sockets.push(socket);
+      socket.on('message', (message) => {
+        const parsed = JSON.parse(message.toString());
+        if (parsed.method === 'subscribe') {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              result: { status: 'OK', subId: parsed.params.subId },
+              id: parsed.id,
+            }),
+          );
+        }
+      });
+    });
+
+    const conn = new WSConnection(url);
+
+    try {
+      await conn.connect();
+      const callback = vi.fn();
+      const subId = conn.createSubscription(
+        { kind: 'bolt11_mint_quote', filters: ['old-quote'] },
+        callback,
+        vi.fn(),
+      );
+      await waitForSubscription(conn, subId);
+
+      // The mint drops the connection: an abnormal remote close, not an app-driven conn.close().
+      sockets[0].close({ wasClean: false, code: 1006, reason: 'dropped' });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Mint.ts reuses the same WSConnection instance on the next connectWebSocket() call.
+      await conn.connect();
+
+      sockets[1].send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'subscribe',
+          params: { subId, payload: { quote: 'old-quote', state: 'PAID' } },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(conn.activeSubscriptions).not.toContain(subId);
+    } finally {
+      conn.close();
+      srv.close();
+    }
   });
 
   test('activeSubscriptions returns all registered subIds', async () => {
@@ -710,11 +1020,11 @@ describe('WSConnection – listener management', () => {
     const cb2 = vi.fn();
     conn.addSubListener('multi-sub', cb1);
     conn.addSubListener('multi-sub', cb2);
-    conn.close();
 
     conn.cancelSubscription('multi-sub', cb1);
 
     expect(conn.activeSubscriptions).toContain('multi-sub'); // cb2 still registered
+    conn.close();
   });
 
   test('cancelSubscription when socket is closed removes listener without throwing', async () => {
@@ -1121,6 +1431,256 @@ describe('WSConnection – listener management', () => {
       expect(conn.activeSubscriptions).toContain(subId);
       // The stale frame must not have reached the replacement's subscriber.
       expect(payloads).not.toContain('stale');
+      conn.close();
+    } finally {
+      injectWebSocketImpl(WebSocket);
+    }
+  });
+
+  test('closes the connection instead of buffering an unbounded message burst', async () => {
+    class BurstWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      static readonly instances: BurstWebSocket[] = [];
+
+      readyState = BurstWebSocket.CONNECTING;
+      onopen: (() => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+
+      constructor() {
+        BurstWebSocket.instances.push(this);
+      }
+
+      open() {
+        this.readyState = BurstWebSocket.OPEN;
+        this.onopen?.();
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = BurstWebSocket.CLOSING;
+      }
+
+      emitMessage(message: string) {
+        this.onmessage?.({ data: message } as MessageEvent);
+      }
+    }
+
+    injectWebSocketImpl(BurstWebSocket as unknown as typeof WebSocket);
+
+    try {
+      const conn = new WSConnection(fakeUrl);
+      const connecting = conn.connect();
+      const socket = BurstWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      const notification = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: { subId: 'sender', payload: null },
+      });
+      const burstSize = 20_000; // comfortably over MAX_WS_QUEUED_MESSAGES
+      for (let i = 0; i < burstSize; i++) socket.emitMessage(notification);
+
+      const messageQueue = (conn as unknown as { messageQueue: { size: number } }).messageQueue;
+      expect(messageQueue.size).toBe(0); // torn down and drained, not merely capped
+      expect(socket.readyState).not.toBe(BurstWebSocket.OPEN);
+
+      // The connection is gone: a further frame from the superseded socket must not requeue.
+      socket.emitMessage(notification);
+      expect(messageQueue.size).toBe(0);
+
+      conn.close();
+    } finally {
+      injectWebSocketImpl(WebSocket);
+    }
+  });
+
+  test('an overflow close notifies onClose and rejects a pending RPC', async () => {
+    class BurstWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      static readonly instances: BurstWebSocket[] = [];
+
+      readyState = BurstWebSocket.CONNECTING;
+      onopen: (() => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+
+      constructor() {
+        BurstWebSocket.instances.push(this);
+      }
+
+      open() {
+        this.readyState = BurstWebSocket.OPEN;
+        this.onopen?.();
+      }
+
+      // Never acknowledged, so the subscribe RPC listener registered below stays pending.
+      send() {}
+
+      close() {
+        this.readyState = BurstWebSocket.CLOSING;
+      }
+
+      emitMessage(message: string) {
+        this.onmessage?.({ data: message } as MessageEvent);
+      }
+    }
+
+    injectWebSocketImpl(BurstWebSocket as unknown as typeof WebSocket);
+
+    try {
+      const conn = new WSConnection(fakeUrl);
+      const connecting = conn.connect();
+      const socket = BurstWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      const closeCb = vi.fn();
+      conn.onClose(closeCb);
+
+      const rpcErrorCb = vi.fn();
+      conn.createSubscription(
+        { kind: 'bolt11_mint_quote', filters: ['pending'] },
+        vi.fn(),
+        rpcErrorCb,
+      );
+
+      const notification = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: { subId: 'sender', payload: null },
+      });
+      const burstSize = 20_000; // comfortably over MAX_WS_QUEUED_MESSAGES
+      for (let i = 0; i < burstSize; i++) socket.emitMessage(notification);
+
+      expect(closeCb).toHaveBeenCalledTimes(1);
+      expect(rpcErrorCb).toHaveBeenCalledWith(expect.any(Error));
+      conn.close();
+    } finally {
+      injectWebSocketImpl(WebSocket);
+    }
+  });
+
+  test('a message burst that stays within the queue bound is buffered normally', async () => {
+    class SmallBurstWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly instances: SmallBurstWebSocket[] = [];
+
+      readyState = SmallBurstWebSocket.CONNECTING;
+      onopen: (() => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+
+      constructor() {
+        SmallBurstWebSocket.instances.push(this);
+      }
+
+      open() {
+        this.readyState = SmallBurstWebSocket.OPEN;
+        this.onopen?.();
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = 3;
+      }
+
+      emitMessage(message: string) {
+        this.onmessage?.({ data: message } as MessageEvent);
+      }
+    }
+
+    injectWebSocketImpl(SmallBurstWebSocket as unknown as typeof WebSocket);
+
+    try {
+      const conn = new WSConnection(fakeUrl);
+      const connecting = conn.connect();
+      const socket = SmallBurstWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      const notification = JSON.stringify({ jsonrpc: '2.0', method: 'subscribe', params: {} });
+      for (let i = 0; i < 5; i++) socket.emitMessage(notification);
+
+      expect(socket.readyState).toBe(SmallBurstWebSocket.OPEN);
+      conn.close();
+    } finally {
+      injectWebSocketImpl(WebSocket);
+    }
+  });
+
+  test('a burst under the queue cap is fully delivered after a single tick', async () => {
+    class SmallBurstWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly instances: SmallBurstWebSocket[] = [];
+
+      readyState = SmallBurstWebSocket.CONNECTING;
+      onopen: (() => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+
+      constructor() {
+        SmallBurstWebSocket.instances.push(this);
+      }
+
+      open() {
+        this.readyState = SmallBurstWebSocket.OPEN;
+        this.onopen?.();
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = 3;
+      }
+
+      emitMessage(message: string) {
+        this.onmessage?.({ data: message } as MessageEvent);
+      }
+    }
+
+    injectWebSocketImpl(SmallBurstWebSocket as unknown as typeof WebSocket);
+
+    try {
+      const conn = new WSConnection(fakeUrl);
+      const connecting = conn.connect();
+      const socket = SmallBurstWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      const callback = vi.fn();
+      conn.addSubListener('burst-sub', callback);
+
+      const burstSize = 500; // well under MAX_WS_QUEUED_MESSAGES, well above one-frame-per-tick
+      const notification = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: { subId: 'burst-sub', payload: {} },
+      });
+      for (let i = 0; i < burstSize; i++) socket.emitMessage(notification);
+
+      // A single macrotask turn is enough for a whole-queue drain to clear the burst; a
+      // one-frame-per-tick drain would still be far short of burstSize here.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(callback).toHaveBeenCalledTimes(burstSize);
+      expect(socket.readyState).toBe(SmallBurstWebSocket.OPEN);
       conn.close();
     } finally {
       injectWebSocketImpl(WebSocket);

--- a/test/wallet/WalletEvents.test.ts
+++ b/test/wallet/WalletEvents.test.ts
@@ -363,7 +363,8 @@ describe('WalletEvents', () => {
       await expect(p).rejects.toMatchObject({ name: 'AbortError' });
       const ws = mock.mint.webSocketConnection!;
       await flushMicrotasks();
-      expect(ws.cancelSubscription).toHaveBeenCalled();
+      // Aborted before the connect settled, so the filters were never sent.
+      expect(ws.createSubscription).not.toHaveBeenCalled();
     });
 
     it('rejects on timeout and unsubscribes', async () => {
@@ -504,7 +505,8 @@ describe('WalletEvents', () => {
       await expect(p).rejects.toMatchObject({ name: 'AbortError' });
       const ws = mock.mint.webSocketConnection!;
       await flushMicrotasks();
-      expect(ws.cancelSubscription).toHaveBeenCalled();
+      // Aborted before the connect settled, so the filters were never sent.
+      expect(ws.createSubscription).not.toHaveBeenCalled();
       expect(rmSpy).toHaveBeenCalled();
     });
 
@@ -1090,9 +1092,9 @@ describe('WalletEvents', () => {
       for await (const x of iter) out.push(x);
 
       expect(out).toEqual([]);
-      const ws = mock.mint.webSocketConnection!;
       await flushMicrotasks();
-      expect(ws.cancelSubscription).toHaveBeenCalled();
+      // Already aborted before the stream started, so the WebSocket connect was never attempted.
+      expect(mock.mint.connectWebSocket).not.toHaveBeenCalled();
     });
   });
 
@@ -1310,13 +1312,13 @@ describe('WalletEvents', () => {
       expect(ws.cancelSubscription).toHaveBeenCalled();
     });
 
-    it('an already-aborted signal cancels the subscription immediately', async () => {
+    it('an already-aborted signal skips the subscription setup entirely', async () => {
       const ac = new AbortController();
       ac.abort();
       await events.mintQuoteUpdates(['a'], vi.fn(), vi.fn(), { signal: ac.signal });
-      const ws = mock.mint.webSocketConnection!;
       await flushMicrotasks();
-      expect(ws.cancelSubscription).toHaveBeenCalled();
+      expect(mock.mint.connectWebSocket).not.toHaveBeenCalled();
+      expect(mock.mint.webSocketConnection).toBeUndefined();
     });
 
     it('the returned canceller detaches the abort listener (no double cancel on later abort)', async () => {
@@ -1328,6 +1330,68 @@ describe('WalletEvents', () => {
       ac.abort();
       await flushMicrotasks();
       expect(ws.cancelSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send proof filters when aborted while the WebSocket connects', async () => {
+      let finishConnect!: () => void;
+      const connecting = new Promise<void>((resolve) => {
+        finishConnect = resolve;
+      });
+      const ws = new MockWS();
+      const wallet = {
+        mint: {
+          connectWebSocket: vi.fn(() => connecting),
+          webSocketConnection: ws,
+        },
+        computeY,
+      };
+      const ev = new WalletEvents(wallet as any);
+      const ac = new AbortController();
+      const proofs: Proof[] = [
+        { amount: Amount.from(1), id: '00bd033559de27d0', secret: 'private-secret', C: 'c' },
+      ];
+
+      const pending = ev.proofStateUpdates(proofs, vi.fn(), vi.fn(), { signal: ac.signal });
+      ac.abort();
+      finishConnect();
+      await pending;
+
+      expect(ws.createSubscription).not.toHaveBeenCalled();
+    });
+
+    it('a polling fallback does not subscribe when aborted while the WebSocket connects', async () => {
+      let finishConnect!: () => void;
+      const connecting = new Promise<void>((resolve) => {
+        finishConnect = resolve;
+      });
+      const ws = new MockWS();
+      const wallet = {
+        mint: {
+          connectWebSocket: vi.fn(() => connecting),
+          webSocketConnection: ws,
+        },
+        computeY,
+        unit: 'sat',
+        getMintInfo: () => nut17(['proof_state']),
+        checkProofsStates: vi.fn(async () => []),
+      };
+      const ev = new WalletEvents(wallet as any);
+      const ac = new AbortController();
+      const proofs: Proof[] = [
+        { amount: Amount.from(1), id: '00bd033559de27d0', secret: 'poll-secret', C: 'c' },
+      ];
+
+      const pending = ev.proofStateUpdates(proofs, vi.fn(), vi.fn(), {
+        signal: ac.signal,
+        pollMs: 1000,
+      });
+      ac.abort();
+      finishConnect();
+      await pending;
+      await flushMicrotasks();
+
+      expect(ws.createSubscription).not.toHaveBeenCalled();
+      expect(wallet.checkProofsStates).not.toHaveBeenCalled();
     });
   });
 
@@ -1702,6 +1766,90 @@ describe('WalletEvents', () => {
       };
       const ev = new WalletEvents(wallet as any);
       await expect(ev.onceAnyMintPaid(['a', 'b'])).rejects.toThrow('No subscriptions remaining');
+    });
+  });
+
+  describe('async consumer callback containment', () => {
+    // A rejecting async consumer callback must not escape as an unhandled rejection; safeCallback
+    // is the local pattern already used for onMode/countersReserved/keychainUpdated.
+    it('contains and logs a rejecting websocket delivery callback', async () => {
+      const logger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        log: vi.fn(),
+      };
+      const ws = new MockWS();
+      const wallet = {
+        mint: { connectWebSocket: vi.fn(async () => {}), webSocketConnection: ws },
+        computeY,
+        logger,
+      };
+      const ev = new WalletEvents(wallet as any);
+
+      await ev.mintQuoteUpdates(
+        ['q1'],
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async-callback tolerance is what's under test
+        async () => {
+          throw new Error('deliver boom');
+        },
+        vi.fn(),
+      );
+      ws.emit('bolt11_mint_quote', { quote: 'q1', state: 'PAID' });
+      await flushMicrotasks(4);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'callback failed',
+        expect.objectContaining({
+          event: 'bolt11_mint_quote',
+          error: expect.objectContaining({ message: 'deliver boom' }),
+        }),
+      );
+    });
+
+    it('contains and logs a rejecting polling-fallback callback', async () => {
+      const logger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        log: vi.fn(),
+      };
+      const wallet = {
+        mint: new MockMint(),
+        computeY,
+        unit: 'sat',
+        // Mint does not push mint-quote updates, so _watch falls straight to polling.
+        getMintInfo: () => nut17([]),
+        checkMintQuote: vi.fn(async (_m: string, quote: string) => ({
+          quote,
+          amount_paid: Amount.from(1),
+          amount_issued: Amount.from(0),
+        })),
+        logger,
+      };
+      const ev = new WalletEvents(wallet as any);
+      const ac = new AbortController();
+
+      await ev.mintQuoteUpdates(
+        ['q1'],
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async-callback tolerance is what's under test
+        async () => {
+          throw new Error('poll boom');
+        },
+        vi.fn(),
+        { pollMs: 5, signal: ac.signal },
+      );
+      await flushMicrotasks(4);
+      ac.abort();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'callback failed',
+        expect.objectContaining({ error: expect.objectContaining({ message: 'poll boom' }) }),
+      );
     });
   });
 


### PR DESCRIPTION
The WebSocket transport now bounds its inbound queue, tears down the same way on every close path, contains async subscription callbacks, and honours an abort signal before the socket opens.

## Why

`WSConnection` queued inbound frames without a bound and drained one per timer tick, so a burst could sit in memory for many ticks. Subscription listeners were cleared on an explicit `close()` but not on a remote close, and the same instance is reused on reconnect, so a subscription id from before the drop still mapped to its old callback. An async callback's rejection escaped the transport's containment, and the wallet-level dispatch dropped the return value entirely. A `wallet.on.*` subscription cancelled during a slow connect still sent its subscribe request once the socket opened. A connect abandoned by `close()` left its timer running and any in-flight subscribe waiting for a close event that never came.

## Changes

Frames are refused past `MAX_WS_QUEUED_MESSAGES` (10,000, matching `ABSOLUTE_MAX_ARRAY_LENGTH`) and the connection is closed, with `onClose` fired so the polling fallback engages; teardown runs first and callbacks last, as the natural close path does. The drain loop empties the whole queue per tick, so the cap bounds arrivals within one tick and a [NUT-17](https://github.com/cashubtc/nuts/blob/main/17.md) replay of one frame per filter fits in one burst. It also means up to a cap's worth of callbacks run in one synchronous task. Listeners are cleared in `stopMessageHandling`, which every teardown path reaches. Returned thenables are duck-typed and contained, and `WalletEvents` routes consumer callbacks through `safeCallback` on both the socket and polling paths. `_subscribe` checks the abort signal before and after the connect. `close()` settles a pending connect, drops its timer and fails pending RPCs.

## Impact

After any close, old subscriptions are gone rather than half-alive; with `pollMs` set the fallback takes over, without it the consumer resubscribes. A pending connect rejects with `WebSocket closed` when `close()` is called instead of timing out later. No public API change.
