### PR TITLE
fix(wallet): enforce payment-request terms and guard counters, previews and cache age

### DIFF
--- a/.github/scripts/generate-agenda.mjs
+++ b/.github/scripts/generate-agenda.mjs
@@ -69,6 +69,14 @@ const hasLabel = (item, names) => (item.labels || []).some((l) => names.includes
 const skip = (item) => hasLabel(item, [...REPORT_LABELS, ...SKIP_LABELS]);
 const isBackport = (pr) => /^\[backport/i.test(pr.title.trim());
 
+// Titles and display names are contributor text, so they go in as text: GitHub renders a
+// backslash-escaped ASCII punctuation mark as itself.
+function md(value) {
+  return String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/[!-/:-@[-`{-~]/g, '\\$&');
+}
+
 // Group items by author as [type, item] pairs
 const byUser = new Map();
 function add(type, items, filter = () => true) {
@@ -76,9 +84,11 @@ function add(type, items, filter = () => true) {
     if (skip(item) || !filter(item)) continue;
     const a = item.author || {};
     const key = a.login || 'unknown';
-    const display = a.name ? `${a.name} (${a.login})` : key;
+    const display = a.name ? `${md(a.name)} (${md(a.login)})` : md(key);
     if (!byUser.has(key)) byUser.set(key, { display, rows: [] });
-    byUser.get(key).rows.push(`- [ ] **${type}:** [#${item.number}](${item.url}) - ${item.title}`);
+    byUser
+      .get(key)
+      .rows.push(`- [ ] **${type}:** [#${item.number}](${item.url}) - ${md(item.title)}`);
   }
 }
 
@@ -90,7 +100,7 @@ add('Backport', merged, isBackport);
 
 const fmt = (items) =>
   items.length
-    ? items.map((i) => `- [ ] [#${i.number}](${i.url}) - ${i.title}`).join('\n')
+    ? items.map((i) => `- [ ] [#${i.number}](${i.url}) - ${md(i.title)}`).join('\n')
     : '- None';
 
 // Spec activity is an ecosystem feed, not personal credit: one section,
@@ -99,7 +109,10 @@ const fmt = (items) =>
 const fmtNuts = (items) =>
   items.length
     ? items
-        .map((i) => `- [ ] [nuts#${i.number}](${i.url}) - ${i.title} (${i.author?.login || '?'})`)
+        .map(
+          (i) =>
+            `- [ ] [nuts#${i.number}](${i.url}) - ${md(i.title)} (${md(i.author?.login || '?')})`,
+        )
         .join('\n')
     : '- None';
 

--- a/docs-src/usage/payment_requests.md
+++ b/docs-src/usage/payment_requests.md
@@ -131,8 +131,13 @@ if (!request.includesMint(payload.mint)) return;
 The requested amount is what the payee must **net**, so check incoming proofs against the input fees they will cost to swap, plus any per-method fee the payer owed, before treating the payment as settled. A wallet on the payload's mint has everything needed:
 
 ```typescript
-if (!wallet.isPaymentRequestSatisfied(pr, payload.proofs)) {
-  // Underpaid: sum(proofs) - inputFees < amount + mf. Ignore or refund.
+try {
+  if (!wallet.isPaymentRequestSatisfied(pr, payload.proofs)) {
+    // Underpaid: sum(proofs) - inputFees < amount + mf. Ignore or refund.
+  }
+} catch {
+  // This mint cannot settle the request (wrong unit, outside a strict mint
+  // list, or no melt method the request accepts). Ignore or refund.
 }
 ```
 
@@ -144,7 +149,7 @@ A **locked** request needs a fourth: the private key it locks to. The check then
 wallet.isPaymentRequestSatisfied(pr, payload.proofs, undefined, { privkeys: myPrivkey });
 ```
 
-The check covers the amount and the requested lock. What it cannot cover is a blind-me leaf key belonging to someone else: only that key's owner can resolve its blinding, so a cosigner checks their own. Mint admissibility (`isMintListStrict` / `includesMint`) and proof integrity (DLEQ) remain separate checks, as does whether a script-path leaf is satisfiable today: ask `wallet.spendOptions(proof, { privkeys })` for that.
+The check covers the amount, the requested lock, and this mint's admissibility: it throws when the mint is outside a strict mint list, or cannot melt the request unit via any method the request accepts. What it cannot cover is a blind-me leaf key belonging to someone else: only that key's owner can resolve its blinding, so a cosigner checks their own. Proof integrity (DLEQ) remains a separate check, as does whether a script-path leaf is satisfiable today: ask `wallet.spendOptions(proof, { privkeys })` for that.
 
 ## Manual control
 

--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -2324,7 +2324,7 @@ export function selectProofsRotating(proofs: ProofLike[], amountToSelect: Amount
 
 // @public
 export class SendBuilder {
-    constructor(wallet: Wallet, amount: AmountLike, proofs: ProofLike[], lockFamily?: "v3" | "legacy" | undefined);
+    constructor(wallet: Wallet, amount: AmountLike, proofs: ProofLike[], lockFamily?: "v3" | "legacy" | undefined, fromRequest?: boolean);
     asCustom(data: OutputDataLike[]): this;
     asDeterministic(counter?: number, denoms?: AmountLike[]): this;
     asFactory(factory: OutputDataFactory, denoms?: AmountLike[]): this;

--- a/src/model/PaymentRequest.ts
+++ b/src/model/PaymentRequest.ts
@@ -152,7 +152,7 @@ export class PaymentRequest {
   feesFor(mint: string, meltMethods?: string[]): Amount {
     this.assertUnitRule();
     // Fees compensate the payee for melting out: payments from a listed mint carry none.
-    if (!this.supportedMethods?.length || this.mints?.includes(mint)) {
+    if (!this.supportedMethods?.length || this.includesMint(mint)) {
       return Amount.zero();
     }
     const applicable = this.supportedMethods

--- a/src/model/types/keyset.ts
+++ b/src/model/types/keyset.ts
@@ -134,7 +134,9 @@ export type KeyChainCache = {
    */
   mintUrl: string;
   /**
-   * Unix timestamp (ms) when this cache was created. Use for TTL / staleness checks.
+   * Unix timestamp (ms) when the data was fetched from the mint; restoring and re-saving a cache
+   * carries the original value over, so it stays usable for TTL / staleness checks. Undefined when
+   * the provenance is unknown.
    */
   savedAt?: number;
 };

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -119,7 +119,12 @@ export class EphemeralCounterSource implements CounterSource {
 
   constructor(initial?: Record<string, number>) {
     if (initial) {
-      for (const [k, v] of Object.entries(initial)) this.next.set(normalizeCounterKey(k), v);
+      // Two spellings of one id keep the higher cursor, whatever order the seed lists them in.
+      for (const [key, v] of Object.entries(initial)) {
+        const k = normalizeCounterKey(key);
+        assertSafeCounter(k, v);
+        this.next.set(k, Math.max(this.next.get(k) ?? 0, v));
+      }
     }
   }
 
@@ -145,9 +150,8 @@ export class EphemeralCounterSource implements CounterSource {
     if (n < 0) throw new CTSError('reserve called with negative count');
     return this.withLock(counterKey, (k) => {
       const cur = this.next.get(k) ?? 0;
-      // A seeded or setNext cursor is accepted verbatim, so even a read-only report is checked.
-      assertSafeCounter(k, cur + n);
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
+      assertSafeCounter(k, cur + n);
       this.next.set(k, cur + n);
       return { start: cur, count: n };
     });
@@ -173,13 +177,17 @@ export class EphemeralCounterSource implements CounterSource {
   async advanceToAtLeast(counterKey: string, minNext: number): Promise<void> {
     await this.withLock(counterKey, (k) => {
       const cur = this.next.get(k) ?? 0;
-      if (minNext > cur) this.next.set(k, minNext);
+      if (minNext > cur) {
+        assertSafeCounter(k, minNext);
+        this.next.set(k, minNext);
+      }
     });
   }
 
   async setNext(counterKey: string, next: number): Promise<void> {
     await this.withLock(counterKey, (k) => {
       if (next < 0) throw new CTSError('setNext: negative next not allowed');
+      assertSafeCounter(k, next);
       this.next.set(k, next);
     });
   }

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -1,4 +1,6 @@
+import { LEGACY_KEYSET_ID_LENGTH } from '../crypto/curves';
 import { CTSError } from '../model/Errors';
+import { isValidHex } from '../utils';
 /**
  * Usable counters in range is [start, start+count-1]
  *
@@ -88,6 +90,27 @@ export type OperationCounters = {
 };
 
 /**
+ * Hex keyset ids are byte identifiers, so two spellings of one id must share a cursor. Anything
+ * else (the quote-lock key, legacy base64 ids) is case-sensitive and kept verbatim.
+ */
+function normalizeCounterKey(counterKey: string): string {
+  // A legacy base64 id is case-sensitive and its alphabet overlaps hex, so it is left alone.
+  if (counterKey.length === LEGACY_KEYSET_ID_LENGTH) return counterKey;
+  return isValidHex(counterKey) ? counterKey.toLowerCase() : counterKey;
+}
+
+/**
+ * A cursor past 2^53 stops advancing, so equal reservations would repeat (NUT-13).
+ */
+function assertSafeCounter(counterKey: string, next: number): void {
+  if (!Number.isSafeInteger(next)) {
+    throw new CTSError(
+      `Reservation for counter key ${counterKey} would take the cursor to ${next}, outside the safe integer range`,
+    );
+  }
+}
+
+/**
  * In memory implementation with per keyset locks for atomic counters.
  */
 export class EphemeralCounterSource implements CounterSource {
@@ -96,11 +119,12 @@ export class EphemeralCounterSource implements CounterSource {
 
   constructor(initial?: Record<string, number>) {
     if (initial) {
-      for (const [k, v] of Object.entries(initial)) this.next.set(k, v);
+      for (const [k, v] of Object.entries(initial)) this.next.set(normalizeCounterKey(k), v);
     }
   }
 
-  private async withLock<T>(k: string, fn: () => T | Promise<T>): Promise<T> {
+  private async withLock<T>(counterKey: string, fn: (k: string) => T | Promise<T>): Promise<T> {
+    const k = normalizeCounterKey(counterKey);
     const prev = this.locks.get(k) ?? Promise.resolve();
     let release!: () => void;
     const p = new Promise<void>((resolve) => (release = resolve));
@@ -108,7 +132,7 @@ export class EphemeralCounterSource implements CounterSource {
     this.locks.set(k, chain);
     try {
       await prev;
-      return await fn();
+      return await fn(k);
     } finally {
       release();
       if (this.locks.get(k) === chain) {
@@ -119,10 +143,12 @@ export class EphemeralCounterSource implements CounterSource {
 
   async reserve(counterKey: string, n: number): Promise<CounterRange> {
     if (n < 0) throw new CTSError('reserve called with negative count');
-    return this.withLock(counterKey, () => {
-      const cur = this.next.get(counterKey) ?? 0;
+    return this.withLock(counterKey, (k) => {
+      const cur = this.next.get(k) ?? 0;
+      // A seeded or setNext cursor is accepted verbatim, so even a read-only report is checked.
+      assertSafeCounter(k, cur + n);
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
-      this.next.set(counterKey, cur + n);
+      this.next.set(k, cur + n);
       return { start: cur, count: n };
     });
   }
@@ -131,29 +157,30 @@ export class EphemeralCounterSource implements CounterSource {
     if (start < 0 || count < 0) {
       throw new CTSError('reserveAt called with a negative start or count');
     }
-    return this.withLock(counterKey, () => {
-      const cur = this.next.get(counterKey) ?? 0;
+    return this.withLock(counterKey, (k) => {
+      const cur = this.next.get(k) ?? 0;
       if (start < cur) {
         throw new CTSError(
-          `Counter ${start} for counter key ${counterKey} was already issued (next is ${cur})`,
+          `Counter ${start} for counter key ${k} was already issued (next is ${cur})`,
         );
       }
-      this.next.set(counterKey, start + count);
+      assertSafeCounter(k, start + count);
+      this.next.set(k, start + count);
       return { start, count };
     });
   }
 
   async advanceToAtLeast(counterKey: string, minNext: number): Promise<void> {
-    await this.withLock(counterKey, () => {
-      const cur = this.next.get(counterKey) ?? 0;
-      if (minNext > cur) this.next.set(counterKey, minNext);
+    await this.withLock(counterKey, (k) => {
+      const cur = this.next.get(k) ?? 0;
+      if (minNext > cur) this.next.set(k, minNext);
     });
   }
 
   async setNext(counterKey: string, next: number): Promise<void> {
-    await this.withLock(counterKey, () => {
+    await this.withLock(counterKey, (k) => {
       if (next < 0) throw new CTSError('setNext: negative next not allowed');
-      this.next.set(counterKey, next);
+      this.next.set(k, next);
     });
   }
 

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -27,6 +27,8 @@ export class KeyChain {
   // would slip past the not-found guard in getKeyset).
   private keysets: { [id: string]: Keyset } = Object.create(null) as { [id: string]: Keyset };
   private pendingKeyFetches: Map<string, Promise<Keyset>> = new Map();
+  // When this chain's data was fetched or, for restored data, when the cache it came from was.
+  private savedAt?: number;
 
   private assertInitialized(): void {
     if (Object.keys(this.keysets).length === 0) {
@@ -144,6 +146,7 @@ export class KeyChain {
       await Promise.all([this.mint.getKeySets(), this.mint.getKeys()]);
 
     this.buildKeychain(allKeysetsResponse.keysets, allKeysResponse.keysets);
+    this.savedAt = Date.now();
   }
 
   /**
@@ -157,6 +160,7 @@ export class KeyChain {
   loadFromCache(cache: KeyChainCache): void {
     const { keysets, keys } = KeyChain.cacheToMintDTO(cache);
     this.buildKeychain(keysets, keys);
+    this.savedAt = cache.savedAt;
   }
 
   /**
@@ -371,6 +375,9 @@ export class KeyChain {
     const keysList: MintKeys[] = allKeysets
       .map((k) => k.toMintKeys())
       .filter((mk): mk is MintKeys => mk !== null);
-    return KeyChain.mintToCacheDTO(this.mint.mintUrl, metaList, keysList);
+    const cache = KeyChain.mintToCacheDTO(this.mint.mintUrl, metaList, keysList);
+    // Reserializing restored data does not make it fresh: keep the provenance it came with.
+    cache.savedAt = this.savedAt;
+    return cache;
   }
 }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -1955,22 +1955,24 @@ class Wallet {
    *
    * @remarks
    * Verifies `sum(proofs) - inputFees >= amount + mf`, with input fees from this wallet's keysets
-   * and `mf` priced from this mint's NUT-05 melt methods for the wallet unit. A locked request also
-   * checks that each proof carries the lock that was asked for: exactly the requested tree for a
-   * nutroot request, and exactly the requested condition for a nut10 one. A receiver-keyed nutroot
-   * request needs `opts.privkeys`, because binding a proof to the receiver key is an ECDH
-   * trial-match only that key can do (NUT-28); without it there is nothing to check and the call
-   * throws rather than passing a payment the payee cannot spend. Proof integrity (pairing/DLEQ)
-   * remains a separate check.
+   * and `mf` priced from this mint's NUT-05 melt methods for the wallet unit. This mint must also
+   * be admissible: inside a strict mint list, and able to melt via a method the request accepts. A
+   * locked request also checks that each proof carries the lock that was asked for: exactly the
+   * requested tree for a nutroot request, and exactly the requested condition for a nut10 one. A
+   * receiver-keyed nutroot request needs `opts.privkeys`, because binding a proof to the receiver
+   * key is an ECDH trial-match only that key can do (NUT-28); without it there is nothing to check
+   * and the call throws rather than passing a payment the payee cannot spend. Proof integrity
+   * (pairing/DLEQ) remains a separate check.
    * @param pr - The payment request being settled.
    * @param proofs - The received proofs (from this wallet's mint), with spend info when present.
    * @param expectedAmount - Expected amount for amountless requests; ignored when the request sets
    *   `a`.
    * @param opts.privkeys - The receiver key(s) the request locks to. Required for a receiver-keyed
    *   nutroot request, unused otherwise.
-   * @throws If no amount is available to check against, the request unit does not match this
-   *   wallet, a proof keyset is unknown, the request is invalid per NUT-18, a receiver-keyed
-   *   nutroot request is checked without its key, or a proof does not carry the requested lock.
+   * @throws If no amount is available to check against, this wallet's mint is not admissible for
+   *   the request (unit, strict mint list, or no accepted melt method), a proof keyset is unknown,
+   *   the request is invalid per NUT-18, a receiver-keyed nutroot request is checked without its
+   *   key, or a proof does not carry the requested lock.
    */
   isPaymentRequestSatisfied(
     pr: PaymentRequest,
@@ -2012,14 +2014,25 @@ class Wallet {
         this.assertNut10Lock(nut10Lock, p.secret);
       }
     }
+    // Admissibility, as the payer side checks it (NUT-18): a strict list binds the issuer, and the
+    // proofs must be redeemable through a method the request accepts.
+    const listed = pr.includesMint(this.mint.mintUrl);
+    this.failIf(
+      pr.isMintListStrict === true && !listed,
+      "this wallet's mint is not in the request's strict mint list",
+    );
     // mf applies only when this mint is outside the request's mint list (NUT-18).
     let mf = Amount.zero();
-    if (pr.supportedMethods?.length && !pr.includesMint(this.mint.mintUrl)) {
+    if (pr.supportedMethods?.length) {
       const meltMethods = this.getMintInfo()
         .supportedMethods('melt')
         .filter((m) => m.unit === this._unit)
         .map((m) => m.method);
-      mf = pr.feesFor(this.mint.mintUrl, meltMethods);
+      this.failIf(
+        !pr.supportedMethods.some((m) => meltMethods.includes(m.method)),
+        `mint cannot melt ${this._unit} via any method the request accepts`,
+      );
+      mf = listed ? Amount.zero() : pr.feesFor(this.mint.mintUrl, meltMethods);
     }
     const needed = expected.add(mf).add(this.getFeesForProofs(proofs));
     return sumProofs(proofs).compareTo(needed) >= 0;
@@ -3369,12 +3382,15 @@ class Wallet {
     mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
     const { payload, outputData, method, legacySignature } = mintPreview;
+    // Ask the mint to sign the outputs this preview can unblind, rather than a field that a
+    // persisted preview may no longer agree with.
+    const request: MintRequest = { ...payload, outputs: outputData.map((d) => d.blindedMessage) };
     // TODO: Remove legacy message support
     const { signatures } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
         legacySignature !== undefined,
-        () => this.mint.mint(method, payload),
-        () => this.mint.mint(method, { ...payload, signature: legacySignature }),
+        () => this.mint.mint(method, request),
+        () => this.mint.mint(method, { ...request, signature: legacySignature }),
       ),
     );
     this.failIf(
@@ -3588,12 +3604,18 @@ class Wallet {
     batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
     const { method, payload, outputData, legacySignatures } = batchPreview;
+    // Ask the mint to sign the outputs this preview can unblind, rather than a field that a
+    // persisted preview may no longer agree with.
+    const request: BatchMintRequest = {
+      ...payload,
+      outputs: outputData.map((d) => d.blindedMessage),
+    };
     // TODO: Remove legacy message support
     const { signatures: sigs } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
         legacySignatures !== undefined,
-        () => this.mint.mintBatch(method, payload),
-        () => this.mint.mintBatch(method, { ...payload, signatures: legacySignatures! }),
+        () => this.mint.mintBatch(method, request),
+        () => this.mint.mintBatch(method, { ...request, signatures: legacySignatures! }),
       ),
     );
     this.failIf(

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -63,7 +63,8 @@ export class WalletOps {
    * @param proofs - Proofs to select from.
    * @param amount - Payer-chosen amount for amountless requests; forbidden when the request sets
    *   `a`.
-   * @returns A preconfigured {@link SendBuilder}; chain further options and `.run()`.
+   * @returns A preconfigured {@link SendBuilder}; chain further options and `.run()`. The terms the
+   *   request set are fixed: chaining cannot replace its lock or disable `includeFees`.
    * @throws If the wallet's mint, unit, or melt methods are unacceptable to the request, the
    *   request's lock cannot be honoured, or the request is invalid per NUT-18.
    */
@@ -76,8 +77,11 @@ export class WalletOps {
     if (!base) {
       throw new CTSError('amountless payment request: pass the chosen amount');
     }
-    if (pr.amount && !pr.unit) {
-      throw new CTSError('invalid payment request: amount (a) without unit (u)');
+    // NUT-18: u MUST be set if a or sm is set, since mf is denominated in the request unit.
+    if (!pr.unit && (pr.amount !== undefined || pr.supportedMethods?.length)) {
+      throw new CTSError(
+        'invalid payment request: unit (u) is required when an amount (a) or supported methods (sm) are set',
+      );
     }
     if (pr.unit && pr.unit !== wallet.unit) {
       throw new CTSError(`request unit '${pr.unit}' does not match wallet unit '${wallet.unit}'`);
@@ -113,7 +117,7 @@ export class WalletOps {
     const v3 = isBlsKeyset(wallet.keysetId);
     // Only a locked request negotiates an encoding; an unlocked one may use any keyset.
     const family = lock || nutroot ? (v3 ? 'v3' : 'legacy') : undefined;
-    const builder = new SendBuilder(wallet, base.add(fee), proofs, family).includeFees(true);
+    const builder = new SendBuilder(wallet, base.add(fee), proofs, family, true).includeFees(true);
     if (family) builder.keyset(wallet.keysetId);
     if (nutroot && v3) {
       return builder.asLocked(nutrootToLockOptions(nutroot));
@@ -192,14 +196,28 @@ export class SendBuilder {
   /**
    * @param lockFamily Set by `sendToRequest`: the keyset family the request was negotiated for
    *   (NUT-18). `keyset()` then refuses an id from the other family.
+   * @param fromRequest Set by `sendToRequest`: the request's own terms (its lock, and selection net
+   *   of input fees) are then fixed, and chaining cannot replace them.
    */
   constructor(
     private wallet: Wallet,
     amount: AmountLike,
     private proofs: ProofLike[],
     private lockFamily?: 'v3' | 'legacy',
+    private fromRequest = false,
   ) {
     this.amount = Amount.from(amount);
+  }
+
+  /**
+   * Guards a send output the payment request itself asked for (NUT-18).
+   */
+  private assertSendOutputMutable(): void {
+    if (this.fromRequest && this.sendOT) {
+      throw new CTSError(
+        'the payment request mandates this send output; it cannot be replaced by chaining',
+      );
+    }
   }
 
   /**
@@ -208,6 +226,7 @@ export class SendBuilder {
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
   asRandom(denoms?: AmountLike[]) {
+    this.assertSendOutputMutable();
     this.sendOT = { type: 'random', denominations: denoms };
     return this;
   }
@@ -219,6 +238,7 @@ export class SendBuilder {
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
   asDeterministic(counter = 0, denoms?: AmountLike[]) {
+    this.assertSendOutputMutable();
     this.sendOT = { type: 'deterministic', counter, denominations: denoms };
     return this;
   }
@@ -230,6 +250,7 @@ export class SendBuilder {
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
   asLocked(lock: LockOptions | LockBuilder, denoms?: AmountLike[]) {
+    this.assertSendOutputMutable();
     const options = lock instanceof LockBuilder ? lock.toOptions() : lock;
     this.sendOT = { type: 'lock', options, denominations: denoms };
     return this;
@@ -242,6 +263,7 @@ export class SendBuilder {
    * @param denoms Optional custom split. Can be partial if you only need SOME specific amounts.
    */
   asFactory(factory: OutputDataFactory, denoms?: AmountLike[]) {
+    this.assertSendOutputMutable();
     this.sendOT = { type: 'factory', factory, denominations: denoms };
     return this;
   }
@@ -253,6 +275,7 @@ export class SendBuilder {
    *   wallet will throw.
    */
   asCustom(data: OutputDataLike[]) {
+    this.assertSendOutputMutable();
     this.sendOT = { type: 'custom', data };
     return this;
   }
@@ -317,6 +340,12 @@ export class SendBuilder {
    * @param on When true, include fees in the sent amount. Default true if called.
    */
   includeFees(on = true) {
+    // A payment request is settled net of input fees (NUT-18), so the payee nets the amount asked.
+    if (this.fromRequest && !on) {
+      throw new CTSError(
+        'a payment request is sent net of input fees; includeFees cannot be disabled',
+      );
+    }
     this.config.includeFees = on;
     return this;
   }
@@ -416,8 +445,17 @@ export class SendBuilder {
    * @remarks
    * Call `wallet.completeSwap(SwapPreview)` to complete the send.
    * @returns A SwapPreview containing inputs, outputs, amount, fee and unselectedProofs.
+   * @throws If an offline mode is set: an offline selection has no swap to complete.
    */
   async prepare() {
+    // An offline selection reuses existing proofs and never reaches the mint, so there is no
+    // preview to hand to completeSwap.
+    if (this.offlineExact || this.offlineClose) {
+      throw new CTSError(
+        'Offline selection has nothing to prepare; call run() instead, or drop the offline mode for an online swap.',
+      );
+    }
+
     // Construct an OutputConfig using default send if no customizations
     const outputConfig: OutputConfig = {
       send: this.sendOT ?? this.wallet.defaultOutputType(),

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -56,6 +56,28 @@ describe('EphemeralCounterSource', () => {
     expect(used.size).toBe(4);
   });
 
+  it('keeps the higher cursor when a seed lists two spellings of one key', async () => {
+    const lower = '00bd033559de27d0';
+    const upper = lower.toUpperCase();
+    expect(await new EphemeralCounterSource({ [upper]: 100, [lower]: 5 }).snapshot()).toEqual({
+      [lower]: 100,
+    });
+    expect(await new EphemeralCounterSource({ [lower]: 5, [upper]: 100 }).snapshot()).toEqual({
+      [lower]: 100,
+    });
+  });
+
+  it('refuses an unsafe cursor at every entry point', async () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 2;
+    expect(() => new EphemeralCounterSource({ k: unsafe })).toThrow(/safe integer/i);
+    const src = new EphemeralCounterSource();
+    await expect(src.setNext('k', unsafe)).rejects.toThrow(/safe integer/i);
+    await expect(src.setNext('k', 1.5)).rejects.toThrow(/safe integer/i);
+    await expect(src.advanceToAtLeast('k', unsafe)).rejects.toThrow(/safe integer/i);
+    // Nothing above moved the cursor.
+    await expect(src.reserve('k', 0)).resolves.toEqual({ start: 0, count: 0 });
+  });
+
   it('gives two spellings of one hex counter key the same cursor', async () => {
     const lower = '00bd033559de27d0';
     const upper = lower.toUpperCase();
@@ -80,7 +102,7 @@ describe('EphemeralCounterSource', () => {
     await expect(src.reserveAt('k', Number.MAX_SAFE_INTEGER, 2)).rejects.toThrow(/safe integer/i);
     // A rejected reservation leaves the cursor where it was.
     expect((await src.snapshot()).k).toBe(Number.MAX_SAFE_INTEGER);
-    // The last usable counter is still reservable.
+    // A cursor sitting at the last usable counter is still reported.
     await expect(src.reserve('k', 0)).resolves.toEqual({
       start: Number.MAX_SAFE_INTEGER,
       count: 0,

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -56,6 +56,37 @@ describe('EphemeralCounterSource', () => {
     expect(used.size).toBe(4);
   });
 
+  it('gives two spellings of one hex counter key the same cursor', async () => {
+    const lower = '00bd033559de27d0';
+    const upper = lower.toUpperCase();
+    const src = new EphemeralCounterSource({ [upper]: 4 });
+
+    expect((await src.reserve(lower, 1)).start).toBe(4);
+    expect((await src.reserve(upper, 1)).start).toBe(5);
+    await src.advanceToAtLeast(upper, 8);
+    await src.reserveAt(lower, 9, 1);
+    await src.setNext(upper, 12);
+    expect(await src.snapshot()).toEqual({ [lower]: 12 });
+
+    // Keys that are not hex (the quote-lock cursor, legacy base64 ids) keep their spelling.
+    await src.reserve('Zz+/', 1);
+    expect(Object.keys(await src.snapshot())).toContain('Zz+/');
+  });
+
+  it('rejects a reservation the cursor could not advance past', async () => {
+    const src = new EphemeralCounterSource({ k: Number.MAX_SAFE_INTEGER });
+
+    await expect(src.reserve('k', 1)).rejects.toThrow(/safe integer/i);
+    await expect(src.reserveAt('k', Number.MAX_SAFE_INTEGER, 2)).rejects.toThrow(/safe integer/i);
+    // A rejected reservation leaves the cursor where it was.
+    expect((await src.snapshot()).k).toBe(Number.MAX_SAFE_INTEGER);
+    // The last usable counter is still reservable.
+    await expect(src.reserve('k', 0)).resolves.toEqual({
+      start: Number.MAX_SAFE_INTEGER,
+      count: 0,
+    });
+  });
+
   it('constructor seeds initial next values', async () => {
     const src = new EphemeralCounterSource({ a: 5, b: 2 });
     const snap = await src.snapshot();

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -354,6 +354,40 @@ describe('WalletOps builders', () => {
       expect(() => ops.sendToRequest(pr, proofs)).toThrow(/unit/);
     });
 
+    it('rejects supported methods without a unit, listed mint or not', async () => {
+      const pr = new PaymentRequest({
+        mints: [myMint],
+        supportedMethods: [{ method: 'bolt11', fee: 1 }],
+      });
+      expect(() => ops.sendToRequest(pr, proofs, 100)).toThrow(/unit/);
+
+      const withAmount = new PaymentRequest({ amount: 100 });
+      expect(() => ops.sendToRequest(withAmount, proofs)).toThrow(/unit/);
+      expect(wallet.send).not.toHaveBeenCalled();
+
+      // A request setting neither is not covered by the rule; the payer picks both.
+      const bare = new PaymentRequest({});
+      await ops.sendToRequest(bare, proofs, 100).run();
+      expect(Amount.from(wallet.send.mock.calls[0][0]).equals(100)).toBeTruthy();
+    });
+
+    it('keeps the request terms when further options are chained', async () => {
+      const locked = new PaymentRequest({
+        amount: 100,
+        unit: 'sat',
+        nut10: { kind: 'P2PK', data: '02'.padEnd(66, 'a') },
+      });
+      expect(() => ops.sendToRequest(locked, proofs).asRandom()).toThrow(/payment request/);
+      expect(() => ops.sendToRequest(locked, proofs).includeFees(false)).toThrow(/payment request/);
+
+      // An unlocked request mandates no send output, so shaping one is still allowed.
+      const unlocked = new PaymentRequest({ amount: 100, unit: 'sat' });
+      await ops.sendToRequest(unlocked, proofs).asRandom([50, 50]).includeFees(true).run();
+      const [, , config, outputConfig] = wallet.send.mock.calls[0];
+      expect(config?.includeFees).toBe(true);
+      expect(outputConfig?.send).toMatchObject({ type: 'random' });
+    });
+
     it('rejects when the mint cannot melt the request unit via any accepted method', () => {
       // The mock mint melts bolt12 only in usd, so bolt12 does not count for a sat request.
       const pr = new PaymentRequest({
@@ -556,6 +590,13 @@ describe('WalletOps builders', () => {
       await expect(ops.send(5, proofs).keepAsRandom().offlineCloseMatch().run()).rejects.toThrow(
         /Offline selection cannot be combined/i,
       );
+    });
+
+    it('refuses to prepare an online swap in an offline mode', async () => {
+      await expect(ops.send(5, proofs).offlineExactOnly().prepare()).rejects.toThrow(/offline/i);
+      await expect(ops.send(5, proofs).offlineCloseMatch().prepare()).rejects.toThrow(/offline/i);
+      expect(wallet.prepareSwapToSend).not.toHaveBeenCalled();
+      expect(wallet.sendOffline).not.toHaveBeenCalled();
     });
 
     it('asLocked and keepAsLocked accept a LockBuilder directly', async () => {

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -322,6 +322,25 @@ describe('KeyChain initialization', () => {
     expect(newCache.mintUrl).toEqual(originalCache.mintUrl);
   });
 
+  test('carries the loaded savedAt through a reserialization, and stamps a fetch', async () => {
+    const originalChain = new KeyChain(mint, unit);
+    await originalChain.init();
+    const fetchedAt = originalChain.cache.savedAt;
+    expect(fetchedAt).toBeGreaterThan(0);
+
+    const savedAt = 1_600_000_000_000;
+    const restored = KeyChain.fromCache(mint, unit, { ...originalChain.cache, savedAt });
+    expect(restored.cache.savedAt).toBe(savedAt);
+
+    // A cache saved without the timestamp cannot invent one for the data it carries.
+    const undated = KeyChain.fromCache(mint, unit, { ...originalChain.cache, savedAt: undefined });
+    expect(undated.cache.savedAt).toBeUndefined();
+
+    // A refresh from the mint is fresh data, so it takes the current time.
+    await restored.init(true);
+    expect(restored.cache.savedAt).toBeGreaterThan(savedAt);
+  });
+
   test('loading a sat cache into a usd KeyChain still loads data; getKeysets throws for missing unit', async () => {
     const originalChain = new KeyChain(mint, unit); // 'sat'
     await originalChain.init();

--- a/test/wallet/paymentRequests.test.ts
+++ b/test/wallet/paymentRequests.test.ts
@@ -230,6 +230,23 @@ describe('payment requests', () => {
       expect(mp.feesFor('https://out.example.com', ['bolt12']).equals(5)).toBeTruthy();
     });
 
+    test('feesFor treats an equivalent spelling of a listed mint as listed', () => {
+      const pr = new PaymentRequest({
+        id: 'norm',
+        amount: 100,
+        unit: 'sat',
+        mints: ['https://mint.example.com/'],
+        mintsPreferred: true,
+        supportedMethods: [{ method: 'bolt12', fee: 50 }],
+      });
+
+      expect(pr.includesMint('https://mint.example.com')).toBe(true);
+      expect(pr.feesFor('https://mint.example.com', ['bolt12']).equals(0)).toBeTruthy();
+      expect(pr.amountToSend('https://mint.example.com', ['bolt12']).equals(100)).toBeTruthy();
+      // A mint that really is outside the list still owes the fee.
+      expect(pr.feesFor('https://other.example.com', ['bolt12']).equals(50)).toBeTruthy();
+    });
+
     test('unit rule: a or sm without u fails on encode and pricing, decode stays lenient', () => {
       // NUT-18: u MUST be set if a or sm is set (mf is denominated in the request unit).
       const smNoUnit = new PaymentRequest({

--- a/test/wallet/wallet-fees.node.test.ts
+++ b/test/wallet/wallet-fees.node.test.ts
@@ -300,6 +300,43 @@ describe('wallet.isPaymentRequestSatisfied', () => {
     expect(wallet.isPaymentRequestSatisfied(listed, proofsTotalling([100]))).toBe(true);
   });
 
+  test('does not settle a request this mint is not admissible for', async () => {
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    // Strict list (mp absent) naming another mint.
+    const strict = new PaymentRequest({
+      id: 'strict',
+      amount: 100,
+      unit: 'sat',
+      mints: ['https://other.mint'],
+    });
+    expect(() => wallet.isPaymentRequestSatisfied(strict, proofsTotalling([100]))).toThrow(
+      /strict mint list/,
+    );
+
+    // The fixture mint melts sat via bolt11 only, so a swift-only request is unsettleable here.
+    const unsupported = new PaymentRequest({
+      id: 'method',
+      amount: 100,
+      unit: 'sat',
+      supportedMethods: [{ method: 'swift' }],
+    });
+    expect(() => wallet.isPaymentRequestSatisfied(unsupported, proofsTotalling([100]))).toThrow(
+      /cannot melt/,
+    );
+
+    // A listed mint that melts an accepted method still settles.
+    const ok = new PaymentRequest({
+      id: 'ok',
+      amount: 100,
+      unit: 'sat',
+      mints: [mintUrl],
+      supportedMethods: [{ method: 'bolt11', fee: 5 }],
+    });
+    expect(wallet.isPaymentRequestSatisfied(ok, proofsTotalling([100]))).toBe(true);
+  });
+
   test('a both-encoded request settles only legacy proofs carrying the requested lock', async () => {
     const wallet = new Wallet(mint, { unit });
     await wallet.loadMint();

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -152,6 +152,52 @@ describe('requestTokens', () => {
     expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
   });
 
+  test('mints the outputs it can unblind, whatever the payload field says', async () => {
+    let sent: Array<{ B_: string; id: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11', async ({ request }) => {
+        sent = ((await request.json()) as { outputs: Array<{ B_: string; id: string }> }).outputs;
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 1, {
+      quote: 'restored-quote-id',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      method: 'bolt11',
+      state: MintQuoteState.PAID,
+      amount_paid: Amount.from(1),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+      expiry: null,
+    });
+    const prepared = preview.outputData[0].blindedMessage.B_;
+
+    // The payload field is replay metadata a restored preview may no longer agree with: the
+    // outputs that can be unblinded are the ones that count.
+    preview.payload.outputs[0] = {
+      ...preview.payload.outputs[0],
+      B_: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    };
+
+    const proofs = await wallet.completeMint(preview);
+
+    expect(sent[0].B_).toBe(prepared);
+    expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+  });
+
   test('prepareMint accepts expiry: 0 as "no expiry" (CDK quirk)', async () => {
     // Spec says expiry is <int|null> with null meaning "no expiry". CDK emits 0
     // for the same meaning. Treat 0 as null rather than "expired in 1970".
@@ -215,6 +261,51 @@ describe('requestTokens', () => {
     await expect(wallet.completeMint(preview)).rejects.toThrow(
       'Mint supports NUT-12, but returned a signature without DLEQ proof',
     );
+  });
+
+  test('batch-mints the outputs it can unblind, whatever the payload field says', async () => {
+    let sent: Array<{ B_: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11/batch', async ({ request }) => {
+        const body = (await request.json()) as { outputs: Array<{ B_: string; amount: unknown }> };
+        sent = body.outputs;
+        return HttpResponse.json({
+          signatures: body.outputs.map((o) => ({
+            id: '00bd033559de27d0',
+            amount: o.amount,
+            C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const quote: MintQuoteBolt11Response = {
+      quote: 'restored-batch-quote',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      method: 'bolt11',
+      state: MintQuoteState.PAID,
+      amount_paid: Amount.from(1),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+      expiry: null,
+    };
+    const preview = await wallet.prepareBatchMint('bolt11', [{ amount: 1, quote }]);
+    const prepared = preview.outputData[0].blindedMessage.B_;
+
+    // Same rule as completeMint: the payload field is replay metadata, outputData is what counts.
+    preview.payload.outputs[0] = {
+      ...preview.payload.outputs[0],
+      B_: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    };
+
+    const proofs = await wallet.completeBatchMint(preview);
+
+    expect(sent[0].B_).toBe(prepared);
+    expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
   });
 
   test('prepareBatchMint consolidates outputs and completeBatchMint sends batch request', async () => {


### PR DESCRIPTION
Wallet-layer consistency guards: mint completion signs the outputs it can unblind, payment-request checks match on both sides, request builders keep their terms, and counters and the keyset cache stop drifting.

## Why

`completeMint` and `completeBatchMint` sent the preview's stored `payload.outputs` while unblinding with `outputData`, so a persisted preview whose two halves disagreed asked the mint to sign outputs the wallet could not use. `isPaymentRequestSatisfied` priced fees but ignored a strict mint list and the accepted melt methods, so a payee could approve a payment the payer side would have refused. A builder from `sendToRequest` could have its lock replaced or its fees switched off by chaining, and `prepare()` ignored an offline mode. Counter keys were not canonicalised, and a reservation could push a cursor past `2^53`. `KeyChain` restamped `savedAt` on every serialisation, which defeats the TTL check the field exists for. The agenda script interpolated contributor names into Markdown unescaped.

## Changes

Mint requests are rebuilt from `outputData` at completion. `isPaymentRequestSatisfied` enforces the strict mint list and melt-method intersection per [NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md) and throws on either; the unit rule now covers `sm` as well as `a`; `mf` is priced against normalised mint membership. `SendBuilder` gains an optional `fromRequest` flag, and such a builder refuses `includeFees(false)`, lock replacement and offline modes. `EphemeralCounterSource` lowercases hex keys, leaves legacy base64 ids alone, and bounds every cursor it hands out. `KeyChain` carries the fetch or cache time through serialisation. The agenda script escapes Markdown.

## Impact

`isPaymentRequestSatisfied` now throws where it previously returned `false` for an inadmissible mint; the payee docs show the `try`/`catch`. `asCustom` is unreachable on a request builder, since custom outputs and included fees already exclude each other. `KeyChainCache.savedAt` can be `undefined` after restoring a cache saved without one. The `SendBuilder` constructor widening is additive.
