### PR TITLE
fix(transport): scope request logs, merge headers case-insensitively, sanitize log context

### DIFF
--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -198,6 +198,8 @@ await wallet.meltProofsBolt11(quote, proofs);
 
 Catch it where a melt can fail, and recover once the keys are reachable. The `cause` says whether that is possible: a keyset that will load rebuilds, while an invalid DLEQ or a signature count mismatch needs a NUT-09 restore.
 
+`outputData` and `quote` are non-enumerable, like `cause`. Read them directly and persist those values; a spread or `JSON.stringify` of the error will not carry them.
+
 ```ts
 // Before: the melt is paid, and the change is gone
 await wallet.meltProofsBolt11(quote, proofs);

--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -405,6 +405,7 @@ export class AuthManager implements AuthProvider {
       const info = await this.req<GetInfoResponse>({
         endpoint: joinUrls(this.mintUrl, '/v1/info'),
         method: 'GET',
+        logger: this.logger,
       });
       this.info = new MintInfo(info, this.logger);
     }
@@ -414,10 +415,12 @@ export class AuthManager implements AuthProvider {
         this.req<GetKeysetsResponse>({
           endpoint: joinUrls(this.mintUrl, '/v1/auth/blind/keysets'),
           method: 'GET',
+          logger: this.logger,
         }),
         this.req<GetKeysResponse>({
           endpoint: joinUrls(this.mintUrl, '/v1/auth/blind/keys'),
           method: 'GET',
+          logger: this.logger,
         }),
       ]);
       const normalizedKeysets = allKeysets.keysets.map((keyset) => normalizeMintKeyset(keyset));
@@ -481,6 +484,7 @@ export class AuthManager implements AuthProvider {
       // A CAT must never be replayed to a redirect target: fail rather than follow.
       ...(cat ? { redirect: 'error' as const } : {}),
       requestBody: payload,
+      logger: this.logger,
     });
     if (!Array.isArray(res?.signatures) || res.signatures.length !== outputs.length) {
       throw new CTSError('AuthManager: bad BAT mint response');

--- a/src/logger/ConsoleLogger.ts
+++ b/src/logger/ConsoleLogger.ts
@@ -1,3 +1,5 @@
+import { MAX_LOG_CONTEXT_DEPTH } from '../utils/limits';
+
 import { type Logger, type LogLevel } from './Logger';
 
 const LEVEL_ORDER: Record<LogLevel, number> = {
@@ -8,19 +10,55 @@ const LEVEL_ORDER: Record<LogLevel, number> = {
   trace: 4,
 };
 
-const CONTROL_ESCAPES: Record<string, string> = { '\n': '\\n', '\r': '\\r', '\t': '\\t' };
+const CONTROL_ESCAPES: Record<string, string> = {
+  '\n': '\\n',
+  '\r': '\\r',
+  '\t': '\\t',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
 // eslint-disable-next-line no-control-regex -- matching control chars is the point
-const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/g;
 
 /**
- * Escapes C0/C1 control characters so one message renders as one log line and cannot carry terminal
- * escape sequences.
+ * Escapes C0/C1 control characters and Unicode line/paragraph separators so one message renders as
+ * one log line and cannot carry terminal escape sequences.
  */
 function escapeControlChars(message: string): string {
   return String(message).replace(
     CONTROL_CHARS,
     (ch) => CONTROL_ESCAPES[ch] ?? '\\x' + ch.charCodeAt(0).toString(16).padStart(2, '0'),
   );
+}
+
+/**
+ * Recursively sanitizes context values: escapes string leaves (including an `Error`'s `message` and
+ * `stack`, since `stack` restates the message) and rebuilds plain objects through `defineProperty`
+ * so an own `__proto__` key becomes a data property instead of hitting the setter. Depth-bounded so
+ * a deeply nested payload cannot exhaust the stack.
+ */
+function sanitizeContextValue(value: unknown, depth: number): unknown {
+  if (typeof value === 'string') return escapeControlChars(value);
+  if (value instanceof Error) {
+    return {
+      message: escapeControlChars(value.message),
+      stack: value.stack === undefined ? undefined : escapeControlChars(value.stack),
+    };
+  }
+  if (depth >= MAX_LOG_CONTEXT_DEPTH || value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map((entry) => sanitizeContextValue(entry, depth + 1));
+  const proto: unknown = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) {
+    Object.defineProperty(out, k, {
+      value: sanitizeContextValue(v, depth + 1),
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return out;
 }
 
 /**
@@ -64,12 +102,7 @@ export class ConsoleLogger implements Logger {
     return `[${level.toUpperCase()}] ${escapeControlChars(message)}`;
   }
   private flattenContext(ctx?: Record<string, unknown>): Record<string, unknown> | undefined {
-    if (!ctx) return undefined;
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(ctx)) {
-      out[k] = v instanceof Error ? { message: v.message, stack: v.stack } : v;
-    }
-    return out;
+    return ctx ? (sanitizeContextValue(ctx, 0) as Record<string, unknown>) : undefined;
   }
   private emit(level: LogLevel, message: string, context?: Record<string, unknown>) {
     if (!this.should(level)) return;

--- a/src/mint/Mint.ts
+++ b/src/mint/Mint.ts
@@ -183,6 +183,7 @@ class Mint {
     const response = await requestInstance<GetInfoResponse>({
       endpoint: joinUrls(this._mintUrl, '/v1/info'),
       onResponseMeta: this._captureResponseMetadata,
+      logger: this._logger,
     });
     return MintInfo.normalizeInfo(response, this._logger);
   }
@@ -454,8 +455,10 @@ class Mint {
     );
 
     if (!Array.isArray(data) || data.length !== quotes.length) {
+      // Log the counts, not the response: quote ids do not belong in a shared log sink.
       this._logger.error('Invalid response from mint...', {
-        data,
+        expectedCount: quotes.length,
+        actualCount: Array.isArray(data) ? data.length : undefined,
         op: `checkMintQuoteBatch.${method}`,
       });
       throw new CTSError('Invalid response from mint');
@@ -464,7 +467,7 @@ class Mint {
     return data.map((response, index) => {
       if (response.quote !== quotes[index]) {
         this._logger.error('Invalid response from mint...', {
-          data,
+          index,
           op: `checkMintQuoteBatch.${method}`,
         });
         throw new CTSError('Invalid response from mint');
@@ -1062,6 +1065,7 @@ class Mint {
         ? joinUrls(targetUrl, '/v1/keys', keysetId)
         : joinUrls(targetUrl, '/v1/keys'),
       onResponseMeta: this._captureResponseMetadata,
+      logger: this._logger,
     });
 
     if (!isObj(data) || !Array.isArray(data.keysets)) {
@@ -1087,6 +1091,7 @@ class Mint {
     const data = await requestInstance<GetKeysetsResponse>({
       endpoint: joinUrls(this._mintUrl, '/v1/keysets'),
       onResponseMeta: this._captureResponseMetadata,
+      logger: this._logger,
     });
     if (!isObj(data) || !Array.isArray(data.keysets)) {
       this._logger.error('Invalid response from mint...', { data, op: 'getKeySets' });
@@ -1117,6 +1122,7 @@ class Mint {
       requestBody: restorePayload,
       idempotent: true,
       onResponseMeta: this._captureResponseMetadata,
+      logger: this._logger,
     });
 
     // Per NUT-09 the mint returns paired outputs and signatures, one pair per requested output.
@@ -1267,6 +1273,7 @@ class Mint {
       ...(bat || cat || init.requestBody ? { redirect: 'error' as const } : {}),
       ...(nut19?.supported && nut19.params ? nut19.params : {}),
       onResponseMeta: this._captureResponseMetadata,
+      logger: init.logger ?? this._logger,
     });
   }
 
@@ -1425,7 +1432,8 @@ class Mint {
     } else {
       const derived = this.deriveMintQuoteAccounting(data);
       if (!derived) {
-        this._logger.error('Invalid response from mint...', { data, op });
+        // Log the reason, not the response: it carries the quote id.
+        this._logger.error('Invalid response from mint...', { op });
         throw new CTSError('Invalid response from mint');
       }
       [data.amount_paid, data.amount_issued] = derived;
@@ -1441,7 +1449,7 @@ class Mint {
       typeof data.request !== 'string' ||
       typeof data.unit !== 'string'
     ) {
-      this._logger.error('Invalid response from mint...', { data, op });
+      this._logger.error('Invalid response from mint...', { op });
       throw new CTSError('Invalid response from mint');
     }
   }
@@ -1454,7 +1462,7 @@ class Mint {
     if (data.method === undefined) {
       data.method = method;
     } else if (data.method !== method) {
-      this._logger.error('Invalid response from mint...', { data, op });
+      this._logger.error('Invalid response from mint...', { op });
       throw new CTSError('Invalid response from mint');
     }
   }
@@ -1599,7 +1607,9 @@ class Mint {
       typeof data.expiry !== 'number' ||
       !Object.values(MeltQuoteState).includes(data.state as MeltQuoteState)
     ) {
-      this._logger.error('Invalid response from mint...', { data, op });
+      // Log the reason, not the response: it carries the quote id, payment request, and any
+      // change signatures.
+      this._logger.error('Invalid response from mint...', { op });
       throw new CTSError('Invalid response from mint');
     }
   }
@@ -1616,7 +1626,7 @@ class Mint {
     const hasFeeReserve =
       data.fee_reserve instanceof Amount || (execution && data.fee_reserve === undefined);
     if (!hasFeeReserve) {
-      this._logger.error('Invalid response from mint...', { data, op });
+      this._logger.error('Invalid response from mint...', { op });
       throw new CTSError('Invalid response from mint');
     }
     // Per NUT-23, payment_preimage is `<str | null>`. Some mints may omit it
@@ -1639,14 +1649,14 @@ class Mint {
       data.fee_options.length === 0 ||
       data.fee_options.length > MAX_MINT_INFO_LIST
     ) {
-      this._logger.error('Invalid response from mint...', { data, op: 'onchain melt quote' });
+      this._logger.error('Invalid response from mint...', { op: 'onchain melt quote' });
       throw new CTSError('Invalid response from mint');
     }
     data.fee_options = data.fee_options.map((raw) => {
       const opt = raw as Record<string, unknown>;
       // fee_index is the load-bearing selector for the melt request
       if (!Number.isSafeInteger(opt.fee_index)) {
-        this._logger.error('Invalid response from mint...', { data, op: 'onchain melt quote' });
+        this._logger.error('Invalid response from mint...', { op: 'onchain melt quote' });
         throw new CTSError('Invalid response from mint');
       }
       return {
@@ -1661,7 +1671,7 @@ class Mint {
       (data.selected_fee_index !== null && !Number.isSafeInteger(data.selected_fee_index)) ||
       (data.outpoint !== null && typeof data.outpoint !== 'string')
     ) {
-      this._logger.error('Invalid response from mint...', { data, op: 'onchain melt quote' });
+      this._logger.error('Invalid response from mint...', { op: 'onchain melt quote' });
       throw new CTSError('Invalid response from mint');
     }
   }

--- a/src/model/Errors.ts
+++ b/src/model/Errors.ts
@@ -85,17 +85,19 @@ export class UnknownKeysetError extends CTSError {
  * The inputs are spent and the payment stands. `cause` says which recovery applies: a keyset that
  * can be loaded (see `keyChain.ensureKeysetKeys`) rebuilds from `outputData` and the quote's
  * `change` signatures via `wallet.createMeltChangeProofs()`. Anything else, eg invalid DLEQ or a
- * signature count mismatch, needs a NUT-09 restore on a seeded wallet.
+ * signature count mismatch, needs a NUT-09 restore on a seeded wallet. `outputData` and `quote` are
+ * non-enumerable, so read them directly; a spread or `JSON.stringify` of the error will not carry
+ * them.
  */
 export class MeltChangeError extends CTSError {
   /**
    * The melt's blank outputs, the input to change recovery.
    */
-  readonly outputData: OutputDataLike[];
+  readonly outputData!: OutputDataLike[];
   /**
    * The melt quote, merged from the preview and the mint's response.
    */
-  readonly quote: MeltQuoteBaseResponse;
+  readonly quote!: MeltQuoteBaseResponse;
   constructor(
     outputData: OutputDataLike[],
     quote: MeltQuoteBaseResponse,
@@ -105,8 +107,20 @@ export class MeltChangeError extends CTSError {
       'Melt completed but its change could not be reconstructed; see cause: a keyset that will load rebuilds via createMeltChangeProofs(), anything else needs a NUT-09 restore',
       options,
     );
-    this.outputData = outputData;
-    this.quote = quote;
+    // Non-enumerable like cause: read outputData/quote directly, not via a spread or
+    // JSON.stringify of the error.
+    Object.defineProperty(this, 'outputData', {
+      configurable: true,
+      enumerable: false,
+      value: outputData,
+      writable: true,
+    });
+    Object.defineProperty(this, 'quote', {
+      configurable: true,
+      enumerable: false,
+      value: quote,
+      writable: true,
+    });
     this.name = 'MeltChangeError';
     Object.setPrototypeOf(this, MeltChangeError.prototype);
   }

--- a/src/transport/request.ts
+++ b/src/transport/request.ts
@@ -64,7 +64,7 @@ const IS_BROWSER_LIKE = detectBrowserLike(globalThis);
  * native HTTP stacks otherwise leak fingerprintable identifiers (undici, NSURLSession, OkHttp).
  * Skipped in browsers + workers because Firefox/WebKit can promote it to a CORS preflight even
  * though the Fetch spec lists it as a forbidden header. Caller-supplied `requestHeaders` always
- * wins.
+ * wins, matched case-insensitively (HTTP header names are not case-sensitive).
  * @internal
  */
 export function buildRequestHeaders(
@@ -72,12 +72,14 @@ export function buildRequestHeaders(
   requestHeaders: Record<string, string> | undefined,
   isBrowserLike: boolean = IS_BROWSER_LIKE,
 ): Record<string, string> {
-  return {
-    Accept: 'application/json, text/plain, */*',
-    ...(body ? { 'Content-Type': 'application/json' } : undefined),
-    ...(isBrowserLike ? undefined : { 'User-Agent': 'Mozilla/5.0' }),
-    ...requestHeaders,
-  };
+  return mergeHeadersCaseInsensitive(
+    {
+      Accept: 'application/json, text/plain, */*',
+      ...(body ? { 'Content-Type': 'application/json' } : undefined),
+      ...(isBrowserLike ? undefined : { 'User-Agent': 'Mozilla/5.0' }),
+    },
+    requestHeaders,
+  );
 }
 
 /**
@@ -144,25 +146,29 @@ export async function readBodyText(
     else signal.addEventListener('abort', onAbort, { once: true });
   }
   try {
-    const chunks: Uint8Array[] = [];
+    // Copy each chunk into a growing buffer immediately rather than retaining every chunk view
+    // until EOF: a stream delivering many tiny chunks would otherwise hold one object per chunk.
+    let bytes = new Uint8Array(0);
     let received = 0;
     for (;;) {
       const result = await reader.read();
       if (aborted) throw new CTSError('response body read aborted');
       if (result.done) break;
-      received += result.value.byteLength;
-      if (received > maxBytes) {
+      const nextReceived = received + result.value.byteLength;
+      if (nextReceived > maxBytes) {
         throw new CTSError(`response body exceeds ${maxBytes} bytes`);
       }
-      chunks.push(result.value);
+      if (nextReceived > bytes.byteLength) {
+        const grown = new Uint8Array(
+          Math.min(maxBytes, Math.max(nextReceived, bytes.byteLength * 2)),
+        );
+        grown.set(bytes);
+        bytes = grown;
+      }
+      bytes.set(result.value, received);
+      received = nextReceived;
     }
-    const bytes = new Uint8Array(received);
-    let offset = 0;
-    for (const chunk of chunks) {
-      bytes.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return new TextDecoder('utf-8').decode(bytes);
+    return new TextDecoder('utf-8').decode(bytes.subarray(0, received));
   } finally {
     if (onAbort) signal?.removeEventListener('abort', onAbort);
     reader.cancel().catch(() => undefined); // release the connection; no-op if already closed
@@ -389,9 +395,11 @@ export function setGlobalRequestOptions(options: Partial<RequestOptions>): void 
 }
 
 /**
- * Allows a logger to be set.
+ * Sets the process-wide fallback logger for transport calls.
  *
- * @param {Logger} logger The logger instance to use.
+ * @remarks
+ * A per-call or global `logger` request option takes precedence; this only applies when neither is
+ * set.
  */
 export function setRequestLogger(logger: Logger): void {
   requestLogger = logger;
@@ -487,6 +495,8 @@ function endpointPathMatchesCachedPath(endpointPath: string, cachedPath: string)
  */
 async function requestWithRetry(options: RequestOptions): Promise<unknown> {
   const { ttl, cached_endpoints, endpoint } = options;
+  // Per-call logger wins; the process-wide default only covers callers that never set one.
+  const activeLogger = options.logger ?? requestLogger;
   // A BAT is single-use (NUT-22): if the first attempt reached the mint, a retry replays a spent
   // token and fails auth, hiding the original result. The auth layer issues a fresh one per call.
   const carriesBat = Object.keys(options.headers ?? {}).some(
@@ -525,7 +535,7 @@ async function requestWithRetry(options: RequestOptions): Promise<unknown> {
       ) {
         throw e;
       }
-      requestLogger.info('Network error on an idempotent request, retrying once', { e });
+      activeLogger.info('Network error on an idempotent request, retrying once', { e });
       return await _request(options);
     }
   }
@@ -547,14 +557,14 @@ async function requestWithRetry(options: RequestOptions): Promise<unknown> {
           const delay = Math.random() * cappedDelay;
 
           if (totalElapsedTime + delay > ttl) {
-            requestLogger.error(`Network Error: request abandoned after ${retries} retries`, {
+            activeLogger.error(`Network Error: request abandoned after ${retries} retries`, {
               e,
               retries,
             });
             throw e;
           }
           retries++;
-          requestLogger.info(`Network Error: attempting retry ${retries} in ${delay}ms`, {
+          activeLogger.info(`Network Error: attempting retry ${retries} in ${delay}ms`, {
             e,
             retries,
             delay,
@@ -564,7 +574,7 @@ async function requestWithRetry(options: RequestOptions): Promise<unknown> {
           return retry();
         }
       }
-      requestLogger.error(`Request failed and could not be retried`, { e });
+      activeLogger.error(`Request failed and could not be retried`, { e });
       throw e;
     }
   };
@@ -601,7 +611,8 @@ async function _request(options: RequestOptions): Promise<unknown> {
   void cached_endpoints;
   void ttl;
   void idempotent;
-  void logger;
+  // Per-call logger wins; the process-wide default only covers callers that never set one.
+  const activeLogger = logger ?? requestLogger;
 
   if (
     maxResponseBytes !== undefined &&
@@ -701,7 +712,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
         rateLimitPolicy: response.headers.get('RateLimit-Policy') ?? undefined,
         headers: response.headers,
       };
-      safeCallback(onResponseMeta, meta, requestLogger, {
+      safeCallback(onResponseMeta, meta, activeLogger, {
         op: 'request.onResponseMeta',
         status: response.status,
         endpoint,
@@ -709,6 +720,16 @@ async function _request(options: RequestOptions): Promise<unknown> {
     }
 
     if (!response.ok) {
+      // The status is already known: check it before reading the optional body, so a stalled
+      // body cannot turn a known 429 into a retryable network failure.
+      if (response.status === 429) {
+        const body = response.body;
+        if (body && typeof body.cancel === 'function') {
+          body.cancel().catch(() => undefined);
+        }
+        throw new RateLimitError('429 Too Many Requests', retryAfterMs);
+      }
+
       let errorData: ApiError;
       let errorDataCause: unknown;
       try {
@@ -720,10 +741,6 @@ async function _request(options: RequestOptions): Promise<unknown> {
         if (aborted) throw aborted;
         errorDataCause = err;
         errorData = { error: 'bad response' };
-      }
-
-      if (response.status === 429) {
-        throw new RateLimitError('429 Too Many Requests', retryAfterMs);
       }
 
       if (
@@ -754,7 +771,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
       // like the fetch-level catch so cached-endpoint retry still engages on a timeout.
       const aborted = abortError(err, timeoutController, requestTimeout, callerSignal);
       if (aborted) throw aborted;
-      requestLogger.error('Failed to read HTTP response', { err });
+      activeLogger.error('Failed to read HTTP response', { err });
       // Surface our own reason (eg the size cap), but keep a foreign transport error behind the
       // stable "bad response" message rather than exposing it.
       const message = err instanceof CTSError ? err.message : 'bad response';
@@ -767,7 +784,7 @@ async function _request(options: RequestOptions): Promise<unknown> {
       }
       return JSONInt.parse(responseText, undefined, { strict: true });
     } catch (err) {
-      requestLogger.error('Failed to parse HTTP response', { err });
+      activeLogger.error('Failed to parse HTTP response', { err });
       throw new HttpResponseError('bad response', response.status, { cause: err });
     }
   } finally {
@@ -798,6 +815,25 @@ function parseErrorBody(errorText: string): ApiError {
 }
 
 /**
+ * Merges header records by lowercase name so a global and a per-call header differing only in case
+ * do not both survive; `overrides` wins per name and its original spelling is kept.
+ *
+ * @internal
+ */
+function mergeHeadersCaseInsensitive(
+  base: Record<string, string> | undefined,
+  overrides: Record<string, string> | undefined,
+): Record<string, string> {
+  const merged = new Map<string, [string, string]>();
+  for (const headers of [base, overrides]) {
+    for (const [name, value] of Object.entries(headers ?? {})) {
+      merged.set(name.toLowerCase(), [name, value]);
+    }
+  }
+  return Object.fromEntries(merged.values());
+}
+
+/**
  * Performs HTTP request with exponential backoff retry for NUT-19 cached endpoints. Retries occur
  * for network errors and 5xx responses on endpoints specified in cached_endpoints. 4xx errors
  * (including 429 Too Many Requests) are not retried. Nut19Policy for a given endpoint should be
@@ -812,17 +848,20 @@ export default async function request<T>(options: RequestOptions): Promise<T> {
     if (options[key] !== undefined) (merged as Record<string, unknown>)[key] = options[key];
   }
   // Neither side owns the header bag: a global adds app-wide headers, per-call carries auth.
-  merged.headers = { ...globalRequestOptions.headers, ...options.headers };
+  // Header names are case-insensitive over the wire, so the merge must be too, or a per-call
+  // header differing only in case leaves the global value in place alongside it.
+  merged.headers = mergeHeadersCaseInsensitive(globalRequestOptions.headers, options.headers);
 
   // Both set: wrap in safeCallback so a throw in one doesn't prevent the other from firing.
   if (perRequest && globalMeta && perRequest !== globalMeta) {
+    const activeLogger = merged.logger ?? requestLogger;
     merged.onResponseMeta = (meta) => {
-      safeCallback(perRequest, meta, requestLogger, {
+      safeCallback(perRequest, meta, activeLogger, {
         op: 'request.onResponseMeta',
         scope: 'per-request',
         endpoint: options.endpoint,
       });
-      safeCallback(globalMeta, meta, requestLogger, {
+      safeCallback(globalMeta, meta, activeLogger, {
         op: 'request.onResponseMeta',
         scope: 'global',
         endpoint: options.endpoint,

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -553,10 +553,16 @@ function handleTokens(token: string): Token {
   const encodedToken = token.slice(1);
   if (version === 'A') {
     const parsedV3Token = decodeBase64UrlToJson<DeprecatedToken>(encodedToken);
+    if (!parsedV3Token || !Array.isArray(parsedV3Token.token)) {
+      throw new CTSError('Invalid token');
+    }
     if (parsedV3Token.token.length > 1) {
       throw new CTSError('Multi entry token are not supported');
     }
     const entry = parsedV3Token.token[0];
+    if (!entry || !Array.isArray(entry.proofs)) {
+      throw new CTSError('Invalid token');
+    }
     const proofs = entry.proofs.map((p) => ({
       ...p,
       amount: Amount.from(p.amount as AmountLike),

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -191,3 +191,9 @@ export const MAX_P2PK_PUBKEYS = 16;
  * signer, so signatures need more headroom than keys ({@link MAX_P2PK_PUBKEYS}).
  */
 export const MAX_P2PK_SIGNATURES = 64;
+
+/**
+ * How deep `ConsoleLogger` recurses into structured log context to sanitize nested strings. Bounds
+ * the recursion over a nested mint response object.
+ */
+export const MAX_LOG_CONTEXT_DEPTH = 8;

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -461,6 +461,27 @@ describe('AuthManager: BAT pool minting/topUp/ensure', () => {
     expect(am.poolSize).toBe(3);
     expect(outputsSpy).toHaveBeenCalledWith(3, expect.any(Object));
   });
+
+  test('topUp threads the configured logger into the BAT mint request', async () => {
+    const logger: Logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn, logger });
+    am['info'] = fakeInfo({ batMax: 3 });
+    seedKeychain(am);
+    stubOutputs(3);
+    reqSpy.mockResolvedValueOnce({ signatures: [fakeSig, fakeSig, fakeSig] });
+
+    await am.ensure(3);
+
+    expect(reqSpy).toHaveBeenCalledTimes(1);
+    expect((reqSpy.mock.calls[0][0] as { logger?: Logger }).logger).toBe(logger);
+  });
 });
 
 /* --------------------------
@@ -499,6 +520,39 @@ describe('AuthManager: init fetches info then builds KeyChain via wallet mock', 
     expect(KeyChainMock.fromCache).toHaveBeenCalledWith(mintUrl, 'auth', expect.any(Object));
 
     expect(am.activeAuthKeysetId).toBe('00authkeyset0001');
+  });
+
+  test('threads the configured logger into every init request, not the process-global', async () => {
+    const logger: Logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      log: vi.fn(),
+    };
+    const am = new AuthManager(mintUrl, { request: reqSpy as RequestFn, logger });
+
+    reqSpy
+      .mockResolvedValueOnce({
+        name: 'mint',
+        version: 'x',
+        methods: {},
+        nuts: { '22': { bat_max_mint: 7 }, '21': { client_id: 'cashu-client' } },
+      })
+      .mockResolvedValueOnce({
+        keysets: [{ id: '00k', unit: 'auth', active: true, input_fee_ppk: 0 }],
+      })
+      .mockResolvedValueOnce({
+        keysets: [{ id: '00k', unit: 'auth', keys: { 1: '02aa' } }],
+      });
+
+    await am['init']();
+
+    expect(reqSpy).toHaveBeenCalledTimes(3);
+    for (const call of reqSpy.mock.calls) {
+      expect((call[0] as { logger?: Logger }).logger).toBe(logger);
+    }
   });
 });
 

--- a/test/logger/logger.test.ts
+++ b/test/logger/logger.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, test, expect, vi } from 'vitest';
 
 import { ConsoleLogger, NULL_LOGGER } from '../../src/logger';
+import { MAX_LOG_CONTEXT_DEPTH } from '../../src/utils/limits';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -8,9 +9,9 @@ afterEach(() => {
 
 describe('ConsoleLogger', () => {
   test('logs messages at or above minLevel', () => {
-    const errorSpy = vi.spyOn(console, 'error');
-    const warnSpy = vi.spyOn(console, 'warn');
-    const infoSpy = vi.spyOn(console, 'info');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
 
     const logger = new ConsoleLogger('warn');
 
@@ -24,11 +25,11 @@ describe('ConsoleLogger', () => {
   });
 
   test('uses correct console method for each log level', () => {
-    const errorSpy = vi.spyOn(console, 'error');
-    const warnSpy = vi.spyOn(console, 'warn');
-    const infoSpy = vi.spyOn(console, 'info');
-    const debugSpy = vi.spyOn(console, 'debug');
-    const traceSpy = vi.spyOn(console, 'trace');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const traceSpy = vi.spyOn(console, 'trace').mockImplementation(() => undefined);
 
     const logger = new ConsoleLogger('trace');
 
@@ -46,7 +47,7 @@ describe('ConsoleLogger', () => {
   });
 
   test('Message with context', () => {
-    const infoSpy = vi.spyOn(console, 'info');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const logger = new ConsoleLogger('info');
 
     // Context in object
@@ -68,7 +69,7 @@ describe('ConsoleLogger', () => {
   });
 
   test('handles Error objects in context', () => {
-    const errorSpy = vi.spyOn(console, 'error');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const logger = new ConsoleLogger('error');
     const err = new Error('Test error');
 
@@ -79,8 +80,93 @@ describe('ConsoleLogger', () => {
     });
   });
 
+  test('escapes Unicode separators carried in a context Error stack', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('error');
+    const err = new Error('rejected [ERROR] forged event');
+    err.stack = 'Error: rejected [ERROR] forged event\n    at somewhere';
+
+    logger.error('Invalid response from mint', { error: err });
+
+    const emitted = errorSpy.mock.calls[0]?.[1] as { error: { message: string; stack: string } };
+    expect(emitted.error.message).toBe('rejected\\u2028[ERROR] forged event');
+    expect(emitted.error.stack).not.toMatch(/[\u2028\u2029]/u);
+  });
+
+  test('leaves a missing Error stack as undefined rather than throwing', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('error');
+    const err = new Error('Test error');
+    err.stack = undefined;
+
+    logger.error('Error occurred', { error: err });
+
+    expect(errorSpy).toHaveBeenCalledWith('[ERROR] Error occurred', {
+      error: { message: 'Test error', stack: undefined },
+    });
+  });
+
+  test('escapes an Error nested below the top level of context', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('error');
+    const err = new Error('rejected [ERROR] forged event');
+
+    logger.error('Invalid response from mint', { data: { cause: err } });
+
+    const emitted = errorSpy.mock.calls[0]?.[1] as {
+      data: { cause: { message: string } };
+    };
+    expect(emitted.data.cause.message).toBe('rejected\\u2028[ERROR] forged event');
+  });
+
+  test('truncates recursion into deeply nested context', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('error');
+    const buriedLeaf = 'buried leaf';
+
+    // `MAX_LOG_CONTEXT_DEPTH` hops of `.next` reach the object at the depth cap.
+    let atCap: Record<string, unknown> = { value: buriedLeaf };
+    for (let i = 0; i < MAX_LOG_CONTEXT_DEPTH; i++) {
+      atCap = { next: atCap };
+    }
+
+    logger.error('deep', { ...atCap, shallow: 'top level' });
+
+    const emitted = errorSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+    // A field beside the chain, well within the cap, is still escaped.
+    expect(emitted.shallow).toBe('top\\u2028level');
+
+    let cursor = emitted;
+    for (let i = 0; i < MAX_LOG_CONTEXT_DEPTH; i++) {
+      cursor = cursor.next as Record<string, unknown>;
+    }
+    // The object at the cap is returned unprocessed, so its leaf survives unescaped.
+    expect(cursor.value).toBe(buriedLeaf);
+  });
+
+  test('escapes strings inside array context values', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('error');
+
+    logger.error('items', { items: ['a b', 'plain'] });
+
+    expect(errorSpy).toHaveBeenCalledWith('[ERROR] items', {
+      items: ['a\\u2028b', 'plain'],
+    });
+  });
+
+  test('leaves non-plain context objects and null/number leaves untouched', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('info');
+    const at = new Date(0);
+
+    logger.info('x', { at, n: 1, z: null });
+
+    expect(infoSpy).toHaveBeenCalledWith('[INFO] x', { at, n: 1, z: null });
+  });
+
   test('escapes control characters in the message', () => {
-    const infoSpy = vi.spyOn(console, 'info');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const logger = new ConsoleLogger('info');
 
     logger.info('alice logged out\n[INFO] admin role granted\r\x1b[31malert\x00');
@@ -90,9 +176,47 @@ describe('ConsoleLogger', () => {
     );
   });
 
+  test('escapes Unicode line and paragraph separators in the message', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('info');
+
+    logger.info('alice logged out [ERROR] admin role granted [WARN] forged event');
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[INFO] alice logged out\\u2028[ERROR] admin role granted\\u2029[WARN] forged event',
+    );
+  });
+
+  test('escapes Unicode separators in nested context string values', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('error');
+
+    logger.error('Invalid response from mint', {
+      data: { detail: 'rejected [ERROR] forged event [INFO] accepted' },
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith('[ERROR] Invalid response from mint', {
+      data: { detail: 'rejected\\u2028[ERROR] forged event\\u2029[INFO] accepted' },
+    });
+  });
+
+  test('preserves an own __proto__ field in structured context', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const logger = new ConsoleLogger('info');
+    const context = JSON.parse('{"__proto__":{"action":"grant-admin"}}') as Record<string, unknown>;
+
+    logger.info('Event', context);
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const emittedContext = infoSpy.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(emittedContext).toBeDefined();
+    expect(Object.prototype.hasOwnProperty.call(emittedContext, '__proto__')).toBe(true);
+    expect(emittedContext?.['__proto__']).toEqual({ action: 'grant-admin' });
+  });
+
   test('generic log method works correctly', () => {
-    const infoSpy = vi.spyOn(console, 'info');
-    const debugSpy = vi.spyOn(console, 'debug');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
     const logger = new ConsoleLogger('info');
 
     logger.log('info', 'Info message');
@@ -106,7 +230,7 @@ describe('ConsoleLogger', () => {
 describe('NullLogger', () => {
   test('does not log anything', () => {
     const nullLogger = NULL_LOGGER;
-    const errorSpy = vi.spyOn(console, 'error');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     nullLogger.error('Should not log');
 

--- a/test/mint/Mint-mutants.node.test.ts
+++ b/test/mint/Mint-mutants.node.test.ts
@@ -449,7 +449,6 @@ describe('Mint mutation coverage', () => {
         'Invalid response from mint',
       );
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 123 }),
         op: 'custom-pay melt quote',
       });
     });
@@ -465,7 +464,6 @@ describe('Mint mutation coverage', () => {
         'Invalid response from mint',
       );
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ unit: 42 }),
         op: 'custom-pay melt quote',
       });
     });
@@ -483,7 +481,6 @@ describe('Mint mutation coverage', () => {
         'Invalid response from mint',
       );
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ expiry: undefined }),
         op: 'custom-pay melt quote',
       });
     });

--- a/test/mint/Mint.node.test.ts
+++ b/test/mint/Mint.node.test.ts
@@ -14,6 +14,8 @@ import {
   JSONInt,
 } from '../../src';
 import type { AuthProvider, Logger, MintQuoteBaseResponse, Proof, RequestFn } from '../../src';
+import { NULL_LOGGER } from '../../src/logger';
+import { setRequestLogger } from '../../src/transport/request';
 import { MAX_KEYSET_LIST, MAX_MINT_INFO_LIST } from '../../src/utils/limits';
 import { MINTINFORESP } from '../consts';
 
@@ -103,6 +105,30 @@ describe('Mint normalization', () => {
   it('exposes the sanitized mintUrl', () => {
     const mint = new Mint('https://localhost:3338');
     expect(mint.mintUrl).toBe('https://localhost:3338');
+  });
+
+  it('keeps transport retry logs on the originating Mint logger', async () => {
+    const victimLogger = createLogger();
+    const otherLogger = createLogger();
+    const failingFetch = vi.fn(async () => {
+      throw new Error('transport detail');
+    }) as typeof fetch;
+    const victim = new Mint(mintUrl, {
+      requestFetch: failingFetch,
+      logger: victimLogger,
+    });
+
+    // Constructing an unrelated Mint afterwards must not redirect the victim's transport logs.
+    new Mint('https://other.example', { logger: otherLogger });
+    try {
+      await expect(victim.getInfo()).rejects.toThrow();
+
+      expect(otherLogger.info).not.toHaveBeenCalled();
+      expect(victimLogger.info).toHaveBeenCalled();
+    } finally {
+      // The constructor above installed otherLogger process-wide; do not leak it into later tests.
+      setRequestLogger(NULL_LOGGER);
+    }
   });
 
   it('oidcAuth throws when the mint does not advertise NUT-21 discovery metadata', async () => {
@@ -634,7 +660,8 @@ describe('Mint normalization', () => {
       'Invalid response from mint',
     );
     expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-      data: { quotes: [] },
+      expectedCount: 1,
+      actualCount: undefined,
       op: 'checkMintQuoteBatch.bolt11',
     });
   });
@@ -722,6 +749,36 @@ describe('Mint normalization', () => {
     await expect(mint.checkMintQuoteBatchBolt11(['q1', 'q2'])).rejects.toThrow(
       'Invalid response from mint',
     );
+  });
+
+  it('does not log quote ids from an out-of-order batch response', async () => {
+    const logger = createLogger();
+    const bearerQuote = 'unlocked-quote-id';
+    const mint = new Mint(mintUrl, {
+      customRequest: makeRequest([
+        {
+          quote: 'q2',
+          request: 'lnbc50...',
+          unit: 'sat',
+          amount: 50,
+          state: 'PAID',
+          expiry: 123,
+        },
+        {
+          quote: bearerQuote,
+          request: 'lnbc100...',
+          unit: 'sat',
+          amount: 100,
+          state: 'PAID',
+          expiry: 123,
+        },
+      ]),
+      logger,
+    });
+
+    await expect(mint.checkMintQuoteBatchBolt11([bearerQuote, 'q2'])).rejects.toThrow();
+
+    expect(JSON.stringify(vi.mocked(logger.error).mock.calls)).not.toContain(bearerQuote);
   });
 
   it('throws for invalid custom method strings', async () => {
@@ -946,6 +1003,21 @@ describe('Mint normalization', () => {
         'Invalid response from mint',
       );
       expect(logger.error).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not log the quote id when the reported method disagrees with the endpoint', async () => {
+      const logger = createLogger();
+      const bearerQuote = 'unlocked-quote-id';
+      const wrongMint = new Mint(mintUrl, {
+        customRequest: makeRequest({ ...mintQuote, quote: bearerQuote, method: 'bolt12' }),
+        logger,
+      });
+
+      await expect(wrongMint.checkMintQuoteBolt11(bearerQuote)).rejects.toThrow(
+        'Invalid response from mint',
+      );
+
+      expect(JSON.stringify(vi.mocked(logger.error).mock.calls)).not.toContain(bearerQuote);
     });
   });
 
@@ -1357,7 +1429,8 @@ describe('Mint normalization', () => {
       'Invalid response from mint',
     );
     expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-      data: { not_quotes: true },
+      expectedCount: 1,
+      actualCount: undefined,
       op: 'checkMintQuoteBatch.bolt11',
     });
   });
@@ -1465,7 +1538,6 @@ describe('Mint normalization', () => {
 
     await expect(mint.checkMeltQuoteBolt12('q1')).rejects.toThrow('Invalid response from mint');
     expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-      data: expect.objectContaining({ quote: 'q1', state: 'BROKEN' }),
       op: 'bolt12 melt quote',
     });
   });
@@ -1486,7 +1558,6 @@ describe('Mint normalization', () => {
 
     await expect(mint.checkMeltQuoteBolt12('q1')).rejects.toThrow('Invalid response from mint');
     expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-      data: expect.objectContaining({ quote: 'q1' }),
       op: 'bolt12 melt quote',
     });
   });
@@ -1565,7 +1636,6 @@ describe('Mint normalization', () => {
 
       await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 'q1' }),
         op: 'onchain melt quote',
       });
     });
@@ -1579,7 +1649,6 @@ describe('Mint normalization', () => {
 
       await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 'q1' }),
         op: 'onchain melt quote',
       });
     });
@@ -1601,7 +1670,6 @@ describe('Mint normalization', () => {
 
       await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 'q1' }),
         op: 'onchain melt quote',
       });
     });
@@ -1618,8 +1686,8 @@ describe('Mint normalization', () => {
       });
 
       await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
+      // The request-string check lives in the shared base-field normalizer, not the onchain one.
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 'q1' }),
         op: 'onchain melt quote',
       });
     });
@@ -1637,7 +1705,6 @@ describe('Mint normalization', () => {
 
       await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 'q1' }),
         op: 'onchain melt quote',
       });
     });
@@ -1655,7 +1722,6 @@ describe('Mint normalization', () => {
 
       await expect(mint.checkMeltQuoteOnchain('q1')).rejects.toThrow('Invalid response from mint');
       expect(logger.error).toHaveBeenCalledWith('Invalid response from mint...', {
-        data: expect.objectContaining({ quote: 'q1' }),
         op: 'onchain melt quote',
       });
     });

--- a/test/model/Errors.test.ts
+++ b/test/model/Errors.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, test } from 'vitest';
 
+import { Amount } from '../../src/model/Amount';
 import {
   CTSError,
   HttpResponseError,
   isMintOperationError,
+  MeltChangeError,
   MintOperationError,
   NetworkError,
   RateLimitError,
   StaleKeysetError,
   UnknownKeysetError,
 } from '../../src/model/Errors';
+import type { OutputDataLike } from '../../src/model/OutputData';
+import type { MeltQuoteBaseResponse } from '../../src/model/types';
 
 describe('CTSError', () => {
   test('sets name and message', () => {
@@ -54,6 +58,40 @@ describe('CTSError', () => {
     const err = new CTSError('boom', { cause: new Error('first') });
     expect(() => Object.defineProperty(err, 'cause', { value: 'redefined' })).not.toThrow();
     expect(err.cause).toBe('redefined');
+  });
+});
+
+describe('MeltChangeError', () => {
+  const outputData: OutputDataLike[] = [
+    {
+      blindedMessage: { amount: Amount.zero(), B_: '02' + '11'.repeat(32), id: '00deadbeefdeadbe' },
+      blindingFactor: 123456789n,
+      secret: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
+      toProof: () => {
+        throw new Error('unused');
+      },
+    },
+  ];
+  const quote: MeltQuoteBaseResponse = {
+    quote: 'quote-id',
+    request: 'lnbc-payment-request',
+    amount: Amount.from(1),
+    method: 'bolt11',
+    unit: 'sat',
+    state: 'PAID',
+    expiry: 0,
+  };
+
+  test('exposes outputData and quote directly but not enumerably', () => {
+    const err = new MeltChangeError(outputData, quote);
+    expect(err.outputData).toBe(outputData);
+    expect(err.quote).toBe(quote);
+
+    // Non-enumerable: a spread/JSON.stringify of the error must not carry the recovery material.
+    expect(Object.keys(err)).not.toContain('outputData');
+    expect(Object.keys(err)).not.toContain('quote');
+    expect({ ...err }).not.toHaveProperty('outputData');
+    expect({ ...err }).not.toHaveProperty('quote');
   });
 });
 

--- a/test/transport/request.node.test.ts
+++ b/test/transport/request.node.test.ts
@@ -316,6 +316,31 @@ describe('requests', { timeout: 7500 }, () => {
     expect(headers!.get('x-both')).toBe('per-request');
   });
 
+  test('a per-request header overrides a global one differing only in case', async () => {
+    let observed: Headers | undefined;
+    const captureFetch = (async (
+      _input: Parameters<RequestFetch>[0],
+      init?: Parameters<RequestFetch>[1],
+    ) => {
+      observed = new Headers(init?.headers);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as RequestFetch;
+
+    setGlobalRequestOptions({ headers: { Authorization: 'Bearer global' } });
+    await request({
+      endpoint: `${mintUrl}/v1/info`,
+      headers: { authorization: 'Bearer per-request' },
+      fetch: captureFetch,
+    });
+
+    // A combined value ("Bearer global, Bearer per-request") means both headers were sent;
+    // Headers itself joins duplicates this way, so an exact match proves only one survived.
+    expect(observed?.get('authorization')).toBe('Bearer per-request');
+  });
+
   test('handles HttpResponseError on non-200 response', async () => {
     server.use(
       http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
@@ -1395,6 +1420,32 @@ describe('response body size cap', () => {
     expect(text).toHaveLength(chunks.length);
   });
 
+  test('reads a chunk before the transport reuses its buffer for the next one', async () => {
+    const source = enc('abc');
+    const scratch = new Uint8Array(1);
+    let index = 0;
+    const cancel = () => Promise.resolve();
+    const reader = {
+      read: async () => {
+        if (index === source.length) return { done: true, value: undefined };
+        // A transport may hand back the same view on the next call; the reader must not
+        // keep this reference around expecting it to still hold this chunk's bytes.
+        scratch[0] = source[index++];
+        return { done: false, value: scratch };
+      },
+      cancel,
+    };
+    const response = {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: { getReader: () => reader, cancel },
+      text: async () => '',
+    } as unknown as Response;
+
+    await expect(readBodyText(response, source.length)).resolves.toBe('abc');
+  });
+
   test('rejects an oversized error body but still surfaces an HttpResponseError', async () => {
     const chunk = enc('z'.repeat(600));
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -1414,6 +1465,40 @@ describe('response body size cap', () => {
     await expect(request({ endpoint, maxResponseBytes: 0 })).rejects.toThrow(
       'maxResponseBytes must be a positive integer',
     );
+  });
+
+  test('does not retry a 429 response whose body stalls', async () => {
+    let fetchCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      fetchCount++;
+      return streamResponse([enc('{"error":')], { status: 429, hangAfter: true });
+    });
+
+    const thrown = await request({
+      endpoint,
+      requestTimeout: 50,
+      ttl: 60_000,
+      cached_endpoints: [{ method: 'GET', path: '/v1/keys' }],
+    }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    // The status is already known; a stalled optional body must not turn it into a retryable error.
+    expect(fetchCount).toBe(1);
+  });
+
+  test('surfaces RateLimitError for a 429 whose body has no cancel method', async () => {
+    const response = {
+      ok: false,
+      status: 429,
+      headers: new Headers(),
+      body: { getReader: () => ({ read: async () => ({ done: true, value: undefined }) }) },
+      text: async () => '',
+    } as unknown as Response;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+
+    const thrown = await request({ endpoint }).catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(RateLimitError);
   });
 
   test('timeout during a hung body read maps to NetworkError', async () => {
@@ -1680,6 +1765,12 @@ describe('buildRequestHeaders', () => {
   test('caller-supplied User-Agent always wins', () => {
     expect(buildRequestHeaders(undefined, { 'User-Agent': 'X' }, false)['User-Agent']).toBe('X');
     expect(buildRequestHeaders(undefined, { 'User-Agent': 'X' }, true)['User-Agent']).toBe('X');
+  });
+
+  test('caller-supplied header replaces a default differing only in case', () => {
+    const headers = buildRequestHeaders(undefined, { 'user-agent': 'X' }, false);
+    expect(headers['user-agent']).toBe('X');
+    expect(Object.keys(headers).filter((k) => k.toLowerCase() === 'user-agent')).toHaveLength(1);
   });
 
   test('Content-Type is added only when body is present', () => {

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -1752,6 +1752,32 @@ describe('tokenFromTemplate rejects valid CBOR of wrong shape', () => {
   });
 });
 
+describe('legacy cashuA token shape validation', () => {
+  test('rejects an empty token array with CTSError instead of a raw TypeError', () => {
+    const body = encodeJsonToBase64Url({ token: [], unit: 'sat' });
+    const token = 'cashuA' + body;
+
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+
+  test('rejects a token whose root is not the expected object shape', () => {
+    const body = encodeJsonToBase64Url(['not', 'an', 'object']);
+    const token = 'cashuA' + body;
+
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+
+  test('rejects a token entry missing its proofs array', () => {
+    const body = encodeJsonToBase64Url({
+      token: [{ mint: 'http://localhost:3338' }],
+      unit: 'sat',
+    });
+    const token = 'cashuA' + body;
+
+    expect(() => utils.getDecodedToken(token, [])).toThrow(CTSError);
+  });
+});
+
 describe('deriveKeysetId edge cases', () => {
   test('throws for unknown version byte', () => {
     expect(() => utils.deriveKeysetId(keys, { versionByte: 99 })).toThrow(

--- a/test/wallet/wallet-init.node.test.ts
+++ b/test/wallet/wallet-init.node.test.ts
@@ -711,7 +711,7 @@ describe('multi mint', async () => {
         mintUrl + '/v1/melt/quote/bolt11',
         async ({ request }) => {
           const body = await request.json();
-          if (!body?.options.mpp) {
+          if (!body?.options?.mpp) {
             return new HttpResponse('No MPP', { status: 400 });
           }
           return HttpResponse.json({


### PR DESCRIPTION
Transport logs stay on the Mint or AuthManager that made the request, header merges are case-insensitive, the logger escapes Unicode line separators at any depth, and a few mint-facing paths stop logging response payloads or crashing on malformed input.

## Why

`request()` discarded the per-call `logger` option, so every transport log went to whichever logger `setRequestLogger` installed last, usually the most recently constructed `Mint`. Headers were merged with an object spread, so a name differing only in case produced two headers on the wire. The console logger did not escape U+2028/U+2029, only touched top-level strings, and dropped an own `__proto__` context key. A 429 whose body stalled became a `NetworkError` and was retried. The streaming body reader kept every chunk view until EOF. Quote normalizers logged the whole response, a malformed legacy token threw a raw `TypeError`, and `MeltChangeError`'s `outputData` and `quote` were copied by any spread or `JSON.stringify` of the error.

## Changes

Per-call and global `logger` options now take effect, with `setRequestLogger` as the fallback of last resort; `Mint` and `AuthManager` pass their own logger on every call. One `mergeHeadersCaseInsensitive` helper serves both merge sites, later entry wins. `sanitizeContextValue` escapes strings at any depth including nested `Error` message and stack, rebuilds plain and null-prototype objects through `defineProperty`, and stops at `MAX_LOG_CONTEXT_DEPTH` (8). The 429 check precedes the body read and cancels the body when possible. `readBodyText` grows one buffer clamped to `maxResponseBytes`. Quote logs carry `op` and counts only. `handleTokens` throws `CTSError` on a malformed `cashuA` shape. `MeltChangeError` fields are non-enumerable and the docblock says so.

## Impact

No public API change. Consumers who set both `setRequestLogger` and a `logger` request option will now see the option win. Everything else is invisible unless a mint sends malformed data.
