### PR TITLE
fix(core): reject incomplete DLEQ proofs on encode and decode [backport v4-dev]

### DIFF
--- a/src/model/OutputData.ts
+++ b/src/model/OutputData.ts
@@ -114,6 +114,17 @@ export class OutputData implements OutputDataLike {
     secret: Uint8Array,
     ephemeralE?: string,
   ) {
+    // Cheap JS runtime guards, as this runs per output on the send and receive path
+    // c.f: `deserialize` re-blinds the secret and compares when hydrating stored data.
+    if (typeof blindingFactor !== 'bigint' || blindingFactor <= 0n) {
+      throw new CTSError('OutputData: blindingFactor must be a positive bigint');
+    }
+    if (!(secret instanceof Uint8Array) || secret.length === 0) {
+      throw new CTSError('OutputData: secret must be a non-empty Uint8Array');
+    }
+    if (blindedMessage == undefined) {
+      throw new CTSError('OutputData: blindedMessage is required');
+    }
     this.secret = secret;
     this.blindingFactor = blindingFactor;
     this.blindedMessage = blindedMessage;
@@ -164,7 +175,7 @@ export class OutputData implements OutputDataLike {
         dleq: {
           s: bytesToHex(dleq.s),
           e: bytesToHex(dleq.e),
-          r: numberToHexPadded64(dleq.r ?? BigInt(0)),
+          r: numberToHexPadded64(this.blindingFactor),
         },
       }),
     };

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1,7 +1,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils.js';
 
-import { type DLEQ, pointFromHex, verifyDLEQProof_reblind } from '../crypto';
+import { pointFromHex, verifyDLEQProof_reblind } from '../crypto';
 import { Amount, type AmountLike } from '../model/Amount';
 import { CTSError } from '../model/Errors';
 import { PaymentRequest } from '../model/PaymentRequest';
