### PR TITLE
fix(utils): guard missing DLEQ blinding factor on v4 token decode

### DIFF
--- a/src/model/types/token.v4.ts
+++ b/src/model/types/token.v4.ts
@@ -10,7 +10,7 @@ export type V4DLEQTemplate = {
   /**
    * Blinding factor.
    */
-  r: Uint8Array;
+  r?: Uint8Array;
 };
 
 /**

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -377,7 +377,7 @@ function tokenFromTemplate(template: TokenV4Template): Token {
         id: bytesToHex(t.i),
         ...(p.d && {
           dleq: {
-            r: bytesToHex(p.d.r),
+            r: bytesToHex(p.d.r ?? new Uint8Array([0])),
             s: bytesToHex(p.d.s),
             e: bytesToHex(p.d.e),
           },


### PR DESCRIPTION
<!-- Implementing NUTs? Open with a NUTS: tracking header. The "# " heading and bare refs
     make GitHub render each one with its PR title:


     # NUTS:


     - cashubtc/nuts#xxx


     Add "Fixes #xxx" to auto-close an issue. In the prose below, cite the NUT the change
     lands in, e.g. [NUT-29](https://github.com/cashubtc/nuts/blob/main/29.md), rather than
     the PR number: PRs get squashed and renumbered, the NUT is the stable home. -->

Decode v4 tokens whose DLEQ proof omits the optional blinding factor `r`, preventing a raw `TypeError` crash on valid peer tokens.

## Why

`tokenFromTemplate` called `bytesToHex(p.d.r)` without guarding for `undefined`. NUT-00 and NUT-12 make `r` optional in the DLEQ proof, it is only needed for reblinding. Peer implementations (e.g. cdk) ship tokens whose DLEQ block contains only `{e, s}`.

The encode path already tolerates this (`p.dleq.r ?? '00'`); the decode path did not, creating an asymmetric wire contract that caused `getDecodedToken`, `getTokenMetadata`, and `wallet.receive` to crash on valid tokens. `findCashuPayload` silently swallowed the error, making valid pasted/QR-scanned tokens unfindable.

## Changes

- `src/utils/core.ts:392` - guard `p.d.r` with `?? new Uint8Array([0])`, matching the encode side's fallback behavior.
- `src/model/types/token.v4.ts:13` - mark `V4DLEQTemplate.r` as optional (`r?: Uint8Array`) so the type reflects the CBOR wire format from other implementations.

## Impact

Non-breaking. Consumers decoding v4 tokens from other Cashu implementations will no longer crash on well-formed tokens with an omitted DLEQ `r` field. Existing tokens with `r` present continue to decode identically. No public API surface change.