### PR TITLE
fix(wallet): guard counters, mint previews and cache age [backport v4-dev]

### DIFF
--- a/src/model/types/keyset.ts
+++ b/src/model/types/keyset.ts
@@ -129,7 +129,9 @@ export type KeyChainCache = {
    */
   mintUrl: string;
   /**
-   * Unix timestamp (ms) when this cache was created. Use for TTL / staleness checks.
+   * Unix timestamp (ms) when the data was fetched from the mint; restoring and re-saving a cache
+   * carries the original value over, so it stays usable for TTL / staleness checks. Undefined when
+   * the provenance is unknown.
    */
   savedAt?: number;
 };

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -92,7 +92,12 @@ export class EphemeralCounterSource implements CounterSource {
 
   constructor(initial?: Record<string, number>) {
     if (initial) {
-      for (const [k, v] of Object.entries(initial)) this.next.set(normalizeCounterKey(k), v);
+      // Two spellings of one id keep the higher cursor, whatever order the seed lists them in.
+      for (const [key, v] of Object.entries(initial)) {
+        const k = normalizeCounterKey(key);
+        assertSafeCounter(k, v);
+        this.next.set(k, Math.max(this.next.get(k) ?? 0, v));
+      }
     }
   }
 
@@ -118,9 +123,8 @@ export class EphemeralCounterSource implements CounterSource {
     if (n < 0) throw new CTSError('reserve called with negative count');
     return this.withLock(counterKey, (k) => {
       const cur = this.next.get(k) ?? 0;
-      // A seeded or setNext cursor is accepted verbatim, so even a read-only report is checked.
-      assertSafeCounter(k, cur + n);
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
+      assertSafeCounter(k, cur + n);
       this.next.set(k, cur + n);
       return { start: cur, count: n };
     });
@@ -146,13 +150,17 @@ export class EphemeralCounterSource implements CounterSource {
   async advanceToAtLeast(counterKey: string, minNext: number): Promise<void> {
     await this.withLock(counterKey, (k) => {
       const cur = this.next.get(k) ?? 0;
-      if (minNext > cur) this.next.set(k, minNext);
+      if (minNext > cur) {
+        assertSafeCounter(k, minNext);
+        this.next.set(k, minNext);
+      }
     });
   }
 
   async setNext(counterKey: string, next: number): Promise<void> {
     await this.withLock(counterKey, (k) => {
       if (next < 0) throw new CTSError('setNext: negative next not allowed');
+      assertSafeCounter(k, next);
       this.next.set(k, next);
     });
   }

--- a/src/wallet/CounterSource.ts
+++ b/src/wallet/CounterSource.ts
@@ -1,4 +1,6 @@
+import { LEGACY_KEYSET_ID_LENGTH } from '../crypto/core';
 import { CTSError } from '../model/Errors';
+import { isValidHex } from '../utils';
 /**
  * Usable counters in range is [start, start+count-1]
  *
@@ -61,6 +63,27 @@ export type OperationCounters = {
 };
 
 /**
+ * Hex keyset ids are byte identifiers, so two spellings of one id must share a cursor. Anything
+ * else (the quote-lock key, legacy base64 ids) is case-sensitive and kept verbatim.
+ */
+function normalizeCounterKey(counterKey: string): string {
+  // A legacy base64 id is case-sensitive and its alphabet overlaps hex, so it is left alone.
+  if (counterKey.length === LEGACY_KEYSET_ID_LENGTH) return counterKey;
+  return isValidHex(counterKey) ? counterKey.toLowerCase() : counterKey;
+}
+
+/**
+ * A cursor past 2^53 stops advancing, so equal reservations would repeat (NUT-13).
+ */
+function assertSafeCounter(counterKey: string, next: number): void {
+  if (!Number.isSafeInteger(next)) {
+    throw new CTSError(
+      `Reservation for counter key ${counterKey} would take the cursor to ${next}, outside the safe integer range`,
+    );
+  }
+}
+
+/**
  * In memory implementation with per keyset locks for atomic counters.
  */
 export class EphemeralCounterSource implements CounterSource {
@@ -69,11 +92,12 @@ export class EphemeralCounterSource implements CounterSource {
 
   constructor(initial?: Record<string, number>) {
     if (initial) {
-      for (const [k, v] of Object.entries(initial)) this.next.set(k, v);
+      for (const [k, v] of Object.entries(initial)) this.next.set(normalizeCounterKey(k), v);
     }
   }
 
-  private async withLock<T>(k: string, fn: () => T | Promise<T>): Promise<T> {
+  private async withLock<T>(counterKey: string, fn: (k: string) => T | Promise<T>): Promise<T> {
+    const k = normalizeCounterKey(counterKey);
     const prev = this.locks.get(k) ?? Promise.resolve();
     let release!: () => void;
     const p = new Promise<void>((resolve) => (release = resolve));
@@ -81,7 +105,7 @@ export class EphemeralCounterSource implements CounterSource {
     this.locks.set(k, chain);
     try {
       await prev;
-      return await fn();
+      return await fn(k);
     } finally {
       release();
       if (this.locks.get(k) === chain) {
@@ -90,43 +114,46 @@ export class EphemeralCounterSource implements CounterSource {
     }
   }
 
-  async reserve(keysetId: string, n: number): Promise<CounterRange> {
+  async reserve(counterKey: string, n: number): Promise<CounterRange> {
     if (n < 0) throw new CTSError('reserve called with negative count');
-    return this.withLock(keysetId, () => {
-      const cur = this.next.get(keysetId) ?? 0;
+    return this.withLock(counterKey, (k) => {
+      const cur = this.next.get(k) ?? 0;
+      // A seeded or setNext cursor is accepted verbatim, so even a read-only report is checked.
+      assertSafeCounter(k, cur + n);
       if (n === 0) return { start: cur, count: 0 }; // report current, do not move
-      this.next.set(keysetId, cur + n);
+      this.next.set(k, cur + n);
       return { start: cur, count: n };
     });
   }
 
-  async reserveAt(keysetId: string, start: number, count: number): Promise<CounterRange> {
+  async reserveAt(counterKey: string, start: number, count: number): Promise<CounterRange> {
     if (start < 0 || count < 0) {
       throw new CTSError('reserveAt called with a negative start or count');
     }
-    return this.withLock(keysetId, () => {
-      const cur = this.next.get(keysetId) ?? 0;
+    return this.withLock(counterKey, (k) => {
+      const cur = this.next.get(k) ?? 0;
       if (start < cur) {
         throw new CTSError(
-          `Counter ${start} for keyset ${keysetId} was already issued (next is ${cur})`,
+          `Counter ${start} for counter key ${k} was already issued (next is ${cur})`,
         );
       }
-      this.next.set(keysetId, start + count);
+      assertSafeCounter(k, start + count);
+      this.next.set(k, start + count);
       return { start, count };
     });
   }
 
-  async advanceToAtLeast(keysetId: string, minNext: number): Promise<void> {
-    await this.withLock(keysetId, () => {
-      const cur = this.next.get(keysetId) ?? 0;
-      if (minNext > cur) this.next.set(keysetId, minNext);
+  async advanceToAtLeast(counterKey: string, minNext: number): Promise<void> {
+    await this.withLock(counterKey, (k) => {
+      const cur = this.next.get(k) ?? 0;
+      if (minNext > cur) this.next.set(k, minNext);
     });
   }
 
-  async setNext(keysetId: string, next: number): Promise<void> {
-    await this.withLock(keysetId, () => {
+  async setNext(counterKey: string, next: number): Promise<void> {
+    await this.withLock(counterKey, (k) => {
       if (next < 0) throw new CTSError('setNext: negative next not allowed');
-      this.next.set(keysetId, next);
+      this.next.set(k, next);
     });
   }
 

--- a/src/wallet/KeyChain.ts
+++ b/src/wallet/KeyChain.ts
@@ -27,6 +27,8 @@ export class KeyChain {
   // would slip past the not-found guard in getKeyset).
   private keysets: { [id: string]: Keyset } = Object.create(null) as { [id: string]: Keyset };
   private pendingKeyFetches: Map<string, Promise<Keyset>> = new Map();
+  // When this chain's data was fetched or, for restored data, when the cache it came from was.
+  private savedAt?: number;
 
   private assertInitialized(): void {
     if (Object.keys(this.keysets).length === 0) {
@@ -144,6 +146,7 @@ export class KeyChain {
       await Promise.all([this.mint.getKeySets(), this.mint.getKeys()]);
 
     this.buildKeychain(allKeysetsResponse.keysets, allKeysResponse.keysets);
+    this.savedAt = Date.now();
   }
 
   /**
@@ -157,6 +160,7 @@ export class KeyChain {
   loadFromCache(cache: KeyChainCache): void {
     const { keysets, keys } = KeyChain.cacheToMintDTO(cache);
     this.buildKeychain(keysets, keys);
+    this.savedAt = cache.savedAt;
   }
 
   /**
@@ -371,6 +375,9 @@ export class KeyChain {
     const keysList: MintKeys[] = allKeysets
       .map((k) => k.toMintKeys())
       .filter((mk): mk is MintKeys => mk !== null);
-    return KeyChain.mintToCacheDTO(this.mint.mintUrl, metaList, keysList);
+    const cache = KeyChain.mintToCacheDTO(this.mint.mintUrl, metaList, keysList);
+    // Reserializing restored data does not make it fresh: keep the provenance it came with.
+    cache.savedAt = this.savedAt;
+    return cache;
   }
 }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -2749,12 +2749,15 @@ class Wallet {
     mintPreview: MintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
     const { payload, outputData, method, legacySignature } = mintPreview;
+    // Ask the mint to sign the outputs this preview can unblind, rather than a field that a
+    // persisted preview may no longer agree with.
+    const request: MintRequest = { ...payload, outputs: outputData.map((d) => d.blindedMessage) };
     // TODO: Remove legacy message support
     const { signatures } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
         legacySignature !== undefined,
-        () => this.mint.mint(method, payload),
-        () => this.mint.mint(method, { ...payload, signature: legacySignature }),
+        () => this.mint.mint(method, request),
+        () => this.mint.mint(method, { ...request, signature: legacySignature }),
       ),
     );
     this.failIf(
@@ -2926,12 +2929,18 @@ class Wallet {
     batchPreview: BatchMintPreview<Pick<MintQuoteBaseResponse, 'quote'>>,
   ): Promise<Proof[]> {
     const { method, payload, outputData, legacySignatures } = batchPreview;
+    // Ask the mint to sign the outputs this preview can unblind, rather than a field that a
+    // persisted preview may no longer agree with.
+    const request: BatchMintRequest = {
+      ...payload,
+      outputs: outputData.map((d) => d.blindedMessage),
+    };
     // TODO: Remove legacy message support
     const { signatures: sigs } = await this.withStaleKeysetRepair(() =>
       this.withLegacyQuoteSigFallback(
         legacySignatures !== undefined,
-        () => this.mint.mintBatch(method, payload),
-        () => this.mint.mintBatch(method, { ...payload, signatures: legacySignatures! }),
+        () => this.mint.mintBatch(method, request),
+        () => this.mint.mintBatch(method, { ...request, signatures: legacySignatures! }),
       ),
     );
     this.failIf(

--- a/src/wallet/WalletOps.ts
+++ b/src/wallet/WalletOps.ts
@@ -322,8 +322,17 @@ export class SendBuilder {
    * @remarks
    * Call `wallet.completeSwap(SwapPreview)` to complete the send.
    * @returns A SwapPreview containing inputs, outputs, amount, fee and unselectedProofs.
+   * @throws If an offline mode is set: an offline selection has no swap to complete.
    */
   async prepare() {
+    // An offline selection reuses existing proofs and never reaches the mint, so there is no
+    // preview to hand to completeSwap.
+    if (this.offlineExact || this.offlineClose) {
+      throw new CTSError(
+        'Offline selection has nothing to prepare; call run() instead, or drop the offline mode for an online swap.',
+      );
+    }
+
     // Construct an OutputConfig using default send if no customizations
     const outputConfig: OutputConfig = {
       send: this.sendOT ?? this.wallet.defaultOutputType(),

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -68,6 +68,28 @@ describe('EphemeralCounterSource', () => {
     expect(used.size).toBe(4);
   });
 
+  it('keeps the higher cursor when a seed lists two spellings of one key', async () => {
+    const lower = '00bd033559de27d0';
+    const upper = lower.toUpperCase();
+    expect(await new EphemeralCounterSource({ [upper]: 100, [lower]: 5 }).snapshot()).toEqual({
+      [lower]: 100,
+    });
+    expect(await new EphemeralCounterSource({ [lower]: 5, [upper]: 100 }).snapshot()).toEqual({
+      [lower]: 100,
+    });
+  });
+
+  it('refuses an unsafe cursor at every entry point', async () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 2;
+    expect(() => new EphemeralCounterSource({ k: unsafe })).toThrow(/safe integer/i);
+    const src = new EphemeralCounterSource();
+    await expect(src.setNext('k', unsafe)).rejects.toThrow(/safe integer/i);
+    await expect(src.setNext('k', 1.5)).rejects.toThrow(/safe integer/i);
+    await expect(src.advanceToAtLeast('k', unsafe)).rejects.toThrow(/safe integer/i);
+    // Nothing above moved the cursor.
+    await expect(src.reserve('k', 0)).resolves.toEqual({ start: 0, count: 0 });
+  });
+
   it('gives two spellings of one hex counter key the same cursor', async () => {
     const lower = '00bd033559de27d0';
     const upper = lower.toUpperCase();
@@ -92,7 +114,7 @@ describe('EphemeralCounterSource', () => {
     await expect(src.reserveAt('k', Number.MAX_SAFE_INTEGER, 2)).rejects.toThrow(/safe integer/i);
     // A rejected reservation leaves the cursor where it was.
     expect((await src.snapshot()).k).toBe(Number.MAX_SAFE_INTEGER);
-    // The last usable counter is still reservable.
+    // A cursor sitting at the last usable counter is still reported.
     await expect(src.reserve('k', 0)).resolves.toEqual({
       start: Number.MAX_SAFE_INTEGER,
       count: 0,

--- a/test/wallet/EphemeralCounterSource.test.ts
+++ b/test/wallet/EphemeralCounterSource.test.ts
@@ -68,6 +68,37 @@ describe('EphemeralCounterSource', () => {
     expect(used.size).toBe(4);
   });
 
+  it('gives two spellings of one hex counter key the same cursor', async () => {
+    const lower = '00bd033559de27d0';
+    const upper = lower.toUpperCase();
+    const src = new EphemeralCounterSource({ [upper]: 4 });
+
+    expect((await src.reserve(lower, 1)).start).toBe(4);
+    expect((await src.reserve(upper, 1)).start).toBe(5);
+    await src.advanceToAtLeast(upper, 8);
+    await src.reserveAt(lower, 9, 1);
+    await src.setNext(upper, 12);
+    expect(await src.snapshot()).toEqual({ [lower]: 12 });
+
+    // Keys that are not hex (the quote-lock cursor, legacy base64 ids) keep their spelling.
+    await src.reserve('Zz+/', 1);
+    expect(Object.keys(await src.snapshot())).toContain('Zz+/');
+  });
+
+  it('rejects a reservation the cursor could not advance past', async () => {
+    const src = new EphemeralCounterSource({ k: Number.MAX_SAFE_INTEGER });
+
+    await expect(src.reserve('k', 1)).rejects.toThrow(/safe integer/i);
+    await expect(src.reserveAt('k', Number.MAX_SAFE_INTEGER, 2)).rejects.toThrow(/safe integer/i);
+    // A rejected reservation leaves the cursor where it was.
+    expect((await src.snapshot()).k).toBe(Number.MAX_SAFE_INTEGER);
+    // The last usable counter is still reservable.
+    await expect(src.reserve('k', 0)).resolves.toEqual({
+      start: Number.MAX_SAFE_INTEGER,
+      count: 0,
+    });
+  });
+
   it('reserve(n=0) returns {start:0,count:0} and does not mutate state', async () => {
     const src = new EphemeralCounterSource();
     const r = await src.reserve('k', 0);

--- a/test/wallet/WalletOps.test.ts
+++ b/test/wallet/WalletOps.test.ts
@@ -373,6 +373,13 @@ describe('WalletOps builders', () => {
       );
     });
 
+    it('refuses to prepare an online swap in an offline mode', async () => {
+      await expect(ops.send(5, proofs).offlineExactOnly().prepare()).rejects.toThrow(/offline/i);
+      await expect(ops.send(5, proofs).offlineCloseMatch().prepare()).rejects.toThrow(/offline/i);
+      expect(wallet.prepareSwapToSend).not.toHaveBeenCalled();
+      expect(wallet.sendOffline).not.toHaveBeenCalled();
+    });
+
     it('asLocked accepts a LockBuilder directly and matches asP2PK', async () => {
       const pk = '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2';
       const builder = new LockBuilder().addMainPubkey(pk);

--- a/test/wallet/keychain.node.test.ts
+++ b/test/wallet/keychain.node.test.ts
@@ -322,6 +322,25 @@ describe('KeyChain initialization', () => {
     expect(newCache.mintUrl).toEqual(originalCache.mintUrl);
   });
 
+  test('carries the loaded savedAt through a reserialization, and stamps a fetch', async () => {
+    const originalChain = new KeyChain(mint, unit);
+    await originalChain.init();
+    const fetchedAt = originalChain.cache.savedAt;
+    expect(fetchedAt).toBeGreaterThan(0);
+
+    const savedAt = 1_600_000_000_000;
+    const restored = KeyChain.fromCache(mint, unit, { ...originalChain.cache, savedAt });
+    expect(restored.cache.savedAt).toBe(savedAt);
+
+    // A cache saved without the timestamp cannot invent one for the data it carries.
+    const undated = KeyChain.fromCache(mint, unit, { ...originalChain.cache, savedAt: undefined });
+    expect(undated.cache.savedAt).toBeUndefined();
+
+    // A refresh from the mint is fresh data, so it takes the current time.
+    await restored.init(true);
+    expect(restored.cache.savedAt).toBeGreaterThan(savedAt);
+  });
+
   test('loading a sat cache into a usd KeyChain still loads data; getKeysets throws for missing unit', async () => {
     const originalChain = new KeyChain(mint, unit); // 'sat'
     await originalChain.init();

--- a/test/wallet/wallet-mint.node.test.ts
+++ b/test/wallet/wallet-mint.node.test.ts
@@ -135,6 +135,52 @@ describe('requestTokens', () => {
     expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
   });
 
+  test('mints the outputs it can unblind, whatever the payload field says', async () => {
+    let sent: Array<{ B_: string; id: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11', async ({ request }) => {
+        sent = ((await request.json()) as { outputs: Array<{ B_: string; id: string }> }).outputs;
+        return HttpResponse.json({
+          signatures: [
+            {
+              id: '00bd033559de27d0',
+              amount: 1,
+              C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+            },
+          ],
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const preview = await wallet.prepareMint('bolt11', 1, {
+      quote: 'restored-quote-id',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      method: 'bolt11',
+      state: MintQuoteState.PAID,
+      amount_paid: Amount.from(1),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+      expiry: null,
+    });
+    const prepared = preview.outputData[0].blindedMessage.B_;
+
+    // The payload field is replay metadata a restored preview may no longer agree with: the
+    // outputs that can be unblinded are the ones that count.
+    preview.payload.outputs[0] = {
+      ...preview.payload.outputs[0],
+      B_: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    };
+
+    const proofs = await wallet.completeMint(preview);
+
+    expect(sent[0].B_).toBe(prepared);
+    expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
+  });
+
   test('prepareMint accepts expiry: 0 as "no expiry" (CDK quirk)', async () => {
     // Spec says expiry is <int|null> with null meaning "no expiry". CDK emits 0
     // for the same meaning. Treat 0 as null rather than "expired in 1970".
@@ -198,6 +244,50 @@ describe('requestTokens', () => {
     await expect(wallet.completeMint(preview)).rejects.toThrow(
       'Mint supports NUT-12, but returned a signature without DLEQ proof',
     );
+  });
+
+  test('batch-mints the outputs it can unblind, whatever the payload field says', async () => {
+    let sent: Array<{ B_: string }> = [];
+    server.use(
+      http.post(mintUrl + '/v1/mint/bolt11/batch', async ({ request }) => {
+        const body = (await request.json()) as { outputs: Array<{ B_: string; amount: unknown }> };
+        sent = body.outputs;
+        return HttpResponse.json({
+          signatures: body.outputs.map((o) => ({
+            id: '00bd033559de27d0',
+            amount: o.amount,
+            C_: '0361a2725cfd88f60ded718378e8049a4a6cee32e214a9870b44c3ffea2dc9e625',
+          })),
+        });
+      }),
+    );
+    const wallet = new Wallet(mint, { unit });
+    await wallet.loadMint();
+
+    const quote: MintQuoteBolt11Response = {
+      quote: 'restored-batch-quote',
+      request: 'lnbc...',
+      amount: Amount.from(1),
+      unit: 'sat',
+      state: MintQuoteState.PAID,
+      amount_paid: Amount.from(1),
+      amount_issued: Amount.from(0),
+      updated_at: null,
+      expiry: null,
+    };
+    const preview = await wallet.prepareBatchMint('bolt11', [{ amount: 1, quote }]);
+    const prepared = preview.outputData[0].blindedMessage.B_;
+
+    // Same rule as completeMint: the payload field is replay metadata, outputData is what counts.
+    preview.payload.outputs[0] = {
+      ...preview.payload.outputs[0],
+      B_: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    };
+
+    const proofs = await wallet.completeBatchMint(preview);
+
+    expect(sent[0].B_).toBe(prepared);
+    expect(proofs[0]).toMatchObject({ amount: Amount.from(1), id: '00bd033559de27d0' });
   });
 
   test('prepareBatchMint consolidates outputs and completeBatchMint sends batch request', async () => {


### PR DESCRIPTION
Backport of #1127 to v4-dev, limited to what exists on this line: mint completion signs the outputs it can unblind, `SendBuilder.prepare()` refuses an offline mode, counter keys are canonicalised and bounded, and the keyset cache keeps its real age.

## Why

`completeMint` and `completeBatchMint` sent the preview's stored `payload.outputs` while unblinding with `outputData`, so a persisted preview whose two halves disagreed asked the mint to sign outputs the wallet could not use. `prepare()` on a send builder ignored an offline mode and reached the mint anyway. Counter keys were not canonicalised, so two spellings of one hex keyset id got separate cursors, and a reservation could push a cursor past `2^53`. `KeyChain` restamped `savedAt` on every serialisation, which defeats the TTL check the field exists for.

## Changes

Mint requests are rebuilt from `outputData` at completion. `SendBuilder.prepare()` throws when `offlineExactOnly` or `offlineCloseMatch` is set, pointing at `run()`. `EphemeralCounterSource` lowercases hex keys, leaves legacy base64 ids alone, and rejects any reservation or cursor report outside the safe integer range. `KeyChain` carries the fetch or cache time through serialisation and leaves `savedAt` undefined when unknown.

Not carried from main: the payment-request items (`sendToRequest`, `isPaymentRequestSatisfied` and the `supportedMethods` rules do not exist on v4) and the agenda script escaping (no such script here).

## Impact

No public API change. `KeyChainCache.savedAt` can be `undefined` after restoring a cache saved without one. A reservation that would overflow the cursor now throws instead of silently aliasing.
