### PR TITLE
fix(model): validate persisted outputs and pin the hash-to-curve counter [backport v4-dev]

### DIFF
--- a/docs-src/usage/create_wallet.md
+++ b/docs-src/usage/create_wallet.md
@@ -52,8 +52,9 @@ class CustomOutputDataCreator implements OutputDataCreator {
   }
 
   createSingleP2PKData(...args: Parameters<OutputDataCreator['createSingleP2PKData']>) {
-    const [p2pk, amount, keysetId] = args;
-    return OutputData.createSingleP2PKData(p2pk, amount, keysetId);
+    const [p2pk, amount, keysetId, eBytes] = args;
+    // Forward eBytes as-is: a SIG_ALL batch relies on every output sharing this key.
+    return OutputData.createSingleP2PKData(p2pk, amount, keysetId, eBytes);
   }
 
   createRandomData(...args: Parameters<OutputDataCreator['createRandomData']>) {

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -1468,7 +1468,7 @@ export interface OutputDataCreator {
     // (undocumented)
     createSingleDeterministicData(amount: AmountLike, seed: Uint8Array, counter: number, keysetId: string): OutputDataLike;
     // (undocumented)
-    createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputDataLike;
+    createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string, eBytes?: Uint8Array): OutputDataLike;
     // (undocumented)
     createSingleRandomData(amount: AmountLike, keysetId: string): OutputDataLike;
 }

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -46,15 +46,19 @@ const DOMAIN_SEPARATOR = utf8ToBytes('Secp256k1_HashToCurve_Cashu_');
 
 export function hashToCurve(secret: Uint8Array): WeierstrassPoint<bigint> {
   const msgToHash = sha256(concatBytes(DOMAIN_SEPARATOR, secret));
-  const counter = new Uint32Array(1);
+  // NUT-00 fixes the counter as little-endian; a typed array's backing bytes follow host
+  // endianness instead, so DataView pins the encoding explicitly.
+  let counter = 0;
+  const counterBytes = new Uint8Array(4);
+  const counterView = new DataView(counterBytes.buffer);
   const maxIterations = 2 ** 16;
   for (let i = 0; i < maxIterations; i++) {
-    const counterBytes = new Uint8Array(counter.buffer);
+    counterView.setUint32(0, counter, true);
     const hash = sha256(concatBytes(msgToHash, counterBytes));
     try {
       return pointFromHex(bytesToHex(concatBytes(new Uint8Array([0x02]), hash)));
     } catch {
-      counter[0]++;
+      counter++;
     }
   }
   throw new CTSError('No valid point found');

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -411,11 +411,11 @@ export class OutputData implements OutputDataLike {
       if (!/^(0|[1-9]\d*)$/.test(serialized.blindingFactor)) {
         throw new CTSError('blindingFactor must be a canonical decimal integer');
       }
+      // Validate
       const secret = hexToBytes(serialized.secret);
-      decodeUtf8Field(secret);
+      decodeUtf8Field(secret); // asserts round trip
       const blindingFactor = BigInt(serialized.blindingFactor);
-      // r == 0 is rejected inside blindMessage.
-      const { B_ } = blindMessage(secret, blindingFactor);
+      const { B_ } = blindMessage(secret, blindingFactor); // asserts valid `r`
       if (B_.toHex(true) !== serialized.blindedMessage.B_.toLowerCase()) {
         throw new CTSError(
           'stored output does not match its secret. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -16,6 +16,7 @@ import {
   type P2PKOptions,
 } from '../crypto';
 import { numberToHexPadded64, splitAmount } from '../utils';
+import { decodeUtf8Field } from '../utils/bytes';
 import { MAX_SECRET_LENGTH } from '../utils/limits';
 
 import { Amount, type AmountLike } from './Amount';
@@ -158,7 +159,7 @@ export class OutputData implements OutputDataLike {
       id: sig.id,
       amount: sig.amount,
       C: unblinded.C.toHex(true),
-      secret: new TextDecoder().decode(unblinded.secret),
+      secret: decodeUtf8Field(unblinded.secret),
       ...(dleq && {
         dleq: {
           s: bytesToHex(dleq.s),
@@ -400,14 +401,25 @@ export class OutputData implements OutputDataLike {
   /**
    * Reconstructs concrete {@link OutputData} from its JSON-safe representation.
    *
-   * @throws {@link CTSError} If any field fails validation (non-canonical blindingFactor, malformed
-   *   hex secret/ephemeralE, or an Amount that cannot be parsed).
+   * @throws {@link CTSError} If any field fails validation: non-canonical or zero blindingFactor,
+   *   malformed hex secret/ephemeralE, a secret that is not valid UTF-8, a B_ that does not match
+   *   the secret and blindingFactor, or an Amount that cannot be parsed.
    * @see {@link OutputData.serialize} for the persist/restore lifecycle example.
    */
   static deserialize(serialized: SerializedOutputData): OutputData {
     try {
       if (!/^(0|[1-9]\d*)$/.test(serialized.blindingFactor)) {
-        throw new Error('blindingFactor must be a canonical decimal integer');
+        throw new CTSError('blindingFactor must be a canonical decimal integer');
+      }
+      const secret = hexToBytes(serialized.secret);
+      decodeUtf8Field(secret);
+      const blindingFactor = BigInt(serialized.blindingFactor);
+      // r == 0 is rejected inside blindMessage.
+      const { B_ } = blindMessage(secret, blindingFactor);
+      if (B_.toHex(true) !== serialized.blindedMessage.B_.toLowerCase()) {
+        throw new CTSError(
+          'stored output does not match its secret. Inputs may already be spent; if the wallet is seeded, try restoring (NUT-09) to recover.',
+        );
       }
       return new OutputData(
         {
@@ -415,9 +427,9 @@ export class OutputData implements OutputDataLike {
           B_: serialized.blindedMessage.B_,
           id: serialized.blindedMessage.id,
         },
-        BigInt(serialized.blindingFactor),
-        hexToBytes(serialized.secret),
-        serialized.ephemeralE,
+        blindingFactor,
+        secret,
+        serialized.ephemeralE ? pointFromHex(serialized.ephemeralE).toHex(true) : undefined,
       );
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/model/OutputDataCreator.ts
+++ b/src/model/OutputDataCreator.ts
@@ -1,7 +1,8 @@
-import { type P2PKOptions } from '../crypto';
+import { createRandomSecretKey, type P2PKOptions } from '../crypto';
 import { splitAmount } from '../utils';
 
 import { type AmountLike } from './Amount';
+import { CTSError } from './Errors';
 import { OutputData, type OutputDataLike } from './OutputData';
 import type { HasKeysetKeys } from './types';
 
@@ -21,7 +22,17 @@ export interface OutputDataCreator {
     keyset: HasKeysetKeys,
     customSplit?: AmountLike[],
   ): OutputDataLike[];
-  createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputDataLike;
+  /**
+   * @param eBytes Shared P2BK ephemeral key for a SIG_ALL batch (NUT-28). Batch callers pass the
+   *   same key to every output in the split; an override must forward it as-is, not derive a fresh
+   *   one, or the split's outputs stop sharing locking data.
+   */
+  createSingleP2PKData(
+    p2pk: P2PKOptions,
+    amount: AmountLike,
+    keysetId: string,
+    eBytes?: Uint8Array,
+  ): OutputDataLike;
   createRandomData(
     amount: AmountLike,
     keyset: HasKeysetKeys,
@@ -62,11 +73,28 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
       return OutputData.createP2PKData(p2pk, amount, keyset, customSplit);
     }
     const amounts = splitAmount(amount, keyset.keys, customSplit);
-    return amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id));
+    // Mirrors OutputData.createP2PKData's shared key, so a subclassed hook's SIG_ALL
+    // split still carries identical data/tags across every output (NUT-28).
+    const eBytes =
+      p2pk.blindKeys && p2pk.sigFlag === 'SIG_ALL' ? createRandomSecretKey() : undefined;
+    const outputs = amounts.map((a) => this.createSingleP2PKData(p2pk, a, keyset.id, eBytes));
+    // An override that ignores eBytes silently reverts to a fresh key per output, which
+    // defeats the point of sharing one: catch that here rather than at the mint.
+    if (eBytes && new Set(outputs.map((o) => o.ephemeralE)).size > 1) {
+      throw new CTSError(
+        'createSingleP2PKData override must reuse the shared eBytes ephemeral key for a SIG_ALL split',
+      );
+    }
+    return outputs;
   }
 
-  createSingleP2PKData(p2pk: P2PKOptions, amount: AmountLike, keysetId: string): OutputDataLike {
-    return OutputData.createSingleP2PKData(p2pk, amount, keysetId);
+  createSingleP2PKData(
+    p2pk: P2PKOptions,
+    amount: AmountLike,
+    keysetId: string,
+    eBytes?: Uint8Array,
+  ): OutputDataLike {
+    return OutputData.createSingleP2PKData(p2pk, amount, keysetId, eBytes);
   }
 
   createRandomData(
@@ -98,6 +126,16 @@ export class DefaultOutputDataCreator implements OutputDataCreator {
       return OutputData.createDeterministicData(amount, seed, counter, keyset, customSplit);
     }
     const amounts = splitAmount(amount, keyset.keys, customSplit);
+    // The canonical batch path rejects an unsafe counter itself; a custom hook may not, so
+    // the whole range is checked before it aliases two outputs onto the same counter.
+    const lastCounter = counter + (amounts.length - 1);
+    if (
+      !Number.isSafeInteger(counter) ||
+      counter < 0 ||
+      (amounts.length > 0 && !Number.isSafeInteger(lastCounter))
+    ) {
+      throw new CTSError('Counter must be an integer in the range 0 <= counter <= 2^53 - 1');
+    }
     return amounts.map((a, i) =>
       this.createSingleDeterministicData(a, seed, counter + i, keyset.id),
     );

--- a/test/crypto/core.test.ts
+++ b/test/crypto/core.test.ts
@@ -3,7 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToNumberBE } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import {
   hashToCurve,
@@ -68,6 +68,41 @@ describe('testing hash to curve', () => {
     const Y = hashToCurve(secret);
     const hexY = Y.toHex(true);
     expect(hexY).toBe('022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf');
+  });
+
+  test('produces the same point regardless of host byte order', () => {
+    const NativeUint32Array = globalThis.Uint32Array;
+    // Simulates a big-endian host's typed-array backing store, so the counter encoding
+    // must be pinned explicitly rather than following whatever the host happens to use.
+    const BigEndianTypedArrays = new Proxy(NativeUint32Array, {
+      construct(Target, args) {
+        if (args.length !== 1 || args[0] !== 1) {
+          return Reflect.construct(Target, args);
+        }
+        const buffer = new ArrayBuffer(4);
+        const view = new DataView(buffer);
+        return {
+          buffer,
+          get 0() {
+            return view.getUint32(0, false);
+          },
+          set 0(value: number) {
+            view.setUint32(0, value, false);
+          },
+        };
+      },
+    });
+
+    vi.stubGlobal('Uint32Array', BigEndianTypedArrays);
+    try {
+      // This vector reaches counter 3 before finding a valid point.
+      const secret = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
+      expect(hashToCurve(secret).toHex(true)).toBe(
+        '022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf',
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -2,9 +2,11 @@ import { bytesToHex } from '@noble/curves/utils.js';
 import { describe, expect, test } from 'vitest';
 
 import {
+  blindMessage,
   createBlindSignature,
   createDLEQProof,
   getPubKeyFromPrivKey,
+  hashToCurve,
   pointFromHex,
 } from '../../src/crypto';
 import { verifyUnblindedSignature } from '../../src/crypto/NUT01';
@@ -120,6 +122,35 @@ describe('OutputData secp round-trip (secp256k1 + NUT-12 DLEQ)', () => {
     const tampered: SerializedBlindedSignature = { ...sig, dleq: { s: sig.dleq!.s, e: badE } };
     expect(() => out.toProof(tampered, keyset)).toThrowError(/DLEQ verification failed/);
   });
+
+  test('rejects a mint response that unblinds to a non-UTF-8 secret', () => {
+    // Bypass the factories (which only ever build UTF-8 secrets) to exercise toProof's own guard.
+    const secretBytes = Uint8Array.of(0xff);
+    const { r, B_ } = blindMessage(secretBytes);
+    const out = new OutputData(
+      { amount: Amount.from(1), B_: B_.toHex(true), id: keyset.id },
+      r,
+      secretBytes,
+    );
+    const sig = signWithMint(out, privKeys, keyset.id);
+    expect(() => out.toProof(sig, keyset)).toThrow(/utf-8/i);
+  });
+
+  test('keeps a leading BOM as secret content so the proof re-encodes to the bytes that were blinded', () => {
+    // efbbbf61 is a UTF-8 BOM followed by 'a'; the mint hashes the UTF-8 bytes of the string it
+    // receives, so the BOM must survive decoding or Y would no longer match.
+    const secretBytes = Uint8Array.of(0xef, 0xbb, 0xbf, 0x61);
+    const { r, B_ } = blindMessage(secretBytes);
+    const out = new OutputData(
+      { amount: Amount.from(1), B_: B_.toHex(true), id: keyset.id },
+      r,
+      secretBytes,
+    );
+    const sig = signWithMint(out, privKeys, keyset.id);
+    const proof = out.toProof(sig, keyset);
+    expect(proof.secret).toBe('\uFEFFa');
+    expect(new TextEncoder().encode(proof.secret)).toEqual(secretBytes);
+  });
 });
 
 describe('OutputData.assertValidTagKey and reserved tags', () => {
@@ -156,5 +187,79 @@ describe('OutputData.deserialize', () => {
     expect((caught as CTSError).message).toMatch(/Invalid SerializedOutputData/);
     // Cause must be preserved for diagnostics (kills `{ cause: e }` -> `{}`).
     expect((caught as CTSError).cause).toBeInstanceOf(Error);
+  });
+
+  test('accepts a blinded message that matches its secret and blinding factor', () => {
+    const original = OutputData.createSingleRandomData(1, '009a1f293253e41e');
+    const serialized = OutputData.serialize(original);
+    const restored = OutputData.deserialize(serialized);
+    expect(restored.blindedMessage.B_).toBe(original.blindedMessage.B_);
+  });
+
+  test('rejects a blinded message that does not match its secret and blinding factor', () => {
+    const original = OutputData.createSingleRandomData(1, '009a1f293253e41e');
+    const replacement = OutputData.createSingleRandomData(1, '009a1f293253e41e');
+    const serialized = OutputData.serialize(original);
+
+    expect(() =>
+      OutputData.deserialize({
+        ...serialized,
+        blindedMessage: { ...serialized.blindedMessage, B_: replacement.blindedMessage.B_ },
+      }),
+    ).toThrow(/does not match/i);
+  });
+
+  test('rejects a zero blinding factor', () => {
+    const secret = new TextEncoder().encode('output-secret');
+    const Y = hashToCurve(secret);
+
+    expect(() =>
+      OutputData.deserialize({
+        blindedMessage: { amount: '1', B_: Y.toHex(true), id: '009a1f293253e41e' },
+        blindingFactor: '0',
+        secret: bytesToHex(secret),
+      }),
+    ).toThrow(/blinding factor/i);
+  });
+
+  test('rejects a malformed persisted P2BK ephemeral public key', () => {
+    const output = OutputData.createSingleP2PKData(
+      { pubkey: bytesToHex(getPubKeyFromPrivKey(secpPriv(0))), blindKeys: true },
+      1,
+      '009a1f293253e41e',
+    );
+    const serialized = OutputData.serialize(output);
+    expect(serialized.ephemeralE).toBeDefined();
+    expect(OutputData.deserialize(serialized).ephemeralE).toBe(serialized.ephemeralE);
+    expect(() => OutputData.deserialize({ ...serialized, ephemeralE: 'not-hex' })).toThrow(
+      /invalid/i,
+    );
+  });
+
+  test('rejects secret bytes that cannot round-trip through a UTF-8 proof string', () => {
+    const secret = Uint8Array.of(0xff);
+    const { B_, r } = blindMessage(secret, 1n);
+
+    expect(() =>
+      OutputData.deserialize({
+        blindedMessage: { amount: '1', B_: B_.toHex(true), id: '009a1f293253e41e' },
+        blindingFactor: r.toString(),
+        secret: 'ff',
+      }),
+    ).toThrow(/utf-8/i);
+  });
+
+  test('accepts a secret with a leading BOM and preserves its bytes', () => {
+    // efbbbf61 is a UTF-8 BOM followed by 'a'; the BOM is content, not framing, so the stored
+    // bytes round-trip unchanged and still match B_.
+    const secret = Uint8Array.of(0xef, 0xbb, 0xbf, 0x61);
+    const { B_, r } = blindMessage(secret, 1n);
+
+    const restored = OutputData.deserialize({
+      blindedMessage: { amount: '1', B_: B_.toHex(true), id: '009a1f293253e41e' },
+      blindingFactor: r.toString(),
+      secret: 'efbbbf61',
+    });
+    expect(restored.secret).toEqual(secret);
   });
 });

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -115,6 +115,48 @@ describe('DefaultOutputDataCreator', () => {
     expect(new Set(outputs.map((o) => o.ephemeralE)).size).toBe(1);
   });
 
+  test('the default single-output P2PK hook forwards eBytes to OutputData', () => {
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
+    const eBytes = hexToBytes('02'.repeat(32));
+    const expectedE = bytesToHex(getPubKeyFromPrivKey(eBytes));
+
+    const output = new DefaultOutputDataCreator().createSingleP2PKData(
+      { pubkey, blindKeys: true, sigFlag: 'SIG_ALL' },
+      1,
+      '009a1f293253e41e',
+      eBytes,
+    );
+    expect(output.ephemeralE).toBe(expectedE);
+  });
+
+  test('a subclassed single-output P2PK hook that drops eBytes is rejected for a SIG_ALL split', () => {
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
+    const keyset: HasKeysetKeys = {
+      id: '009a1f293253e41e',
+      keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
+    };
+
+    class ForgetfulCreator extends DefaultOutputDataCreator {
+      override createSingleP2PKData(
+        p2pk: P2PKOptions,
+        amount: AmountLike,
+        keysetId: string,
+      ): OutputData {
+        return OutputData.createSingleP2PKData(p2pk, amount, keysetId);
+      }
+    }
+
+    expect(() =>
+      new ForgetfulCreator().createP2PKData(
+        { pubkey, blindKeys: true, sigFlag: 'SIG_ALL' },
+        7,
+        keyset,
+      ),
+    ).toThrow(/shared eBytes/);
+  });
+
   test('a batch whose counters run past the safe range is rejected, not silently aliased', () => {
     const keyset: HasKeysetKeys = {
       id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
@@ -168,6 +210,17 @@ describe('DefaultOutputDataCreator', () => {
         creator.createDeterministicData(3, new Uint8Array(64).fill(1), counter, keyset, [1, 2]),
       ).toThrow(/counter/i);
     }
+    expect(seen).toEqual([]);
+
+    // An empty split has no counter range to check and calls nothing.
+    expect(
+      creator.createDeterministicData(
+        0,
+        new Uint8Array(64).fill(1),
+        Number.MAX_SAFE_INTEGER,
+        keyset,
+      ),
+    ).toEqual([]);
     expect(seen).toEqual([]);
   });
 

--- a/test/model/OutputDataCreator.test.ts
+++ b/test/model/OutputDataCreator.test.ts
@@ -86,6 +86,35 @@ describe('DefaultOutputDataCreator', () => {
     expect(seen).toHaveLength(3);
   });
 
+  test('a subclassed single-output P2PK hook shares one ephemeral key for a SIG_ALL split', () => {
+    const privkey = hexToBytes('01'.repeat(32));
+    const pubkey = bytesToHex(getPubKeyFromPrivKey(privkey));
+    const keyset: HasKeysetKeys = {
+      id: '009a1f293253e41e',
+      keys: { '1': 'unused', '2': 'unused', '4': 'unused' },
+    };
+
+    class CustomCreator extends DefaultOutputDataCreator {
+      override createSingleP2PKData(
+        p2pk: P2PKOptions,
+        amount: AmountLike,
+        keysetId: string,
+        eBytes?: Uint8Array,
+      ): OutputData {
+        return OutputData.createSingleP2PKData(p2pk, amount, keysetId, eBytes);
+      }
+    }
+
+    const outputs = new CustomCreator().createP2PKData(
+      { pubkey, blindKeys: true, sigFlag: 'SIG_ALL' },
+      7,
+      keyset,
+    );
+
+    expect(outputs).toHaveLength(3);
+    expect(new Set(outputs.map((o) => o.ephemeralE)).size).toBe(1);
+  });
+
   test('a batch whose counters run past the safe range is rejected, not silently aliased', () => {
     const keyset: HasKeysetKeys = {
       id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
@@ -99,6 +128,79 @@ describe('DefaultOutputDataCreator', () => {
     expect(() =>
       creator.createDeterministicData(3, seed, Number.MAX_SAFE_INTEGER, keyset, [1, 2]),
     ).toThrow(/counter/i);
+  });
+
+  test('a subclassed single-output hook also rejects counter ranges that would alias', () => {
+    const keyset: HasKeysetKeys = {
+      id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
+      keys: { '1': 'unused', '2': 'unused' },
+    };
+    const seen: number[] = [];
+
+    class CustomOutputDataCreator extends DefaultOutputDataCreator {
+      override createSingleDeterministicData(
+        _amount: AmountLike,
+        _seed: Uint8Array,
+        counter: number,
+        _keysetId: string,
+      ): OutputDataLike {
+        seen.push(counter);
+        throw new Error('not used');
+      }
+    }
+
+    const creator = new CustomOutputDataCreator();
+
+    expect(() =>
+      creator.createDeterministicData(
+        3,
+        new Uint8Array(64).fill(1),
+        Number.MAX_SAFE_INTEGER,
+        keyset,
+        [1, 2],
+      ),
+    ).toThrow(/counter/i);
+    // Rejected before the hook is ever called, so no aliased counter is derived.
+    expect(seen).toEqual([]);
+
+    for (const counter of [-1, 1.5]) {
+      expect(() =>
+        creator.createDeterministicData(3, new Uint8Array(64).fill(1), counter, keyset, [1, 2]),
+      ).toThrow(/counter/i);
+    }
+    expect(seen).toEqual([]);
+  });
+
+  test('a subclassed single-output hook is called once per counter within a safe range', () => {
+    const keyset: HasKeysetKeys = {
+      id: '012e23479a0029432eaad0d2040c09be53bab592d5cbf1d55e0dd26c9495951b30',
+      keys: { '1': 'unused', '2': 'unused' },
+    };
+    const seen: number[] = [];
+
+    class CustomOutputDataCreator extends DefaultOutputDataCreator {
+      override createSingleDeterministicData(
+        amount: AmountLike,
+        seed: Uint8Array,
+        counter: number,
+        keysetId: string,
+      ): OutputDataLike {
+        seen.push(counter);
+        return OutputData.createSingleDeterministicData(amount, seed, counter, keysetId);
+      }
+    }
+
+    const creator = new CustomOutputDataCreator();
+    const outputs = creator.createDeterministicData(
+      3,
+      new Uint8Array(64).fill(1),
+      7,
+      keyset,
+      [1, 2],
+    );
+
+    expect(outputs).toHaveLength(2);
+    expect(seen).toEqual([7, 8]);
   });
 
   test('delegates deterministic batch creation to subclassed single-output override', () => {
@@ -132,7 +234,13 @@ describe('DefaultOutputDataCreator', () => {
     }
 
     const creator = new CustomOutputDataCreator();
-    const outputs = creator.createDeterministicData(3, new Uint8Array([1]), 7, keyset, [1, 2]);
+    const outputs = creator.createDeterministicData(
+      3,
+      new Uint8Array(64).fill(1),
+      7,
+      keyset,
+      [1, 2],
+    );
 
     expect(outputs.map((output) => output.blindedMessage.B_)).toEqual(['blind-7', 'blind-8']);
     expect(calls).toEqual([


### PR DESCRIPTION
Backport of #1123 to v4-dev. Persisted outputs are validated against their own secret and blinding factor when restored, subclassed output creators keep the batch invariants the canonical paths enforce, and the hash-to-curve counter is little-endian on every host.

## Why

`OutputData.deserialize` trusted every stored field: any hex secret, any `B_`, a zero blinding factor and an unchecked `ephemeralE` all became an `OutputData` whose proofs the mint would never accept, and `toProof` decoded secrets non-fatally. `DefaultOutputDataCreator`'s subclass-hook fallbacks skipped two batch invariants: a blinded SIG_ALL split derived a fresh ephemeral key per output, which [NUT-28](https://github.com/cashubtc/nuts/blob/main/28.md) forbids, and a deterministic split never checked the counter range, so counters near 2^53 could alias. `hashToCurve` wrote its counter in host byte order where [NUT-00](https://github.com/cashubtc/nuts/blob/main/00.md) fixes little-endian.

## Changes

`deserialize` recomputes `B_` and rejects a mismatch (which also rejects `r = 0`), decodes the secret with the shared fatal UTF-8 decoder, and parses `ephemeralE` as a compressed secp point, treating an empty string as absent. `toProof` uses the same decoder. `createSingleP2PKData` gains an optional `eBytes` that the SIG_ALL fallback fills and then verifies across the split; the deterministic fallback validates the whole counter range up front. `hashToCurve` writes its counter through a `DataView`. The docs example forwards `eBytes`.

Differences from main: v4 has no v3 keysets, so the point-secret requirement and the BLS tests do not apply, and the endianness fix lives in `src/crypto/core.ts`.

## Impact

A stored output that disagrees with its secret now throws with the NUT-09 recovery hint instead of yielding an unspendable proof. A leading BOM in a secret is kept as content, since the mint hashes the bytes it receives. The `OutputDataCreator` interface widens by one optional parameter; three-argument overrides keep compiling, but a SIG_ALL override that ignores `eBytes` now throws. Hash-to-curve vectors are unchanged.