@@ -11,8 +11,10 @@ import type {
   Keys,
   Proof,
   ProofLike,
+  SerializedDLEQ,
   Token,
   TokenV4Template,
+  V4DLEQTemplate,
   V4InnerToken,
   V4ProofTemplate,
   HasKeysetKeys,
@@ -245,12 +247,6 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
   if (removeDleq) {
     proofs = stripDleq(proofs);
   }
-  // Make sure each DLEQ has its blinding factor
-  proofs.forEach((p) => {
-    if (p.dleq && p.dleq.r == undefined) {
-      throw new CTSError('Missing blinding factor in included DLEQ proof');
-    }
-  });
   const nonHex = hasNonHexId(proofs);
   if (nonHex) {
     throw new CTSError('can not encode to v4 token if proofs contain non-hex keyset id');
@@ -258,7 +254,7 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
   // Map keyset IDs to short IDs
   proofs = convertToShortKeysetId(proofs);
 
-  const tokenTemplate = templateFromToken({ ...token, proofs });
+  const tokenTemplate = toV4CborTemplate({ ...token, proofs });
 
   const encodedData = encodeCBOR(tokenTemplate);
   const prefix = 'cashu';
@@ -267,7 +263,22 @@ function getEncodedTokenV4(token: Token, removeDleq?: boolean): string {
   return prefix + version + base64Data;
 }
 
-function templateFromToken(token: Token): TokenV4Template {
+/**
+ * Encodes a proof's DLEQ for the v4 wire format.
+ *
+ * @remarks
+ * Per NUT-12 the wallet adds its own blinding factor `r` to the mint's `{e, s}`. A DLEQ without it
+ * is unverifiable by the next holder and costs its owner privacy, so refuse rather than pad `r`: a
+ * zero blinding factor would also assert the message was never blinded.
+ */
+function toV4CborDleq(dleq: SerializedDLEQ): V4DLEQTemplate {
+  if (dleq.r == undefined) {
+    throw new CTSError('Missing blinding factor in included DLEQ proof');
+  }
+  return { e: hexToBytes(dleq.e), s: hexToBytes(dleq.s), r: hexToBytes(dleq.r) };
+}
+
+function toV4CborTemplate(token: Token): TokenV4Template {
   // Keyed by token-supplied IDs, so a plain object would resolve `__proto__` etc. to inherited members.
   const idMap = Object.create(null) as { [id: string]: Proof[] };
   const mint = token.mint;
@@ -291,11 +302,7 @@ function templateFromToken(token: Token): TokenV4Template {
             s: p.secret,
             c: hexToBytes(p.C),
             ...(p.dleq && {
-              d: {
-                e: hexToBytes(p.dleq.e),
-                s: hexToBytes(p.dleq.s),
-                r: hexToBytes(p.dleq.r ?? '00'),
-              },
+              d: toV4CborDleq(p.dleq),
             }),
             ...(p.p2pk_e && {
               pe: hexToBytes(p.p2pk_e),
@@ -314,30 +321,58 @@ function templateFromToken(token: Token): TokenV4Template {
   return tokenTemplate;
 }
 
-function tokenFromTemplate(template: TokenV4Template): Token {
+/**
+ * Hex-encodes a byte string read from a decoded token template.
+ *
+ * @remarks
+ * The template types describe what this library emits, but a decoded token holds whatever the
+ * sender put on the wire and any field may carry any CBOR type. Without this, a wrong-typed field
+ * surfaces as a raw `TypeError` from the hex encoder rather than a token error naming the field.
+ */
+function templateHex(value: unknown, field: string): string {
+  if (!(value instanceof Uint8Array) || value.length === 0) {
+    throw new CTSError(`Invalid token: ${field} must be a non-empty byte string`);
+  }
+  return bytesToHex(value);
+}
+
+/**
+ * True when a decoded v4 DLEQ block carries all three of `e`, `s` and `r`.
+ *
+ * @remarks
+ * A block missing any of them is dropped on decode: without `r` it can never verify, and carrying a
+ * partial one costs the holder privacy (NUT-12). Absent is tolerated, present-but-malformed is not,
+ * so the fields themselves are still read through {@link templateHex}.
+ */
+function isCompleteDleq(d: V4DLEQTemplate | undefined): d is V4DLEQTemplate {
+  return d != undefined && d.e != undefined && d.s != undefined && d.r != undefined;
+}
+
+function fromV4CborTemplate(template: TokenV4Template): Token {
   if (!template || !Array.isArray(template.t)) {
-    throw new CTSError('Invalid token template');
+    throw new CTSError('Invalid token');
   }
   const proofs: Proof[] = [];
   template.t.forEach((t) => {
     if (!t || !Array.isArray(t.p)) {
-      throw new CTSError('Invalid token template');
+      throw new CTSError('Invalid token');
     }
     t.p.forEach((p) => {
+      const id = templateHex(t.i, 'keyset id');
       proofs.push({
         secret: p.s,
-        C: bytesToHex(p.c),
+        C: templateHex(p.c, 'proof C'),
         amount: Amount.from(p.a),
-        id: bytesToHex(t.i),
-        ...(p.d && {
+        id,
+        ...(isCompleteDleq(p.d) && {
           dleq: {
-            r: bytesToHex(p.d.r),
-            s: bytesToHex(p.d.s),
-            e: bytesToHex(p.d.e),
+            r: templateHex(p.d.r, 'dleq r'),
+            s: templateHex(p.d.s, 'dleq s'),
+            e: templateHex(p.d.e, 'dleq e'),
           },
         }),
         ...(p.pe && {
-          p2pk_e: bytesToHex(p.pe),
+          p2pk_e: templateHex(p.pe, 'p2pk_e'),
         }),
         ...(p.w && {
           witness: p.w,
@@ -418,10 +453,15 @@ function handleTokens(token: string): Token {
     if (!entry || !Array.isArray(entry.proofs)) {
       throw new CTSError('Invalid token');
     }
-    const proofs = entry.proofs.map((p) => ({
-      ...p,
-      amount: Amount.from(p.amount as AmountLike),
-    }));
+    const proofs = entry.proofs.map((p) => {
+      const { dleq, ...rest } = p;
+      return {
+        ...rest,
+        amount: Amount.from(p.amount),
+        // Same rule as the v4 path: an incomplete DLEQ is useless and leaky, so it does not travel.
+        ...(dleq?.r && dleq.s && dleq.e && { dleq }),
+      };
+    });
     const tokenObj: Token = {
       mint: entry.mint,
       proofs,
@@ -434,7 +474,7 @@ function handleTokens(token: string): Token {
   } else if (version === 'B') {
     const uInt8Token = decodeBase64AnyToUint8(encodedToken);
     const tokenData = decodeCBOR(uInt8Token) as TokenV4Template;
-    return tokenFromTemplate(tokenData);
+    return fromV4CborTemplate(tokenData);
   }
   throw new CTSError('Token version is not supported');
 }
@@ -767,7 +807,7 @@ export function hasValidDleq(
   keyset: HasKeysetKeys,
   opts?: { require?: boolean },
 ): boolean {
-  const require = opts?.require ?? true;
+  const required = opts?.require ?? true;
   if (!hasCorrespondingKey(proof.amount, keyset.keys)) {
     // An empty keyset means keys were never loaded (eg rotated-out keyset per NUT-01),
     // not that the denomination is missing. Say so: the two failures have different fixes.
@@ -778,15 +818,20 @@ export function hasValidDleq(
     throw new CTSError(message);
   }
   if (proof?.dleq == undefined) {
-    return !require;
+    return !required;
+  }
+  // A DLEQ the wallet never completed with its own `r` is malformed, not absent: it cannot be
+  // re-blinded, and a zero blinding factor would assert the message was never blinded at all.
+  if (proof.dleq.r == undefined) {
+    return false;
   }
   const key = keyset.keys[proof.amount.toString()];
   try {
     const dleq = {
       e: hexToBytes(proof.dleq.e),
       s: hexToBytes(proof.dleq.s),
-      r: hexToNumber(proof.dleq.r ?? '00'),
-    } as DLEQ;
+      r: hexToNumber(proof.dleq.r),
+    };
     return verifyDLEQProof_reblind(
       new TextEncoder().encode(proof.secret),
       dleq,
@@ -820,7 +865,7 @@ export function getEncodedTokenBinary(token: Token): Uint8Array {
       'Proofs contain a legacy keyset ID and cannot be encoded. Swap them at the mint first.',
     );
   }
-  const template = templateFromToken({ ...token, proofs });
+  const template = toV4CborTemplate({ ...token, proofs });
   const binaryTemplate = encodeCBOR(template);
   const prefix = utf8Encoder.encode('craw');
   const version = utf8Encoder.encode('B');
@@ -839,7 +884,7 @@ export function getDecodedTokenBinary(bytes: Uint8Array): Token {
   }
   const binaryToken = bytes.slice(5);
   const decoded = decodeCBOR(binaryToken) as TokenV4Template;
-  return tokenFromTemplate(decoded);
+  return fromV4CborTemplate(decoded);
 }
 
 function removePrefix(token: string): string {

--- a/test/model/OutputData.test.ts
+++ b/test/model/OutputData.test.ts
@@ -1,4 +1,5 @@
 import { bytesToHex } from '@noble/curves/utils.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -121,6 +122,43 @@ describe('OutputData secp round-trip (secp256k1 + NUT-12 DLEQ)', () => {
     const badE = (sig.dleq?.e ?? '').replace(/^./, (c) => (c === 'a' ? 'b' : 'a'));
     const tampered: SerializedBlindedSignature = { ...sig, dleq: { s: sig.dleq!.s, e: badE } };
     expect(() => out.toProof(tampered, keyset)).toThrowError(/DLEQ verification failed/);
+  });
+
+  describe('constructor guards (types are erased for plain-JS callers)', () => {
+    const bm = { amount: Amount.from(1), B_: '02'.repeat(33), id: '009a1f293253e41e' };
+    const secretBytes = utf8ToBytes('s');
+
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a number', 1],
+      ['a decimal string', '123'],
+      ['zero', 0n],
+      ['negative', -1n],
+    ])('rejects a blindingFactor that is %s', (_label, bad) => {
+      expect(() => new OutputData(bm, bad as bigint, secretBytes)).toThrow(
+        'blindingFactor must be a positive bigint',
+      );
+    });
+
+    test('rejects a secret that is not a non-empty Uint8Array', () => {
+      expect(() => new OutputData(bm, 1n, 's' as unknown as Uint8Array)).toThrow(
+        'secret must be a non-empty Uint8Array',
+      );
+      expect(() => new OutputData(bm, 1n, new Uint8Array())).toThrow(
+        'secret must be a non-empty Uint8Array',
+      );
+    });
+
+    test('rejects a missing blindedMessage', () => {
+      expect(() => new OutputData(undefined as unknown as typeof bm, 1n, secretBytes)).toThrow(
+        'blindedMessage is required',
+      );
+    });
+
+    test('accepts a well-formed set', () => {
+      expect(() => new OutputData(bm, 1n, secretBytes)).not.toThrow();
+    });
   });
 
   test('rejects a mint response that unblinds to a non-UTF-8 secret', () => {

--- a/test/utils/core.test.ts
+++ b/test/utils/core.test.ts
@@ -26,7 +26,8 @@ import {
   normalizeMintUrl,
   verifyDleqIfPresent,
 } from '../../src/utils';
-import { encodeJsonToBase64Url } from '../../src/utils/base64';
+import { encodeJsonToBase64Url, encodeUint8ToBase64Url } from '../../src/utils/base64';
+import { encodeCBOR } from '../../src/utils/cbor';
 import {
   NUT02_V1_VECTOR1_KEYS,
   NUT02_V1_VECTOR2_KEYS,
@@ -680,6 +681,84 @@ describe('test v4 encoding', () => {
   });
 });
 
+describe('incomplete DLEQ proofs', () => {
+  const MINT = 'https://nofees.testnut.cashu.space';
+  const ID = '00b4cd27d8861a44';
+  const SECRET = '10216467bb33f6f079ae92349ba54fa34df99ba24572645b8b813688c74b582d';
+  const C = '03ff2e729416437f9ea8d022c501ff5b309d607f98c9ab53d51cd24185b4d3e42b';
+  const E = '8269767ac3f6ac368ad9ea8c05b13724ea8a58469677925aa948435685107b0d';
+  const S = '26f44e265699d95ae2171db58257aeffe03d325e0f69da4bc95b9749358380fc';
+  const R = '40ce4dbe14a1f65ae74328b5f81d83cdb3977595d78ddf01665d9aca6d450233';
+
+  const proofWithPartialDleq = (): Proof => ({
+    amount: Amount.from(1),
+    id: ID,
+    secret: SECRET,
+    C,
+    dleq: { e: E, s: S },
+  });
+
+  // A mint-signed DLEQ that a buggy wallet passed on without adding its own blinding factor.
+  const encodeV4WithPartialDleq = (dleq: object): string =>
+    'cashuB' +
+    encodeUint8ToBase64Url(
+      encodeCBOR({
+        m: MINT,
+        u: 'sat',
+        t: [{ i: hexToBytes(ID), p: [{ a: 1n, s: SECRET, c: hexToBytes(C), d: dleq }] }],
+      }),
+    );
+
+  test('v4 decode drops the DLEQ instead of throwing', () => {
+    const encoded = encodeV4WithPartialDleq({ e: hexToBytes(E), s: hexToBytes(S) });
+    const decoded = utils.getDecodedToken(encoded, [ID]);
+    expect(decoded.proofs[0].C).toBe(C);
+    expect(decoded.proofs[0].dleq).toBeUndefined();
+  });
+
+  test('v4 decode keeps a complete DLEQ', () => {
+    const encoded = utils.getEncodedToken({
+      mint: MINT,
+      proofs: [{ ...proofWithPartialDleq(), dleq: { e: E, s: S, r: R } }],
+    });
+    expect(utils.getDecodedToken(encoded, [ID]).proofs[0].dleq).toEqual({ e: E, s: S, r: R });
+  });
+
+  test('decode reports a wrong-typed byte field instead of a raw TypeError', () => {
+    // Same crash class as an omitted `r`: any CBOR type can land in any field.
+    const encoded = encodeV4WithPartialDleq({ e: hexToBytes(E), s: hexToBytes(S), r: 42n });
+    expect(() => utils.getDecodedToken(encoded, [ID])).toThrow(CTSError);
+    expect(() => utils.getDecodedToken(encoded, [ID])).toThrow(
+      'dleq r must be a non-empty byte string',
+    );
+  });
+
+  test('v3 decode drops the DLEQ', () => {
+    const encoded =
+      'cashuA' +
+      encodeJsonToBase64Url({
+        token: [
+          { mint: MINT, proofs: [{ amount: 1, id: ID, secret: SECRET, C, dleq: { e: E, s: S } }] },
+        ],
+        unit: 'sat',
+      });
+    const decoded = utils.getDecodedToken(encoded, [ID]);
+    expect(decoded.proofs[0].C).toBe(C);
+    expect(decoded.proofs[0].dleq).toBeUndefined();
+  });
+
+  test('encoding refuses to emit a DLEQ without its blinding factor', () => {
+    const token: Token = { mint: MINT, proofs: [proofWithPartialDleq()] };
+    expect(() => utils.getEncodedToken(token)).toThrow('Missing blinding factor');
+    expect(() => utils.getEncodedTokenBinary(token)).toThrow('Missing blinding factor');
+  });
+
+  test('stripping the DLEQ makes an otherwise unencodable token encodable', () => {
+    const token: Token = { mint: MINT, proofs: [proofWithPartialDleq()] };
+    expect(() => utils.getEncodedToken(token, { removeDleq: true })).not.toThrow();
+  });
+});
+
 describe('test output selection', () => {
   test('hasCorrespondingKey accepts AmountLike', () => {
     expect(utils.hasCorrespondingKey('8', keys)).toBe(true);
@@ -765,6 +844,14 @@ describe('test zero-knowledge utilities', () => {
 
     test('returns true for a valid DLEQ', () => {
       expect(verifyDleqIfPresent(serializedProof, keyset)).toBe(true);
+    });
+
+    test('returns false for a DLEQ that carries no blinding factor', () => {
+      const { r, ...partial } = serializedProof.dleq!;
+      void r;
+      const proof: Proof = { ...serializedProof, dleq: partial };
+      expect(verifyDleqIfPresent(proof, keyset)).toBe(false);
+      expect(hasValidDleq(proof, keyset)).toBe(false);
     });
 
     test('returns false for a tampered DLEQ', () => {


### PR DESCRIPTION
Backport of #1135 to v4-dev, limited to the runtime guards: the encoder refuses a DLEQ without its blinding factor, the decoder drops an incomplete one instead of crashing, and malformed byte fields report an invalid token.

## Why

Spotted by @Hardeezah in #1130, who hit a `TypeError` decoding a v4 token whose DLEQ omitted the blinding factor. The crash is real; the tolerance that PR proposed is not.

NUT-12 splits the work. The mint issues `{e, s}`, because it never sees the blinding factor. The wallet adds the `r` it blinded with when it builds the `Proof`. So a proof holding only the mint's half can never be verified by anyone downstream, and padding `r` with zero asserts the message was never blinded at all. It is a wallet bug at the sender, not a shape to accommodate.

The two sides of our own wire disagreed about it: the encoder padded, the decoder crashed. Only the string encoder checked for the blinding factor, so the binary encoder padded regardless.

## Changes

The guard moves into the template builder both encoders share, so `getEncodedTokenBinary` is covered too. Decoding drops an incomplete block, for v3 JSON as well as v4 CBOR, which leaves the verify-if-present behaviour intact; `hasValidDleq` and `verifyDleqIfPresent` report one as invalid rather than verifying against zero. Every other byte field in the decoder now reports an invalid token naming the field, since any CBOR type can occupy any field and raised the same `TypeError`. The `OutputData` constructor checks its arguments, which it took unchecked from plain JS.

`templateFromToken` and `tokenFromTemplate` become `toV4CborTemplate` and `fromV4CborTemplate`, so the direction reads first instead of hiding in the word order.

Not carried from main: the `DLEQ` type split into the mint's pair and a `ProofDLEQ` requiring `r`. It makes the invalid state unrepresentable, but it is a compile-time break for code holding a partial DLEQ, so it stays on the v5 line. Every guard here is a runtime check and needs none of it. `hasValidDleq` also keeps this line's require-by-default.

## Impact

No public API change. Behaviour changes on malformed input only: an incomplete DLEQ is dropped rather than crashing or verifying falsely, and a malformed byte field reports an invalid token. Well-formed tokens encode and decode identically.
