### PR TITLE
fix(core): reject incomplete DLEQ proofs on encode and decode

### DIFF
--- a/etc/cashu-ts.api.md
+++ b/etc/cashu-ts.api.md
@@ -570,11 +570,10 @@ export type DeviceStartResponse = {
 // @public (undocumented)
 export type DigestInput = Uint8Array | string;
 
-// @public (undocumented)
+// @public
 export type DLEQ = {
-    s: Uint8Array;
     e: Uint8Array;
-    r?: bigint;
+    s: Uint8Array;
 };
 
 // @public
@@ -2060,10 +2059,15 @@ export type Proof = {
     amount: Amount;
     secret: string;
     C: string;
-    dleq?: SerializedDLEQ;
+    dleq?: SerializedProofDLEQ;
     p2pk_e?: string;
     witness?: string | P2PKWitness | HTLCWitness;
     spend_info?: SpendInfo;
+};
+
+// @public
+export type ProofDLEQ = DLEQ & {
+    r: bigint;
 };
 
 // @public
@@ -2392,11 +2396,10 @@ export type SerializedBlindedSignature = {
     dleq?: SerializedDLEQ;
 };
 
-// @public (undocumented)
+// @public
 export type SerializedDLEQ = {
     s: string;
     e: string;
-    r?: string;
 };
 
 // @public (undocumented)
@@ -2420,6 +2423,11 @@ export type SerializedOutputData = {
 // @public
 export type SerializedProof = Omit<Proof, 'amount'> & {
     amount: string;
+};
+
+// @public
+export type SerializedProofDLEQ = SerializedDLEQ & {
+    r: string;
 };
 
 // @public
@@ -2710,7 +2718,7 @@ export const verifyDLEQProof: (dleq: DLEQ, B_: WeierstrassPoint<bigint>, C_: Wei
 
 // @public (undocumented)
 export const verifyDLEQProof_reblind: (secret: Uint8Array, // secret
-dleq: DLEQ, C: WeierstrassPoint<bigint>, // unblinded e-cash signature point
+dleq: ProofDLEQ, C: WeierstrassPoint<bigint>, // unblinded e-cash signature point
 A: WeierstrassPoint<bigint>) => boolean;
 
 // @public

--- a/migration-5.0.0.md
+++ b/migration-5.0.0.md
@@ -455,6 +455,37 @@ If you were calling `hasValidDleq(proof, keyset)` and relying on the previous st
 
 ---
 
+## `Proof.dleq` requires `r`; `DLEQ` split from `ProofDLEQ`
+
+The DLEQ types did two jobs. `DLEQ` and `SerializedDLEQ` both carried an optional blinding factor, so they described the mint's proof and the wallet's completed one at once, and nothing in the type said which you held.
+
+NUT-12 splits the work: the mint issues `{e, s}`, because it never sees the blinding factor, and the wallet adds the `r` it blinded with when it builds the `Proof`. v5 splits the types to match.
+
+- `DLEQ` and `SerializedDLEQ` are now the mint's pair, with no `r`. They type `SerializedBlindedSignature.dleq`, which is what the mint returns.
+- `ProofDLEQ` and `SerializedProofDLEQ` add a required `r`. `Proof.dleq` takes the serialized one, and `verifyDLEQProof_reblind` takes the other.
+
+So a `Proof` either has no DLEQ at all, or has a complete one. A two-field DLEQ on a proof is no longer representable, because it can never be verified by the next holder and costs its owner privacy.
+
+Encoding a proof whose DLEQ has no `r` throws, for binary tokens as well as `cashuB`. Decoding a token that carries one drops the block rather than crashing, leaving the verify-if-present behavior above. `hasValidDleq` reports one as invalid instead of verifying against a zero blinding factor.
+
+### Migration
+
+```ts
+// Before
+const dleq: SerializedDLEQ = { e, s };
+const proof: Proof = { id, amount, secret, C, dleq };
+
+// After
+const dleq: SerializedProofDLEQ = { e, s, r };
+const proof: Proof = { id, amount, secret, C, dleq };
+```
+
+Reading is unaffected and gains a guarantee: `proof.dleq.r` is a `string` wherever `proof.dleq` is set, so the `?? '00'` and `!` workarounds around it can go.
+
+You only need to act if your own code builds proofs, which normally means a custom `OutputDataLike`. Proofs from `wallet.receive`, `getDecodedToken` or any mint operation already satisfy this. If you hold a mint's blind signature rather than a proof, keep `SerializedDLEQ`.
+
+---
+
 ## `proofStatesStream` errors now throw
 
 `wallet.on.proofStatesStream` previously treated a WebSocket failure or mint-side RPC error as a graceful end of the iterator — the `for await` loop would exit normally and the consumer was responsible for inferring a problem via timeout. v5 throws the error from the iterator instead, matching the Node `AsyncIterable` convention (`Readable`, async generators, etc.).

--- a/src/crypto/NUT12.ts
+++ b/src/crypto/NUT12.ts
@@ -7,7 +7,7 @@ import { concatBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import { CTSError } from '../model/Errors';
 
-import { type DLEQ } from './core';
+import { type ProofDLEQ, type DLEQ } from './core';
 import { assertSecpPoint, hash_e, hashToCurve } from './curve_secp';
 
 const DST_R = utf8ToBytes('Cashu_DLEQ_R_v1');
@@ -50,10 +50,11 @@ export const verifyDLEQProof = (
 
 export const verifyDLEQProof_reblind = (
   secret: Uint8Array, // secret
-  dleq: DLEQ,
+  dleq: ProofDLEQ,
   C: WeierstrassPoint<bigint>, // unblinded e-cash signature point
   A: WeierstrassPoint<bigint>, // mint public key point
 ) => {
+  // Exported, so a plain-JS caller can still omit `r` whatever the type says.
   if (dleq.r === undefined)
     throw new CTSError('verifyDLEQProof_reblind: Undefined blinding factor');
   const Y = hashToCurve(secret);

--- a/src/crypto/core.ts
+++ b/src/crypto/core.ts
@@ -22,10 +22,27 @@ export type RawBlindedMessage = {
   secret: Uint8Array;
 };
 
+/**
+ * DLEQ proof as the mint issues it (NUT-12).
+ *
+ * @remarks
+ * The mint never sees the wallet's blinding factor, so its proof is `{e, s}` alone. Verifying it
+ * against a `Proof` needs {@link ProofDLEQ}.
+ */
 export type DLEQ = {
-  s: Uint8Array; // signature
   e: Uint8Array; // challenge
-  r?: bigint; // optional: blinding factor
+  s: Uint8Array; // response
+};
+
+/**
+ * A mint's DLEQ proof completed by the wallet with its own blinding factor.
+ *
+ * @remarks
+ * The shape that travels on a `Proof`. NUT-12 requires the wallet to add `r`; without it the proof
+ * cannot be re-blinded and so cannot be verified by anyone downstream.
+ */
+export type ProofDLEQ = DLEQ & {
+  r: bigint; // blinding factor
 };
 
 export type UnblindedSignature = {

--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -27,7 +27,7 @@ import {
   verifyDLEQProof,
   verifyUnblindedSignatureBls,
   type CurvePoint,
-  type DLEQ,
+  type ProofDLEQ,
   type BlindSignature,
   type G1Point,
   type G2Point,
@@ -132,6 +132,17 @@ export class OutputData implements OutputDataLike {
     secretKey?: Uint8Array,
     spendInfo?: SpendInfo,
   ) {
+    // Cheap JS runtime guards, as this runs per output on the send and receive path
+    // c.f: `deserialize` re-blinds the secret and compares when hydrating stored data.
+    if (typeof blindingFactor !== 'bigint' || blindingFactor <= 0n) {
+      throw new CTSError('OutputData: blindingFactor must be a positive bigint');
+    }
+    if (!(secret instanceof Uint8Array) || secret.length === 0) {
+      throw new CTSError('OutputData: secret must be a non-empty Uint8Array');
+    }
+    if (blindedMessage == undefined) {
+      throw new CTSError('OutputData: blindedMessage is required');
+    }
     this.secret = secret;
     this.blindingFactor = blindingFactor;
     this.blindedMessage = blindedMessage;
@@ -220,7 +231,8 @@ export class OutputData implements OutputDataLike {
       });
     }
 
-    let dleq: DLEQ | undefined;
+    // NUT-12: the mint issues `{e, s}`, the wallet completes it with the `r` it blinded with.
+    let dleq: ProofDLEQ | undefined;
     if (sig.dleq) {
       dleq = {
         s: hexToBytes(sig.dleq.s),
@@ -250,7 +262,7 @@ export class OutputData implements OutputDataLike {
         dleq: {
           s: bytesToHex(dleq.s),
           e: bytesToHex(dleq.e),
-          r: numberToHexPadded64(dleq.r ?? BigInt(0)),
+          r: numberToHexPadded64(dleq.r),
         },
       }),
     };

--- a/src/model/types/blinded.ts
+++ b/src/model/types/blinded.ts
@@ -46,12 +46,24 @@ export type SerializedBlindedSignature = {
   dleq?: SerializedDLEQ;
 };
 
-/*
- * Zero-Knowledge that BlindedSignature
- * was generated using a specific public key
+/**
+ * Zero-knowledge proof that a BlindSignature was generated using a specific public key (NUT-12).
+ *
+ * @remarks
+ * The mint's half of the proof. The wallet completes it into a {@link SerializedProofDLEQ}.
  */
 export type SerializedDLEQ = {
   s: string;
   e: string;
-  r?: string;
+};
+
+/**
+ * A mint's DLEQ proof completed by the wallet with its own blinding factor, as carried on a Proof.
+ *
+ * @remarks
+ * NUT-12 splits the work: the mint issues `{e, s}`, the wallet adds the `r` it blinded with. A
+ * Proof carrying only `{e, s}` cannot be verified by the next holder and is not valid.
+ */
+export type SerializedProofDLEQ = SerializedDLEQ & {
+  r: string;
 };

--- a/src/model/types/proof.ts
+++ b/src/model/types/proof.ts
@@ -1,6 +1,6 @@
 import { type Amount, type AmountLike } from '../Amount';
 
-import { type SerializedDLEQ } from './blinded';
+import { type SerializedProofDLEQ } from './blinded';
 
 /**
  * A proof-shaped object whose `amount` field has not yet been normalized to `Amount`.
@@ -38,9 +38,13 @@ export type Proof = {
    */
   C: string;
   /**
-   * DLEQ proof.
+   * DLEQ proof, complete with the blinding factor the wallet used (NUT-12).
+   *
+   * @remarks
+   * Optional as a whole. Present means all three fields are present: a proof carrying only the
+   * mint's `{e, s}` cannot be verified and must not be built or forwarded.
    */
-  dleq?: SerializedDLEQ;
+  dleq?: SerializedProofDLEQ;
   /**
    * The P2BK ephemeral pubkey "E" (SEC1-compressed 33-byte hex).
    */

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -2,7 +2,6 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
 import {
-  type DLEQ,
   type G1Point,
   type G2Point,
   assertV3PointSecret,
@@ -38,8 +37,10 @@ import type {
   Keys,
   Proof,
   ProofLike,
+  SerializedProofDLEQ,
   Token,
   TokenV4Template,
+  V4DLEQTemplate,
   V4InnerToken,
   V4ProofTemplate,
   HasKeysetKeys,
@@ -280,12 +281,6 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
   if (removeDleq) {
     proofs = stripDleq(proofs);
   }
-  // Make sure each DLEQ has its blinding factor
-  proofs.forEach((p) => {
-    if (p.dleq && p.dleq.r == undefined) {
-      throw new CTSError('Missing blinding factor in included DLEQ proof');
-    }
-  });
   const nonHex = hasNonHexId(proofs);
   if (nonHex) {
     throw new CTSError('can not encode to v4 token if proofs contain non-hex keyset id');
@@ -293,7 +288,7 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
   // Map keyset IDs to short IDs
   proofs = convertToShortKeysetId(proofs);
 
-  const tokenTemplate = templateFromToken({ ...token, proofs });
+  const tokenTemplate = toV4CborTemplate({ ...token, proofs });
 
   const encodedData = encodeCBOR(tokenTemplate);
   const prefix = 'cashu';
@@ -319,7 +314,22 @@ function isV3TransactionWitness(keysetId: string, secret: string): boolean {
   return isBlsKeyset(keysetId) && isV3PointSecret(secret);
 }
 
-function templateFromToken(token: Token): TokenV4Template {
+/**
+ * Encodes a proof's DLEQ for the v4 wire format.
+ *
+ * @remarks
+ * Per NUT-12 the wallet adds its own blinding factor `r` to the mint's `{e, s}`. A DLEQ without it
+ * is unverifiable by the next holder and costs its owner privacy, so refuse rather than pad `r`: a
+ * zero blinding factor would also assert the message was never blinded.
+ */
+function toV4CborDleq(dleq: SerializedProofDLEQ): V4DLEQTemplate {
+  if (dleq.r == undefined) {
+    throw new CTSError('Missing blinding factor in included DLEQ proof');
+  }
+  return { e: hexToBytes(dleq.e), s: hexToBytes(dleq.s), r: hexToBytes(dleq.r) };
+}
+
+function toV4CborTemplate(token: Token): TokenV4Template {
   // Keyed by token-supplied IDs, so a plain object would resolve `__proto__` etc. to inherited members.
   const idMap = Object.create(null) as { [id: string]: Proof[] };
   const mint = token.mint;
@@ -341,11 +351,7 @@ function templateFromToken(token: Token): TokenV4Template {
         s: p.secret,
         c: hexToBytes(p.C),
         ...(p.dleq && {
-          d: {
-            e: hexToBytes(p.dleq.e),
-            s: hexToBytes(p.dleq.s),
-            r: hexToBytes(p.dleq.r ?? '00'),
-          },
+          d: toV4CborDleq(p.dleq),
         }),
         ...(p.p2pk_e && {
           pe: hexToBytes(p.p2pk_e),
@@ -372,42 +378,72 @@ function templateFromToken(token: Token): TokenV4Template {
   return tokenTemplate;
 }
 
-function tokenFromTemplate(template: TokenV4Template): Token {
+/**
+ * Hex-encodes a byte string read from a decoded token template.
+ *
+ * @remarks
+ * The template types describe what this library emits, but a decoded token holds whatever the
+ * sender put on the wire and any field may carry any CBOR type. Without this, a wrong-typed field
+ * surfaces as a raw `TypeError` from the hex encoder rather than a token error naming the field.
+ */
+function templateHex(value: unknown, field: string): string {
+  if (!(value instanceof Uint8Array) || value.length === 0) {
+    throw new CTSError(`Invalid token: ${field} must be a non-empty byte string`);
+  }
+  return bytesToHex(value);
+}
+
+/**
+ * True when a decoded v4 DLEQ block carries all three of `e`, `s` and `r`.
+ *
+ * @remarks
+ * A block missing any of them is dropped on decode: without `r` it can never verify, and carrying a
+ * partial one costs the holder privacy (NUT-12). Absent is tolerated, present-but-malformed is not,
+ * so the fields themselves are still read through {@link templateHex}.
+ */
+function isCompleteDleq(d: V4DLEQTemplate | undefined): d is V4DLEQTemplate {
+  return d != undefined && d.e != undefined && d.s != undefined && d.r != undefined;
+}
+
+function fromV4CborTemplate(template: TokenV4Template): Token {
   if (!template || !Array.isArray(template.t)) {
-    throw new CTSError('Invalid token template');
+    throw new CTSError('Invalid token');
   }
   const proofs: Proof[] = [];
   template.t.forEach((t) => {
     if (!t || !Array.isArray(t.p)) {
-      throw new CTSError('Invalid token template');
+      throw new CTSError('Invalid token');
     }
     t.p.forEach((p) => {
+      const id = templateHex(t.i, 'keyset id');
       proofs.push({
         secret: p.s,
-        C: bytesToHex(p.c),
+        C: templateHex(p.c, 'proof C'),
         amount: Amount.from(p.a),
-        id: bytesToHex(t.i),
-        ...(p.d && {
+        id,
+        ...(isCompleteDleq(p.d) && {
           dleq: {
-            r: bytesToHex(p.d.r),
-            s: bytesToHex(p.d.s),
-            e: bytesToHex(p.d.e),
+            r: templateHex(p.d.r, 'dleq r'),
+            s: templateHex(p.d.s, 'dleq s'),
+            e: templateHex(p.d.e, 'dleq e'),
           },
         }),
         ...(p.pe && {
-          p2pk_e: bytesToHex(p.pe),
+          p2pk_e: templateHex(p.pe, 'p2pk_e'),
         }),
         ...(p.w &&
-          !isV3TransactionWitness(bytesToHex(t.i), p.s) && {
+          !isV3TransactionWitness(id, p.s) && {
             witness: p.w,
           }),
         ...(p.si && {
           spend_info: {
-            ...(p.si.k && { k: bytesToHex(p.si.k) }),
-            ...(p.si.e && { E: bytesToHex(p.si.e) }),
-            ...(p.si.i && { K: bytesToHex(p.si.i) }),
-            ...(p.si.u && { u: bytesToHex(p.si.u) }),
-            ...(p.si.t && { tree: p.si.t.map(bytesToHex) }),
+            ...(p.si.k && { k: templateHex(p.si.k, 'spend_info k') }),
+            ...(p.si.e && { E: templateHex(p.si.e, 'spend_info E') }),
+            ...(p.si.i && { K: templateHex(p.si.i, 'spend_info K') }),
+            ...(p.si.u && { u: templateHex(p.si.u, 'spend_info u') }),
+            ...(p.si.t && {
+              tree: p.si.t.map((leaf) => templateHex(leaf, 'spend_info tree leaf')),
+            }),
           },
         }),
       });
@@ -563,10 +599,15 @@ function handleTokens(token: string): Token {
     if (!entry || !Array.isArray(entry.proofs)) {
       throw new CTSError('Invalid token');
     }
-    const proofs = entry.proofs.map((p) => ({
-      ...p,
-      amount: Amount.from(p.amount as AmountLike),
-    }));
+    const proofs = entry.proofs.map((p) => {
+      const { dleq, ...rest } = p;
+      return {
+        ...rest,
+        amount: Amount.from(p.amount),
+        // Same rule as the v4 path: an incomplete DLEQ is useless and leaky, so it does not travel.
+        ...(dleq?.r && dleq.s && dleq.e && { dleq }),
+      };
+    });
     const tokenObj: Token = {
       mint: entry.mint,
       proofs,
@@ -579,7 +620,7 @@ function handleTokens(token: string): Token {
   } else if (version === 'B') {
     const uInt8Token = decodeBase64UrlToUint8(encodedToken);
     const tokenData = decodeCBOR(uInt8Token) as TokenV4Template;
-    return tokenFromTemplate(tokenData);
+    return fromV4CborTemplate(tokenData);
   }
   throw new CTSError('Token version is not supported');
 }
@@ -1183,7 +1224,7 @@ export function hasValidDleq(
   keyset: HasKeysetKeys,
   opts?: { require?: boolean },
 ): boolean {
-  const require = opts?.require ?? false;
+  const required = opts?.require ?? false;
   // v3 (BLS) proofs carry no DLEQ; pairing verification stands in. Returns true iff
   // e(C, G2) == e(Y, K2). This is "valid signature" in v3 terms — equivalent guarantee
   // to a verifying DLEQ on v0/v1/v2 proofs.
@@ -1213,7 +1254,12 @@ export function hasValidDleq(
   }
 
   if (proof?.dleq == undefined) {
-    return !require;
+    return !required;
+  }
+  // A DLEQ the wallet never completed with its own `r` is malformed, not absent: it cannot be
+  // re-blinded, and a zero blinding factor would assert the message was never blinded at all.
+  if (proof.dleq.r == undefined) {
+    return false;
   }
 
   const key = keyset.keys[proof.amount.toString()];
@@ -1221,8 +1267,8 @@ export function hasValidDleq(
     const dleq = {
       e: hexToBytes(proof.dleq.e),
       s: hexToBytes(proof.dleq.s),
-      r: hexToNumber(proof.dleq.r ?? '00'),
-    } as DLEQ;
+      r: hexToNumber(proof.dleq.r),
+    };
     return verifyDLEQProof_reblind(
       new TextEncoder().encode(proof.secret),
       dleq,
@@ -1352,7 +1398,7 @@ export function getEncodedTokenBinary(token: Token): Uint8Array {
       'Proofs contain a legacy keyset ID and cannot be encoded. Swap them at the mint first.',
     );
   }
-  const template = templateFromToken({ ...token, proofs });
+  const template = toV4CborTemplate({ ...token, proofs });
   const binaryTemplate = encodeCBOR(template);
   const prefix = utf8Encoder.encode('craw');
   const version = utf8Encoder.encode('B');
@@ -1371,7 +1417,7 @@ export function getDecodedTokenBinary(bytes: Uint8Array): Token {
   }
   const binaryToken = bytes.slice(5);
   const decoded = decodeCBOR(binaryToken) as TokenV4Template;
-  return tokenFromTemplate(decoded);
+  return fromV4CborTemplate(decoded);
 }
 
 function removePrefix(token: string): string {

--- a/test/auth/AuthManager.node.test.ts
+++ b/test/auth/AuthManager.node.test.ts
@@ -741,14 +741,14 @@ test('importPool dedupes by secret and exportPool deep-copies and preserves miss
     id: 'k',
     C: 'C1',
     secret: 'S',
-    dleq: { e: 'e1', s: 's1' },
+    dleq: { e: 'e1', s: 's1', r: 'r1' },
     amount: Amount.from(1),
   };
   const b: Proof = {
     id: 'k',
     C: 'C2',
     secret: 'S',
-    dleq: { e: 'e2', s: 's2' },
+    dleq: { e: 'e2', s: 's2', r: 'r2' },
     amount: Amount.from(1),
   }; // dup secret
   const c: Proof = { id: 'k', C: 'C3', secret: 'T', amount: 1 } as any; // no dleq

--- a/test/crypto/NUT12.test.ts
+++ b/test/crypto/NUT12.test.ts
@@ -13,6 +13,7 @@ import {
   verifyDLEQProof_reblind,
   constructUnblindedSignature,
   createRandomRawBlindedMessage,
+  type ProofDLEQ,
 } from '../../src/crypto';
 import { Amount } from '../../src/model/Amount';
 import { OutputData } from '../../src/model/OutputData';
@@ -75,10 +76,11 @@ describe('test DLEQ scheme', () => {
       blindMessage.secret,
       mintPubKey,
     );
-    dleqProof.r = blindMessage.r;
+    // Wallet(Alice) completes the mint's proof with the blinding factor she used
+    const completed = { ...dleqProof, r: blindMessage.r };
 
     // Wallet(Carol)
-    const isValid = verifyDLEQProof_reblind(blindMessage.secret, dleqProof, proof.C, mintPubKey);
+    const isValid = verifyDLEQProof_reblind(blindMessage.secret, completed, proof.C, mintPubKey);
     expect(isValid).toBe(true);
   });
 });
@@ -142,8 +144,10 @@ describe('verifyDLEQProof_reblind blinding factor guard', () => {
     const blindSig = createBlindSignature(blindMsg.B_, mintPrivKey, '');
     const proof = constructUnblindedSignature(blindSig, blindMsg.r, blindMsg.secret, mintPubKey);
     const dleq = createDLEQProof(blindMsg.B_, mintPrivKey);
-    expect(dleq.r).toBeUndefined();
-    expect(() => verifyDLEQProof_reblind(blindMsg.secret, dleq, proof.C, mintPubKey)).toThrow(
+    expect('r' in dleq).toBe(false);
+    // Deliberately malformed: the type forbids this, a plain-JS caller does not.
+    const incomplete = dleq as ProofDLEQ;
+    expect(() => verifyDLEQProof_reblind(blindMsg.secret, incomplete, proof.C, mintPubKey)).toThrow(
       'verifyDLEQProof_reblind: Undefined blinding factor',
     );
   });
@@ -155,8 +159,9 @@ describe('verifyDLEQProof_reblind blinding factor guard', () => {
     const blindSig = createBlindSignature(blindMsg.B_, mintPrivKey, '');
     const proof = constructUnblindedSignature(blindSig, blindMsg.r, blindMsg.secret, mintPubKey);
     const dleq = createDLEQProof(blindMsg.B_, mintPrivKey);
-    dleq.r = createRandomRawBlindedMessage().r; // a blinding factor from an unrelated message
-    expect(verifyDLEQProof_reblind(blindMsg.secret, dleq, proof.C, mintPubKey)).toBe(false);
+    // completed with a blinding factor from an unrelated message
+    const wrong = { ...dleq, r: createRandomRawBlindedMessage().r };
+    expect(verifyDLEQProof_reblind(blindMsg.secret, wrong, proof.C, mintPubKey)).toBe(false);
   });
 });
 

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -139,6 +139,43 @@ describe('OutputData secp round-trip (secp256k1 + NUT-12 DLEQ)', () => {
     expect(() => out.toProof(tampered, keyset)).toThrowError(/DLEQ verification failed/);
   });
 
+  describe('constructor guards (types are erased for plain-JS callers)', () => {
+    const bm = { amount: Amount.from(1), B_: '02'.repeat(33), id: '009a1f293253e41e' };
+    const secretBytes = utf8ToBytes('s');
+
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a number', 1],
+      ['a decimal string', '123'],
+      ['zero', 0n],
+      ['negative', -1n],
+    ])('rejects a blindingFactor that is %s', (_label, bad) => {
+      expect(() => new OutputData(bm, bad as bigint, secretBytes)).toThrow(
+        'blindingFactor must be a positive bigint',
+      );
+    });
+
+    test('rejects a secret that is not a non-empty Uint8Array', () => {
+      expect(() => new OutputData(bm, 1n, 's' as unknown as Uint8Array)).toThrow(
+        'secret must be a non-empty Uint8Array',
+      );
+      expect(() => new OutputData(bm, 1n, new Uint8Array())).toThrow(
+        'secret must be a non-empty Uint8Array',
+      );
+    });
+
+    test('rejects a missing blindedMessage', () => {
+      expect(() => new OutputData(undefined as unknown as typeof bm, 1n, secretBytes)).toThrow(
+        'blindedMessage is required',
+      );
+    });
+
+    test('accepts a well-formed set', () => {
+      expect(() => new OutputData(bm, 1n, secretBytes)).not.toThrow();
+    });
+  });
+
   test('rejects a mint response that unblinds to a non-UTF-8 secret', () => {
     // Bypass the factories (which only ever build UTF-8 secrets) to exercise toProof's own guard.
     const secretBytes = Uint8Array.of(0xff);

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -33,7 +33,8 @@ import {
   sortProofsById,
   normalizeMintUrl,
 } from '../../src/utils';
-import { encodeJsonToBase64Url } from '../../src/utils/base64';
+import { encodeJsonToBase64Url, encodeUint8ToBase64Url } from '../../src/utils/base64';
+import { encodeCBOR } from '../../src/utils/cbor';
 import { MAX_PAYLOAD_DECODE_ATTEMPTS, MAX_PAYLOAD_LENGTH } from '../../src/utils/limits';
 import { auditableLock, lockToNutrootOptions } from '../../src/wallet/lock';
 import {
@@ -838,6 +839,117 @@ describe('test v4 encoding', () => {
   });
 });
 
+describe('incomplete DLEQ proofs', () => {
+  const MINT = 'https://nofees.testnut.cashu.space';
+  const ID = '00b4cd27d8861a44';
+  const SECRET = '10216467bb33f6f079ae92349ba54fa34df99ba24572645b8b813688c74b582d';
+  const C = '03ff2e729416437f9ea8d022c501ff5b309d607f98c9ab53d51cd24185b4d3e42b';
+  const E = '8269767ac3f6ac368ad9ea8c05b13724ea8a58469677925aa948435685107b0d';
+  const S = '26f44e265699d95ae2171db58257aeffe03d325e0f69da4bc95b9749358380fc';
+  const R = '40ce4dbe14a1f65ae74328b5f81d83cdb3977595d78ddf01665d9aca6d450233';
+
+  // Deliberately malformed: Proof.dleq requires `r`, a plain-JS caller can still omit it.
+  const proofWithPartialDleq = (): Proof =>
+    ({
+      amount: Amount.from(1),
+      id: ID,
+      secret: SECRET,
+      C,
+      dleq: { e: E, s: S },
+    }) as Proof;
+
+  // A mint-signed DLEQ that a buggy wallet passed on without adding its own blinding factor.
+  const encodeV4WithPartialDleq = (): string =>
+    'cashuB' +
+    encodeUint8ToBase64Url(
+      encodeCBOR({
+        m: MINT,
+        u: 'sat',
+        t: [
+          {
+            i: hexToBytes(ID),
+            p: [
+              {
+                a: 1n,
+                s: SECRET,
+                c: hexToBytes(C),
+                d: { e: hexToBytes(E), s: hexToBytes(S) },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+  test('v4 decode drops the DLEQ instead of throwing', () => {
+    const decoded = utils.getDecodedToken(encodeV4WithPartialDleq(), [ID]);
+    expect(decoded.proofs[0].C).toBe(C);
+    expect(decoded.proofs[0].dleq).toBeUndefined();
+  });
+
+  test('v4 decode keeps a complete DLEQ', () => {
+    const encoded = utils.getEncodedToken({
+      mint: MINT,
+      proofs: [{ ...proofWithPartialDleq(), dleq: { e: E, s: S, r: R } }],
+    });
+    expect(utils.getDecodedToken(encoded, [ID]).proofs[0].dleq).toEqual({ e: E, s: S, r: R });
+  });
+
+  test('v3 decode drops the DLEQ', () => {
+    const encoded =
+      'cashuA' +
+      encodeJsonToBase64Url({
+        token: [
+          { mint: MINT, proofs: [{ amount: 1, id: ID, secret: SECRET, C, dleq: { e: E, s: S } }] },
+        ],
+        unit: 'sat',
+      });
+    const decoded = utils.getDecodedToken(encoded, [ID]);
+    expect(decoded.proofs[0].C).toBe(C);
+    expect(decoded.proofs[0].dleq).toBeUndefined();
+  });
+
+  test('decode reports a wrong-typed byte field instead of a raw TypeError', () => {
+    // Same crash class as an omitted `r`: any CBOR type can land in any field.
+    const encoded =
+      'cashuB' +
+      encodeUint8ToBase64Url(
+        encodeCBOR({
+          m: MINT,
+          u: 'sat',
+          t: [
+            {
+              i: hexToBytes(ID),
+              p: [
+                {
+                  a: 1n,
+                  s: SECRET,
+                  c: hexToBytes(C),
+                  d: { e: hexToBytes(E), s: hexToBytes(S), r: 42n },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+    expect(() => utils.getDecodedToken(encoded, [ID])).toThrow(CTSError);
+    expect(() => utils.getDecodedToken(encoded, [ID])).toThrow(
+      'dleq r must be a non-empty byte string',
+    );
+  });
+
+  test('encoding refuses to emit a DLEQ without its blinding factor', () => {
+    const token: Token = { mint: MINT, proofs: [proofWithPartialDleq()] };
+    expect(() => utils.getEncodedToken(token)).toThrow('Missing blinding factor');
+    expect(() => utils.getEncodedTokenBinary(token)).toThrow('Missing blinding factor');
+  });
+
+  test('stripping the DLEQ makes an otherwise unencodable token encodable', () => {
+    const token: Token = { mint: MINT, proofs: [proofWithPartialDleq()] };
+    expect(() => utils.getEncodedToken(token, { removeDleq: true })).not.toThrow();
+  });
+});
+
 describe('test deriveKeysetId edge cases', () => {
   // v3 (BLS) keysets folded case 2 into the case 1 unit-required branch and rewrote the
   // throw to interpolate the version byte. Cover both paths against the shared guard.
@@ -1020,6 +1132,14 @@ describe('test zero-knowledge utilities', () => {
 
     test('returns true for a valid DLEQ', () => {
       expect(hasValidDleq(serializedProof, keyset)).toBe(true);
+    });
+
+    test('returns false for a DLEQ that carries no blinding factor', () => {
+      const { r, ...partial } = serializedProof.dleq!;
+      void r;
+      // Deliberately malformed, as above.
+      const proof = { ...serializedProof, dleq: partial } as Proof;
+      expect(hasValidDleq(proof, keyset)).toBe(false);
     });
 
     test('returns false for a tampered DLEQ', () => {
@@ -1722,7 +1842,7 @@ describe('getDecodedTokenBinary edge cases', () => {
   });
 });
 
-describe('tokenFromTemplate rejects valid CBOR of wrong shape', () => {
+describe('fromV4CborTemplate rejects valid CBOR of wrong shape', () => {
   test('getDecodedToken (cashuB) throws CTSError, not a raw TypeError', () => {
     const body = utils.encodeCBOR({ m: 'http://localhost:3338', u: 'sat' });
     const token = 'cashuB' + utils.encodeUint8ToBase64Url(body);


### PR DESCRIPTION
A DLEQ carrying only the mint's `e` and `s` crashed the decoder and was silently padded by the encoder. Both now refuse it, and the types no longer allow a proof to hold one.

## Why

Spotted by @Hardeezah in #1130, who hit a `TypeError` decoding a v4 token whose DLEQ omitted the blinding factor. The crash is real; the tolerance the PR proposed is not.

NUT-12 splits the work. The mint issues `{e, s}`, because it never sees the blinding factor. The wallet adds the `r` it blinded with when it builds the `Proof`. So a proof holding only the mint's half can never be verified by anyone downstream, and padding `r` with zero asserts the message was never blinded at all. It is a wallet bug at the sender, not a shape to accommodate.

The two sides of our own wire disagreed about it: the encoder padded, the decoder crashed. Only the v4 string encoder checked for the blinding factor, so the binary encoder padded regardless.

## Changes

- Split the types so the invalid state is unrepresentable. `DLEQ` is the mint's pair, which is what `createDLEQProof` already returned; `ProofDLEQ` adds a required `r`; `Proof.dleq` takes the completed form. `OutputData` builds one by construction.
- Encoding a DLEQ without its blinding factor throws, from the template builder both encoders share rather than one of them.
- Decoding drops an incomplete block, for v3 JSON as well as v4 CBOR, which leaves NUT-12's verify-if-present behaviour intact. `hasValidDleq` reports one as invalid rather than verifying against zero.
- Guard the decoder's other byte fields. Any CBOR type can occupy any field, so a wrong-typed `C`, keyset id, P2BK key or spend-info entry raised the same `TypeError`. They now report an invalid token naming the field.
- Guard the `OutputData` constructor, which took its arguments unchecked from plain JS.
- Rename `templateFromToken` and `tokenFromTemplate`, near-anagrams that hid which way they ran, to `toV4CborTemplate` and `fromV4CborTemplate`.

## Impact

`Proof.dleq` now requires `r` when present. Readers gain a guarantee. Code constructing a partial DLEQ gets a type error, which is the point. Pre-GA, so the window for this is now.

Behaviour changes on malformed input only: an incomplete DLEQ is dropped rather than crashing or verifying falsely, and a malformed byte field reports an invalid token. Well-formed tokens encode and decode identically.

Closes #1130.
